### PR TITLE
feat(iris): display Iris processing stage status in chat

### DIFF
--- a/extension/src/extension/services/websocket/websocketMessageHandler.ts
+++ b/extension/src/extension/services/websocket/websocketMessageHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ArtemisWebsocketService } from './artemisWebsocketService';
 import { IrisWebSocketSessionClient } from '../iris/irisWebSocketSessionClient';
-import type { IrisChatMessage } from '../../types';
+import type { IrisChatMessage, IrisStageDTO } from '../../types';
 import { logger, LogCategory } from '../loggingService';
 import { extractIrisMessageContent } from '../iris/messageUtils';
 import { ExtensionMsg } from '../../../shared/messageContracts';
@@ -65,9 +65,20 @@ export class IrisWebSocketMessageHandler {
                 logger.info('Skipping message (either USER message or no content)', LogCategory.WEBSOCKET);
             }
         } else if (data.type === 'STATUS') {
-            // Handle status updates (e.g., "Iris is thinking...")
-            logger.info(`Iris status update: ${JSON.stringify(data)}`, LogCategory.WEBSOCKET);
-            // TODO: Show status indicator in UI
+            const rawStages = data['stages'];
+            if (Array.isArray(rawStages)) {
+                const visibleStages = (rawStages as unknown[]).filter(
+                    (stage): stage is IrisStageDTO =>
+                        typeof stage === 'object' && stage !== null && (stage as IrisStageDTO).internal !== true
+                );
+                logger.info(`Iris status update: ${visibleStages.length} visible stage(s)`, LogCategory.WEBSOCKET);
+                this._postMessage({
+                    type: ExtensionMsg.UpdateIrisStages,
+                    stages: visibleStages,
+                });
+            } else {
+                logger.info(`Iris STATUS message without stages array: ${JSON.stringify(data)}`, LogCategory.WEBSOCKET);
+            }
         }
     }
 

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -7,6 +7,7 @@ import type {
     StudentExam,
     ResultSummary,
     SubmissionSummary,
+    IrisStageDTO,
 } from '../types/apiResponses';
 import type { CourseData, ArchivedCourse, CourseDetailData, RecentCourseNode } from './domainTypes';
 import type { ChatContextType } from '../types/context';
@@ -54,6 +55,7 @@ export const ExtensionMsg = {
     ShowDisabledState: 'showDisabledState',
     HideDisabledState: 'hideDisabledState',
     UpdateNoAiStatus: 'updateNoAiStatus',
+    UpdateIrisStages: 'updateIrisStages',
 
     // Exercise/Repo responses
     UpdateRepoStatus: 'updateRepoStatus',
@@ -232,6 +234,9 @@ interface ExtensionMsgPayloads {
     updateNoAiStatus: {
         isNoAiDetected: boolean;
         noAiFilePath?: string;
+    };
+    updateIrisStages: {
+        stages: IrisStageDTO[];
     };
 
     // Exercise/Repo responses

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -132,6 +132,15 @@ export interface IrisChatMessageContent {
     [key: string]: unknown;
 }
 
+export interface IrisStageDTO {
+    name?: string;
+    weight?: number;
+    state?: 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'SKIPPED' | 'ERROR';
+    message?: string;
+    internal?: boolean;
+    [key: string]: unknown;
+}
+
 export interface IrisSettingsResponse {
     settings?: {
         enabled?: boolean;

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -6,7 +6,8 @@ import type {
     ChatContext,
     ContextItem,
     ReferencedFilesData,
-    StreamingState
+    StreamingState,
+    IrisStageDTO,
 } from '../views/IrisChat/types';
 import type { ExtMsg } from '../../shared/messageContracts';
 
@@ -25,6 +26,9 @@ interface ChatState {
 
     // Streaming
     streaming: StreamingState;
+
+    // Iris processing stages
+    irisStages: IrisStageDTO[];
 
     // UI state
     isLoading: boolean;
@@ -45,6 +49,10 @@ interface ChatState {
     startStreaming: (localId: string) => void;
     appendStreamChunk: (chunk: string) => void;
     finishStreaming: (finalContent: string) => void;
+
+    // Iris stage actions
+    setIrisStages: (stages: IrisStageDTO[]) => void;
+    resetTransientChatUi: () => void;
 
     // UI actions
     setLoading: (loading: boolean) => void;
@@ -72,6 +80,7 @@ export const useChatStore = create<ChatState>()(
                 messageLocalId: null,
                 visibleChunks: [],
             },
+            irisStages: [],
             isLoading: false,
             isWebSocketConnected: false,
             disabledMessage: null,
@@ -121,6 +130,7 @@ export const useChatStore = create<ChatState>()(
             clearMessages: () => {
                 set({
                     messages: [],
+                    irisStages: [],
                     streaming: { isStreaming: false, messageLocalId: null, visibleChunks: [] },
                 }, false, 'clearMessages');
             },
@@ -169,6 +179,17 @@ export const useChatStore = create<ChatState>()(
                             : state.messages,
                     };
                 }, false, 'finishStreaming');
+            },
+
+            setIrisStages: (stages) => {
+                set({ irisStages: stages }, false, 'setIrisStages');
+            },
+
+            resetTransientChatUi: () => {
+                set({
+                    irisStages: [],
+                    streaming: { isStreaming: false, messageLocalId: null, visibleChunks: [] },
+                }, false, 'resetTransientChatUi');
             },
 
             // UI actions

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -244,7 +244,9 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // Check if workspace exercise exists
     const hasWorkspaceExercise = store.allExercises.some(ex => ex.isWorkspace);
 
-    // Derive active stage: first stage that is not DONE or SKIPPED
+    // Derive active stage: first stage that is not DONE or SKIPPED.
+    // NOT_STARTED is intentionally included: it shows dots immediately while
+    // Artemis transitions the stage to IN_PROGRESS (provides instant feedback).
     const activeStage = useMemo<IrisStageDTO | null>(() => {
         for (const stage of store.irisStages) {
             if (stage.state !== 'DONE' && stage.state !== 'SKIPPED') {

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { ExtensionMsg, postCommand } from '../../../shared/messageContracts';
 import type { VsCodeApi } from '../../../shared/messageContracts';
+import type { IrisStageDTO } from './types';
 import { useChatStore } from '../../stores/useChatStore';
 import { useExtensionMessage } from '../../hooks/useExtensionMessage';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -20,7 +21,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     const {
         setIrisState, setShowDiagnostics, addMessage, setMessages,
         clearMessages, setReferencedFiles, setWebSocketConnected,
-        setDisabledMessage, setNoAiDetected,
+        setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi,
     } = store;
     const [sideMenuOpen, setSideMenuOpen] = useState(false);
     const [forceContextPicker, setForceContextPicker] = useState(false);
@@ -79,12 +80,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     status: 'sent',
                 });
                 if (m.role === 'assistant') {
-                    store.finishStreaming(m.content);
+                    resetTransientChatUi();
                 }
                 break;
             }
 
             case ExtensionMsg.LoadMessages: {
+                resetTransientChatUi();
                 setMessages(msg.messages.map((m) => ({
                     id: m.id,
                     localId: crypto.randomUUID(),
@@ -98,6 +100,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             }
 
             case ExtensionMsg.ClearChatMessages:
+                resetTransientChatUi();
                 clearMessages();
                 break;
 
@@ -112,6 +115,9 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
             case ExtensionMsg.UpdateWebSocketStatus: {
                 setWebSocketConnected(msg.isConnected);
+                if (!msg.isConnected) {
+                    resetTransientChatUi();
+                }
                 break;
             }
 
@@ -128,8 +134,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 setNoAiDetected(msg.isNoAiDetected);
                 break;
             }
+
+            case ExtensionMsg.UpdateIrisStages: {
+                setIrisStages(msg.stages);
+                break;
+            }
         }
-    }, [setIrisState, setShowDiagnostics, addMessage, setMessages, clearMessages, setReferencedFiles, setWebSocketConnected, setDisabledMessage, setNoAiDetected]);
+    }, [setIrisState, setShowDiagnostics, addMessage, setMessages, clearMessages, setReferencedFiles, setWebSocketConnected, setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi]);
 
     // State persistence (only forceContextPicker)
     useEffect(() => {
@@ -147,6 +158,9 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
     const handleSendMessage = (text: string) => {
         const localId = crypto.randomUUID();
+
+        // Clear any stale stages/streaming from previous request
+        resetTransientChatUi();
 
         // Add optimistic message
         store.addMessage({
@@ -229,6 +243,16 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
     // Check if workspace exercise exists
     const hasWorkspaceExercise = store.allExercises.some(ex => ex.isWorkspace);
+
+    // Derive active stage: first stage that is not DONE or SKIPPED
+    const activeStage = useMemo<IrisStageDTO | null>(() => {
+        for (const stage of store.irisStages) {
+            if (stage.state !== 'DONE' && stage.state !== 'SKIPPED') {
+                return stage;
+            }
+        }
+        return null;
+    }, [store.irisStages]);
 
     return (
         <div className={styles.container}>
@@ -376,6 +400,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     <ChatMessageList
                         messages={store.messages}
                         streaming={store.streaming}
+                        activeStage={activeStage}
                         onFeedback={handleFeedback}
                         onSendPrompt={handleSendMessage}
                         hasContext={store.context !== null}

--- a/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
@@ -3,12 +3,13 @@ import { MessageBubble } from './MessageBubble';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { WelcomeState } from './WelcomeState';
 import { useAutoScroll } from '../../../hooks/useAutoScroll';
-import type { ChatMessage, StreamingState } from '../types';
+import type { ChatMessage, StreamingState, IrisStageDTO } from '../types';
 import styles from './ChatMessageList.module.css';
 
 interface ChatMessageListProps {
     messages: ChatMessage[];
     streaming: StreamingState;
+    activeStage: IrisStageDTO | null;
     onFeedback: (messageId: number, feedback: 'positive' | 'negative') => void;
     onSendPrompt: (text: string) => void;
     hasContext: boolean;
@@ -18,6 +19,7 @@ interface ChatMessageListProps {
 export function ChatMessageList({
     messages,
     streaming,
+    activeStage,
     onFeedback,
     onSendPrompt,
     hasContext,
@@ -33,8 +35,13 @@ export function ChatMessageList({
     // Show welcome state when no messages
     const showWelcome = messages.length === 0;
 
-    // Show thinking indicator when streaming started but no chunks yet
-    const showThinking = streaming.isStreaming && streaming.visibleChunks.length === 0;
+    // Stage indicator takes priority; both suppressed once streaming chunks arrive
+    const hasChunks = streaming.visibleChunks.length > 0;
+    const showStageIndicator = activeStage !== null && !hasChunks;
+    const showLegacyThinking = !showStageIndicator
+        && streaming.isStreaming
+        && !hasChunks;
+    const showThinking = showStageIndicator || showLegacyThinking;
 
     return (
         <div ref={scrollRef} className={styles.scrollContainer}>
@@ -63,7 +70,12 @@ export function ChatMessageList({
                         })}
 
                         {/* Show thinking indicator between user message and first chunk */}
-                        {showThinking && <ThinkingIndicator isVisible={true} />}
+                        {showThinking && (
+                            <ThinkingIndicator
+                                isVisible={true}
+                                activeStage={showStageIndicator ? activeStage : null}
+                            />
+                        )}
                     </>
                 )}
             </div>

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
@@ -1,26 +1,23 @@
 .container {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
+    gap: 8px;
     padding: 12px 16px;
     margin: 8px 0;
     max-width: 70%;
     transition: opacity 150ms ease-out;
 }
 
-.dotsContainer {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 8px 12px;
-    background: var(--vscode-editor-background);
-    border-radius: 12px;
-    border: 1px solid var(--vscode-panel-border);
+.logo {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    animation: pulse 2s ease-in-out infinite;
 }
 
 .statusText {
     font-size: 12px;
     color: var(--vscode-descriptionForeground);
-    margin-right: 8px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -30,15 +27,6 @@
 .labelWrapper {
     display: inline-block;
     animation: slideUp 0.4s ease-out;
-}
-
-.dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--vscode-foreground);
-    opacity: 0.4;
-    animation: bounce 1.2s infinite ease-in-out;
 }
 
 .errorContainer {
@@ -61,15 +49,9 @@
     color: var(--vscode-errorForeground, #f44);
 }
 
-@keyframes bounce {
-    0%, 80%, 100% {
-        transform: translateY(0);
-        opacity: 0.4;
-    }
-    40% {
-        transform: translateY(-8px);
-        opacity: 1;
-    }
+@keyframes pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(0.92); }
 }
 
 @keyframes slideUp {
@@ -84,9 +66,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .dot {
+    .logo {
         animation: none;
-        opacity: 0.6;
     }
 
     .labelWrapper {

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
@@ -17,6 +17,21 @@
     border: 1px solid var(--vscode-panel-border);
 }
 
+.statusText {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin-right: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+}
+
+.labelWrapper {
+    display: inline-block;
+    animation: slideUp 0.4s ease-out;
+}
+
 .dot {
     width: 8px;
     height: 8px;
@@ -24,6 +39,26 @@
     background: var(--vscode-foreground);
     opacity: 0.4;
     animation: bounce 1.2s infinite ease-in-out;
+}
+
+.errorContainer {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    background: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+    border-radius: 12px;
+    border: 1px solid var(--vscode-inputValidation-errorBorder, #f44);
+}
+
+.errorIcon {
+    color: var(--vscode-errorForeground, #f44);
+    flex-shrink: 0;
+}
+
+.errorText {
+    font-size: 12px;
+    color: var(--vscode-errorForeground, #f44);
 }
 
 @keyframes bounce {
@@ -34,5 +69,27 @@
     40% {
         transform: translateY(-8px);
         opacity: 1;
+    }
+}
+
+@keyframes slideUp {
+    from {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dot {
+        animation: none;
+        opacity: 0.6;
+    }
+
+    .labelWrapper {
+        animation: none;
     }
 }

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
@@ -1,19 +1,95 @@
+import { useState, useEffect, useRef } from 'react';
+import type { IrisStageDTO } from '../types';
 import styles from './ThinkingIndicator.module.css';
+
+const ROTATION_LABELS = [
+    'Thinking hard',
+    'Analyzing context',
+    'Processing your request',
+    'Formulating a response',
+];
+const ROTATION_INTERVAL_MS = 2600;
 
 interface ThinkingIndicatorProps {
     isVisible?: boolean;
+    activeStage?: IrisStageDTO | null;
 }
 
-export function ThinkingIndicator({ isVisible = true }: ThinkingIndicatorProps) {
-    if (!isVisible) {return null;}
+export function ThinkingIndicator({
+    isVisible = true,
+    activeStage = null,
+}: ThinkingIndicatorProps) {
+    if (!isVisible) { return null; }
+
+    if (activeStage?.state === 'ERROR') {
+        return (
+            <div className={styles.container}>
+                <div className={styles.errorContainer} role="alert">
+                    <span className={styles.errorIcon} aria-hidden="true">&#9888;</span>
+                    <span className={styles.errorText}>{activeStage.message || 'An error occurred'}</span>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={styles.container}>
             <div className={styles.dotsContainer}>
+                {activeStage?.state === 'IN_PROGRESS' ? (
+                    <StageLabel activeStage={activeStage} />
+                ) : null}
                 <span className={styles.dot} style={{ animationDelay: '0s' }} />
                 <span className={styles.dot} style={{ animationDelay: '0.2s' }} />
                 <span className={styles.dot} style={{ animationDelay: '0.4s' }} />
             </div>
         </div>
+    );
+}
+
+/** Internal component managing label rotation, keyed on stageKey for stable identity */
+function StageLabel({ activeStage }: { activeStage: IrisStageDTO }) {
+    const stageKey = `${activeStage.name}:${activeStage.state}`;
+    const initialLabel = (activeStage.message && activeStage.message.length > 0)
+        ? activeStage.message
+        : ROTATION_LABELS[0];
+
+    const [displayLabel, setDisplayLabel] = useState(initialLabel);
+    const [animKey, setAnimKey] = useState(0);
+    const rotationIndex = useRef(0);
+
+    // Effect 1: Reset rotation when stage identity changes
+    useEffect(() => {
+        const startLabel = (activeStage.message && activeStage.message.length > 0)
+            ? activeStage.message
+            : ROTATION_LABELS[0];
+        rotationIndex.current = 0;
+        setDisplayLabel(startLabel);
+        setAnimKey((k) => k + 1);
+
+        const interval = setInterval(() => {
+            rotationIndex.current = (rotationIndex.current + 1) % ROTATION_LABELS.length;
+            setDisplayLabel(ROTATION_LABELS[rotationIndex.current]);
+            setAnimKey((k) => k + 1);
+        }, ROTATION_INTERVAL_MS);
+
+        return () => clearInterval(interval);
+        // Intentionally keyed on stageKey only — restarts rotation when stage identity changes
+    }, [stageKey]);
+
+    // Effect 2: Update label when server message changes without restarting timer
+    useEffect(() => {
+        if (activeStage.message && activeStage.message.length > 0) {
+            setDisplayLabel(activeStage.message);
+            setAnimKey((k) => k + 1);
+        }
+        // Intentionally only reacts to message text changes, not full stageKey re-keying
+    }, [activeStage.message]);
+
+    return (
+        <span className={styles.statusText} aria-live="polite">
+            <span key={animKey} className={styles.labelWrapper}>
+                {displayLabel}
+            </span>
+        </span>
     );
 }

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
@@ -32,16 +32,16 @@ export function ThinkingIndicator({
         );
     }
 
+    const irisLogoUri = document.getElementById('root')?.dataset.irisLogoUri;
+
     return (
-        <div className={styles.container}>
-            <div className={styles.dotsContainer}>
-                {activeStage?.state === 'IN_PROGRESS' ? (
-                    <StageLabel activeStage={activeStage} />
-                ) : null}
-                <span className={styles.dot} style={{ animationDelay: '0s' }} />
-                <span className={styles.dot} style={{ animationDelay: '0.2s' }} />
-                <span className={styles.dot} style={{ animationDelay: '0.4s' }} />
-            </div>
+        <div className={styles.container} data-testid="thinking-indicator">
+            {irisLogoUri && (
+                <img src={irisLogoUri} alt="" className={styles.logo} />
+            )}
+            {activeStage?.state === 'IN_PROGRESS' ? (
+                <StageLabel activeStage={activeStage} />
+            ) : null}
         </div>
     );
 }

--- a/extension/src/webview/views/IrisChat/types.ts
+++ b/extension/src/webview/views/IrisChat/types.ts
@@ -1,4 +1,5 @@
 import type { ExerciseRef } from '../../../shared/types';
+export type { IrisStageDTO } from '../../../shared/types/apiResponses';
 
 // Chat message as rendered in the UI
 export interface ChatMessage {

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -180,6 +180,20 @@ describe('Message contracts: ExtensionToWebviewMessage types', () => {
         expect(typeof msg.startTime).toBe('number');
         expect(typeof msg.totalDuration).toBe('number');
     });
+
+    it('UpdateIrisStagesMessage has required stages array', () => {
+        const msg = {
+            type: 'updateIrisStages' as const,
+            stages: [
+                { name: 'thinking', weight: 10, state: 'IN_PROGRESS' as const, message: 'Thinking hard', internal: false },
+            ],
+        } satisfies ExtMsg<'updateIrisStages'>;
+
+        expect(msg.type).toBe('updateIrisStages');
+        expect(Array.isArray(msg.stages)).toBe(true);
+        expect(msg.stages[0].name).toBe('thinking');
+        expect(msg.stages[0].state).toBe('IN_PROGRESS');
+    });
 });
 
 // ============================================================================

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useChatStore } from '../../../src/webview/stores/useChatStore';
-import type { ChatMessage, ChatContext, ReferencedFilesData } from '../../../src/webview/views/IrisChat/types';
+import type { ChatMessage, ChatContext, ReferencedFilesData, IrisStageDTO } from '../../../src/webview/views/IrisChat/types';
 import type { ExtMsg } from '../../../src/shared/messageContracts';
 
 const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
@@ -20,6 +20,15 @@ const makeIrisState = (overrides: Partial<ExtMsg<'updateIrisState'>['state']> = 
 	recentCourses: [],
 	allExercises: [],
 	allCourses: [],
+	...overrides,
+});
+
+const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
+	name: 'thinking',
+	weight: 10,
+	state: 'IN_PROGRESS',
+	message: 'Thinking hard',
+	internal: false,
 	...overrides,
 });
 
@@ -386,5 +395,88 @@ describe('useChatStore', () => {
 		});
 
 		expect(result.current.context).toBeNull();
+	});
+
+	it('initializes with empty irisStages', () => {
+		const { result } = renderHook(() => useChatStore());
+		expect(result.current.irisStages).toEqual([]);
+	});
+
+	it('setIrisStages replaces the stages array', () => {
+		const { result } = renderHook(() => useChatStore());
+		const stages = [makeStage({ name: 'thinking' }), makeStage({ name: 'analyzing', state: 'NOT_STARTED' })];
+
+		act(() => {
+			result.current.setIrisStages(stages);
+		});
+
+		expect(result.current.irisStages).toHaveLength(2);
+		expect(result.current.irisStages[0].name).toBe('thinking');
+		expect(result.current.irisStages[1].state).toBe('NOT_STARTED');
+	});
+
+	it('setIrisStages replaces previous stages', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setIrisStages([makeStage({ name: 'old' })]);
+		});
+
+		act(() => {
+			result.current.setIrisStages([makeStage({ name: 'new' })]);
+		});
+
+		expect(result.current.irisStages).toHaveLength(1);
+		expect(result.current.irisStages[0].name).toBe('new');
+	});
+
+	it('resetTransientChatUi clears irisStages and streaming state', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setIrisStages([makeStage()]);
+			result.current.startStreaming('msg-1');
+		});
+
+		act(() => {
+			result.current.resetTransientChatUi();
+		});
+
+		expect(result.current.irisStages).toEqual([]);
+		expect(result.current.streaming.isStreaming).toBe(false);
+		expect(result.current.streaming.messageLocalId).toBeNull();
+		expect(result.current.streaming.visibleChunks).toEqual([]);
+	});
+
+	it('resetTransientChatUi does not clear messages', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.addMessage(makeMessage({ localId: 'msg-1' }));
+			result.current.setIrisStages([makeStage()]);
+		});
+
+		act(() => {
+			result.current.resetTransientChatUi();
+		});
+
+		expect(result.current.messages).toHaveLength(1);
+		expect(result.current.irisStages).toEqual([]);
+	});
+
+	it('clearMessages also clears irisStages', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.addMessage(makeMessage({ localId: 'msg-1' }));
+			result.current.setIrisStages([makeStage()]);
+		});
+
+		act(() => {
+			result.current.clearMessages();
+		});
+
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.irisStages).toEqual([]);
 	});
 });

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -41,6 +41,7 @@ describe('IrisChatView', () => {
 			allCourses: [],
 			messages: [],
 			streaming: { isStreaming: false, messageLocalId: null, visibleChunks: [] },
+			irisStages: [],
 			isLoading: false,
 			isWebSocketConnected: true,
 			disabledMessage: null,
@@ -255,6 +256,124 @@ describe('IrisChatView', () => {
 
 		await waitFor(() => {
 			expect(screen.queryByText('Existing msg')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('irisStages reset paths', () => {
+		beforeEach(() => {
+			useChatStore.setState({
+				irisStages: [{ name: 'thinking', state: 'IN_PROGRESS', message: 'Thinking', weight: 10 }],
+				context: {
+					type: 'exercise',
+					id: 1,
+					title: 'Test Exercise',
+					locked: false,
+					source: 'user-selected',
+				},
+			});
+		});
+
+		it('clears irisStages when assistant AddMessage arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'addMessage',
+				message: { id: 1, role: 'assistant', content: 'Response', timestamp: Date.now() },
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toEqual([]);
+			});
+		});
+
+		it('does not clear irisStages when user AddMessage arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'addMessage',
+				message: { id: 1, role: 'user', content: 'Question', timestamp: Date.now() },
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toHaveLength(1);
+			});
+		});
+
+		it('clears irisStages when LoadMessages arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'loadMessages',
+				messages: [{ id: 1, role: 'user', content: 'Loaded', timestamp: Date.now(), helpful: null }],
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toEqual([]);
+			});
+		});
+
+		it('clears irisStages when ClearChatMessages arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({ type: 'clearChatMessages' });
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toEqual([]);
+			});
+		});
+
+		it('clears irisStages when UpdateWebSocketStatus(false) arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({ type: 'updateWebSocketStatus', isConnected: false });
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toEqual([]);
+			});
+		});
+
+		it('does not clear irisStages when UpdateWebSocketStatus(true) arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({ type: 'updateWebSocketStatus', isConnected: true });
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toHaveLength(1);
+			});
+		});
+
+		it('clears irisStages when user sends a message', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await userEvent.type(textarea, 'Hello{Enter}');
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toEqual([]);
+			});
+		});
+
+		it('sets irisStages when UpdateIrisStages arrives', async () => {
+			useChatStore.setState({ irisStages: [] });
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'updateIrisStages',
+				stages: [{ name: 'analyzing', state: 'IN_PROGRESS', message: 'Analyzing', weight: 20 }],
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().irisStages).toHaveLength(1);
+				expect(useChatStore.getState().irisStages[0].name).toBe('analyzing');
+			});
 		});
 	});
 });

--- a/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
@@ -53,6 +53,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={[]}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -67,6 +68,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={[]}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={false}
@@ -86,6 +88,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -101,6 +104,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -119,6 +123,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -143,6 +148,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={streamingState}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -159,6 +165,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -175,6 +182,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={[]}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -192,6 +200,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={vi.fn()}
 				onSendPrompt={vi.fn()}
 				hasContext={true}
@@ -210,6 +219,7 @@ describe('ChatMessageList', () => {
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
+				activeStage={null}
 				onFeedback={onFeedback}
 				onSendPrompt={vi.fn()}
 				hasContext={true}

--- a/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import type { ChatMessage, StreamingState } from '../../../../../src/webview/views/IrisChat/types';
+import type { ChatMessage, StreamingState, IrisStageDTO } from '../../../../../src/webview/views/IrisChat/types';
 
 // Mock use-stick-to-bottom (ESM package used via useAutoScroll)
 vi.mock('use-stick-to-bottom', () => ({
@@ -36,6 +36,14 @@ const defaultStreaming: StreamingState = {
 	messageLocalId: null,
 	visibleChunks: [],
 };
+
+const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
+    name: 'thinking',
+    weight: 10,
+    state: 'IN_PROGRESS',
+    message: 'Thinking hard',
+    ...overrides,
+});
 
 function makeMessage(overrides: Partial<ChatMessage> = {}, index = 0): ChatMessage {
 	return {
@@ -227,5 +235,61 @@ describe('ChatMessageList', () => {
 		);
 		// onFeedback is passed through — verify message renders
 		expect(screen.getByText('Answer')).toBeInTheDocument();
+	});
+
+	it('shows stage indicator when activeStage is present', () => {
+		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
+		render(
+			<ChatMessageList
+				messages={messages}
+				streaming={defaultStreaming}
+				activeStage={makeStage()}
+				onFeedback={vi.fn()}
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+			/>
+		);
+		expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+	});
+
+	it('hides stage indicator when streaming chunks arrive', () => {
+		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
+		const streamingWithChunks: StreamingState = {
+			isStreaming: true,
+			messageLocalId: 'msg-1',
+			visibleChunks: ['Some response'],
+		};
+		render(
+			<ChatMessageList
+				messages={messages}
+				streaming={streamingWithChunks}
+				activeStage={makeStage()}
+				onFeedback={vi.fn()}
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+			/>
+		);
+		expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
+	});
+
+	it('shows legacy thinking dots when no activeStage but streaming with no chunks', () => {
+		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
+		const streamingNoChunks: StreamingState = {
+			isStreaming: true,
+			messageLocalId: 'msg-1',
+			visibleChunks: [],
+		};
+		const { container } = render(
+			<ChatMessageList
+				messages={messages}
+				streaming={streamingNoChunks}
+				activeStage={null}
+				onFeedback={vi.fn()}
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+			/>
+		);
+		const dots = container.querySelectorAll('span');
+		expect(dots.length).toBeGreaterThan(0);
 	});
 });

--- a/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
@@ -162,14 +162,12 @@ describe('ChatMessageList', () => {
 				hasContext={true}
 			/>
 		);
-		// ThinkingIndicator renders 3 span elements when visible
-		const spans = container.querySelectorAll('span');
-		expect(spans.length).toBeGreaterThan(0);
+		expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
 	});
 
 	it('does not show thinking indicator when not streaming', () => {
 		const messages = [makeMessage({ content: 'Done' }, 0)];
-		const { container } = render(
+		render(
 			<ChatMessageList
 				messages={messages}
 				streaming={defaultStreaming}
@@ -179,10 +177,7 @@ describe('ChatMessageList', () => {
 				hasContext={true}
 			/>
 		);
-		// ThinkingIndicator should not render — its container has the dots
-		// Streamdown elements are present but no ThinkingIndicator dots
-		const spans = container.querySelectorAll('span');
-		expect(spans.length).toBe(0);
+		expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument();
 	});
 
 	it('renders scroll container div', () => {
@@ -289,7 +284,6 @@ describe('ChatMessageList', () => {
 				hasContext={true}
 			/>
 		);
-		const dots = container.querySelectorAll('span');
-		expect(dots.length).toBeGreaterThan(0);
+		expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
 	});
 });

--- a/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
@@ -30,18 +30,10 @@ describe('ThinkingIndicator', () => {
         expect(container.firstChild).toBeNull();
     });
 
-    it('renders three animated dots with no activeStage (fallback)', () => {
+    it('renders container with no label when no activeStage (fallback)', () => {
         const { container } = render(<ThinkingIndicator />);
-        const dots = container.querySelectorAll('span');
-        expect(dots.length).toBe(3);
-    });
-
-    it('dots have staggered animation delays', () => {
-        const { container } = render(<ThinkingIndicator isVisible={true} />);
-        const dots = container.querySelectorAll('span');
-        expect((dots[0] as HTMLElement).style.animationDelay).toBe('0s');
-        expect((dots[1] as HTMLElement).style.animationDelay).toBe('0.2s');
-        expect((dots[2] as HTMLElement).style.animationDelay).toBe('0.4s');
+        expect(container.firstChild).toBeInTheDocument();
+        expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
     });
 
     it('shows stage label when activeStage is IN_PROGRESS', () => {
@@ -49,13 +41,11 @@ describe('ThinkingIndicator', () => {
         expect(screen.getByText('Thinking hard')).toBeInTheDocument();
     });
 
-    it('shows dots only (no label) when activeStage is NOT_STARTED', () => {
-        const { container } = render(
+    it('shows no label when activeStage is NOT_STARTED', () => {
+        render(
             <ThinkingIndicator activeStage={makeStage({ state: 'NOT_STARTED' })} />
         );
         expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
-        const dots = container.querySelectorAll('span');
-        expect(dots.length).toBe(3);
     });
 
     it('shows error state when activeStage is ERROR', () => {

--- a/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
@@ -1,35 +1,94 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { ThinkingIndicator } from '../../../../../src/webview/views/IrisChat/components/ThinkingIndicator';
+import type { IrisStageDTO } from '../../../../../src/webview/views/IrisChat/types';
+
+const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
+    name: 'thinking',
+    weight: 10,
+    state: 'IN_PROGRESS',
+    message: 'Thinking hard',
+    ...overrides,
+});
 
 describe('ThinkingIndicator', () => {
-	it('renders when isVisible is true (default)', () => {
-		const { container } = render(<ThinkingIndicator isVisible={true} />);
-		expect(container.firstChild).toBeInTheDocument();
-	});
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
 
-	it('returns null when isVisible is false', () => {
-		const { container } = render(<ThinkingIndicator isVisible={false} />);
-		expect(container.firstChild).toBeNull();
-	});
+    afterEach(() => {
+        vi.useRealTimers();
+    });
 
-	it('renders by default (no props — isVisible defaults to true)', () => {
-		const { container } = render(<ThinkingIndicator />);
-		expect(container.firstChild).toBeInTheDocument();
-	});
+    it('renders when isVisible is true (default)', () => {
+        const { container } = render(<ThinkingIndicator isVisible={true} />);
+        expect(container.firstChild).toBeInTheDocument();
+    });
 
-	it('renders three animated dots', () => {
-		const { container } = render(<ThinkingIndicator isVisible={true} />);
-		// Three span.dot elements for the animated dots
-		const dots = container.querySelectorAll('span');
-		expect(dots.length).toBe(3);
-	});
+    it('returns null when isVisible is false', () => {
+        const { container } = render(<ThinkingIndicator isVisible={false} />);
+        expect(container.firstChild).toBeNull();
+    });
 
-	it('dots have staggered animation delays', () => {
-		const { container } = render(<ThinkingIndicator isVisible={true} />);
-		const dots = container.querySelectorAll('span');
-		expect((dots[0] as HTMLElement).style.animationDelay).toBe('0s');
-		expect((dots[1] as HTMLElement).style.animationDelay).toBe('0.2s');
-		expect((dots[2] as HTMLElement).style.animationDelay).toBe('0.4s');
-	});
+    it('renders three animated dots with no activeStage (fallback)', () => {
+        const { container } = render(<ThinkingIndicator />);
+        const dots = container.querySelectorAll('span');
+        expect(dots.length).toBe(3);
+    });
+
+    it('dots have staggered animation delays', () => {
+        const { container } = render(<ThinkingIndicator isVisible={true} />);
+        const dots = container.querySelectorAll('span');
+        expect((dots[0] as HTMLElement).style.animationDelay).toBe('0s');
+        expect((dots[1] as HTMLElement).style.animationDelay).toBe('0.2s');
+        expect((dots[2] as HTMLElement).style.animationDelay).toBe('0.4s');
+    });
+
+    it('shows stage label when activeStage is IN_PROGRESS', () => {
+        render(<ThinkingIndicator activeStage={makeStage({ message: 'Thinking hard' })} />);
+        expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+    });
+
+    it('shows dots only (no label) when activeStage is NOT_STARTED', () => {
+        const { container } = render(
+            <ThinkingIndicator activeStage={makeStage({ state: 'NOT_STARTED' })} />
+        );
+        expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
+        const dots = container.querySelectorAll('span');
+        expect(dots.length).toBe(3);
+    });
+
+    it('shows error state when activeStage is ERROR', () => {
+        render(<ThinkingIndicator activeStage={makeStage({ state: 'ERROR', message: 'Something failed' })} />);
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText('Something failed')).toBeInTheDocument();
+    });
+
+    it('shows default error message when ERROR stage has no message', () => {
+        render(<ThinkingIndicator activeStage={makeStage({ state: 'ERROR', message: undefined })} />);
+        expect(screen.getByText('An error occurred')).toBeInTheDocument();
+    });
+
+    it('rotates labels every 2600ms when IN_PROGRESS', () => {
+        render(<ThinkingIndicator activeStage={makeStage()} />);
+        expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+
+        act(() => { vi.advanceTimersByTime(2600); });
+        expect(screen.getByText('Analyzing context')).toBeInTheDocument();
+
+        act(() => { vi.advanceTimersByTime(2600); });
+        expect(screen.getByText('Processing your request')).toBeInTheDocument();
+
+        act(() => { vi.advanceTimersByTime(2600); });
+        expect(screen.getByText('Formulating a response')).toBeInTheDocument();
+
+        act(() => { vi.advanceTimersByTime(2600); });
+        expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+    });
+
+    it('has aria-live polite on status text', () => {
+        const { container } = render(<ThinkingIndicator activeStage={makeStage()} />);
+        const ariaLive = container.querySelector('[aria-live="polite"]');
+        expect(ariaLive).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
## Summary

- Display the current Iris processing stage (e.g. "Thinking hard", "Analyzing context") in the chat panel as a single-line status indicator
- Wire WebSocket STATUS messages through a new `UpdateIrisStages` message contract into the chat store
- Show a pulsing Iris logo with rotating status text while Iris processes a request
- Clear stages on all relevant paths (assistant reply, session switch, disconnect, user send)

Closes #105

## Changes

- **`IrisStageDTO`** wire type matching the Artemis server DTO
- **`UpdateIrisStages`** message contract (extension -> webview)
- **WebSocket handler** parses STATUS messages, validates objects, filters internal stages
- **Chat store** adds `irisStages` state, `setIrisStages`, `resetTransientChatUi` actions
- **IrisChatView** wires listener + 5 reset paths (assistant message, load messages, clear, disconnect, user send)
- **ChatMessageList** mutually exclusive visibility (stage indicator vs legacy streaming dots)
- **ThinkingIndicator** pulsing Iris logo + rotating label (2.6s interval, stageKey-based reset) + error state + a11y

## Test plan

- [ ] Verify ThinkingIndicator appears with rotating text when sending a message to Iris
- [ ] Verify indicator disappears when Iris response arrives
- [ ] Verify indicator disappears on WebSocket disconnect
- [ ] Verify indicator disappears on session switch
- [ ] Verify error state displays when stage has ERROR status
- [ ] Run `npx vitest run` (839 tests pass, 7 pre-existing failures unrelated)