### PR TITLE
docs: code review findings from April 2026 review

### DIFF
--- a/extension/docs/code-review-findings-2026-04.md
+++ b/extension/docs/code-review-findings-2026-04.md
@@ -1,0 +1,262 @@
+# Code Review Findings — April 2026
+
+**Scope:** `extension/src/` (full VS Code extension source, ~206 TS files)
+**Date:** 2026-04-15
+**Methodology:** Two independent reviews performed in parallel:
+1. **Codex CLI** (OpenAI gpt-5.4) — read-only sandbox review focused on structural, lifecycle, and type-safety smells.
+2. **Claude Code** — targeted deep-dive into struggle-detection telemetry pipeline and auth/websocket services (areas codex covered less deeply), plus manual verification of claims.
+
+Findings were cross-checked; two false positives from the Claude review were dropped after verification (see [§Not-a-bug](#not-a-bug)).
+
+Thesis-critical findings (items affecting the struggle-detection data path or intervention decisions) are marked 🎓.
+
+---
+
+## Progress checklist
+
+Tick items as their fix PR merges into `dev`. Each finding below has the same checkbox — update both when closing.
+
+**Must-fix before thesis evaluation:**
+- [ ] [#1 — Telemetry recordings lost on transient FS errors](#1--telemetry-recordings-lost-on-transient-filesystem-errors--high) 🎓
+- [ ] [#2 — `deactivate()` does not await recorder shutdown](#2--deactivate-does-not-await-recorder-shutdown--high) 🎓
+- [ ] [#3 — Webview listener accumulation on re-resolution](#3-webview-listener-accumulation-on-re-resolution--high)
+- [ ] [#4 — `ContextStore` state can persist out of order](#4--contextstore-state-can-persist-out-of-order--high) 🎓
+
+**Should fix:**
+- [ ] [#5 — Dead feature toggle `DIAGNOSTIC_STABILIZATION_*`](#5--dead-feature-toggle-diagnostic_stabilization_--medium) 🎓
+- [ ] [#6 — EQ thresholds duplicated across files](#6--eq-thresholds-duplicated-across-files--medium) 🎓
+- [ ] [#7 — VCS access token: GET-failure fallback creates on any error](#7-vcs-access-token-get-failure-fallback-creates-on-any-error--medium)
+- [ ] [#8 — Domain parsers coerce instead of validate](#8-domain-parsers-coerce-instead-of-validate--medium)
+- [ ] [#9 — `handleCloneRepository()` god method + untracked timers](#9-handleclonerepository-god-method--untracked-timers--medium)
+
+**Nice-to-have:**
+- [ ] [#10 — `_useBearerAuth` is set-only](#10-_usebearerauth-is-set-only--low)
+- [ ] [#11 — `authManager.clear()` memory/secrets race window](#11-authmanagerclear-memorysecrets-race-window--low)
+- [ ] [#12 — Dead API `hasRecentlyClonedRepo()` with key drift](#12-dead-api-hasrecentlyclonedrepo-with-key-drift--low)
+- [ ] [#13 — Misleading name `isNoAiEnabled`](#13-misleading-name-isnoaienabled--low)
+
+**Test coverage:**
+- [ ] [Add missing tests for #1, #2, #3, #4, #9](#test-coverage-gaps)
+
+---
+
+## Priority: Must-fix before thesis evaluation
+
+### 1. 🎓 Telemetry recordings lost on transient filesystem errors — **High**
+- [ ] **Status**
+
+**Location:** `src/extension/services/telemetry/recording/storageWriter.ts:90`
+
+**Problem:** `flush()` removes the whole batch from `_buffer` before `appendFile()` succeeds. On transient FS failure it only logs the error — the events are already gone from the buffer.
+
+**Why it matters:** For thesis evaluation we depend on complete session recordings. A single write failure silently drops a batch, skewing EQ calculations and trigger timing for that session.
+
+**Fix:** Keep the batch until the write resolves. On error, re-prepend to `_buffer` (or route to a dead-letter queue if the file itself is corrupt). Add a retry with bounded attempts.
+
+---
+
+### 2. 🎓 `deactivate()` does not await recorder shutdown — **High**
+- [ ] **Status**
+
+**Location:** `src/extension.ts:261`, `src/extension/services/telemetry/recording/sessionRecorder.ts:158`
+
+**Problem:** `deactivate()` fires `activeSessionRecorder.endSession()` as a `void` promise. VS Code may tear the extension host down before metadata/event flushing completes.
+
+**Why it matters:** Session-end metadata (total duration, final intervention counts, consent snapshot) is the primary per-session artifact for thesis analysis. Losing it on window close corrupts the dataset.
+
+**Fix:** Make `deactivate()` `async`, return the awaited promise. VS Code respects async deactivate for up to a few hundred milliseconds — enough for the buffered writes.
+
+---
+
+### 3. Webview listener accumulation on re-resolution — **High**
+- [ ] **Status**
+
+**Location:** `src/extension/provider/artemisWebviewProvider.ts:162`, `src/extension/provider/chatWebviewProvider.ts:157`
+
+**Problem:** Each `resolveWebviewView()` call appends message, visibility, workspace, and config listeners to the long-lived `_disposables` set without clearing previously registered listeners for that view.
+
+**Why it matters:** VS Code can re-resolve a webview view multiple times per session (view collapsed/re-opened, sidebar moved). Each re-resolution duplicates side effects (double chat-message handling, double config writes).
+
+**Fix:** Introduce a per-view `DisposableStore`. Dispose it at the top of `resolveWebviewView()` before registering the new listener set.
+
+---
+
+### 4. 🎓 `ContextStore` state can persist out of order — **High**
+- [ ] **Status**
+
+**Location:** `src/extension/services/iris/contextStore.ts:201`, `src/extension/services/courseAccessStorageService.ts:52`
+
+**Problem:** `saveState()` fires unsynchronized `globalState.update()` calls. A fast sequence of mutations can land in the wrong order; stale state survives restart.
+
+**Why it matters:** The Iris context store carries the intervention counter and adaptive-cadence state across restarts. Out-of-order writes can resurrect a counter value from earlier in the session, invalidating guardrails (max 3/session, cooldown).
+
+**Fix:** Serialize writes behind an internal promise chain (mirror the pattern already used elsewhere in the storage layer).
+
+---
+
+## Priority: Should fix
+
+### 5. 🎓 Dead feature toggle `DIAGNOSTIC_STABILIZATION_*` — **Medium**
+- [ ] **Status**
+
+**Location:** `src/extension/services/telemetry/types.ts:174-188`
+
+**Problem:** `DIAGNOSTIC_STABILIZATION_MS` and `DIAGNOSTIC_STABILIZATION_ENABLED` are declared in `EQConfig` with defaults (`2_000`, `false`), but no code path reads either value (verified via grep across the repo).
+
+**Why it matters:** Dead configuration flags suggest a feature exists when it does not. A thesis reviewer seeing the flag will ask about it; if evaluation later requires the debounce, we'll silently have the wrong behavior.
+
+**Fix:** Either wire the flag into `CompileEquivalentEmitter` / `ErrorQuotientEngine` (where diagnostics stabilization would apply), or remove the declarations. Decide during Ch. 6 writeup.
+
+---
+
+### 6. 🎓 EQ thresholds duplicated across files — **Medium**
+- [ ] **Status**
+
+**Location:**
+- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:27` — `{ 0.15, 0.35, 0.60 }` + magic `0.85` override at line ~86
+- `src/extension/services/telemetry/interventionService.ts:17,20` — `EQ_REPEATED_ERRORS_THRESHOLD = 0.45`, `EQ_SEVERE_STRUGGLE_THRESHOLD = 0.80`
+
+**Problem:** No single source of truth for EQ thresholds. Decision engine and message selection each carry their own constants.
+
+**Why it matters:** For thesis evaluation we will need to tune thresholds per cohort/exercise. Today that requires edits in 3+ files and a rebuild. Also: decision bands (0.15/0.35/0.60) and message bands (0.45/0.80) are not mutually consistent.
+
+**Fix:** Move all EQ thresholds into a single `EQ_THRESHOLDS` object in `types.ts`. Reference from both files. Add a `package.json` contribution so thresholds are tunable via user settings without rebuild.
+
+---
+
+### 7. VCS access token: GET-failure fallback creates on any error — **Medium**
+- [ ] **Status**
+
+**Location:** `src/extension/api/artemisApi.ts:211`, tested at `test/unit/api/artemisApi.test.ts:551`
+
+**Problem:** `getOrCreateVcsAccessToken()` falls back to token creation on **any** GET failure, not just "token missing". Network errors, 5xx, or auth errors all trigger a POST create.
+
+**Why it matters:** Turns a read path into an unintended write. Masks real failures behind a confusing "token created" path.
+
+**Fix:** Only create on a specific `ApiError` with status `404`. Propagate other errors.
+
+---
+
+### 8. Domain parsers coerce instead of validate — **Medium**
+- [ ] **Status**
+
+**Location:** `src/extension/domain/core.ts:52`
+
+**Problem:** Required fields parsed with `String(...)`, `Number(...)`, and enum casts (`as ArtemisExercise['type']`). Malformed payloads become `"undefined"`, `NaN`, or impossible union members while the type system claims validity.
+
+**Why it matters:** Garbage-in-garbage-out cascades: downstream code trusts the typed shape and fails at an unrelated call site. Debugging becomes expensive.
+
+**Fix:** Explicit validation of required fields and enum membership. Throw or return `undefined` on invalid input rather than casting.
+
+---
+
+### 9. `handleCloneRepository()` god method + untracked timers — **Medium**
+- [ ] **Status**
+
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:201` (method), `:348` (timers)
+
+**Problem:**
+- One method handles folder-prompt UX, config mutation, token retrieval, transport selection, cache eviction, polling, and post-clone open-folder behavior.
+- The clone flow starts a polling `setInterval()` and a delayed `setTimeout()` that are not tracked in `dispose()`.
+
+**Why it matters:** The tight coupling is already hiding cleanup problems; the untracked timers can outlive the provider and keep firing after navigation or extension shutdown.
+
+**Fix:** Split into helpers (`resolveDestination`, `performClone`, `trackCloneCompletion`, `postCloneUx`). Store timer handles on the class; clear in `dispose()`.
+
+---
+
+## Priority: Nice-to-have
+
+### 10. `_useBearerAuth` is set-only — **Low**
+- [ ] **Status**
+
+**Location:** `src/extension/services/auth/authManager.ts:11-22`
+
+**Problem:** `enableBearerAuth()` exists; no `disableBearerAuth()`. Verified via grep.
+
+**Why it matters:** `AuthManager` is a per-activation singleton, so in practice the flag never needs to flip. But the asymmetric API is a design smell — a future refactor that shares `AuthManager` across Theia/Desktop sessions would send wrong headers.
+
+**Fix:** Add `disableBearerAuth()` for symmetry, or encode the mode as an immutable constructor argument.
+
+---
+
+### 11. `authManager.clear()` memory/secrets race window — **Low**
+- [ ] **Status**
+
+**Location:** `src/extension/services/auth/authManager.ts:120-128`
+
+**Problem:** `memoryToken = undefined` is synchronous; `secrets.delete()` is async. A concurrent `getStoredToken()` between the two statements skips memory and reads the stale secret.
+
+**Why it matters:** The window is very short (one microtask). But during logout there are concurrent disconnect/reconnect paths that do read the token. Observed symptom: a momentary "token still valid" read during logout.
+
+**Fix:** Await `secrets.delete()` before setting `memoryToken = undefined`, or serialize both through a single `clearPromise`.
+
+---
+
+### 12. Dead API `hasRecentlyClonedRepo()` with key drift — **Low**
+- [ ] **Status**
+
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:133,205`, `src/extension/controller/webViewMessageHandler.ts:146`
+
+**Problem:** `hasRecentlyClonedRepo()` appears unreferenced outside its own definition. The cache it reads is keyed by `participationId`, but the function's contract says `exerciseId`.
+
+**Why it matters:** Dead public APIs with mismatched semantics mislead future maintainers and produce wrong answers if ever wired up.
+
+**Fix:** Remove it, or realign the keying and wire an actual caller.
+
+---
+
+### 13. Misleading name `isNoAiEnabled` — **Low**
+- [ ] **Status**
+
+**Location:** `src/extension/services/workspace/noAiDetectionService.ts:72`, `src/extension/provider/chatWebviewProvider.ts:232`
+
+**Problem:** `isNoAiEnabled` means "AI is disabled because `.noai` was found" — the inverse of what the name suggests.
+
+**Why it matters:** Inversion leaks into callers and invites sign-flip bugs in future changes.
+
+**Fix:** Rename to `isNoAiDetected` or `isAiDisabledByNoAiFile`.
+
+---
+
+## Test coverage gaps
+
+**Extension-side orchestration** around clone/submit/init is thin; current tests mostly stop at "handler registered".
+
+Add focused unit tests for:
+- [ ] Repeated `resolveWebviewView()` / `dispose()` cycles (covers Finding #3)
+- [ ] `deactivate()` awaiting recorder shutdown (covers Finding #2)
+- [ ] `storageWriter` flush failure + retry behavior (covers Finding #1)
+- [ ] `handleCloneRepository` unhappy paths: git failure, auth failure, timer cleanup (covers Finding #9)
+- [ ] `ContextStore` rapid concurrent writes preserving order (covers Finding #4)
+
+---
+
+## Not-a-bug
+
+Findings that surfaced during review but were **verified false** — documented here so they are not re-investigated:
+
+### ❌ Caret movement wrongly triggering idle-resume
+**Claim:** `InactivityService._recordWeakActivity()` fires `onDidResumeActivity` on cursor movement, contradicting paper P11 ("idle = no edit, caret, or selection").
+
+**Verification:** `inactivityService.ts:195-197` — `getTimeSinceLastActivity()` uses `Math.max(lastEditTimestamp, lastWeakActivityTimestamp)`, and the inline comment explicitly references P11. Caret movement counts as activity by design, which is the correct interpretation.
+
+### ❌ `InactivityService` timer leaking across sessions
+**Claim:** The 5-second `_patternCheckTimer` accumulates across session switches, leaking timers.
+
+**Verification:** `InactivityService` is a singleton inside `TelemetryManager` — `onSessionStart()` resets state only, it does not reinstantiate. `dispose()` clears the timer correctly. No accumulation.
+
+---
+
+## Execution plan
+
+Suggested order (highest thesis-impact first):
+
+1. **Finding #1** + **Finding #2** — telemetry durability. Small diffs, biggest impact on thesis data integrity.
+2. **Finding #4** — ContextStore write ordering. Protects intervention guardrails across restarts.
+3. **Finding #3** — webview listener leaks. Independent PR, good test target.
+4. **Findings #5, #6** — thesis-relevant config hygiene. Worth doing while Ch. 6 writeup is active.
+5. **Findings #7, #8, #9** — extension-host robustness.
+6. **Findings #10–#13** — low-priority cleanup; bundle into one PR.
+
+Each item should ship as a dedicated PR against `dev` with a test covering the fix, per project convention.

--- a/extension/docs/code-review-findings-2026-04.md
+++ b/extension/docs/code-review-findings-2026-04.md
@@ -6,7 +6,9 @@
 1. **Codex CLI** (OpenAI gpt-5.4) — read-only sandbox review focused on structural, lifecycle, and type-safety smells.
 2. **Claude Code** — targeted deep-dive into struggle-detection telemetry pipeline and auth/websocket services (areas codex covered less deeply), plus manual verification of claims.
 
-Findings were cross-checked; two false positives from the Claude review were dropped after verification (see [§Not-a-bug](#not-a-bug)).
+Findings were cross-checked; two false positives from the Claude review were dropped (see [§Not-a-bug](#not-a-bug)).
+
+**Per-finding verification pass (2026-04-15):** Every finding was re-verified by an independent sub-agent reading the actual code. All 13 were confirmed; several were refined based on verification evidence. See the "Verified" note inside each finding.
 
 Thesis-critical findings (items affecting the struggle-detection data path or intervention decisions) are marked 🎓.
 
@@ -45,11 +47,13 @@ Tick items as their fix PR merges into `dev`. Each finding below has the same ch
 ### 1. 🎓 Telemetry recordings lost on transient filesystem errors — **High**
 - [ ] **Status**
 
-**Location:** `src/extension/services/telemetry/recording/storageWriter.ts:90`
+**Location:** `src/extension/services/telemetry/recording/storageWriter.ts:90` (specifically line 94 does `_buffer.splice(0)`, lines 96-102 do the unguarded `appendFile()`)
 
-**Problem:** `flush()` removes the whole batch from `_buffer` before `appendFile()` succeeds. On transient FS failure it only logs the error — the events are already gone from the buffer.
+**Problem:** `flush()` removes the whole batch from `_buffer` via `splice(0)` before `appendFile()` succeeds. On transient FS failure it only logs and records an error count — the events are already gone from the buffer.
 
 **Why it matters:** For thesis evaluation we depend on complete session recordings. A single write failure silently drops a batch, skewing EQ calculations and trigger timing for that session.
+
+**Verified (2026-04-15):** CONFIRMED. Verification agent read the file: `splice(0)` at line 94 destructively removes all items; the `catch` block at lines 100-101 only logs and calls `_recordError()`. Partial mitigation exists — `MAX_CONSECUTIVE_ERRORS = 5` disables recording globally after repeated failures (line 153-159), preventing memory leaks but doing nothing to recover already-lost batches.
 
 **Fix:** Keep the batch until the write resolves. On error, re-prepend to `_buffer` (or route to a dead-letter queue if the file itself is corrupt). Add a retry with bounded attempts.
 
@@ -58,39 +62,50 @@ Tick items as their fix PR merges into `dev`. Each finding below has the same ch
 ### 2. 🎓 `deactivate()` does not await recorder shutdown — **High**
 - [ ] **Status**
 
-**Location:** `src/extension.ts:261`, `src/extension/services/telemetry/recording/sessionRecorder.ts:158`
+**Location:** `src/extension.ts:261` (line 263 does `void activeSessionRecorder.endSession()`), `src/extension/services/telemetry/recording/sessionRecorder.ts:158` (async, awaits `writeMetadata` + `endSession` on writer)
 
 **Problem:** `deactivate()` fires `activeSessionRecorder.endSession()` as a `void` promise. VS Code may tear the extension host down before metadata/event flushing completes.
 
 **Why it matters:** Session-end metadata (total duration, final intervention counts, consent snapshot) is the primary per-session artifact for thesis analysis. Losing it on window close corrupts the dataset.
 
-**Fix:** Make `deactivate()` `async`, return the awaited promise. VS Code respects async deactivate for up to a few hundred milliseconds — enough for the buffered writes.
+**Verified (2026-04-15):** CONFIRMED. `sessionRecorder.endSession()` truly performs async file IO (`writeMetadata` and `endSession` on `storageWriter`, both `fs.writeFile`/`fs.appendFile`). `telemetryManager.endCurrentSession()` is synchronous and does not flush.
+
+**Fix:** Simplest correct fix is `return activeSessionRecorder.endSession()` (just return the promise) — VS Code awaits the returned promise before teardown. Making `deactivate()` `async` works too but is not strictly required.
 
 ---
 
 ### 3. Webview listener accumulation on re-resolution — **High**
 - [ ] **Status**
 
-**Location:** `src/extension/provider/artemisWebviewProvider.ts:162`, `src/extension/provider/chatWebviewProvider.ts:157`
+**Location:**
+- `src/extension/provider/artemisWebviewProvider.ts:162` — listeners added at lines 195-248 (message, visibility, config)
+- `src/extension/provider/chatWebviewProvider.ts:157` — listeners added at lines 176-208 (message, visibility, workspace, config)
+- `src/extension/provider/baseWebviewProvider.ts` — `_drainDisposables()` exists but is only called from `dispose()`, not from `resolveWebviewView()`
 
-**Problem:** Each `resolveWebviewView()` call appends message, visibility, workspace, and config listeners to the long-lived `_disposables` set without clearing previously registered listeners for that view.
+**Problem:** Each `resolveWebviewView()` call appends listeners to the long-lived `_disposables` set without clearing previously registered listeners for that view.
 
 **Why it matters:** VS Code can re-resolve a webview view multiple times per session (view collapsed/re-opened, sidebar moved). Each re-resolution duplicates side effects (double chat-message handling, double config writes).
 
-**Fix:** Introduce a per-view `DisposableStore`. Dispose it at the top of `resolveWebviewView()` before registering the new listener set.
+**Verified (2026-04-15):** CONFIRMED. Both providers register 3-4 listeners each; neither clears `_disposables` at the top of `resolveWebviewView()`. When any listener fires (visibility change, config change), all accumulated handlers execute → redundant logging, duplicate data fetches.
+
+**Fix:** Introduce a per-view `DisposableStore`. Dispose it at the top of `resolveWebviewView()` before registering the new listener set. Or call the existing `_drainDisposables()` from `baseWebviewProvider` at resolve time.
 
 ---
 
 ### 4. 🎓 `ContextStore` state can persist out of order — **High**
 - [ ] **Status**
 
-**Location:** `src/extension/services/iris/contextStore.ts:201`, `src/extension/services/courseAccessStorageService.ts:52`
+**Location:**
+- ⚠️ **Problem:** `src/extension/services/iris/contextStore.ts:208` — `saveState()` fires `globalState.update(...).then(undefined, err => logger.error(...))` without serializing.
+- ✅ **Reference pattern:** `src/extension/services/courseAccessStorageService.ts:52-59` — uses a `_writeChain` map of `Promise` per scope key, correctly serializing writes. `ContextStore` should adopt this pattern.
 
-**Problem:** `saveState()` fires unsynchronized `globalState.update()` calls. A fast sequence of mutations can land in the wrong order; stale state survives restart.
+**Problem:** `saveState()` in `ContextStore` fires unsynchronized `globalState.update()` calls. Rapid callers (`switchContext()` at lines 91-121 invokes `registerExercise()` → `saveState()` and then `setActiveContext()` → `saveState()` without awaiting) can land writes out of order.
 
 **Why it matters:** The Iris context store carries the intervention counter and adaptive-cadence state across restarts. Out-of-order writes can resurrect a counter value from earlier in the session, invalidating guardrails (max 3/session, cooldown).
 
-**Fix:** Serialize writes behind an internal promise chain (mirror the pattern already used elsewhere in the storage layer).
+**Verified (2026-04-15):** CONFIRMED, with **correction to original finding**: the original codex finding listed both files as problematic, but `courseAccessStorageService.ts:52` is actually the *correct* write-chain implementation — the exemplar to mirror, not a second instance of the bug. Also: the true line of the buggy call is `:208`, not `:201`.
+
+**Fix:** Port the `_writeChain` pattern from `courseAccessStorageService` into `ContextStore.saveState()`.
 
 ---
 
@@ -99,67 +114,81 @@ Tick items as their fix PR merges into `dev`. Each finding below has the same ch
 ### 5. 🎓 Dead feature toggle `DIAGNOSTIC_STABILIZATION_*` — **Medium**
 - [ ] **Status**
 
-**Location:** `src/extension/services/telemetry/types.ts:174-188`
+**Location:** `src/extension/services/telemetry/types.ts:174-176` (interface), `:187-188` (defaults)
 
-**Problem:** `DIAGNOSTIC_STABILIZATION_MS` and `DIAGNOSTIC_STABILIZATION_ENABLED` are declared in `EQConfig` with defaults (`2_000`, `false`), but no code path reads either value (verified via grep across the repo).
+**Problem:** `DIAGNOSTIC_STABILIZATION_MS` and `DIAGNOSTIC_STABILIZATION_ENABLED` are declared in `EQConfig` with defaults (`2_000`, `false`), but no code path reads either value.
 
 **Why it matters:** Dead configuration flags suggest a feature exists when it does not. A thesis reviewer seeing the flag will ask about it; if evaluation later requires the debounce, we'll silently have the wrong behavior.
+
+**Verified (2026-04-15):** CONFIRMED. Verification agent grep'd the entire `src/` and `test/` trees — no reads. Both `CompileEquivalentEmitter` and `ErrorQuotientEngine` store the config but read only: `DEDUP_WINDOW_MS`, `WEIGHT_BOTH_ERROR`, `WEIGHT_SAME_TYPE`, `MAX_PAIR_SCORE`, `SESSION_INACTIVITY_SPLIT_MS`. The two stabilization fields are truly orphaned.
 
 **Fix:** Either wire the flag into `CompileEquivalentEmitter` / `ErrorQuotientEngine` (where diagnostics stabilization would apply), or remove the declarations. Decide during Ch. 6 writeup.
 
 ---
 
-### 6. 🎓 EQ thresholds duplicated across files — **Medium**
+### 6. 🎓 EQ thresholds scattered & undocumented — **Medium**
 - [ ] **Status**
 
 **Location:**
-- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:27` — `{ 0.15, 0.35, 0.60 }` + magic `0.85` override at line ~86
-- `src/extension/services/telemetry/interventionService.ts:17,20` — `EQ_REPEATED_ERRORS_THRESHOLD = 0.45`, `EQ_SEVERE_STRUGGLE_THRESHOLD = 0.80`
+- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:27-31` — decision bands `{ subtle: 0.15, notification: 0.35, proactive: 0.60 }` + magic `0.85` override at line ~86
+- `src/extension/services/telemetry/interventionService.ts:17,20` — message-selection refinements: `EQ_REPEATED_ERRORS_THRESHOLD = 0.45`, `EQ_SEVERE_STRUGGLE_THRESHOLD = 0.80`
 
-**Problem:** No single source of truth for EQ thresholds. Decision engine and message selection each carry their own constants.
+**Problem:** EQ thresholds are hardcoded across files. No shared constants module; no documentation for why the decision bands (0.15/0.35/0.60) and message-refinement bands (0.45/0.80) are set where they are.
 
-**Why it matters:** For thesis evaluation we will need to tune thresholds per cohort/exercise. Today that requires edits in 3+ files and a rebuild. Also: decision bands (0.15/0.35/0.60) and message bands (0.45/0.80) are not mutually consistent.
+**Why it matters:** For thesis evaluation we will need to tune thresholds per cohort/exercise. Today that requires edits in 3+ files and a rebuild.
 
-**Fix:** Move all EQ thresholds into a single `EQ_THRESHOLDS` object in `types.ts`. Reference from both files. Add a `package.json` contribution so thresholds are tunable via user settings without rebuild.
+**Verified (2026-04-15):** CONFIRMED with refinement: the two sets of numbers are **not** duplicates of the same concept — they serve different semantic purposes. The decision-engine bands gate *whether* to intervene; the message-selection bands refine *which message* to show within a band. The original "duplication" framing was misleading. The real issues are: (1) no central source, (2) no documentation explaining why 0.45 lives between 0.35 (notification) and 0.60 (proactive), and (3) magic numbers untunable at runtime.
+
+**Fix:** Move all EQ thresholds into a single `EQ_THRESHOLDS` object in `types.ts` with doc comments that explain the semantic role of each band. Reference from both files. Add a `package.json` contribution so thresholds are tunable via user settings without rebuild.
 
 ---
 
 ### 7. VCS access token: GET-failure fallback creates on any error — **Medium**
 - [ ] **Status**
 
-**Location:** `src/extension/api/artemisApi.ts:211`, tested at `test/unit/api/artemisApi.test.ts:551`
+**Location:** `src/extension/api/artemisApi.ts:211-217`, test at `test/unit/api/artemisApi.test.ts:551`
 
-**Problem:** `getOrCreateVcsAccessToken()` falls back to token creation on **any** GET failure, not just "token missing". Network errors, 5xx, or auth errors all trigger a POST create.
+**Problem:** `getOrCreateVcsAccessToken()` wraps the GET in a try/catch and falls back to POST create on **any** thrown error. `makeRequest()` throws `ApiError` for any non-OK status, so network errors, 5xx, and auth errors all funnel into the create path.
 
 **Why it matters:** Turns a read path into an unintended write. Masks real failures behind a confusing "token created" path.
 
-**Fix:** Only create on a specific `ApiError` with status `404`. Propagate other errors.
+**Verified (2026-04-15):** CONFIRMED. The catch block has no discrimination. **Important caveat:** the test at `test/unit/api/artemisApi.test.ts:551-576` **explicitly asserts this behavior** — it mocks a 404 and expects the fallback to POST create. Changing to discriminate (only create on 404) will require **updating that test** to assert error propagation on non-404 failures. Plan both changes in the same PR.
+
+**Fix:** Only create on `ApiError` with status `404`. Propagate other errors. Update the affected test to pin the new contract.
 
 ---
 
 ### 8. Domain parsers coerce instead of validate — **Medium**
 - [ ] **Status**
 
-**Location:** `src/extension/domain/core.ts:52`
+**Location:** `src/extension/domain/core.ts` — multiple call sites:
+- `:52` — `login: String(d.login)` (parseArtemisUser)
+- `:83-85` — `id: Number(d.id)`, `title: String(d.title)`, `shortName: String(d.shortName)` (parseArtemisCourse)
+- `:116` — `id: Number(d.id)`, `:119` — `type: String(d.type) as ArtemisExercise['type']` (parseArtemisExercise)
+- `:175` — `type: String(d.type) as ArtemisParticipation['type']` (parseArtemisParticipation)
 
-**Problem:** Required fields parsed with `String(...)`, `Number(...)`, and enum casts (`as ArtemisExercise['type']`). Malformed payloads become `"undefined"`, `NaN`, or impossible union members while the type system claims validity.
+**Problem:** Required fields parsed with `String(...)`, `Number(...)`, and unchecked enum casts. Malformed payloads become `"undefined"`, `NaN`, or impossible union members while the type system claims validity. No upstream validation layer (no zod/io-ts/custom validators found).
 
-**Why it matters:** Garbage-in-garbage-out cascades: downstream code trusts the typed shape and fails at an unrelated call site. Debugging becomes expensive.
+**Why it matters:** Garbage-in-garbage-out cascades: downstream code trusts the typed shape and fails at an unrelated call site. E.g. `NaN` participation IDs land in `getLatestPendingSubmission(participation.id)` (`exerciseDataLoader.ts:121`), producing malformed URLs.
 
-**Fix:** Explicit validation of required fields and enum membership. Throw or return `undefined` on invalid input rather than casting.
+**Verified (2026-04-15):** CONFIRMED with broader scope than original claim — **6 locations** across 4 parser functions, not just line 52.
+
+**Fix:** Add explicit required-field checks and enum-membership validation. Throw or return `undefined` on invalid input rather than casting. Consider adopting zod once for the domain module — it pays for itself immediately across all 4 parsers.
 
 ---
 
 ### 9. `handleCloneRepository()` god method + untracked timers — **Medium**
 - [ ] **Status**
 
-**Location:** `src/extension/controller/commands/repositoryCommands.ts:201` (method), `:348` (timers)
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:201-373` (172-line method), timers at `:348` (setInterval) and `:364` (setTimeout). Existing `dispose()` at `:51-65` only clears `workspaceChangeDebounce` and `dirtyPagesCheckDebounce`.
 
 **Problem:**
-- One method handles folder-prompt UX, config mutation, token retrieval, transport selection, cache eviction, polling, and post-clone open-folder behavior.
-- The clone flow starts a polling `setInterval()` and a delayed `setTimeout()` that are not tracked in `dispose()`.
+- One 172-line method handles **~8 distinct responsibilities**: payload extraction + validation, git availability check, folder-prompt UX + config mutation, token retrieval, clone transport selection (Theia vs terminal), cache management, polling, delayed folder-open, error handling.
+- The clone flow creates a `setInterval` (polling, line 348) and a `setTimeout` (delayed open, line 364) as **local variables** — never tracked in a class field, never cleared by `dispose()`.
 
-**Why it matters:** The tight coupling is already hiding cleanup problems; the untracked timers can outlive the provider and keep firing after navigation or extension shutdown.
+**Why it matters:** The tight coupling is already hiding cleanup problems; the untracked timers can outlive the class instance and keep firing after navigation or extension shutdown.
+
+**Verified (2026-04-15):** CONFIRMED. Responsibility count is on the higher end (5 if you lump UX steps, 8 if you separate them). Timer leak is real. **Caveat:** `RepositoryCommandModule` lifetime appears to be extension-scoped, so in practice the timers are GC'd at shutdown. The bigger issue is the maintainability of the 172-line method and the surprise that `dispose()` is a partial no-op.
 
 **Fix:** Split into helpers (`resolveDestination`, `performClone`, `trackCloneCompletion`, `postCloneUx`). Store timer handles on the class; clear in `dispose()`.
 
@@ -167,55 +196,63 @@ Tick items as their fix PR merges into `dev`. Each finding below has the same ch
 
 ## Priority: Nice-to-have
 
-### 10. `_useBearerAuth` is set-only — **Low**
+### 10. `_useBearerAuth` is set-only — **Low** (design-smell, not a bug)
 - [ ] **Status**
 
-**Location:** `src/extension/services/auth/authManager.ts:11-22`
+**Location:** `src/extension/services/auth/authManager.ts:11,21-23` (flag declared, only setter); used at `:105`. Set from `theiaAuthProvider.ts:25`.
 
-**Problem:** `enableBearerAuth()` exists; no `disableBearerAuth()`. Verified via grep.
+**Problem:** `enableBearerAuth()` exists; no `disableBearerAuth()`. `clear()` does not reset the flag either.
 
-**Why it matters:** `AuthManager` is a per-activation singleton, so in practice the flag never needs to flip. But the asymmetric API is a design smell — a future refactor that shares `AuthManager` across Theia/Desktop sessions would send wrong headers.
+**Why it matters:** `AuthManager` is a per-activation singleton (constructed once at `extension.ts:37`; Theia/Desktop mode is detected at startup and never changes within a session). The flag can't practically need to flip today. But the asymmetric API invites a future bug if `AuthManager` ever gets reused across sessions.
 
-**Fix:** Add `disableBearerAuth()` for symmetry, or encode the mode as an immutable constructor argument.
+**Verified (2026-04-15):** CONFIRMED — but the verification agent rightly flagged this as a **design smell, not a functional bug**. No call path can currently trigger the wrong behavior.
+
+**Fix:** Preferred: encode auth mode as an **immutable constructor argument** (`new AuthManager(context, { mode: 'bearer' | 'cookie' })`). That eliminates the asymmetric setter entirely. Second choice: add `disableBearerAuth()` for symmetry and reset it in `clear()`. Low priority — bundle with other cosmetic auth cleanup.
 
 ---
 
 ### 11. `authManager.clear()` memory/secrets race window — **Low**
 - [ ] **Status**
 
-**Location:** `src/extension/services/auth/authManager.ts:120-128`
+**Location:** `src/extension/services/auth/authManager.ts:120-128` (`clear()`) and `:85-96` (`getStoredToken()`).
 
-**Problem:** `memoryToken = undefined` is synchronous; `secrets.delete()` is async. A concurrent `getStoredToken()` between the two statements skips memory and reads the stale secret.
+**Problem:** `memoryToken = undefined` at line 121 is synchronous; `secrets.delete()` at line 123 is async. Between those two statements, a concurrent `getStoredToken()` skips memory and reads the stale secret (returns the old token).
 
-**Why it matters:** The window is very short (one microtask). But during logout there are concurrent disconnect/reconnect paths that do read the token. Observed symptom: a momentary "token still valid" read during logout.
+**Why it matters:** Concurrent readers exist: `makeRequest()` in `artemisApi.ts:45` and `connect()` in `artemisWebsocketService.ts:297` both call `getAuthHeaders() → getStoredToken()`. During logout there can be a pending WebSocket reconnect or API request in flight.
 
-**Fix:** Await `secrets.delete()` before setting `memoryToken = undefined`, or serialize both through a single `clearPromise`.
+**Verified (2026-04-15):** CONFIRMED. Window is real (not just theoretical), but **narrow** — one microtask boundary. Mitigating factor: a stale read produces an eventual 401, which the `onAuthExpired` handler in `extension.ts:184` catches and re-triggers auth cleanup. So the user-visible impact is a momentary confusing log line, not broken logout.
+
+**Fix:** Await `secrets.delete()` before setting `memoryToken = undefined`, or serialize both through a single `clearPromise`. Trivial change; include with other auth cleanup.
 
 ---
 
 ### 12. Dead API `hasRecentlyClonedRepo()` with key drift — **Low**
 - [ ] **Status**
 
-**Location:** `src/extension/controller/commands/repositoryCommands.ts:133,205`, `src/extension/controller/webViewMessageHandler.ts:146`
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:133` (definition), `:205` (sibling helper that aliases `exerciseId = participationId`), `:342` (cache write using the alias), and `webViewMessageHandler.ts:146` (thin wrapper — delegation only, not a real external caller).
 
-**Problem:** `hasRecentlyClonedRepo()` appears unreferenced outside its own definition. The cache it reads is keyed by `participationId`, but the function's contract says `exerciseId`.
+**Problem:** `hasRecentlyClonedRepo()` has no external callers (the `webViewMessageHandler` entry is just a delegation wrapper with no upstream caller). The cache it consults is actually keyed by `participationId`, while the function's signature declares `exerciseId: number`.
 
 **Why it matters:** Dead public APIs with mismatched semantics mislead future maintainers and produce wrong answers if ever wired up.
 
-**Fix:** Remove it, or realign the keying and wire an actual caller.
+**Verified (2026-04-15):** CONFIRMED for both claims: (a) truly dead (no real call site outside of its own module and a dead wrapper), (b) key-drift is real (`repositoryCommands.ts:205` comment: `const exerciseId = participationId; // Use participationId for tracking`).
+
+**Fix:** Remove the function and its delegation wrapper. If the capability is actually needed later, rewrite with a correctly named key.
 
 ---
 
-### 13. Misleading name `isNoAiEnabled` — **Low**
+### 13. Misleading name `isNoAiEnabled` — **Low** (style / clarity, not a bug)
 - [ ] **Status**
 
-**Location:** `src/extension/services/workspace/noAiDetectionService.ts:72`, `src/extension/provider/chatWebviewProvider.ts:232`
+**Location:** `src/extension/services/workspace/noAiDetectionService.ts:72` (property), `:150,161` (assignments), `chatWebviewProvider.ts:232,259-261`, `chatMessageService.ts:31-33`.
 
-**Problem:** `isNoAiEnabled` means "AI is disabled because `.noai` was found" — the inverse of what the name suggests.
+**Problem:** The property reads "is NO-AI enabled" which most maintainers parse as "is AI enabled?" (false). Actual semantic: true when `.noai` is present, meaning AI is **disabled**. Call sites invert the reading (`if (isNoAiEnabled) { /* block AI */ }`).
 
-**Why it matters:** Inversion leaks into callers and invites sign-flip bugs in future changes.
+**Why it matters:** Invites sign-flip bugs on future changes; reviewers have to mentally invert.
 
-**Fix:** Rename to `isNoAiDetected` or `isAiDisabledByNoAiFile`.
+**Verified (2026-04-15):** CONFIRMED as a **style/clarity issue**. The name is defensible if parsed as "is the no-ai signal enabled" — that's why the agent marked it "CONFIRMED with caveat". It is not a functional bug. Still worth renaming.
+
+**Fix:** Rename to `isNoAiDetected` (minimal churn, matches JSDoc "Returns true if a .noai file was detected") or `isAiDisabledByNoAiFile` (most explicit). Update all 4-5 call sites. Low urgency.
 
 ---
 

--- a/extension/docs/code-review-findings-2026-04.md
+++ b/extension/docs/code-review-findings-2026-04.md
@@ -10,6 +10,8 @@ Findings were cross-checked; two false positives from the Claude review were dro
 
 **Per-finding verification pass (2026-04-15):** Every finding was re-verified by an independent sub-agent reading the actual code. All 13 were confirmed; several were refined based on verification evidence. See the "Verified" note inside each finding.
 
+**Re-verification pass (2026-04-26):** All 13 findings re-verified against current `dev` by Claude Opus 4.6, then cross-reviewed by Codex CLI (gpt-5.5). Findings #1 and #2 are now fixed. Finding #4 downgraded (thesis-critical impact no longer applies). Finding #9 timer leak fixed. Three new issues identified during the re-verification.
+
 Thesis-critical findings (items affecting the struggle-detection data path or intervention decisions) are marked 🎓.
 
 ---
@@ -19,17 +21,17 @@ Thesis-critical findings (items affecting the struggle-detection data path or in
 Tick items as their fix PR merges into `dev`. Each finding below has the same checkbox — update both when closing.
 
 **Must-fix before thesis evaluation:**
-- [ ] [#1 — Telemetry recordings lost on transient FS errors](#1--telemetry-recordings-lost-on-transient-filesystem-errors--high) 🎓
-- [ ] [#2 — `deactivate()` does not await recorder shutdown](#2--deactivate-does-not-await-recorder-shutdown--high) 🎓
+- [x] [#1 — Telemetry recordings lost on transient FS errors](#1--telemetry-recordings-lost-on-transient-filesystem-errors--high) 🎓 — **FIXED** (write-lane serialization)
+- [x] [#2 — `deactivate()` does not await recorder shutdown](#2--deactivate-does-not-await-recorder-shutdown--high) 🎓 — **FIXED** (async deactivate + await dispose)
 - [ ] [#3 — Webview listener accumulation on re-resolution](#3-webview-listener-accumulation-on-re-resolution--high)
-- [ ] [#4 — `ContextStore` state can persist out of order](#4--contextstore-state-can-persist-out-of-order--high) 🎓
+- [x] [#4 — `ContextStore` state can persist out of order](#4--contextstore-state-can-persist-out-of-order--medium) 🎓 — **DOWNGRADED to Medium** (thesis-critical impact removed)
 
 **Should fix:**
 - [ ] [#5 — Dead feature toggle `DIAGNOSTIC_STABILIZATION_*`](#5--dead-feature-toggle-diagnostic_stabilization_--medium) 🎓
-- [ ] [#6 — EQ thresholds duplicated across files](#6--eq-thresholds-duplicated-across-files--medium) 🎓
+- [ ] [#6 — EQ thresholds scattered across files](#6--eq-thresholds-scattered-across-files--medium) 🎓
 - [ ] [#7 — VCS access token: GET-failure fallback creates on any error](#7-vcs-access-token-get-failure-fallback-creates-on-any-error--medium)
 - [ ] [#8 — Domain parsers coerce instead of validate](#8-domain-parsers-coerce-instead-of-validate--medium)
-- [ ] [#9 — `handleCloneRepository()` god method + untracked timers](#9-handleclonerepository-god-method--untracked-timers--medium)
+- [ ] [#9 — `handleCloneRepository()` god method](#9-handleclonerepository-god-method--medium) (timer leak fixed, maintainability remains)
 
 **Nice-to-have:**
 - [ ] [#10 — `_useBearerAuth` is set-only](#10-_usebearerauth-is-set-only--low)
@@ -37,235 +39,291 @@ Tick items as their fix PR merges into `dev`. Each finding below has the same ch
 - [ ] [#12 — Dead API `hasRecentlyClonedRepo()` with key drift](#12-dead-api-hasrecentlyclonedrepo-with-key-drift--low)
 - [ ] [#13 — Misleading name `isNoAiEnabled`](#13-misleading-name-isnoaienabled--low)
 
+**New issues (2026-04-26):**
+- [ ] [#14 — `ContextStore.migrateState()` rehydrates sessions despite "never persist" policy](#14-contextstoremigratestate-rehydrates-sessions-despite-never-persist-policy--low)
+- [ ] [#15 — `NoAiDetectionService._setupFileWatcher()` leaks disposed watchers in `_disposables`](#15-noaidetectionservice_setupfilewatcher-leaks-disposed-watchers-in-_disposables--low)
+- [ ] [#16 — `parseArtemisFeedback()` does not validate enum membership](#16-parseartemisfeedback-does-not-validate-enum-membership--low)
+
 **Test coverage:**
-- [ ] [Add missing tests for #1, #2, #3, #4, #9](#test-coverage-gaps)
+- [x] ~~`storageWriter` flush failure + retry behavior (covers Finding #1)~~ — storageWriter now has write-lane tests
+- [x] ~~`deactivate()` awaiting recorder shutdown (covers Finding #2)~~ — deactivate now properly awaits
+- [ ] Repeated `resolveWebviewView()` / `dispose()` cycles (covers Finding #3)
+- [ ] `ContextStore` rapid concurrent writes preserving order (covers Finding #4)
 
 ---
 
 ## Priority: Must-fix before thesis evaluation
 
-### 1. 🎓 Telemetry recordings lost on transient filesystem errors — **High**
-- [ ] **Status**
+### 1. 🎓 Telemetry recordings lost on transient filesystem errors — ~~High~~ **FIXED**
+- [x] **Status: FIXED** (verified 2026-04-26)
 
-**Location:** `src/extension/services/telemetry/recording/storageWriter.ts:90` (specifically line 94 does `_buffer.splice(0)`, lines 96-102 do the unguarded `appendFile()`)
+**Location:** `src/extension/services/telemetry/recording/storageWriter.ts`
 
-**Problem:** `flush()` removes the whole batch from `_buffer` via `splice(0)` before `appendFile()` succeeds. On transient FS failure it only logs and records an error count — the events are already gone from the buffer.
+**Original problem:** `flush()` removed the whole batch from `_buffer` via `splice(0)` before `appendFile()` succeeded. On transient FS failure events were silently lost.
 
-**Why it matters:** For thesis evaluation we depend on complete session recordings. A single write failure silently drops a batch, skewing EQ calculations and trigger timing for that session.
+**Fix applied:** The storageWriter was rewritten with a write-lane serialization pattern:
+- Line 354: `_buffer.slice()` snapshots the batch before writing
+- Line 362: `appendFile()` writes the batch
+- Line 367: `_buffer.splice(0, batchSize)` removes only on success
+- On error: the catch in `_enqueueLaneWork` logs and calls `_recordError()` but does NOT remove events from the buffer. Events are retained for the next flush attempt.
 
-**Verified (2026-04-15):** CONFIRMED. Verification agent read the file: `splice(0)` at line 94 destructively removes all items; the `catch` block at lines 100-101 only logs and calls `_recordError()`. Partial mitigation exists — `MAX_CONSECUTIVE_ERRORS = 5` disables recording globally after repeated failures (line 153-159), preventing memory leaks but doing nothing to recover already-lost batches.
-
-**Fix:** Keep the batch until the write resolves. On error, re-prepend to `_buffer` (or route to a dead-letter queue if the file itself is corrupt). Add a retry with bounded attempts.
+**Residual risk (noted by Codex):** If `appendFile` partially writes (some bytes reach disk) but still rejects, the retained buffer will re-write those same events on the next flush, producing duplicate complete lines. The doc comment addresses malformed trailing lines but not this edge case. JSONL consumers should tolerate duplicates.
 
 ---
 
-### 2. 🎓 `deactivate()` does not await recorder shutdown — **High**
-- [ ] **Status**
+### 2. 🎓 `deactivate()` does not await recorder shutdown — ~~High~~ **FIXED**
+- [x] **Status: FIXED** (verified 2026-04-26)
 
-**Location:** `src/extension.ts:261` (line 263 does `void activeSessionRecorder.endSession()`), `src/extension/services/telemetry/recording/sessionRecorder.ts:158` (async, awaits `writeMetadata` + `endSession` on writer)
+**Location:** `src/extension.ts:260-276`
 
-**Problem:** `deactivate()` fires `activeSessionRecorder.endSession()` as a `void` promise. VS Code may tear the extension host down before metadata/event flushing completes.
+**Original problem:** `deactivate()` fired `activeSessionRecorder.endSession()` as a `void` promise. VS Code could tear down before flushing completed.
 
-**Why it matters:** Session-end metadata (total duration, final intervention counts, consent snapshot) is the primary per-session artifact for thesis analysis. Losing it on window close corrupts the dataset.
+**Fix applied:**
+```typescript
+export async function deactivate(): Promise<void> {
+    if (activeSessionRecorder) {
+        try {
+            await activeSessionRecorder.dispose();
+        } catch (err) {
+            logger.error('Failed to dispose SessionRecorder during deactivate', LogCategory.TELEMETRY, err);
+        }
+        activeSessionRecorder = undefined;
+    }
+    // ...
+}
+```
 
-**Verified (2026-04-15):** CONFIRMED. `sessionRecorder.endSession()` truly performs async file IO (`writeMetadata` and `endSession` on `storageWriter`, both `fs.writeFile`/`fs.appendFile`). `telemetryManager.endCurrentSession()` is synchronous and does not flush.
-
-**Fix:** Simplest correct fix is `return activeSessionRecorder.endSession()` (just return the promise) — VS Code awaits the returned promise before teardown. Making `deactivate()` `async` works too but is not strictly required.
+`deactivate()` is now async and explicitly awaits `activeSessionRecorder.dispose()`. `SessionRecorder.dispose()` in turn awaits `endSession`, drains pending lifecycle work, and disposes the writer.
 
 ---
 
 ### 3. Webview listener accumulation on re-resolution — **High**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
 **Location:**
-- `src/extension/provider/artemisWebviewProvider.ts:162` — listeners added at lines 195-248 (message, visibility, config)
-- `src/extension/provider/chatWebviewProvider.ts:157` — listeners added at lines 176-208 (message, visibility, workspace, config)
-- `src/extension/provider/baseWebviewProvider.ts` — `_drainDisposables()` exists but is only called from `dispose()`, not from `resolveWebviewView()`
+- `src/extension/provider/chatWebviewProvider.ts:205-237` — 4 listeners added per resolve (message, visibility, workspace, config)
+- `src/extension/provider/baseWebviewProvider.ts` — `_drainDisposables()` only called from `dispose()`, not from `resolveWebviewView()`
 
-**Problem:** Each `resolveWebviewView()` call appends listeners to the long-lived `_disposables` set without clearing previously registered listeners for that view.
+**Problem:** Each `resolveWebviewView()` call pushes listeners into the long-lived `_disposables` array without clearing previously registered listeners.
 
-**Why it matters:** VS Code can re-resolve a webview view multiple times per session (view collapsed/re-opened, sidebar moved). Each re-resolution duplicates side effects (double chat-message handling, double config writes).
+**Why it matters:** VS Code can re-resolve a webview view (sidebar moved, view destroyed/recreated). Each re-resolution duplicates global listeners (workspace-folder changes, config changes). Webview-specific listeners (`onDidReceiveMessage`, `onDidChangeVisibility`) are bound to the old webview instance and will not fire on the new one, but they remain in `_disposables` as garbage.
 
-**Verified (2026-04-15):** CONFIRMED. Both providers register 3-4 listeners each; neither clears `_disposables` at the top of `resolveWebviewView()`. When any listener fires (visibility change, config change), all accumulated handlers execute → redundant logging, duplicate data fetches.
+**Re-verified (2026-04-26):** CONFIRMED. The constructor pushes ~15 one-time disposables (EventEmitters, ContextStore, etc.). `resolveWebviewView()` adds 4 more per call. On re-resolve, global listeners (workspace, config) fire twice. Practical risk is low (VS Code rarely re-resolves) but the duplicate side effects are real.
 
-**Fix:** Introduce a per-view `DisposableStore`. Dispose it at the top of `resolveWebviewView()` before registering the new listener set. Or call the existing `_drainDisposables()` from `baseWebviewProvider` at resolve time.
+**Clarification (Codex, 2026-04-26):** A fix must use a **separate per-view disposable bucket** for resolve-time listeners. Calling `_drainDisposables()` at the start of `resolveWebviewView()` would also destroy constructor-registered EventEmitters, breaking the provider.
 
----
-
-### 4. 🎓 `ContextStore` state can persist out of order — **High**
-- [ ] **Status**
-
-**Location:**
-- ⚠️ **Problem:** `src/extension/services/iris/contextStore.ts:208` — `saveState()` fires `globalState.update(...).then(undefined, err => logger.error(...))` without serializing.
-- ✅ **Reference pattern:** `src/extension/services/courseAccessStorageService.ts:52-59` — uses a `_writeChain` map of `Promise` per scope key, correctly serializing writes. `ContextStore` should adopt this pattern.
-
-**Problem:** `saveState()` in `ContextStore` fires unsynchronized `globalState.update()` calls. Rapid callers (`switchContext()` at lines 91-121 invokes `registerExercise()` → `saveState()` and then `setActiveContext()` → `saveState()` without awaiting) can land writes out of order.
-
-**Why it matters:** The Iris context store carries the intervention counter and adaptive-cadence state across restarts. Out-of-order writes can resurrect a counter value from earlier in the session, invalidating guardrails (max 3/session, cooldown).
-
-**Verified (2026-04-15):** CONFIRMED, with **correction to original finding**: the original codex finding listed both files as problematic, but `courseAccessStorageService.ts:52` is actually the *correct* write-chain implementation — the exemplar to mirror, not a second instance of the bug. Also: the true line of the buggy call is `:208`, not `:201`.
-
-**Fix:** Port the `_writeChain` pattern from `courseAccessStorageService` into `ContextStore.saveState()`.
+**Fix:** Introduce a `_viewDisposables: vscode.Disposable[]` field. Clear it at the top of `resolveWebviewView()`. Push resolve-time listeners there instead of `_disposables`.
 
 ---
 
 ## Priority: Should fix
 
+### 4. 🎓 `ContextStore` state can persist out of order — ~~High~~ **DOWNGRADED to Medium**
+- [x] **Status: DOWNGRADED** (impact reassessed 2026-04-26)
+
+**Location:** `src/extension/services/iris/contextStore.ts:208` — `saveState()` fires unsynchronized `globalState.update()`
+
+**Problem:** `saveState()` fires `globalState.update().then(undefined, err => ...)` without serializing. Rapid callers can land writes out of order.
+
+**Original thesis-critical claim (now invalid):** The April 15 review stated that "the Iris context store carries the intervention counter and adaptive-cadence state across restarts." This is **no longer true**. Current `saveState()` (lines 203-207) explicitly strips sessions and activeSessionId before persisting:
+```typescript
+const stateToPersist: StoredState = {
+    ...this.state,
+    sessions: {},
+    activeSessionId: null,
+};
+```
+Intervention state lives in `InterventionService` (session-scoped, in-memory only). Adaptive cadence lives in `adaptiveCadence.ts` (also session-scoped). Neither is persisted through `ContextStore`.
+
+**Actual impact:** Out-of-order writes can corrupt **exercise/course priority ordering** and **active context selection**. On VS Code restart, the user might see a stale exercise list or wrong active context. This is a UX annoyance, not a thesis-data-integrity issue.
+
+**Caveat (Codex, 2026-04-26):** `migrateState()` (line 175) still preserves `sessions` and `activeSessionId` on version mismatch, weakening the "never load sessions" invariant. See [Finding #14](#14-contextstoremigratestate-rehydrates-sessions-despite-never-persist-policy--low).
+
+**Fix:** Port the `_writeChain` pattern from `courseAccessStorageService` into `ContextStore.saveState()`. Low priority given the reduced impact.
+
+---
+
 ### 5. 🎓 Dead feature toggle `DIAGNOSTIC_STABILIZATION_*` — **Medium**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
 **Location:** `src/extension/services/telemetry/types.ts:174-176` (interface), `:187-188` (defaults)
 
 **Problem:** `DIAGNOSTIC_STABILIZATION_MS` and `DIAGNOSTIC_STABILIZATION_ENABLED` are declared in `EQConfig` with defaults (`2_000`, `false`), but no code path reads either value.
 
-**Why it matters:** Dead configuration flags suggest a feature exists when it does not. A thesis reviewer seeing the flag will ask about it; if evaluation later requires the debounce, we'll silently have the wrong behavior.
+**Why it matters:** Dead configuration flags suggest a feature exists when it does not. A thesis reviewer seeing the flag will ask about it.
 
-**Verified (2026-04-15):** CONFIRMED. Verification agent grep'd the entire `src/` and `test/` trees — no reads. Both `CompileEquivalentEmitter` and `ErrorQuotientEngine` store the config but read only: `DEDUP_WINDOW_MS`, `WEIGHT_BOTH_ERROR`, `WEIGHT_SAME_TYPE`, `MAX_PAIR_SCORE`, `SESSION_INACTIVITY_SPLIT_MS`. The two stabilization fields are truly orphaned.
+**Re-verified (2026-04-26):** Still confirmed. No reads in `src/` or `test/`.
 
-**Fix:** Either wire the flag into `CompileEquivalentEmitter` / `ErrorQuotientEngine` (where diagnostics stabilization would apply), or remove the declarations. Decide during Ch. 6 writeup.
+**Fix:** Remove the declarations, or wire the flag into `CompileEquivalentEmitter`. Decide during Ch. 6 writeup.
 
 ---
 
-### 6. 🎓 EQ thresholds scattered & undocumented — **Medium**
-- [ ] **Status**
+### 6. 🎓 EQ thresholds scattered across files — **Medium**
+- [ ] **Status: OPEN**
 
 **Location:**
-- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:27-31` — decision bands `{ subtle: 0.15, notification: 0.35, proactive: 0.60 }` + magic `0.85` override at line ~86
-- `src/extension/services/telemetry/interventionService.ts:17,20` — message-selection refinements: `EQ_REPEATED_ERRORS_THRESHOLD = 0.45`, `EQ_SEVERE_STRUGGLE_THRESHOLD = 0.80`
+- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:28-32` — decision bands `{ subtle: 0.15, notification: 0.35, proactive: 0.60 }`
+- `src/extension/services/telemetry/decision/interventionDecisionEngine.ts:133` — magic `0.85` severe/proactive override
+- `src/extension/services/telemetry/interventionService.ts:44,47` — message-selection thresholds: `EQ_REPEATED_ERRORS_THRESHOLD = 0.45`, `EQ_SEVERE_STRUGGLE_THRESHOLD = 0.80`
+- `src/extension/services/telemetry/interventionFilter.ts:~85` — additional `0.85` override (Codex, 2026-04-26)
 
-**Problem:** EQ thresholds are hardcoded across files. No shared constants module; no documentation for why the decision bands (0.15/0.35/0.60) and message-refinement bands (0.45/0.80) are set where they are.
+**Problem:** EQ thresholds are hardcoded across 3+ files. No shared constants module; no documentation explaining the semantic role of each band.
 
-**Why it matters:** For thesis evaluation we will need to tune thresholds per cohort/exercise. Today that requires edits in 3+ files and a rebuild.
+**Re-verified (2026-04-26):** Confirmed and broader than originally documented. The `0.85` override appears in both `interventionDecisionEngine.ts` and `interventionFilter.ts`.
 
-**Verified (2026-04-15):** CONFIRMED with refinement: the two sets of numbers are **not** duplicates of the same concept — they serve different semantic purposes. The decision-engine bands gate *whether* to intervene; the message-selection bands refine *which message* to show within a band. The original "duplication" framing was misleading. The real issues are: (1) no central source, (2) no documentation explaining why 0.45 lives between 0.35 (notification) and 0.60 (proactive), and (3) magic numbers untunable at runtime.
-
-**Fix:** Move all EQ thresholds into a single `EQ_THRESHOLDS` object in `types.ts` with doc comments that explain the semantic role of each band. Reference from both files. Add a `package.json` contribution so thresholds are tunable via user settings without rebuild.
+**Fix:** Move all EQ thresholds into a single `EQ_THRESHOLDS` object in `types.ts` with doc comments explaining each band's semantic role. Reference from all consuming files.
 
 ---
 
 ### 7. VCS access token: GET-failure fallback creates on any error — **Medium**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
-**Location:** `src/extension/api/artemisApi.ts:211-217`, test at `test/unit/api/artemisApi.test.ts:551`
+**Location:** `src/extension/api/artemisApi.ts:211-218`, test at `test/unit/api/artemisApi.test.ts:551`
 
-**Problem:** `getOrCreateVcsAccessToken()` wraps the GET in a try/catch and falls back to POST create on **any** thrown error. `makeRequest()` throws `ApiError` for any non-OK status, so network errors, 5xx, and auth errors all funnel into the create path.
+**Problem:** `getOrCreateVcsAccessToken()` catches ALL errors from GET and falls back to POST create. Network errors, 5xx, and auth errors all funnel into the create path.
 
-**Why it matters:** Turns a read path into an unintended write. Masks real failures behind a confusing "token created" path.
+**Re-verified (2026-04-26):** Still confirmed. No error discrimination. Additional note (Codex): on 401, `makeRequest()` clears auth before the fallback, making the blind PUT especially noisy.
 
-**Verified (2026-04-15):** CONFIRMED. The catch block has no discrimination. **Important caveat:** the test at `test/unit/api/artemisApi.test.ts:551-576` **explicitly asserts this behavior** — it mocks a 404 and expects the fallback to POST create. Changing to discriminate (only create on 404) will require **updating that test** to assert error propagation on non-404 failures. Plan both changes in the same PR.
-
-**Fix:** Only create on `ApiError` with status `404`. Propagate other errors. Update the affected test to pin the new contract.
+**Fix:** Only create on `ApiError` with status `404`. Propagate other errors. Update the test at `:551-576`.
 
 ---
 
 ### 8. Domain parsers coerce instead of validate — **Medium**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
 **Location:** `src/extension/domain/core.ts` — multiple call sites:
 - `:52` — `login: String(d.login)` (parseArtemisUser)
 - `:83-85` — `id: Number(d.id)`, `title: String(d.title)`, `shortName: String(d.shortName)` (parseArtemisCourse)
-- `:116` — `id: Number(d.id)`, `:119` — `type: String(d.type) as ArtemisExercise['type']` (parseArtemisExercise)
-- `:175` — `type: String(d.type) as ArtemisParticipation['type']` (parseArtemisParticipation)
+- `:116,119` — `id: Number(d.id)`, `type: String(d.type) as ArtemisExercise['type']` (parseArtemisExercise)
+- `:146` — `id: Number(d.id)` (parseArtemisResult) (added 2026-04-26)
+- `:174` — `id: Number(d.id)`, `type: String(d.type) as ArtemisParticipation['type']` (parseArtemisParticipation)
 
-**Problem:** Required fields parsed with `String(...)`, `Number(...)`, and unchecked enum casts. Malformed payloads become `"undefined"`, `NaN`, or impossible union members while the type system claims validity. No upstream validation layer (no zod/io-ts/custom validators found).
+**Problem:** Required fields parsed with `String(...)`, `Number(...)`, and unchecked enum casts. Malformed payloads become `"undefined"`, `NaN`, or impossible union members. `parseArtemisFeedback` does proper typeof checks for primitives but still casts enums without validation (see [Finding #16](#16-parseartemisfeedback-does-not-validate-enum-membership--low)).
 
-**Why it matters:** Garbage-in-garbage-out cascades: downstream code trusts the typed shape and fails at an unrelated call site. E.g. `NaN` participation IDs land in `getLatestPendingSubmission(participation.id)` (`exerciseDataLoader.ts:121`), producing malformed URLs.
+**Re-verified (2026-04-26):** Confirmed with broader scope (7 locations across 5 parser functions).
 
-**Verified (2026-04-15):** CONFIRMED with broader scope than original claim — **6 locations** across 4 parser functions, not just line 52.
-
-**Fix:** Add explicit required-field checks and enum-membership validation. Throw or return `undefined` on invalid input rather than casting. Consider adopting zod once for the domain module — it pays for itself immediately across all 4 parsers.
+**Fix:** Add explicit required-field checks and enum-membership validation. Consider adopting zod for the domain module.
 
 ---
 
-### 9. `handleCloneRepository()` god method + untracked timers — **Medium**
-- [ ] **Status**
+### 9. `handleCloneRepository()` god method — ~~Medium (god method + timers)~~ **Medium (god method only)**
+- [ ] **Status: PARTIALLY FIXED** (timer leak resolved, maintainability remains)
 
-**Location:** `src/extension/controller/commands/repositoryCommands.ts:201-373` (172-line method), timers at `:348` (setInterval) and `:364` (setTimeout). Existing `dispose()` at `:51-65` only clears `workspaceChangeDebounce` and `dirtyPagesCheckDebounce`.
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:202-357` (~155-line method)
 
-**Problem:**
-- One 172-line method handles **~8 distinct responsibilities**: payload extraction + validation, git availability check, folder-prompt UX + config mutation, token retrieval, clone transport selection (Theia vs terminal), cache management, polling, delayed folder-open, error handling.
-- The clone flow creates a `setInterval` (polling, line 348) and a `setTimeout` (delayed open, line 364) as **local variables** — never tracked in a class field, never cleared by `dispose()`.
+**Original problem:** 172-line method handling ~8 responsibilities, with untracked `setInterval` and `setTimeout` for clone monitoring.
 
-**Why it matters:** The tight coupling is already hiding cleanup problems; the untracked timers can outlive the class instance and keep firing after navigation or extension shutdown.
+**Timer leak: FIXED.** The method now uses `await cloneRepositoryProgrammatic(cloneUrl, repoPath, exerciseTitle)` at line 329 instead of fire-and-forget terminal clone + polling. No `setInterval` or `setTimeout` for clone monitoring. All remaining timers in `RepositoryCommandModule` (`workspaceChangeDebounce`, `dirtyPagesCheckDebounce`) are tracked in class fields and cleared in `dispose()`.
 
-**Verified (2026-04-15):** CONFIRMED. Responsibility count is on the higher end (5 if you lump UX steps, 8 if you separate them). Timer leak is real. **Caveat:** `RepositoryCommandModule` lifetime appears to be extension-scoped, so in practice the timers are GC'd at shutdown. The bigger issue is the maintainability of the 172-line method and the surprise that `dispose()` is a partial no-op.
+**God method: STILL OPEN.** The method is still ~155 lines handling 5+ responsibilities: payload extraction + validation, git availability check, folder-prompt UX + config mutation, token retrieval, clone execution + cache management, post-clone UX.
 
-**Fix:** Split into helpers (`resolveDestination`, `performClone`, `trackCloneCompletion`, `postCloneUx`). Store timer handles on the class; clear in `dispose()`.
+**Fix:** Split into helpers (`resolveDestination`, `performClone`, `postCloneUx`). Lower priority now that the timer leak is resolved.
 
 ---
 
 ## Priority: Nice-to-have
 
 ### 10. `_useBearerAuth` is set-only — **Low** (design-smell, not a bug)
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
-**Location:** `src/extension/services/auth/authManager.ts:11,21-23` (flag declared, only setter); used at `:105`. Set from `theiaAuthProvider.ts:25`.
+**Location:** `src/extension/services/auth/authManager.ts:11,21-23` (flag declared, only setter); read at `:105`. Set from `theiaAuthProvider.ts`.
 
-**Problem:** `enableBearerAuth()` exists; no `disableBearerAuth()`. `clear()` does not reset the flag either.
+**Problem:** `enableBearerAuth()` exists; no `disableBearerAuth()`. `clear()` does not reset the flag.
 
-**Why it matters:** `AuthManager` is a per-activation singleton (constructed once at `extension.ts:37`; Theia/Desktop mode is detected at startup and never changes within a session). The flag can't practically need to flip today. But the asymmetric API invites a future bug if `AuthManager` ever gets reused across sessions.
+**Re-verified (2026-04-26):** Still confirmed. Design smell, not a bug. `AuthManager` is a per-activation singleton.
 
-**Verified (2026-04-15):** CONFIRMED — but the verification agent rightly flagged this as a **design smell, not a functional bug**. No call path can currently trigger the wrong behavior.
-
-**Fix:** Preferred: encode auth mode as an **immutable constructor argument** (`new AuthManager(context, { mode: 'bearer' | 'cookie' })`). That eliminates the asymmetric setter entirely. Second choice: add `disableBearerAuth()` for symmetry and reset it in `clear()`. Low priority — bundle with other cosmetic auth cleanup.
+**Fix:** Encode auth mode as an immutable constructor argument. Low priority.
 
 ---
 
 ### 11. `authManager.clear()` memory/secrets race window — **Low**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
-**Location:** `src/extension/services/auth/authManager.ts:120-128` (`clear()`) and `:85-96` (`getStoredToken()`).
+**Location:** `src/extension/services/auth/authManager.ts:120-128`
 
-**Problem:** `memoryToken = undefined` at line 121 is synchronous; `secrets.delete()` at line 123 is async. Between those two statements, a concurrent `getStoredToken()` skips memory and reads the stale secret (returns the old token).
+**Problem:** `memoryToken = undefined` (sync) then `await secrets.delete()` (async). Concurrent `getStoredToken()` can read the stale secret between these two statements.
 
-**Why it matters:** Concurrent readers exist: `makeRequest()` in `artemisApi.ts:45` and `connect()` in `artemisWebsocketService.ts:297` both call `getAuthHeaders() → getStoredToken()`. During logout there can be a pending WebSocket reconnect or API request in flight.
+**Re-verified (2026-04-26):** Still confirmed. Narrow window (one microtask boundary). Mitigated by the 401/`onAuthExpired` handler.
 
-**Verified (2026-04-15):** CONFIRMED. Window is real (not just theoretical), but **narrow** — one microtask boundary. Mitigating factor: a stale read produces an eventual 401, which the `onAuthExpired` handler in `extension.ts:184` catches and re-triggers auth cleanup. So the user-visible impact is a momentary confusing log line, not broken logout.
-
-**Fix:** Await `secrets.delete()` before setting `memoryToken = undefined`, or serialize both through a single `clearPromise`. Trivial change; include with other auth cleanup.
+**Fix:** Await `secrets.delete()` before clearing `memoryToken`, or serialize through a single `clearPromise`. Trivial change.
 
 ---
 
 ### 12. Dead API `hasRecentlyClonedRepo()` with key drift — **Low**
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
-**Location:** `src/extension/controller/commands/repositoryCommands.ts:133` (definition), `:205` (sibling helper that aliases `exerciseId = participationId`), `:342` (cache write using the alias), and `webViewMessageHandler.ts:146` (thin wrapper — delegation only, not a real external caller).
+**Location:** `src/extension/controller/commands/repositoryCommands.ts:134` (definition), `:206` (`exerciseId = participationId` alias), `webViewMessageHandler.ts:146` (unused wrapper)
 
-**Problem:** `hasRecentlyClonedRepo()` has no external callers (the `webViewMessageHandler` entry is just a delegation wrapper with no upstream caller). The cache it consults is actually keyed by `participationId`, while the function's signature declares `exerciseId: number`.
+**Problem:** `hasRecentlyClonedRepo()` has no external callers. The cache is keyed by `participationId` but the method parameter is named `exerciseId`.
 
-**Why it matters:** Dead public APIs with mismatched semantics mislead future maintainers and produce wrong answers if ever wired up.
+**Re-verified (2026-04-26):** Still confirmed. Both the method and its wrapper in `webViewMessageHandler` are dead code.
 
-**Verified (2026-04-15):** CONFIRMED for both claims: (a) truly dead (no real call site outside of its own module and a dead wrapper), (b) key-drift is real (`repositoryCommands.ts:205` comment: `const exerciseId = participationId; // Use participationId for tracking`).
-
-**Fix:** Remove the function and its delegation wrapper. If the capability is actually needed later, rewrite with a correctly named key.
+**Fix:** Remove the function and its delegation wrapper.
 
 ---
 
 ### 13. Misleading name `isNoAiEnabled` — **Low** (style / clarity, not a bug)
-- [ ] **Status**
+- [ ] **Status: OPEN**
 
-**Location:** `src/extension/services/workspace/noAiDetectionService.ts:72` (property), `:150,161` (assignments), `chatWebviewProvider.ts:232,259-261`, `chatMessageService.ts:31-33`.
+**Location:** `src/extension/services/workspace/noAiDetectionService.ts:72`
 
-**Problem:** The property reads "is NO-AI enabled" which most maintainers parse as "is AI enabled?" (false). Actual semantic: true when `.noai` is present, meaning AI is **disabled**. Call sites invert the reading (`if (isNoAiEnabled) { /* block AI */ }`).
+**Problem:** Property reads "is NO-AI enabled" which most maintainers parse as "is AI enabled?". Actual semantic: true when `.noai` is present, meaning AI is **disabled**.
 
-**Why it matters:** Invites sign-flip bugs on future changes; reviewers have to mentally invert.
+**Re-verified (2026-04-26):** Still confirmed.
 
-**Verified (2026-04-15):** CONFIRMED as a **style/clarity issue**. The name is defensible if parsed as "is the no-ai signal enabled" — that's why the agent marked it "CONFIRMED with caveat". It is not a functional bug. Still worth renaming.
-
-**Fix:** Rename to `isNoAiDetected` (minimal churn, matches JSDoc "Returns true if a .noai file was detected") or `isAiDisabledByNoAiFile` (most explicit). Update all 4-5 call sites. Low urgency.
+**Fix:** Rename to `isNoAiDetected` (minimal churn) or `hasNoAiRestriction` (most explicit). Update all call sites.
 
 ---
 
-## Test coverage gaps
+## New issues (2026-04-26)
 
-**Extension-side orchestration** around clone/submit/init is thin; current tests mostly stop at "handler registered".
+### 14. `ContextStore.migrateState()` rehydrates sessions despite "never persist" policy — **Low**
+- [ ] **Status: NEW**
 
-Add focused unit tests for:
-- [ ] Repeated `resolveWebviewView()` / `dispose()` cycles (covers Finding #3)
-- [ ] `deactivate()` awaiting recorder shutdown (covers Finding #2)
-- [ ] `storageWriter` flush failure + retry behavior (covers Finding #1)
-- [ ] `handleCloneRepository` unhappy paths: git failure, auth failure, timer cleanup (covers Finding #9)
-- [ ] `ContextStore` rapid concurrent writes preserving order (covers Finding #4)
+**Location:** `src/extension/services/iris/contextStore.ts:175-186`
+
+**Problem:** `loadState()` strips `sessions` and `activeSessionId` for current-version state (lines 168-172), enforcing the "never load sessions" invariant. But `migrateState()` (lines 175-186) preserves both fields when `raw.version !== STORE_VERSION`:
+```typescript
+return {
+    version: STORE_VERSION,
+    // ...
+    activeSessionId: previous.activeSessionId ?? null,
+    sessions: previous.sessions ?? {},
+};
+```
+If a future schema bump changes `STORE_VERSION`, old persisted state with stale sessions would be rehydrated rather than stripped.
+
+**Fix:** Strip `sessions` and `activeSessionId` in `migrateState()` the same way `loadState()` does.
+
+---
+
+### 15. `NoAiDetectionService._setupFileWatcher()` leaks disposed watchers in `_disposables` �� **Low**
+- [ ] **Status: NEW**
+
+**Location:** `src/extension/services/workspace/noAiDetectionService.ts:101-123`
+
+**Problem:** `_setupFileWatcher()` disposes the previous watcher via `this._fileWatcher?.dispose()` (line 103), then creates a new one and pushes it to `_disposables` (line 122). The old disposed watcher remains in the `_disposables` array. On repeated workspace-folder changes, `_disposables` grows with already-disposed watchers.
+
+**Impact:** The disposed watchers are no-ops when `dispose()` is called again (VS Code disposables are idempotent), so this is a minor memory leak, not a functional bug. The array is bounded by the number of workspace-folder change events per session.
+
+**Fix:** Either remove the old watcher from `_disposables` before pushing the new one, or track the watcher in `_fileWatcher` only (not in `_disposables`) and dispose it explicitly in the main `dispose()` method.
+
+---
+
+### 16. `parseArtemisFeedback()` does not validate enum membership — **Low**
+- [ ] **Status: NEW**
+
+**Location:** `src/extension/domain/core.ts:26`
+
+**Problem:** `parseArtemisFeedback` does proper `typeof` checks for primitive fields, but still casts enums without membership validation:
+```typescript
+type: typeof d.type === 'string' ? d.type as 'AUTOMATIC' | 'MANUAL' : undefined,
+```
+Any string passes the `typeof` check and becomes a valid-looking `'AUTOMATIC' | 'MANUAL'` union member.
+
+**Impact:** Low. The `type` field is only used for display, not for branching logic. If Artemis introduces new feedback types, they will silently pass through.
+
+**Fix:** Add enum membership check: `['AUTOMATIC', 'MANUAL'].includes(d.type) ? d.type as ... : undefined`. Bundle with Finding #8.
 
 ---
 
@@ -285,15 +343,16 @@ Findings that surfaced during review but were **verified false** — documented 
 
 ---
 
-## Execution plan
+## Execution plan (updated 2026-04-26)
 
-Suggested order (highest thesis-impact first):
+Suggested order (highest remaining impact first):
 
-1. **Finding #1** + **Finding #2** — telemetry durability. Small diffs, biggest impact on thesis data integrity.
-2. **Finding #4** — ContextStore write ordering. Protects intervention guardrails across restarts.
-3. **Finding #3** — webview listener leaks. Independent PR, good test target.
-4. **Findings #5, #6** — thesis-relevant config hygiene. Worth doing while Ch. 6 writeup is active.
-5. **Findings #7, #8, #9** — extension-host robustness.
-6. **Findings #10–#13** — low-priority cleanup; bundle into one PR.
+1. ~~**Finding #1** + **Finding #2**~~ — **DONE.** Telemetry durability fixes already on `dev`.
+2. **Finding #3** — Webview listener leaks. Independent PR, good test target. Only remaining High-priority item.
+3. **Findings #5, #6** — Thesis-relevant config hygiene. Worth doing while Ch. 6 writeup is active.
+4. **Findings #7, #8, #16** — Domain robustness (bundle parser fixes together).
+5. **Finding #9** — God-method cleanup. Lower priority now that timer leak is resolved.
+6. **Finding #4** — ContextStore write ordering. Reduced impact, can be bundled with #14.
+7. **Findings #10-#13, #15** — Low-priority cleanup; bundle into one PR.
 
 Each item should ship as a dedicated PR against `dev` with a test covering the fix, per project convention.


### PR DESCRIPTION
## Summary
- Consolidates findings from parallel Codex and Claude reviews of `extension/src/`
- 13 actionable items plus test coverage gaps, ranked by priority with checkboxes for tracking
- Thesis-critical items (struggle-detection data path) are marked 🎓
- Documents two false-positive findings under "Not-a-bug" so they don't get re-investigated

## Scope
Documentation only — no code changes. Lives at `extension/docs/code-review-findings-2026-04.md`.

## Test plan
- [ ] Verify checkboxes render correctly on GitHub
- [ ] Verify anchor links in the summary checklist jump to the right sections