### PR TITLE
feat: server-side problem statement rendering (old codebase, superseded)

### DIFF
--- a/iris-thaumantias/src/api/artemisApi.ts
+++ b/iris-thaumantias/src/api/artemisApi.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { AuthManager } from '../auth';
 import { CONFIG, VSCODE_CONFIG } from '../utils';
 import { IrisHealthStatus, ProfileInfo, PROFILE_IRIS } from '../types';
+import { ProblemStatementRenderRequest, RenderedProblemStatementDTO } from '../types/problemStatementRendering';
 import { logger, LogLevel, LogCategory } from '../services/loggingService';
 
 export class ArtemisApiService {
@@ -592,5 +593,18 @@ export class ArtemisApiService {
             }
         );
         return response.json();
+    }
+
+    // ── Problem Statement Rendering ──
+
+    async renderProblemStatement(request: ProblemStatementRenderRequest): Promise<RenderedProblemStatementDTO> {
+        const response = await this.makeRequest(
+            CONFIG.API.ENDPOINTS.RENDER_PROBLEM_STATEMENT,
+            {
+                method: 'POST',
+                body: JSON.stringify(request),
+            }
+        );
+        return response.json() as Promise<RenderedProblemStatementDTO>;
     }
 }

--- a/iris-thaumantias/src/provider/artemisWebviewProvider.ts
+++ b/iris-thaumantias/src/provider/artemisWebviewProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { AuthManager } from '../auth';
 import { ArtemisApiService } from '../api';
 import { ArtemisWebsocketService } from '../services';
-import { logger, LogLevel, LogCategory } from '../services/loggingService';
+import { logger, LogCategory } from '../services/loggingService';
 import { ProviderRegistry } from '../services/ProviderRegistry';
 import { CONFIG, VSCODE_CONFIG } from '../utils';
 import { AI_EXTENSIONS_BLOCKLIST } from '../utils/aiExtensionsBlocklist';
@@ -16,6 +16,7 @@ import { ExerciseDetailView } from '../views/exerciseDetail/exerciseDetailView';
 import { CourseDetailView } from '../views/courseDetail/courseDetailView';
 import { ExerciseRegistry } from '../services';
 import { WebSocketMessageHandler, ResultDTO, ProgrammingSubmission, SubmissionProcessingMessage } from '../types';
+import { ProblemStatementRenderService } from '../services/problemStatementRenderService';
 
 export class ArtemisWebviewProvider implements vscode.WebviewViewProvider, WebViewActionHandler {
     public static readonly viewType = CONFIG.WEBVIEW.VIEW_TYPE;
@@ -29,6 +30,7 @@ export class ArtemisWebviewProvider implements vscode.WebviewViewProvider, WebVi
     private _websocketService?: ArtemisWebsocketService;
     private _websocketHandler?: WebSocketMessageHandler;
     private _buildCodeLens?: any; // BuildErrorCodeLensProvider
+    private _renderService: ProblemStatementRenderService;
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -38,6 +40,16 @@ export class ArtemisWebviewProvider implements vscode.WebviewViewProvider, WebVi
     ) {
         this._appStateManager = new AppStateManager(this._artemisApi);
         this._viewActionService = new ViewActionService(this._appStateManager);
+        this._renderService = new ProblemStatementRenderService(this._artemisApi);
+
+        // Re-render problem statement on theme change (dark mode affects PlantUML)
+        vscode.window.onDidChangeActiveColorTheme(() => {
+            this._renderService.invalidateAll();
+            if (this._appStateManager.currentState === 'exercise-detail') {
+                this._backgroundRenderProblemStatement();
+            }
+        });
+
         this._messageHandler = new WebViewMessageHandler(
             this._authManager,
             this._artemisApi,
@@ -116,8 +128,14 @@ export class ArtemisWebviewProvider implements vscode.WebviewViewProvider, WebVi
     public async openExerciseDetails(exerciseId: number): Promise<void> {
         const didUpdate = await this._viewActionService.openExerciseDetails(exerciseId);
 
+        logger.info(`[SSR] openExerciseDetails called, didUpdate=${didUpdate}`, LogCategory.GENERAL);
         if (didUpdate) {
+            // Render immediately with client-side fallback (progressive enhancement)
             this.render();
+
+            // Fire background server render for progressive upgrade
+            logger.info('[SSR] Firing _backgroundRenderProblemStatement', LogCategory.GENERAL);
+            this._backgroundRenderProblemStatement();
 
             // Ensure WebSocket is connected for real-time updates
             if (this._websocketService && !this._websocketService.isConnected()) {
@@ -544,6 +562,118 @@ export class ArtemisWebviewProvider implements vscode.WebviewViewProvider, WebVi
                 command: 'newResult',
                 result: result
             });
+        }
+
+        // Trigger debounced server-side re-render of problem statement
+        this._reRenderProblemStatement(result);
+    }
+
+    private async _backgroundRenderProblemStatement(): Promise<void> {
+        const exerciseData = this._appStateManager.currentExerciseData;
+        if (!exerciseData) {
+            logger.info('[SSR] No exercise data, skipping background render', LogCategory.GENERAL);
+            return;
+        }
+
+        const exercise = exerciseData.exercise || exerciseData;
+        if (!exercise?.problemStatement) {
+            logger.info(`[SSR] No problemStatement on exercise (keys: ${Object.keys(exercise).join(', ')})`, LogCategory.GENERAL);
+            return;
+        }
+
+        logger.info(`[SSR] Starting background render for exercise ${exercise.id}`, LogCategory.GENERAL);
+
+        const exerciseId = exercise.id;
+
+        try {
+            const participations = exercise.studentParticipations || [];
+            const participation = participations[0];
+
+            const rendered = await this._renderService.render(
+                exercise,
+                participation,
+                undefined, // No detailed feedbacks on initial load
+                undefined, // Not exam mode (exam exercises use a different path)
+                this._appStateManager.userInfo?.user?.langKey
+            );
+
+            // Guard: verify same exercise is still active after await
+            const currentExercise = this._appStateManager.currentExerciseData?.exercise || this._appStateManager.currentExerciseData;
+            if (currentExercise?.id !== exerciseId) {return;}
+
+            if (rendered.source === 'server' && this._view) {
+                const scriptPayload = rendered.interactiveScript
+                    ? Buffer.from(rendered.interactiveScript, 'utf8').toString('base64')
+                    : undefined;
+
+                this._appStateManager.currentRenderResult = rendered;
+                this._view.webview.postMessage({
+                    command: 'problemStatementUpdated',
+                    html: rendered.html,
+                    scriptPayload,
+                });
+            }
+        } catch (error) {
+            logger.info(`[SSR] Background render failed: ${error}`, LogCategory.GENERAL);
+        }
+    }
+
+    private async _reRenderProblemStatement(result: ResultDTO): Promise<void> {
+        const exerciseData = this._appStateManager.currentExerciseData;
+        if (!exerciseData) {return;}
+
+        const exercise = exerciseData.exercise || exerciseData;
+        if (!exercise?.problemStatement) {return;}
+
+        const exerciseId = exercise.id;
+
+        // Don't re-render in exam mode
+        if (this._appStateManager.currentState === 'exam-exercise-detail') {return;}
+
+        // Verify the result belongs to this exercise's participations
+        const exerciseParticipationIds = (exercise.studentParticipations || []).map((p: any) => p.id);
+        if (result.participation?.id && !exerciseParticipationIds.includes(result.participation.id)) {return;}
+
+        try {
+            const participationId = result.participation?.id;
+            if (!participationId || !result.id) {return;}
+
+            const resultDetails = await this._artemisApi.getResultDetails(participationId, result.id);
+            const feedbacks = resultDetails?.feedbacks;
+
+            // Guard: verify same exercise is still active after await
+            const currentExercise = this._appStateManager.currentExerciseData?.exercise || this._appStateManager.currentExerciseData;
+            if (currentExercise?.id !== exerciseId) {return;}
+
+            const participations = exercise.studentParticipations || [];
+            const participation = participations.find((p: any) => p.id === participationId) || participations[0];
+
+            const rendered = await this._renderService.debouncedRender(
+                exercise.id,
+                exercise,
+                participation,
+                feedbacks,
+                this._appStateManager.userInfo?.user?.langKey
+            );
+
+            // Guard again after second await
+            const stillCurrent = this._appStateManager.currentExerciseData?.exercise || this._appStateManager.currentExerciseData;
+            if (stillCurrent?.id !== exerciseId) {return;}
+
+            if (rendered.source === 'server' && this._view) {
+                const scriptPayload = rendered.interactiveScript
+                    ? Buffer.from(rendered.interactiveScript, 'utf8').toString('base64')
+                    : undefined;
+
+                this._appStateManager.currentRenderResult = rendered;
+                this._view.webview.postMessage({
+                    command: 'problemStatementUpdated',
+                    html: rendered.html,
+                    scriptPayload,
+                });
+            }
+        } catch (error) {
+            logger.warn('Failed to re-render problem statement', LogCategory.GENERAL);
         }
     }
 

--- a/iris-thaumantias/src/services/problemStatementRenderService.ts
+++ b/iris-thaumantias/src/services/problemStatementRenderService.ts
@@ -1,0 +1,323 @@
+import * as vscode from 'vscode';
+import { ArtemisApiService } from '../api/artemisApi';
+import { ArtemisFeedback } from '../types/artemis';
+import {
+    ProblemStatementRenderRequest,
+    RenderedProblemStatementDTO,
+    TestFeedbackInput,
+    ResultSummaryInput,
+} from '../types/problemStatementRendering';
+import { processMarkdown } from '../views/utils/markdownProcessor';
+import { VSCODE_CONFIG, CONFIG } from '../utils/constants';
+import { logger, LogCategory } from './loggingService';
+
+// ── Public types ──
+
+export interface RenderResult {
+    source: 'server' | 'client';
+    html: string;
+    interactiveScript?: string;
+    contentHash?: string;
+    /** Only present for client-side fallback */
+    downloadLinks?: Array<{ text: string; url: string }>;
+    /** Only present for client-side fallback */
+    plantUmlDiagrams?: string[];
+}
+
+export interface ExamContext {
+    isExamExercise: boolean;
+    courseId?: number;
+    examId?: number;
+}
+
+// ── Cache internals ──
+
+interface CacheEntry {
+    exerciseId: number;
+    inputHash: string;
+    result: RenderResult;
+    accessedAt: number;
+}
+
+const MAX_CACHE_SIZE = 10;
+
+// ── Service ──
+
+export class ProblemStatementRenderService {
+    private readonly api: ArtemisApiService;
+    private cache = new Map<number, CacheEntry>();
+    private serverSupportsRendering: boolean | null = null;
+    private requestCounter = 0;
+    private debounceTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+    constructor(api: ArtemisApiService) {
+        this.api = api;
+
+        // Reset feature flag when server URL changes
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.SERVER_URL_KEY}`)) {
+                this.serverSupportsRendering = null;
+                this.cache.clear();
+            }
+        });
+    }
+
+    /**
+     * Render a problem statement, preferring server-side rendering with client-side fallback.
+     * Returns immediately with client-rendered HTML on cache miss, then fires a background
+     * server render whose result can be retrieved via the returned promise.
+     */
+    async render(
+        exercise: { id: number; problemStatement?: string },
+        participation?: any,
+        feedbacks?: ArtemisFeedback[],
+        examContext?: ExamContext,
+        userLangKey?: string,
+    ): Promise<RenderResult> {
+        const markdown = exercise.problemStatement || '';
+
+        // Exam mode: always client-side (no extra API calls)
+        if (examContext?.isExamExercise) {
+            return this.clientSideRender(markdown);
+        }
+
+        // Server feature flag: permanently disabled after 404/405/501
+        if (this.serverSupportsRendering === false) {
+            logger.info('[SSR] Server rendering disabled (previously got 404/405/501)', LogCategory.GENERAL);
+            return this.clientSideRender(markdown);
+        }
+
+        logger.info(`[SSR] Attempting server render (markdown length: ${markdown.length})`, LogCategory.GENERAL);
+
+        // Build request
+        const darkMode = isDarkMode();
+        const locale = getLocale(userLangKey);
+        const testInputs = feedbacks ? mapFeedbacksToTestInputs(feedbacks) : undefined;
+        const resultSummary = participation ? buildResultSummary(participation, exercise as any) : undefined;
+        const interactive = !examContext?.isExamExercise && testInputs !== null && testInputs !== undefined && testInputs.length > 0;
+
+        const request: ProblemStatementRenderRequest = {
+            markdown,
+            testResults: testInputs,
+            resultSummary,
+            locale,
+            darkMode,
+            interactive,
+        };
+
+        // Cache check
+        const serverUrl = this.getServerUrl();
+        const inputHash = computeInputHash(request, serverUrl);
+        const cached = this.cache.get(exercise.id);
+        if (cached && cached.inputHash === inputHash) {
+            cached.accessedAt = Date.now();
+            return cached.result;
+        }
+
+        // Monotonic request token for stale-response discard
+        const token = ++this.requestCounter;
+
+        try {
+            const dto = await this.api.renderProblemStatement(request);
+
+            // Discard if a newer request was fired while we were waiting
+            if (token !== this.requestCounter) {
+                logger.debug('Discarding stale server render response', LogCategory.GENERAL);
+                return this.clientSideRender(markdown);
+            }
+
+            this.serverSupportsRendering = true;
+
+            const result: RenderResult = {
+                source: 'server',
+                html: rewriteRelativeUrls(dto.html, serverUrl),
+                interactiveScript: dto.interactiveScript,
+                contentHash: dto.contentHash,
+            };
+
+            this.putCache(exercise.id, inputHash, result);
+            return result;
+        } catch (error: any) {
+            const status = error?.status;
+            if (status === 404 || status === 405 || status === 501) {
+                this.serverSupportsRendering = false;
+                logger.info(`Server does not support problem statement rendering (HTTP ${status}), using client-side fallback`, LogCategory.GENERAL);
+            } else {
+                logger.warn(`Server render failed (${status || 'network error'}), falling back to client-side`, LogCategory.GENERAL);
+            }
+            return this.clientSideRender(markdown);
+        }
+    }
+
+    private pendingResolvers = new Map<number, (result: RenderResult) => void>();
+
+    /**
+     * Debounced re-render for WebSocket result updates.
+     * Returns a promise that resolves when the debounced render completes.
+     * Superseded promises are resolved with a client-side fallback to prevent leaks.
+     */
+    debouncedRender(
+        exerciseId: number,
+        exercise: { id: number; problemStatement?: string },
+        participation?: any,
+        feedbacks?: ArtemisFeedback[],
+        userLangKey?: string,
+    ): Promise<RenderResult> {
+        // Resolve any previously pending promise for this exercise to prevent leaks
+        const previousResolver = this.pendingResolvers.get(exerciseId);
+        if (previousResolver) {
+            previousResolver(this.clientSideRender(exercise.problemStatement || ''));
+        }
+
+        const existing = this.debounceTimers.get(exerciseId);
+        if (existing) {
+            clearTimeout(existing);
+        }
+
+        return new Promise((resolve) => {
+            this.pendingResolvers.set(exerciseId, resolve);
+            this.debounceTimers.set(exerciseId, setTimeout(async () => {
+                this.debounceTimers.delete(exerciseId);
+                this.pendingResolvers.delete(exerciseId);
+                const result = await this.render(exercise, participation, feedbacks, undefined, userLangKey);
+                resolve(result);
+            }, 500));
+        });
+    }
+
+    /** Invalidate cache for a specific exercise (e.g., on theme change) */
+    invalidateExercise(exerciseId: number): void {
+        this.cache.delete(exerciseId);
+    }
+
+    /** Invalidate all cached renders */
+    invalidateAll(): void {
+        this.cache.clear();
+    }
+
+    /** Whether the server endpoint is known to be available */
+    get isServerAvailable(): boolean | null {
+        return this.serverSupportsRendering;
+    }
+
+    // ── Private helpers ──
+
+    private clientSideRender(markdown: string): RenderResult {
+        const { html, downloadLinks, plantUmlDiagrams } = processMarkdown(markdown || 'No description available');
+        return {
+            source: 'client',
+            html,
+            downloadLinks,
+            plantUmlDiagrams,
+        };
+    }
+
+    private putCache(exerciseId: number, inputHash: string, result: RenderResult): void {
+        // LRU eviction
+        if (this.cache.size >= MAX_CACHE_SIZE && !this.cache.has(exerciseId)) {
+            let oldestKey: number | undefined;
+            let oldestTime = Infinity;
+            for (const [key, entry] of this.cache) {
+                if (entry.accessedAt < oldestTime) {
+                    oldestTime = entry.accessedAt;
+                    oldestKey = key;
+                }
+            }
+            if (oldestKey !== undefined) {
+                this.cache.delete(oldestKey);
+            }
+        }
+        this.cache.set(exerciseId, { exerciseId, inputHash, result, accessedAt: Date.now() });
+    }
+
+    private getServerUrl(): string {
+        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
+        return config.get<string>(VSCODE_CONFIG.SERVER_URL_KEY) || CONFIG.ARTEMIS_SERVER_URL_DEFAULT;
+    }
+}
+
+// ── Mapping functions (exported for testing) ──
+
+export function mapFeedbacksToTestInputs(feedbacks: ArtemisFeedback[]): TestFeedbackInput[] {
+    return feedbacks
+        .filter(f => f.testCase?.id !== null && f.testCase?.id !== undefined)
+        .map(f => ({
+            testId: f.testCase!.id,
+            testName: f.testCase?.testName || f.text || 'Unknown',
+            passed: f.positive === true,
+            message: f.detailText || undefined,
+            credits: f.credits ?? undefined,
+        }));
+}
+
+export function buildResultSummary(
+    participation: any,
+    exercise: { maxPoints?: number; bonusPoints?: number },
+): ResultSummaryInput | undefined {
+    // Use existing participation selection logic
+    const submissions = participation?.submissions;
+    if (!Array.isArray(submissions) || submissions.length === 0) {return undefined;}
+
+    // Find latest submission by ID (sequential)
+    const latestSubmission = submissions.reduce((latest: any, current: any) => {
+        const latestId = typeof latest?.id === 'number' ? latest.id : -Infinity;
+        const currentId = typeof current?.id === 'number' ? current.id : -Infinity;
+        return currentId > latestId ? current : latest;
+    });
+
+    // Find latest result from that submission
+    const results = latestSubmission?.results;
+    if (!Array.isArray(results) || results.length === 0) {return undefined;}
+
+    const latestResult = results.reduce((latest: any, current: any) => {
+        const latestDate = latest?.completionDate ? new Date(latest.completionDate).getTime() : -Infinity;
+        const currentDate = current?.completionDate ? new Date(current.completionDate).getTime() : -Infinity;
+        if (latestDate === currentDate) {
+            return (current?.id ?? 0) > (latest?.id ?? 0) ? current : latest;
+        }
+        return currentDate > latestDate ? current : latest;
+    });
+
+    return {
+        score: latestResult?.score,
+        maxPoints: exercise.maxPoints,
+        bonusPoints: exercise.bonusPoints,
+        commitHash: latestSubmission?.commitHash,
+        submissionDate: latestSubmission?.submissionDate,
+        assessmentType: latestResult?.assessmentType,
+    };
+}
+
+// ── Utility functions ──
+
+function isDarkMode(): boolean {
+    const kind = vscode.window.activeColorTheme.kind;
+    return kind === vscode.ColorThemeKind.Dark || kind === vscode.ColorThemeKind.HighContrast;
+}
+
+function getLocale(userLangKey?: string): string {
+    if (userLangKey) {return userLangKey;}
+    return vscode.env.language || 'en';
+}
+
+function computeInputHash(request: ProblemStatementRenderRequest, serverUrl: string): string {
+    const input = JSON.stringify({
+        markdown: request.markdown,
+        testResults: request.testResults || [],
+        resultSummary: request.resultSummary,
+        locale: request.locale,
+        darkMode: request.darkMode,
+        interactive: request.interactive,
+        serverUrl,
+    });
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+        hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+    }
+    return hash.toString(36);
+}
+
+function rewriteRelativeUrls(html: string, serverUrl: string): string {
+    // Rewrite relative src attributes (images etc.) to absolute
+    return html.replace(/src="\/([^"]+)"/g, `src="${serverUrl}/$1"`);
+}

--- a/iris-thaumantias/src/types/artemis.ts
+++ b/iris-thaumantias/src/types/artemis.ts
@@ -91,6 +91,12 @@ export interface ArtemisFeedback {
     credits?: number;
     type?: 'AUTOMATIC' | 'MANUAL';
     positive?: boolean;
+    testCase?: {
+        id: number;
+        testName: string;
+        type?: string;
+        visibility?: string;
+    };
 }
 
 // WebView message types

--- a/iris-thaumantias/src/types/index.ts
+++ b/iris-thaumantias/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './artemis';
+export * from './problemStatementRendering';
 export type {
     ActiveContext,
     StoredSession,

--- a/iris-thaumantias/src/types/problemStatementRendering.ts
+++ b/iris-thaumantias/src/types/problemStatementRendering.ts
@@ -1,0 +1,41 @@
+/**
+ * TypeScript DTOs for the Artemis problem statement rendering endpoint.
+ * Maps to Java DTOs in de.tum.cit.aet.artemis.exercise.dto.
+ */
+
+/** Maps to Java TestFeedbackInput */
+export interface TestFeedbackInput {
+    testId: number;
+    testName: string;
+    passed: boolean;
+    message?: string;
+    credits?: number;
+}
+
+/** Maps to Java ResultSummaryInput */
+export interface ResultSummaryInput {
+    score?: number;
+    maxPoints?: number;
+    bonusPoints?: number;
+    commitHash?: string;
+    submissionDate?: string;
+    assessmentType?: string;
+}
+
+/** Maps to Java ProblemStatementRenderRequest */
+export interface ProblemStatementRenderRequest {
+    markdown: string;
+    testResults?: TestFeedbackInput[];
+    resultSummary?: ResultSummaryInput;
+    locale?: string;
+    darkMode: boolean;
+    interactive: boolean;
+}
+
+/** Maps to Java RenderedProblemStatementDTO */
+export interface RenderedProblemStatementDTO {
+    html: string;
+    contentHash: string;
+    rendererVersion: string;
+    interactiveScript?: string;
+}

--- a/iris-thaumantias/src/utils/constants.ts
+++ b/iris-thaumantias/src/utils/constants.ts
@@ -21,6 +21,7 @@ export const CONFIG = {
             RESULTS: '/api/core/participations/{participationId}/results',
             VCS_TOKEN: '/api/core/account/participation-vcs-access-token',
             START_PARTICIPATION: '/api/exercise/exercises/{exerciseId}/participations',
+            RENDER_PROBLEM_STATEMENT: '/api/exercise/problem-statement/render',
         },
         USER_AGENT: 'VS Code Extension',
     },

--- a/iris-thaumantias/src/views/app/appStateManager.ts
+++ b/iris-thaumantias/src/views/app/appStateManager.ts
@@ -1,6 +1,7 @@
 import { ArtemisApiService } from '../../api';
 import { logger, LogLevel, LogCategory } from '../../services/loggingService';
 import { getRecommendedExtensionsByCategory, type RecommendedExtensionCategory } from '../../utils/recommendedExtensions';
+import { RenderResult } from '../../services/problemStatementRenderService';
 
 export type AppState = 'login' | 'dashboard' | 'course-list' | 'course-detail' | 'exercise-detail' | 'exam-exercise-detail' | 'ai-config' | 'service-status' | 'struggle-detection' | 'recommended-extensions' | 'git-credentials' | 'exam-start' | 'exam-conduction';
 
@@ -34,6 +35,7 @@ export class AppStateManager {
     private _currentExamData?: any;
     private _aiExtensions?: AiExtension[];
     private _recommendedExtensions?: RecommendedExtensionCategory[];
+    private _currentRenderResult?: RenderResult;
 
     constructor(private readonly _artemisApi: ArtemisApiService) { }
 
@@ -64,6 +66,14 @@ export class AppStateManager {
 
     get currentExamData(): any {
         return this._currentExamData;
+    }
+
+    get currentRenderResult(): RenderResult | undefined {
+        return this._currentRenderResult;
+    }
+
+    set currentRenderResult(result: RenderResult | undefined) {
+        this._currentRenderResult = result;
     }
 
     get aiExtensions(): AiExtension[] | undefined {
@@ -98,6 +108,7 @@ export class AppStateManager {
         this._archivedCoursesData = undefined;
         this._currentCourseData = undefined;
         this._currentExerciseData = undefined;
+        this._currentRenderResult = undefined;
         this._recommendedExtensions = undefined;
     }
 
@@ -149,6 +160,7 @@ export class AppStateManager {
             logger.view(`🔄 Fetching fresh exercise data for exercise ${exerciseId}`);
             const exerciseDetails = await this._artemisApi.getExerciseDetails(exerciseId);
             this._currentExerciseData = exerciseDetails;
+            this._currentRenderResult = undefined; // Clear stale render from previous exercise
 
             // Check for pending submissions (builds in progress)
             const participation = exerciseDetails.exercise?.studentParticipations?.[0];
@@ -200,6 +212,7 @@ export class AppStateManager {
 
     public clearCurrentExerciseData(): void {
         this._currentExerciseData = undefined;
+        this._currentRenderResult = undefined;
     }
 
     public clearDashboardData(): void {

--- a/iris-thaumantias/src/views/app/commands/utilityCommands.ts
+++ b/iris-thaumantias/src/views/app/commands/utilityCommands.ts
@@ -23,6 +23,8 @@ export class UtilityCommandModule {
             fetchBuildLogsForError: this.handleFetchBuildLogsForError,
             clearBuildErrors: this.handleClearBuildErrors,
             webviewLog: this.handleWebviewLog,
+            openExternalLink: this.handleOpenExternalLink,
+            downloadFile: this.handleDownloadFile,
         };
     }
 
@@ -388,5 +390,31 @@ export class UtilityCommandModule {
                 logger.info(text, logCategory);
                 break;
         }
+    };
+
+    private handleOpenExternalLink = async (message: any): Promise<void> => {
+        if (!message?.url) {return;}
+        let url: string = message.url;
+        // If relative URL, prepend server URL
+        if (url.startsWith('/')) {
+            const config = vscode.workspace.getConfiguration('artemis');
+            const serverUrl = config.get<string>('serverUrl') || 'https://artemis.tum.de';
+            url = serverUrl + url;
+        }
+        // Only allow http/https schemes
+        if (!url.startsWith('http://') && !url.startsWith('https://')) {return;}
+        await vscode.env.openExternal(vscode.Uri.parse(url));
+    };
+
+    private handleDownloadFile = async (message: any): Promise<void> => {
+        if (!message?.url) {return;}
+        let url: string = message.url;
+        if (url.startsWith('/')) {
+            const config = vscode.workspace.getConfiguration('artemis');
+            const serverUrl = config.get<string>('serverUrl') || 'https://artemis.tum.de';
+            url = serverUrl + url;
+        }
+        if (!url.startsWith('http://') && !url.startsWith('https://')) {return;}
+        await vscode.env.openExternal(vscode.Uri.parse(url));
     };
 }

--- a/iris-thaumantias/src/views/app/viewRouter.ts
+++ b/iris-thaumantias/src/views/app/viewRouter.ts
@@ -81,7 +81,12 @@ export class ViewRouter {
             case 'course-detail':
                 return await this._courseDetailView.generateHtml(this._appStateManager.currentCourseData, hideDeveloperTools, webview);
             case 'exercise-detail':
-                return this._exerciseDetailView.generateHtml(this._appStateManager.currentExerciseData, hideDeveloperTools, webview);
+                return this._exerciseDetailView.generateHtml(
+                    this._appStateManager.currentExerciseData,
+                    hideDeveloperTools,
+                    webview,
+                    this._appStateManager.currentRenderResult
+                );
             case 'exam-exercise-detail': {
                 // Use the dedicated ExamExerciseDetailView
                 const exerciseData = this._appStateManager.currentExerciseData;

--- a/iris-thaumantias/src/views/examExerciseDetail/exam-exercise-detail.css
+++ b/iris-thaumantias/src/views/examExerciseDetail/exam-exercise-detail.css
@@ -1289,6 +1289,28 @@
             font-size: 13px;
         }
 
+        /* CSS bridge: map VS Code theme variables to Artemis server CSS variables */
+        .artemis-problem-statement {
+            --body-color: var(--theme-foreground);
+            --border-color: var(--theme-border);
+            --link-color: var(--theme-link-color);
+            --success: var(--theme-success);
+            --danger: var(--theme-error);
+            --secondary: var(--vscode-descriptionForeground);
+            --info: var(--vscode-notificationsInfoIcon-foreground);
+            --body-bg: var(--theme-card-background);
+            --artemis-pre-background: var(--theme-code-background);
+            --artemis-pre-color: var(--theme-code-foreground);
+            --artemis-pre-border: var(--theme-border);
+            --markdown-preview-blockquote: var(--vscode-descriptionForeground);
+            --markdown-preview-blockquote-border: var(--theme-border);
+
+            white-space: normal;
+            font-size: 14px;
+            line-height: 1.6;
+            margin: 0;
+        }
+
         .downloads-section {
             margin-top: 20px;
         }

--- a/iris-thaumantias/src/views/examExerciseDetail/examExerciseDetailView.ts
+++ b/iris-thaumantias/src/views/examExerciseDetail/examExerciseDetailView.ts
@@ -11,6 +11,7 @@ import { SubmissionStatusComponent } from "../exerciseDetail/components/submissi
 import { ParticipationActionsComponent } from "../exerciseDetail/components/participationActionsComponent";
 import { RepositoryStatusScripts } from "../exerciseDetail/components/repositoryStatusScripts";
 import { BuildProgressComponent } from "../exerciseDetail/components/buildProgressComponent";
+import { RenderResult } from "../../services/problemStatementRenderService";
 
 export interface ExamContext {
     isExamExercise: boolean;
@@ -40,7 +41,8 @@ export class ExamExerciseDetailView {
         exerciseData: any,
         hideDeveloperTools: boolean = false,
         webview?: vscode.Webview,
-        examContext?: ExamContext
+        examContext?: ExamContext,
+        renderedProblemStatement?: RenderResult
     ): string {
         const styles = readCssFiles(
             "components/backLink/back-link.css",
@@ -74,7 +76,8 @@ export class ExamExerciseDetailView {
             hideDeveloperTools,
             styles,
             webviewComponentsScriptTag,
-            examContext
+            examContext,
+            renderedProblemStatement
         );
     }
 
@@ -119,7 +122,8 @@ export class ExamExerciseDetailView {
         hideDeveloperTools: boolean,
         styles: string,
         webviewComponentsScriptTag: string,
-        examContext?: ExamContext
+        examContext?: ExamContext,
+        renderedProblemStatement?: RenderResult
     ): string {
         const isExam = examContext?.isExamExercise ?? false;
 
@@ -138,9 +142,21 @@ export class ExamExerciseDetailView {
         const uploadMessageIcon = this._getUploadMessageIcon();
         const starAssistIcon = IconDefinitions.getIcon("star_4_edges");
 
-        // Process markdown problem statement
-        const { html: problemStatement, downloadLinks, plantUmlDiagrams } =
-            processMarkdown(exercise.problemStatement || "No description available");
+        // Problem statement: exam mode always uses client-side rendering
+        let problemStatement: string;
+        let downloadLinks: Array<{ text: string; url: string }> = [];
+        let plantUmlDiagrams: string[] = [];
+
+        if (renderedProblemStatement?.source === 'client') {
+            problemStatement = renderedProblemStatement.html;
+            downloadLinks = renderedProblemStatement.downloadLinks || [];
+            plantUmlDiagrams = renderedProblemStatement.plantUmlDiagrams || [];
+        } else {
+            const result = processMarkdown(exercise.problemStatement || "No description available");
+            problemStatement = result.html;
+            downloadLinks = result.downloadLinks;
+            plantUmlDiagrams = result.plantUmlDiagrams;
+        }
 
         // Course information
         const course = exercise.course;

--- a/iris-thaumantias/src/views/exerciseDetail/exercise-detail.css
+++ b/iris-thaumantias/src/views/exerciseDetail/exercise-detail.css
@@ -1289,6 +1289,28 @@
             font-size: 13px;
         }
 
+        /* CSS bridge: map VS Code theme variables to Artemis server CSS variables */
+        .artemis-problem-statement {
+            --body-color: var(--theme-foreground);
+            --border-color: var(--theme-border);
+            --link-color: var(--theme-link-color);
+            --success: var(--theme-success);
+            --danger: var(--theme-error);
+            --secondary: var(--vscode-descriptionForeground);
+            --info: var(--vscode-notificationsInfoIcon-foreground);
+            --body-bg: var(--theme-card-background);
+            --artemis-pre-background: var(--theme-code-background);
+            --artemis-pre-color: var(--theme-code-foreground);
+            --artemis-pre-border: var(--theme-border);
+            --markdown-preview-blockquote: var(--vscode-descriptionForeground);
+            --markdown-preview-blockquote-border: var(--theme-border);
+
+            white-space: normal;
+            font-size: 14px;
+            line-height: 1.6;
+            margin: 0;
+        }
+
         .downloads-section {
             margin-top: 20px;
         }

--- a/iris-thaumantias/src/views/exerciseDetail/exerciseDetailView.ts
+++ b/iris-thaumantias/src/views/exerciseDetail/exerciseDetailView.ts
@@ -11,6 +11,7 @@ import { SubmissionStatusComponent } from "./components/submissionStatusComponen
 import { ParticipationActionsComponent } from "./components/participationActionsComponent";
 import { RepositoryStatusScripts } from "./components/repositoryStatusScripts";
 import { BuildProgressComponent } from "./components/buildProgressComponent";
+import { RenderResult } from "../../services/problemStatementRenderService";
 
 export class ExerciseDetailView {
     private _extensionContext: vscode.ExtensionContext;
@@ -32,7 +33,8 @@ export class ExerciseDetailView {
     public generateHtml(
         exerciseData: any,
         hideDeveloperTools: boolean = false,
-        webview?: vscode.Webview
+        webview?: vscode.Webview,
+        renderedProblemStatement?: RenderResult
     ): string {
         const styles = readCssFiles(
             "components/backLink/back-link.css",
@@ -65,7 +67,8 @@ export class ExerciseDetailView {
             exerciseData,
             hideDeveloperTools,
             styles,
-            webviewComponentsScriptTag
+            webviewComponentsScriptTag,
+            renderedProblemStatement
         );
     }
 
@@ -105,7 +108,8 @@ export class ExerciseDetailView {
         exerciseData: any,
         hideDeveloperTools: boolean,
         styles: string,
-        webviewComponentsScriptTag: string
+        webviewComponentsScriptTag: string,
+        renderedProblemStatement?: RenderResult
     ): string {
         const exercise = exerciseData?.exercise;
 
@@ -121,9 +125,26 @@ export class ExerciseDetailView {
         const uploadMessageIcon = this._getUploadMessageIcon();
         const starAssistIcon = IconDefinitions.getIcon("star_4_edges");
 
-        // Process markdown problem statement
-        const { html: problemStatement, downloadLinks, plantUmlDiagrams } =
-            processMarkdown(exercise.problemStatement || "No description available");
+        // Problem statement rendering: prefer server-side, fallback to client-side
+        let problemStatement: string;
+        let downloadLinks: Array<{ text: string; url: string }> = [];
+        let plantUmlDiagrams: string[] = [];
+        const isServerRendered = renderedProblemStatement?.source === 'server';
+
+        if (isServerRendered) {
+            problemStatement = renderedProblemStatement!.html;
+            // Server handles PlantUML inline, download links handled by link interception
+        } else if (renderedProblemStatement?.source === 'client') {
+            problemStatement = renderedProblemStatement.html;
+            downloadLinks = renderedProblemStatement.downloadLinks || [];
+            plantUmlDiagrams = renderedProblemStatement.plantUmlDiagrams || [];
+        } else {
+            // Direct client-side fallback (no pre-rendered result provided)
+            const result = processMarkdown(exercise.problemStatement || "No description available");
+            problemStatement = result.html;
+            downloadLinks = result.downloadLinks;
+            plantUmlDiagrams = result.plantUmlDiagrams;
+        }
 
         // Course information
         const course = exercise.course;
@@ -282,8 +303,8 @@ export class ExerciseDetailView {
                 header: {
                     title: 'Exercise Description'
                 },
-                bodyHtml: `<div class="problem-statement">${problemStatement}</div>
-        ${downloadLinks.length > 0
+                bodyHtml: `<div class="problem-statement" data-render-source="${isServerRendered ? 'server' : 'client'}">${problemStatement}</div>
+        ${!isServerRendered && downloadLinks.length > 0
                         ? `
         <div class="downloads-section">
             <div class="downloads-section-title">Downloads</div>
@@ -481,7 +502,11 @@ export class ExerciseDetailView {
             return latestContext;
         }
         
-        // Store PlantUML diagrams for rendering
+        // Rendering mode flag
+        const isServerRendered = ${isServerRendered};
+        const serverUrl = ${JSON.stringify(exerciseData?.exercise?.course ? '' : '')};
+
+        // Store PlantUML diagrams for rendering (client mode only)
         const plantUmlDiagrams = ${JSON.stringify(plantUmlDiagrams)};
         
         // Timeout for test results fetching to prevent infinite loading
@@ -544,9 +569,9 @@ export class ExerciseDetailView {
             }
         });
         
-        // Auto-render all PlantUML diagrams on page load
-        if (plantUmlDiagrams.length > 0) {
-            vscode.postMessage({ command: 'webviewLog', level: 'info', text: '[PlantUML] 📊 Found ' + plantUmlDiagrams.length + ' diagram(s), auto-rendering...' });
+        // Auto-render all PlantUML diagrams on page load (client mode only — server mode has inline SVGs)
+        if (!isServerRendered && plantUmlDiagrams.length > 0) {
+            vscode.postMessage({ command: 'webviewLog', level: 'info', text: '[PlantUML] Found ' + plantUmlDiagrams.length + ' diagram(s), auto-rendering...' });
             plantUmlDiagrams.forEach((diagram, index) => {
                 renderPlantUmlDiagram(index, diagram);
             });
@@ -897,6 +922,52 @@ export class ExerciseDetailView {
         // Build progress management (from BuildProgressComponent)
         ${BuildProgressComponent.generateScript()}
 
+        // Link interception for server-rendered problem statements
+        function interceptServerLinks(container) {
+            if (!container) return;
+            container.querySelectorAll('a[href]').forEach(function(a) {
+                a.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    var href = a.getAttribute('href');
+                    if (!href) return;
+                    if (href.startsWith('#')) {
+                        // Hash link: local scroll
+                        var target = document.querySelector(href);
+                        if (target) target.scrollIntoView();
+                    } else if (href.indexOf('/api/core/files/') !== -1) {
+                        // File download
+                        var filename = href.split('/').pop() || 'download';
+                        vscode.postMessage({ command: 'downloadFile', url: href, filename: filename });
+                    } else if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('/')) {
+                        // HTTP(S) or relative Artemis link: open in browser
+                        vscode.postMessage({ command: 'openExternalLink', url: href });
+                    }
+                });
+            });
+        }
+
+        // Initialize link interception for server-rendered content on page load
+        if (isServerRendered) {
+            var psEl = document.querySelector('.problem-statement');
+            if (psEl) interceptServerLinks(psEl);
+        }
+
+        // Interactive script bootstrap for server-rendered content
+        ${isServerRendered && renderedProblemStatement?.interactiveScript
+            ? `(function() {
+            try {
+                var scriptB64 = ${JSON.stringify(Buffer.from(renderedProblemStatement.interactiveScript, 'utf8').toString('base64'))};
+                var bytes = Uint8Array.from(atob(scriptB64), function(c) { return c.charCodeAt(0); });
+                var code = new TextDecoder().decode(bytes);
+                var s = document.createElement('script');
+                s.textContent = code;
+                document.body.appendChild(s);
+            } catch (e) {
+                vscode.postMessage({ command: 'webviewLog', level: 'error', text: '[ProblemStatement] Failed to bootstrap interactive script: ' + e });
+            }
+        })();`
+            : ''}
+
         // Listen for messages from the extension
         window.addEventListener('message', function(event) {
             const message = event.data;
@@ -1019,6 +1090,31 @@ export class ExerciseDetailView {
                         } else {
                             unsavedBanner.style.display = 'none';
                         }
+                    }
+                    break;
+                case 'problemStatementUpdated':
+                    // Server-side re-render (e.g., after new build result)
+                    const psContainer = document.querySelector('.problem-statement');
+                    if (psContainer) {
+                        psContainer.innerHTML = message.html;
+                        psContainer.setAttribute('data-render-source', 'server');
+                        // Re-init interactive script if provided
+                        if (message.scriptPayload) {
+                            try {
+                                const bytes = Uint8Array.from(atob(message.scriptPayload), function(c) { return c.charCodeAt(0); });
+                                const code = new TextDecoder().decode(bytes);
+                                const s = document.createElement('script');
+                                s.textContent = code;
+                                document.body.appendChild(s);
+                            } catch (e) {
+                                vscode.postMessage({ command: 'webviewLog', level: 'error', text: '[ProblemStatement] Failed to load interactive script: ' + e });
+                            }
+                        }
+                        // Re-attach link interception for server-rendered content
+                        interceptServerLinks(psContainer);
+                        // Hide client-side downloads section (server handles links inline)
+                        var dlSection = document.querySelector('.downloads-section');
+                        if (dlSection) { dlSection.style.display = 'none'; }
                     }
                     break;
             }


### PR DESCRIPTION
## Summary

Replace the client-side regex-based markdown processor (`markdownProcessor.ts`, ~320 lines) with server-side rendering via the new Artemis `POST api/exercise/problem-statement/render` endpoint.

### Current state (client-side)
- Custom `processMarkdown()` parses markdown with regex (headers, tables, tasks, PlantUML placeholders, code blocks)
- PlantUML diagrams rendered via separate PlantUML service calls
- No interactive task feedback modal
- CSS maintained separately in extension

### Target state (server-side)
- Extension sends raw markdown + test results + config to Artemis endpoint
- Server returns self-contained HTML with:
  - Embedded CSS (Artemis theme, dark mode support)
  - Inline PlantUML SVGs (no extra round-trips)
  - Interactive JS for task feedback modal (optional)
  - Content hash for caching (ETag)
- Extension just injects the HTML into the WebView

### Benefits
- Consistent rendering with Artemis web client
- Interactive task feedback modal with test results, score, pass/fail per task
- Dark mode support built-in via CSS variables
- PlantUML inline SVGs instead of separate service calls
- i18n (en/de) handled server-side
- Less extension code to maintain (~320 lines of regex parsing removed)

### Artemis endpoint (from `feature/exercise/server-side-problem-statement-rendering`)
```
POST api/exercise/problem-statement/render
```
**Request:** `{ markdown, testResults[], resultSummary, locale, darkMode, interactive }`  
**Response:** `{ html, contentHash, rendererVersion, interactiveScript? }`

## Tasks
- [ ] Add API client method for the render endpoint
- [ ] Integrate into `exerciseDetailView.ts` and `examExerciseDetailView.ts`
- [ ] Wire up test results from build tracking
- [ ] Handle dark mode detection and pass to endpoint
- [ ] Implement caching via content hash
- [ ] Remove or deprecate `markdownProcessor.ts`
- [ ] Update WebView CSS to work with server-provided styles
- [ ] Fallback to client-side rendering if endpoint unavailable
- [ ] Tests