### PR TITLE
feat: server-side logout + developer JWT reveal command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -82,12 +82,18 @@
       {
         "command": "artemis.clearTrustedDomains",
         "title": "Artemis: Clear Trusted Domains"
+      },
+      {
+        "command": "artemis.showJwtToken",
+        "title": "Artemis: Show JWT Token (Developer)",
+        "icon": "$(key)"
       }
     ],
     "menus": {
       "commandPalette": [
         { "command": "artemis.login", "when": "!iris:managedEnvironment" },
-        { "command": "artemis.logout", "when": "!iris:managedEnvironment" }
+        { "command": "artemis.logout", "when": "!iris:managedEnvironment" },
+        { "command": "artemis.showJwtToken", "when": "config.artemis.developerMode" }
       ]
     },
     "viewsContainers": {

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -6,7 +6,7 @@ import type { IProviderRegistry } from '../services/ui';
 import type { TelemetryManager } from '../services/telemetry';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '../provider';
 import { logger, LogCategory } from '../services/loggingService';
-import { processPlantUml, normalizeRelativePath, extractErrorMessage } from '../utils';
+import { processPlantUml, normalizeRelativePath, extractErrorMessage, VSCODE_CONFIG } from '../utils';
 import { executeReplayCommand } from '../services/telemetry/replay';
 
 // ── Individual command registrations ─────────────────────────────────
@@ -422,6 +422,50 @@ function registerReplaySessionCommand(globalStorageUri: vscode.Uri): vscode.Disp
     });
 }
 
+/**
+ * Developer-only command: copy the current raw JWT to the clipboard for use
+ * in curl/Postman based server testing. Gated on the `artemis.developerMode`
+ * setting both at the menu level (commandPalette `when` clause) and at runtime
+ * (defense-in-depth against direct invocation via `vscode.commands.executeCommand`).
+ *
+ * The full token is NEVER shown in the UI or written to logs — only a masked
+ * preview appears in the notification, and the full value lands in the clipboard.
+ */
+function registerShowJwtTokenCommand(authManager: AuthManager): vscode.Disposable {
+    return vscode.commands.registerCommand('artemis.showJwtToken', async () => {
+        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
+        const developerMode = config.get<boolean>(VSCODE_CONFIG.DEVELOPER_MODE_KEY, false);
+        if (!developerMode) {
+            vscode.window.showErrorMessage(
+                `Enable '${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.DEVELOPER_MODE_KEY}' in settings to use this command.`
+            );
+            return;
+        }
+
+        const hasToken = await authManager.hasAuthToken();
+        if (!hasToken) {
+            vscode.window.showInformationMessage('Not logged in to Artemis — no JWT to show.');
+            return;
+        }
+
+        const rawJwt = await authManager.getRawJwt();
+        if (!rawJwt) {
+            vscode.window.showErrorMessage('Failed to retrieve JWT token from secret storage.');
+            logger.error('getRawJwt returned undefined despite hasAuthToken=true', LogCategory.AUTH);
+            return;
+        }
+
+        await vscode.env.clipboard.writeText(rawJwt);
+
+        const preview = `${rawJwt.substring(0, 20)}...`;
+        logger.info(`JWT copied to clipboard via developer command (preview: ${preview})`, LogCategory.AUTH);
+
+        vscode.window.showWarningMessage(
+            `JWT copied to clipboard (${preview}). Do not share, do not commit.`
+        );
+    });
+}
+
 // ── Aggregate registration ───────────────────────────────────────────
 
 export interface CommandDeps {
@@ -449,5 +493,6 @@ export function registerAllCommands(deps: CommandDeps): vscode.Disposable {
         registerClearTrustedDomainsCommand(deps.context),
         registerStruggleScoreCommand(deps.telemetryManager),
         registerReplaySessionCommand(deps.context.globalStorageUri),
+        registerShowJwtTokenCommand(deps.authManager),
     );
 }

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -19,11 +19,15 @@ function registerLoginCommand(): vscode.Disposable {
 
 function registerLogoutCommand(
     authManager: AuthManager,
+    artemisApiService: ArtemisApiService,
     updateAuthContext: (isAuthenticated: boolean) => Promise<void>,
     artemisWebviewProvider: ArtemisWebviewProvider,
 ): vscode.Disposable {
     return vscode.commands.registerCommand('artemis.logout', async () => {
         try {
+            // Best-effort server-side logout before clearing local state.
+            // Never throws — local cleanup proceeds regardless.
+            await artemisApiService.logoutFromServer();
             await authManager.clear();
             await updateAuthContext(false);
             vscode.window.showInformationMessage('Successfully logged out of Artemis');
@@ -435,7 +439,7 @@ export interface CommandDeps {
 export function registerAllCommands(deps: CommandDeps): vscode.Disposable {
     return vscode.Disposable.from(
         registerLoginCommand(),
-        registerLogoutCommand(deps.authManager, deps.updateAuthContext, deps.artemisWebviewProvider),
+        registerLogoutCommand(deps.authManager, deps.artemisApiService, deps.updateAuthContext, deps.artemisWebviewProvider),
         registerResetIrisChatCommand(deps.chatWebviewProvider),
         registerIrisHealthCheckCommand(deps.authManager, deps.artemisApiService, deps.providerRegistry),
         registerWebSocketStatusCommand(deps.artemisWebsocketService),

--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -303,6 +303,58 @@ export class ArtemisApiService {
         return { success: true };
     }
 
+    /**
+     * Inform the Artemis server that the user is logging out.
+     *
+     * Best-effort: this method never throws. The calling logout flow
+     * must always clear local state regardless of the server response,
+     * so any failure here is logged and swallowed.
+     *
+     * Uses a direct fetch instead of `makeRequest()` so a non-2xx
+     * response does not trigger the shared 401 handler (which would
+     * re-clear auth and fire the auth-expired callback — both
+     * pointless and confusing during an intentional logout).
+     *
+     * Note: Artemis uses stateless JWTs without server-side blacklisting,
+     * so this call does not invalidate the token on the server. It merely
+     * tells Artemis "the user intentionally logged out" (audit logs) and
+     * returns a Set-Cookie header that clears the jwt cookie in browser
+     * clients. For this Extension the benefit is protocol symmetry with
+     * the Artemis webapp.
+     */
+    async logoutFromServer(): Promise<void> {
+        const headers = await this.authManager.getAuthHeaders();
+        if (Object.keys(headers).length === 0) {
+            // Not authenticated — nothing to tell the server.
+            return;
+        }
+
+        try {
+            const response = await fetch(`${this.getServerUrl()}${CONFIG.API.ENDPOINTS.LOGOUT}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'User-Agent': getUserAgent(),
+                    ...headers,
+                },
+            });
+            if (response.ok) {
+                logger.info('Server-side logout successful', LogCategory.AUTH);
+            } else {
+                logger.warn(
+                    `Server-side logout returned ${response.status}, continuing with local cleanup`,
+                    LogCategory.AUTH
+                );
+            }
+        } catch (err) {
+            logger.warn(
+                'Server-side logout failed, continuing with local cleanup',
+                LogCategory.AUTH,
+                err
+            );
+        }
+    }
+
     // Check Iris health status (course-scoped)
     async checkIrisHealth(courseId: number): Promise<IrisHealthStatus> {
         const response = await this.makeRequest(`/api/iris/courses/${courseId}/status`);

--- a/extension/src/extension/controller/commands/authCommands.ts
+++ b/extension/src/extension/controller/commands/authCommands.ts
@@ -55,6 +55,9 @@ export class AuthCommandModule {
 
     private handleLogout = async (_message: WebviewToExtensionMessage): Promise<void> => {
         try {
+            // Best-effort server-side logout before clearing local state.
+            // Never throws — local cleanup proceeds regardless.
+            await this.context.artemisApi.logoutFromServer();
             await this.context.authManager.clear();
             await this.context.updateAuthContext(false);
 

--- a/extension/src/extension/services/auth/authManager.ts
+++ b/extension/src/extension/services/auth/authManager.ts
@@ -58,6 +58,26 @@ export class AuthManager {
     }
 
     /**
+     * Returns the raw JWT string (without any "jwt=" cookie prefix), suitable
+     * for use in a `Cookie: jwt=<value>` or `Authorization: Bearer <value>` header.
+     *
+     * Intended for developer/debug commands only — normal code paths should use
+     * `getAuthHeaders()` instead so auth-mode handling stays centralized.
+     *
+     * Returns `undefined` if not authenticated.
+     */
+    public async getRawJwt(): Promise<string | undefined> {
+        const stored = await this.getStoredToken();
+        if (!stored) {
+            return undefined;
+        }
+        // Desktop mode stores the token as "jwt=<value>" (cookie string).
+        // Theia mode stores the raw JWT directly. Strip the prefix if present.
+        const prefix = `${CONFIG.AUTH_COOKIE_NAME}=`;
+        return stored.startsWith(prefix) ? stored.substring(prefix.length) : stored;
+    }
+
+    /**
      * Returns the stored token string.
      * In Desktop mode this is a cookie string ("jwt=<token>"),
      * in Theia mode this is a raw JWT.

--- a/extension/src/extension/utils/constants.ts
+++ b/extension/src/extension/utils/constants.ts
@@ -13,6 +13,7 @@ export const CONFIG = {
     API: {
         ENDPOINTS: {
             AUTHENTICATE: '/api/core/public/authenticate',
+            LOGOUT: '/api/core/public/logout',
         },
     },
 } as const;


### PR DESCRIPTION
## Summary

Two related changes bundled for testing convenience:

1. **Server-side logout** — Extension now sends `POST /api/core/public/logout` to Artemis before clearing local credentials, matching the Artemis webapp behavior.
2. **Developer JWT reveal command** — New `artemis.showJwtToken` command copies the raw JWT to the clipboard, gated on `artemis.developerMode`. Enables curl/Postman-based server testing of the logout flow (and other auth-dependent endpoints).

---

## Commit 1 — `feat: call server logout endpoint on user-initiated logout`

### Changes

- **`extension/src/extension/utils/constants.ts`** — Add `LOGOUT: '/api/core/public/logout'` to `API.ENDPOINTS`.
- **`extension/src/extension/api/artemisApi.ts`** — New `logoutFromServer()` method. Best-effort fetch (never throws); bypasses `makeRequest()` to avoid the 401 handler feedback loop during intentional logout.
- **`extension/src/extension/controller/commands/authCommands.ts`** — `handleLogout` calls `artemisApi.logoutFromServer()` before `authManager.clear()`.
- **`extension/src/extension/activation/extensionCommands.ts`** — `artemis.logout` command does the same; `registerLogoutCommand` gains an `ArtemisApiService` dependency.

### Scope

Only **user-initiated logout paths** are affected:
1. Webview logout button (via `AuthCommandModule.handleLogout`)
2. Command Palette `artemis.logout`

Auth-failure cleanups are **intentionally unchanged** — they continue to clear locally only, because in those cases the token is already server-side invalid:
- `artemisApi.ts:61` — 401 response handler
- `authFlowHandler.ts:70,84` — auth flow error paths
- `extension.ts:228` — auth expiry flow

### Notes

- Artemis uses **stateless JWTs without server-side blacklisting**, so this call does not actually invalidate the token — the benefit is protocol symmetry with the webapp and audit-log completeness.
- Verified live against `artemis.tum.de`: endpoint returns 200 with `Set-Cookie: jwt=; Max-Age=0` in ~150ms.

---

## Commit 2 — `feat: add developer command to copy raw JWT to clipboard`

### Changes

- **`extension/package.json`** — New command `artemis.showJwtToken` (title: "Artemis: Show JWT Token (Developer)"). Hidden from the Command Palette unless `artemis.developerMode` is enabled (`when: config.artemis.developerMode`).
- **`extension/src/extension/services/auth/authManager.ts`** — New public helper `getRawJwt()` that returns the stored JWT with the `jwt=` cookie prefix stripped (works in both Desktop Cookie mode and Theia Bearer mode).
- **`extension/src/extension/activation/extensionCommands.ts`** — New `registerShowJwtTokenCommand` function + registration in the aggregate. Double-gates on `developerMode` at runtime for defense-in-depth.

### Security

- Full token is **never** shown in the UI — only a masked preview (first 20 chars) in the warning notification.
- Full token is **never** logged — only the masked preview lands in the Artemis Extension output channel.
- Notification explicitly warns "Do not share, do not commit".
- Command is hidden from Command Palette unless dev mode is enabled.

---

## Test plan

### Logout feature
- [ ] CI passes
- [ ] Enable `artemis.developerMode` in settings
- [ ] Login via webview
- [ ] Run `Artemis: Show JWT Token (Developer)` from Command Palette → JWT is copied to clipboard, warning notification appears with masked preview
- [ ] Click logout in webview → Output panel shows `[AUTH] Server-side logout successful`, webview returns to login view
- [ ] Manual curl with the copied token against `https://artemis.tum.de/api/core/public/account` → still returns 200 (confirms Artemis uses stateless JWTs, as expected)
- [ ] Manual: block network to `artemis.tum.de`, attempt logout → verify local cleanup still completes and no user-visible error appears
- [ ] Theia/EduIDE mode smoke test — `artemis.logout` command still works

### JWT reveal command
- [ ] With `artemis.developerMode` disabled → command is hidden from Command Palette
- [ ] With `artemis.developerMode` disabled + direct `vscode.commands.executeCommand('artemis.showJwtToken')` → shows error asking to enable dev mode
- [ ] With dev mode enabled but not logged in → shows "Not logged in" info message
- [ ] With dev mode enabled + logged in → copies raw JWT, shows masked preview notification