### PR TITLE
fix: Course refresh button throws error due to incorrect parameter type

### DIFF
--- a/iris-thaumantias/src/api/artemisApi.ts
+++ b/iris-thaumantias/src/api/artemisApi.ts
@@ -93,10 +93,10 @@ export class ArtemisApiService {
         return response.json();
     }
 
-    // Get exercises for a specific course
-    async getExercises(courseId: number): Promise<any[]> {
-        const response = await this.makeRequest(`/api/core/courses/${courseId}/exercises`);
-        return response.json() as Promise<any[]>;
+    // Get a single course with exercises and participations for dashboard
+    async getCourseForDashboard(courseId: number): Promise<any> {
+        const response = await this.makeRequest(`/api/core/courses/${courseId}/for-dashboard`);
+        return response.json();
     }
 
     // Get detailed course information for a specific course

--- a/iris-thaumantias/src/views/app/commands/navigationCommands.ts
+++ b/iris-thaumantias/src/views/app/commands/navigationCommands.ts
@@ -326,29 +326,22 @@ export class NavigationCommandModule {
             if (courseId) {
                 this.context.appStateManager.clearCurrentCourseData();
 
-                // Fetch fresh course details, exercises, and exams from the API
-                const [courseDetails, exercises] = await Promise.all([
-                    this.context.artemisApi.getCourseDetails(courseId),
-                    this.context.artemisApi.getExercises(courseId)
-                ]);
+                // Fetch fresh course data from the single-course dashboard endpoint
+                const dashboardDTO = await this.context.artemisApi.getCourseForDashboard(courseId);
 
-                // Fetch exams separately (may fail for some courses)
-                let exams: any[] = [];
+                // Build courseData structure expected by showCourseDetail
+                const courseData = {
+                    course: dashboardDTO.course
+                };
+
+                // Fetch exams separately (not included in dashboard endpoint)
                 try {
-                    exams = await this.context.artemisApi.getExamsForCourse(courseId);
+                    const exams = await this.context.artemisApi.getExamsForCourse(courseId);
+                    courseData.course.exams = exams;
                 } catch (error) {
                     console.error('Error fetching exams during reload:', error);
                     // Continue without exams if fetch fails
                 }
-
-                // Create the courseData structure expected by showCourseDetail
-                const courseData = {
-                    course: {
-                        ...courseDetails,
-                        exercises: exercises || [],
-                        exams: exams || []
-                    }
-                };
 
                 this.context.appStateManager.showCourseDetail(courseData);
                 this.context.actionHandler.render();


### PR DESCRIPTION
Fixes #49. The handleReloadCourseDetail method was passing a courseId (number) directly to showCourseDetail(), which expects a full courseData object. The fix fetches fresh course details, exercises, and exams from the API and constructs the proper courseData object structure.