### PR TITLE
Enable manual trigger for CHANGELOG sync workflow

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -7,6 +7,7 @@ on:
             - main
         paths:
             - "iris-thaumantias/CHANGELOG.md"
+    workflow_dispatch: # Allows manual trigger from GitHub Actions tab
 
 jobs:
     sync-changelog:

--- a/iris-thaumantias/CHANGELOG.md
+++ b/iris-thaumantias/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the Artemis VS Code extension will be documented in this file.
+All notable changes to the Artemis VS Code extension will be documented in this file. 
 
 ## [0.2.1] - 2025-10-25
 


### PR DESCRIPTION
Add the ability to manually trigger the CHANGELOG sync workflow from the GitHub Actions tab. This enhances flexibility in managing the changelog updates.