### PR TITLE
test(recording): robustness test suite (split from #108)

### DIFF
--- a/extension/test/unit/services/telemetry/buildResultGuard.test.ts
+++ b/extension/test/unit/services/telemetry/buildResultGuard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for Block F — shouldAcceptBuildResult guard
+ *
+ * Covers:
+ *   1. activeExerciseId=undefined → false (no active session)
+ *   2. activeExerciseId set, no participation in result → true (permissive)
+ *   3. activeExerciseId=5, participation.id=5, registry maps 5→5 → true
+ *   4. activeExerciseId=5, participation.id=7, registry maps 7→7 → false (known mismatch)
+ *   5. activeExerciseId=5, participation.id=99, registry does NOT know 99 → true (permissive)
+ *   6. activeExerciseId=5, participation.id=7, registry=undefined → true (no registry = permissive)
+ */
+
+import * as assert from 'assert';
+import { shouldAcceptBuildResult } from '../../../../src/extension/services/telemetry/buildResultGuard';
+import { ExerciseRegistry } from '../../../../src/extension/services/exerciseRegistry';
+import type { ResultDTO } from '../../../../src/extension/domain';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeResult(participationId?: number): ResultDTO {
+    return {
+        id: 1,
+        successful: true,
+        participation: participationId !== undefined ? { id: participationId } : undefined,
+    };
+}
+
+function makeRegistry(entries: Array<{ participationId: number; exerciseId: number }>): ExerciseRegistry {
+    const registry = new ExerciseRegistry();
+    for (const { participationId, exerciseId } of entries) {
+        registry.registerExercise(exerciseId, `Exercise ${exerciseId}`, '/repo', undefined, undefined, participationId);
+    }
+    return registry;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('shouldAcceptBuildResult (Block F)', () => {
+    test('1. activeExerciseId=undefined → false', () => {
+        const result = makeResult(5);
+        assert.strictEqual(shouldAcceptBuildResult(result, undefined, undefined), false);
+    });
+
+    test('2. no participation in result → true (permissive)', () => {
+        const result = makeResult(undefined);
+        const registry = makeRegistry([{ participationId: 10, exerciseId: 3 }]);
+        assert.strictEqual(shouldAcceptBuildResult(result, 5, registry), true);
+    });
+
+    test('3. participation maps to active exercise → true', () => {
+        const result = makeResult(5);
+        const registry = makeRegistry([{ participationId: 5, exerciseId: 5 }]);
+        assert.strictEqual(shouldAcceptBuildResult(result, 5, registry), true);
+    });
+
+    test('4. participation maps to different exercise → false (known mismatch)', () => {
+        const result = makeResult(7);
+        const registry = makeRegistry([
+            { participationId: 5, exerciseId: 5 },
+            { participationId: 7, exerciseId: 7 },
+        ]);
+        assert.strictEqual(shouldAcceptBuildResult(result, 5, registry), false);
+    });
+
+    test('5. participation unknown to registry → true (permissive)', () => {
+        const result = makeResult(99);
+        const registry = makeRegistry([{ participationId: 5, exerciseId: 5 }]);
+        // 99 is not in the registry at all
+        assert.strictEqual(shouldAcceptBuildResult(result, 5, registry), true);
+    });
+
+    test('6. registry=undefined, mismatched participation → true (no registry = permissive)', () => {
+        const result = makeResult(7);
+        assert.strictEqual(shouldAcceptBuildResult(result, 5, undefined), true);
+    });
+});

--- a/extension/test/unit/services/telemetry/interventionService.test.ts
+++ b/extension/test/unit/services/telemetry/interventionService.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Unit tests for Block C — Interventions FSM
+ *
+ * Tests cover:
+ *   1. Subtle-Show → StatusBar-Click → onDidAcceptIntervention with same decision
+ *   2. Subtle-Show → hideHint() → onDidDismissIntervention with reason 'hidden'
+ *   3. rawWanted=true, shouldIntervene=false, blockedReason='cooldown' → recordBlockedDecision
+ *      called (not showXxxEQ), 1 onDidBlock event
+ *   4. rawWanted=true, shouldIntervene=false, blockedReason='low-confidence' → 1 onDidBlock event
+ *   5. Five blocks within 60s (same triggerType+reason) → only 1 event (rate-limit)
+ *   6. Five blocks, each 70s apart → 5 events
+ *   7. rawWanted=false → neither show nor block, no event
+ *   8. rawWanted=true, shouldIntervene=true → 'shown' event, no 'blocked'
+ *   9. TelemetryManager dispatch: shouldIntervene=false && rawWanted=false → no recordBlockedDecision
+ *
+ * Additional:
+ *  10. InterventionDecisionEngine: confidence=insufficient with EQ above threshold → rawWanted=true, blockedReason='low-confidence'
+ *  11. InterventionDecisionEngine: EQ below all thresholds → rawWanted=false, no blockedReason
+ *  12. Subtle-Show → second show → first decision dismissed as 'replaced'
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { InterventionService } from '../../../../src/extension/services/telemetry/interventionService';
+import { InterventionDecisionEngine } from '../../../../src/extension/services/telemetry/decision/interventionDecisionEngine';
+import { InterventionFilter } from '../../../../src/extension/services/telemetry/interventionFilter';
+import type { InterventionDecision, InterventionState } from '../../../../src/extension/services/telemetry/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeDecision(overrides: Partial<InterventionDecision> = {}): InterventionDecision {
+    return {
+        rawWanted: true,
+        shouldIntervene: true,
+        level: 'subtle',
+        eq: 0.25,
+        confidence: 'sufficient',
+        triggerType: 'idle',
+        ...overrides,
+    };
+}
+
+function makeState(overrides: Partial<InterventionState> = {}): InterventionState {
+    return {
+        lastInterventionTime: 0,
+        sessionInterventionCount: 0,
+        lastDismissed: false,
+        lastAccepted: false,
+        ...overrides,
+    };
+}
+
+/**
+ * Advance the fake clock used by sinon. We manipulate Date.now() return value
+ * by replacing it with a controllable stub rather than using fake timers (which
+ * would also affect setTimeout and complicate things).
+ */
+function makeDateStub(sandbox: sinon.SinonSandbox): { advance(ms: number): void } {
+    let now = Date.now();
+    sandbox.stub(Date, 'now').callsFake(() => now);
+    return {
+        advance(ms: number) { now += ms; },
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('Block C — InterventionService: subtle accept/dismiss', () => {
+    let service: InterventionService;
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        service = new InterventionService();
+    });
+
+    teardown(() => {
+        service.dispose();
+        sandbox.restore();
+    });
+
+    // Test 1: Subtle-Show → status bar click (handleAcceptSubtle) → onDidAcceptIntervention with same decision
+    test('subtle show → handleAcceptSubtle (status bar click handler) → onDidAcceptIntervention fires with same decision', () => {
+        const decision = makeDecision({ level: 'subtle', eq: 0.3, triggerType: 'execution-error' });
+        const accepted: InterventionDecision[] = [];
+        const sub = service.onDidAcceptIntervention(d => accepted.push(d));
+
+        service.showSubtleHintEQ(decision);
+
+        // Simulate what happens when the status bar is clicked (iris.intervention.acceptSubtle command)
+        service.handleAcceptSubtle();
+
+        sub.dispose();
+
+        assert.strictEqual(accepted.length, 1, 'exactly one accept event should fire');
+        assert.strictEqual(accepted[0].eq, decision.eq, 'accept event should carry the original eq');
+        assert.strictEqual(accepted[0].triggerType, decision.triggerType, 'accept event should carry triggerType');
+    });
+
+    // Test 1b: handleAcceptSubtle with no active subtle decision → fallback to open chat, no accept event
+    test('handleAcceptSubtle with no active subtle decision → no accept event (just opens chat)', () => {
+        const accepted: InterventionDecision[] = [];
+        const sub = service.onDidAcceptIntervention(d => accepted.push(d));
+
+        // No showSubtleHintEQ called first
+        service.handleAcceptSubtle();
+
+        sub.dispose();
+
+        assert.strictEqual(accepted.length, 0, 'no accept event when no subtle hint is active');
+    });
+
+    // Test 2: Subtle-Show → hideHint() → onDidDismissIntervention with reason 'hidden'
+    test('subtle show → hideHint → onDidDismissIntervention fires with dismissReason=hidden', () => {
+        const decision = makeDecision({ level: 'subtle' });
+        const dismissed: Array<{ eq: number; dismissReason: string }> = [];
+        const sub = service.onDidDismissIntervention(p => dismissed.push({ eq: p.eq, dismissReason: p.dismissReason }));
+
+        service.showSubtleHintEQ(decision);
+        service.hideHint();
+
+        sub.dispose();
+
+        assert.strictEqual(dismissed.length, 1, 'exactly one dismiss event should fire from hideHint');
+        assert.strictEqual(dismissed[0].dismissReason, 'hidden', 'dismissReason should be hidden');
+        assert.strictEqual(dismissed[0].eq, decision.eq, 'dismiss event should carry the original eq');
+    });
+
+    // Test 2b: hideHint() when no subtle hint active → no dismiss event
+    test('hideHint with no active subtle hint → no dismiss event', () => {
+        const dismissed: unknown[] = [];
+        const sub = service.onDidDismissIntervention(p => dismissed.push(p));
+
+        service.hideHint();
+
+        sub.dispose();
+
+        assert.strictEqual(dismissed.length, 0, 'no dismiss event should fire when no hint is active');
+    });
+
+    // Test 12: second showSubtleHintEQ while one is active → first dismissed as 'replaced'
+    test('second subtle show while first active → first dismissed as replaced', () => {
+        const decision1 = makeDecision({ eq: 0.2 });
+        const decision2 = makeDecision({ eq: 0.4 });
+        const dismissed: Array<{ eq: number; dismissReason: string }> = [];
+        const sub = service.onDidDismissIntervention(p => dismissed.push({ eq: p.eq, dismissReason: p.dismissReason }));
+
+        service.showSubtleHintEQ(decision1);
+        service.showSubtleHintEQ(decision2);
+
+        sub.dispose();
+
+        assert.strictEqual(dismissed.length, 1, 'first hint should be implicitly dismissed');
+        assert.strictEqual(dismissed[0].eq, decision1.eq, 'dismissed eq should be from the first decision');
+        assert.strictEqual(dismissed[0].dismissReason, 'replaced', 'dismissReason should be replaced');
+    });
+});
+
+suite('Block C — InterventionService: blocked decisions and rate-limiting', () => {
+    let service: InterventionService;
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        service = new InterventionService();
+    });
+
+    teardown(() => {
+        service.dispose();
+        sandbox.restore();
+    });
+
+    // Test 3: rawWanted=true, shouldIntervene=false, blockedReason='cooldown' → 1 onDidBlock event
+    test('recordBlockedDecision → fires onDidBlockIntervention with blockedReason', () => {
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: false,
+            level: 'notification',
+            blockedReason: 'cooldown',
+            triggerType: 'execution-error',
+        });
+        const blocks: InterventionDecision[] = [];
+        const sub = service.onDidBlockIntervention(({ decision: d }) => blocks.push(d));
+
+        service.recordBlockedDecision(decision);
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 1, 'exactly one block event should fire');
+        assert.strictEqual(blocks[0].blockedReason, 'cooldown');
+        assert.strictEqual(blocks[0].triggerType, 'execution-error');
+    });
+
+    // Test 4: blockedReason='low-confidence' (EQ high but confidence insufficient)
+    test('blocked with low-confidence → 1 onDidBlock event with blockedReason=low-confidence', () => {
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: false,
+            level: 'notification',
+            eq: 0.5,
+            confidence: 'insufficient',
+            blockedReason: 'low-confidence',
+            triggerType: 'multiline-paste',
+        });
+        const blocks: string[] = [];
+        const sub = service.onDidBlockIntervention(({ decision: d }) => blocks.push(d.blockedReason ?? ''));
+
+        service.recordBlockedDecision(decision);
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 1);
+        assert.strictEqual(blocks[0], 'low-confidence');
+    });
+
+    // Test 5: Five blocks within 60s for same (triggerType, blockedReason) → only 1 event
+    test('five blocks within 60s for same combination → rate-limited to 1 event', () => {
+        const clock = makeDateStub(sandbox);
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: false,
+            level: 'notification',
+            blockedReason: 'cooldown',
+            triggerType: 'idle',
+        });
+        const blocks: unknown[] = [];
+        const sub = service.onDidBlockIntervention(() => blocks.push(null));
+
+        // Fire 5 times, each 5 seconds apart (well within 60s window)
+        for (let i = 0; i < 5; i++) {
+            service.recordBlockedDecision(decision);
+            clock.advance(5_000);
+        }
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 1, 'rate-limit should suppress 4 of 5 events');
+    });
+
+    // Test 6: Five blocks, each 70s apart → 5 events
+    test('five blocks each 70s apart → all 5 events fire (window expires between each)', () => {
+        const clock = makeDateStub(sandbox);
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: false,
+            level: 'notification',
+            blockedReason: 'cooldown',
+            triggerType: 'idle',
+        });
+        const blocks: unknown[] = [];
+        const sub = service.onDidBlockIntervention(() => blocks.push(null));
+
+        for (let i = 0; i < 5; i++) {
+            service.recordBlockedDecision(decision);
+            clock.advance(70_000);
+        }
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 5, 'each block should fire after window expires');
+    });
+
+    // Test 7: rawWanted=false → recordBlockedDecision is not the right call, but also: no show, no block
+    test('recordBlockedDecision not called when rawWanted=false → no block event fires', () => {
+        // This tests that the service correctly acts on what's passed to it.
+        // With rawWanted=false we should not call recordBlockedDecision at all —
+        // but even if we did, verify no event fires for an empty call (we don't call it here).
+        const blocks: unknown[] = [];
+        const shown: unknown[] = [];
+        const sub1 = service.onDidBlockIntervention(() => blocks.push(null));
+        const sub2 = service.onDidShowIntervention(() => shown.push(null));
+
+        // Do NOT call any service method — simulating TelemetryManager not
+        // dispatching when rawWanted=false
+        sub1.dispose();
+        sub2.dispose();
+
+        assert.strictEqual(blocks.length, 0, 'no block event when rawWanted=false');
+        assert.strictEqual(shown.length, 0, 'no show event when rawWanted=false');
+    });
+
+    // Test 8: rawWanted=true, shouldIntervene=true → shown event, no blocked
+    test('rawWanted=true, shouldIntervene=true → showSubtleHintEQ fires shown, no blocked', () => {
+        const decision = makeDecision({ rawWanted: true, shouldIntervene: true, level: 'subtle' });
+        const shown: unknown[] = [];
+        const blocks: unknown[] = [];
+        const s1 = service.onDidShowIntervention(() => shown.push(null));
+        const s2 = service.onDidBlockIntervention(() => blocks.push(null));
+
+        service.showSubtleHintEQ(decision);
+
+        s1.dispose();
+        s2.dispose();
+
+        assert.strictEqual(shown.length, 1, 'shown event should fire');
+        assert.strictEqual(blocks.length, 0, 'no block event should fire');
+    });
+
+    // Test: showNotificationEQ blocked by cooldown fires onDidBlockIntervention with reason 'cooldown'
+    test('showNotificationEQ blocked by cooldown fires onDidBlockIntervention with cooldown reason', async () => {
+        const clock = makeDateStub(sandbox);
+        // Stub showInformationMessage so the first show completes immediately without user interaction.
+        sandbox.stub(require('vscode').window, 'showInformationMessage').resolves(undefined);
+
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: true,
+            level: 'notification',
+            eq: 0.4,
+            triggerType: 'execution-error',
+        });
+
+        const shown: unknown[] = [];
+        const blocks: InterventionDecision[] = [];
+        const s1 = service.onDidShowIntervention(() => shown.push(null));
+        const s2 = service.onDidBlockIntervention(({ decision: d }) => blocks.push(d));
+
+        // First show — succeeds (sets lastInterventionTime to now)
+        await service.showNotificationEQ(decision);
+
+        // Second show — immediately after (still within 5min cooldown)
+        await service.showNotificationEQ(decision);
+
+        s1.dispose();
+        s2.dispose();
+
+        assert.strictEqual(shown.length, 1, 'only the first show should fire onDidShowIntervention');
+        assert.strictEqual(blocks.length, 1, 'exactly one block event should fire for the cooldown-blocked show');
+        assert.strictEqual(blocks[0].blockedReason, 'cooldown', 'blockedReason should be cooldown');
+        assert.strictEqual(blocks[0].shouldIntervene, false, 'shouldIntervene should be false on the block event');
+
+        void clock; // clock used to make Date.now() controllable; advance not needed here
+    });
+
+    // Test: showProactiveHelpEQ blocked by cooldown fires onDidBlockIntervention with reason 'cooldown'
+    test('showProactiveHelpEQ blocked by cooldown fires onDidBlockIntervention with cooldown reason', async () => {
+        sandbox.stub(require('vscode').window, 'showWarningMessage').resolves(undefined);
+
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: true,
+            level: 'proactive',
+            eq: 0.7,
+            triggerType: 'idle',
+        });
+
+        const shown: unknown[] = [];
+        const blocks: InterventionDecision[] = [];
+        const s1 = service.onDidShowIntervention(() => shown.push(null));
+        const s2 = service.onDidBlockIntervention(({ decision: d }) => blocks.push(d));
+
+        // First show — succeeds
+        await service.showProactiveHelpEQ(decision);
+
+        // Second show — still within 5min cooldown
+        await service.showProactiveHelpEQ(decision);
+
+        s1.dispose();
+        s2.dispose();
+
+        assert.strictEqual(shown.length, 1, 'only the first show should fire onDidShowIntervention');
+        assert.strictEqual(blocks.length, 1, 'exactly one block event should fire for the cooldown-blocked show');
+        assert.strictEqual(blocks[0].blockedReason, 'cooldown', 'blockedReason should be cooldown');
+        assert.strictEqual(blocks[0].shouldIntervene, false, 'shouldIntervene should be false on the block event');
+    });
+
+    // Test: repeated cooldown-blocked showNotificationEQ within 60s only fires one block event (rate-limit)
+    test('repeated cooldown-blocked showNotificationEQ within 60s only fires one block event', async () => {
+        const clock = makeDateStub(sandbox);
+        sandbox.stub(require('vscode').window, 'showInformationMessage').resolves(undefined);
+
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: true,
+            level: 'notification',
+            eq: 0.5,
+            triggerType: 'multiline-paste',
+        });
+
+        const blocks: unknown[] = [];
+        const sub = service.onDidBlockIntervention(() => blocks.push(null));
+
+        // First show — succeeds, sets lastInterventionTime
+        await service.showNotificationEQ(decision);
+
+        // Three more shows within the 60s block-event rate-limit window (advance 5s between each)
+        clock.advance(5_000);
+        await service.showNotificationEQ(decision);
+        clock.advance(5_000);
+        await service.showNotificationEQ(decision);
+        clock.advance(5_000);
+        await service.showNotificationEQ(decision);
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 1, 'rate-limit should suppress 2 of the 3 cooldown-block events');
+    });
+
+    // Rate-limit: different (triggerType, blockedReason) combinations are tracked independently
+    test('different (triggerType, reason) combinations are rate-limited independently', () => {
+        const clock = makeDateStub(sandbox);
+        const decisionA = makeDecision({
+            rawWanted: true, shouldIntervene: false, level: 'notification',
+            blockedReason: 'cooldown', triggerType: 'idle',
+        });
+        const decisionB = makeDecision({
+            rawWanted: true, shouldIntervene: false, level: 'notification',
+            blockedReason: 'session-limit', triggerType: 'idle',
+        });
+        const blocks: string[] = [];
+        const sub = service.onDidBlockIntervention(({ decision: d }) =>
+            blocks.push(`${d.triggerType}:${d.blockedReason}`),
+        );
+
+        // Fire A twice within 60s: only 1 event for A
+        service.recordBlockedDecision(decisionA);
+        clock.advance(5_000);
+        service.recordBlockedDecision(decisionA);
+
+        // Fire B: different reason key → separate rate-limit bucket, should fire
+        service.recordBlockedDecision(decisionB);
+
+        sub.dispose();
+
+        assert.strictEqual(blocks.length, 2, '2 events: 1 for A, 1 for B');
+        assert.ok(blocks.includes('idle:cooldown'), 'A should have fired once');
+        assert.ok(blocks.includes('idle:session-limit'), 'B should have fired once');
+    });
+});
+
+suite('Block C — InterventionDecisionEngine: rawWanted and blockedReason', () => {
+    let filter: InterventionFilter;
+    let engine: InterventionDecisionEngine;
+
+    setup(() => {
+        filter = new InterventionFilter();
+        // Set exercise start time to > 5 minutes ago so warmup doesn't block
+        filter.setExerciseStartTime(Date.now() - 10 * 60 * 1000);
+        engine = new InterventionDecisionEngine(filter);
+    });
+
+    // Test 10: EQ above threshold, confidence=insufficient → rawWanted=true, blockedReason='low-confidence'
+    test('EQ above notification threshold + insufficient confidence → rawWanted=true, blockedReason=low-confidence', () => {
+        const state = makeState();
+        const result = engine.evaluate(0.5, 'insufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, true, 'rawWanted should be true when EQ is above threshold');
+        assert.strictEqual(result.shouldIntervene, false, 'shouldIntervene must be false for insufficient confidence');
+        assert.strictEqual(result.blockedReason, 'low-confidence', 'blockedReason should be low-confidence');
+    });
+
+    // Test 11: EQ below all thresholds (< 0.15) → rawWanted=false, no blockedReason
+    test('EQ below all thresholds → rawWanted=false, shouldIntervene=false, no blockedReason', () => {
+        const state = makeState();
+        const result = engine.evaluate(0.05, 'sufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, false, 'rawWanted should be false when EQ is below all thresholds');
+        assert.strictEqual(result.shouldIntervene, false);
+        assert.strictEqual(result.level, 'none');
+        assert.strictEqual(result.blockedReason, undefined, 'no blockedReason when rawWanted=false');
+    });
+
+    // EQ above threshold + sufficient confidence + no guardrails → shouldIntervene=true
+    test('EQ above threshold + sufficient confidence + no guardrails → shouldIntervene=true, rawWanted=true', () => {
+        const state = makeState();
+        const result = engine.evaluate(0.25, 'sufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, true);
+        assert.strictEqual(result.shouldIntervene, true, 'should intervene when all gates pass');
+        assert.strictEqual(result.blockedReason, undefined, 'no blockedReason when shouldIntervene=true');
+    });
+
+    // Session-limit blocked → rawWanted=true, blockedReason='session-limit'
+    test('session-limit exceeded → rawWanted=true, shouldIntervene=false, blockedReason=session-limit', () => {
+        const state = makeState({ sessionInterventionCount: 3 }); // MAX_INTERVENTIONS_PER_SESSION = 3
+        const result = engine.evaluate(0.5, 'sufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, true);
+        assert.strictEqual(result.shouldIntervene, false);
+        assert.strictEqual(result.blockedReason, 'session-limit');
+    });
+
+    // Warmup-blocked → rawWanted=true, blockedReason='warmup' (exercise start too recent)
+    test('warmup not elapsed → rawWanted=true, shouldIntervene=false, blockedReason=warmup', () => {
+        // Create a fresh filter with start time = now (no time has passed)
+        const freshFilter = new InterventionFilter();
+        freshFilter.setExerciseStartTime(Date.now());
+        const freshEngine = new InterventionDecisionEngine(freshFilter);
+
+        const state = makeState();
+        const result = freshEngine.evaluate(0.5, 'sufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, true);
+        assert.strictEqual(result.shouldIntervene, false);
+        assert.strictEqual(result.blockedReason, 'warmup');
+    });
+
+    // Insufficient confidence with EQ *below* threshold → rawWanted=false, no blockedReason
+    test('EQ below threshold + insufficient confidence → rawWanted=false, no blockedReason', () => {
+        const state = makeState();
+        const result = engine.evaluate(0.05, 'insufficient', 'idle', state);
+
+        assert.strictEqual(result.rawWanted, false);
+        assert.strictEqual(result.blockedReason, undefined);
+    });
+});
+
+suite('Block C — TelemetryManager dispatch routing', () => {
+    // Test 9: shouldIntervene=false && rawWanted=false → no block event
+    // We test this via InterventionDecisionEngine + InterventionService integration
+    // since TelemetryManager._evaluateAndIntervene is private.
+    test('decision with rawWanted=false does not fire onDidBlockIntervention', () => {
+        const filter = new InterventionFilter();
+        filter.setExerciseStartTime(Date.now() - 10 * 60 * 1000);
+        const engine = new InterventionDecisionEngine(filter);
+        const service = new InterventionService();
+
+        const blocks: unknown[] = [];
+        const sub = service.onDidBlockIntervention(() => blocks.push(null));
+
+        // EQ=0.05 → rawWanted=false → should not call recordBlockedDecision
+        const decision = engine.evaluate(0.05, 'sufficient', 'idle', makeState());
+        assert.strictEqual(decision.rawWanted, false, 'precondition: rawWanted must be false');
+
+        if (decision.rawWanted) {
+            service.recordBlockedDecision(decision);
+        }
+        // else: rawWanted=false → normal operation, no call
+
+        sub.dispose();
+        service.dispose();
+
+        assert.strictEqual(blocks.length, 0, 'no block event when rawWanted=false');
+    });
+
+    // Test: rawWanted=true + shouldIntervene=false → recordBlockedDecision should be called
+    test('decision with rawWanted=true + shouldIntervene=false routes to recordBlockedDecision', () => {
+        const service = new InterventionService();
+
+        const decision = makeDecision({
+            rawWanted: true,
+            shouldIntervene: false,
+            level: 'notification',
+            blockedReason: 'low-confidence',
+        });
+
+        const blocks: InterventionDecision[] = [];
+        const sub = service.onDidBlockIntervention(({ decision: d }) => blocks.push(d));
+
+        // Simulate TelemetryManager dispatch logic
+        if (decision.shouldIntervene) {
+            service.showSubtleHintEQ(decision); // would call the appropriate show method
+        } else if (decision.rawWanted) {
+            service.recordBlockedDecision(decision);
+        }
+
+        sub.dispose();
+        service.dispose();
+
+        assert.strictEqual(blocks.length, 1);
+        assert.strictEqual(blocks[0].blockedReason, 'low-confidence');
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/chatRecording.test.ts
+++ b/extension/test/unit/services/telemetry/recording/chatRecording.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for Block H — Chat send-attempt, receive-metadata, feedback events.
+ *
+ * Covers:
+ *   - recordIrisChatSendAttempt: pending/sent/failed events written with correct fields
+ *   - recordIrisChatSent (extended): optional messageId/sessionId/sentAt pass-through
+ *   - recordIrisChatReceived (extended): optional metadata pass-through
+ *   - recordIrisChatFeedback: helpful/not-helpful event written with messageId
+ *   - Phase guard: all new methods no-op outside 'recording' phase
+ *   - Failed send: pending + failed events visible, no irisChatMessage event
+ *   - Successful send: pending + sent attempt events AND separate irisChatMessage event
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SessionRecorder } from '../../../../../src/extension/services/telemetry/recording/sessionRecorder';
+import type {
+    RecordedEvent,
+    IrisChatSendAttemptEvent,
+    IrisChatFeedbackEvent,
+    IrisChatMessageEvent,
+} from '../../../../../src/extension/services/telemetry/recording/types';
+import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+
+// ── Minimal fake FS ───────────────────────────────────────────────────────────
+
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    removedPaths: string[] = [];
+    syncChunks: string[] = [];
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, _opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push(p);
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of [...fakeFs.appendedChunks, ...fakeFs.syncChunks]) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed lines */
+            }
+        }
+    }
+    return events;
+}
+
+function makeRecorder(): { recorder: SessionRecorder; fs: FakeFs } {
+    const fs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(
+        fakeUri,
+        { hasTerminalShellExecution: false, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+    );
+    return { recorder, fs };
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+suite('SessionRecorder — Block H: Chat Recording', () => {
+    let recorder: SessionRecorder;
+    let fs: FakeFs;
+
+    setup(async () => {
+        const ctx = makeRecorder();
+        recorder = ctx.recorder;
+        fs = ctx.fs;
+        recorder.enable();
+        await recorder.startSession(42, 'participant-1');
+    });
+
+    teardown(async () => {
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── H.1: Send-attempt lifecycle ───────────────────────────────────────
+
+    test('pending+sent attempt events are emitted on a successful send', async () => {
+        recorder.recordIrisChatSendAttempt('hello iris', 'pending');
+        recorder.recordIrisChatSendAttempt('hello iris', 'sent');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const attempts = events.filter(
+            (e): e is IrisChatSendAttemptEvent => e.type === 'irisChatSendAttempt',
+        );
+
+        assert.strictEqual(attempts.length, 2, 'two irisChatSendAttempt events expected');
+        assert.strictEqual(attempts[0].status, 'pending');
+        assert.strictEqual(attempts[0].content, 'hello iris');
+        assert.strictEqual(attempts[1].status, 'sent');
+        assert.strictEqual(attempts[1].content, 'hello iris');
+        assert.strictEqual(attempts[1].errorMessage, undefined);
+    });
+
+    test('pending+failed attempt events are emitted on a failed send', async () => {
+        recorder.recordIrisChatSendAttempt('help me', 'pending');
+        recorder.recordIrisChatSendAttempt('help me', 'failed', 'Network timeout');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const attempts = events.filter(
+            (e): e is IrisChatSendAttemptEvent => e.type === 'irisChatSendAttempt',
+        );
+
+        assert.strictEqual(attempts.length, 2, 'two irisChatSendAttempt events expected');
+        assert.strictEqual(attempts[0].status, 'pending');
+        assert.strictEqual(attempts[1].status, 'failed');
+        assert.strictEqual(attempts[1].errorMessage, 'Network timeout');
+    });
+
+    test('failed send: no irisChatMessage event emitted', async () => {
+        recorder.recordIrisChatSendAttempt('will fail', 'pending');
+        recorder.recordIrisChatSendAttempt('will fail', 'failed', 'Timeout');
+        // Note: recordIrisChatSent is NOT called — mirroring what chatWebviewProvider does
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const chatMsgs = events.filter(e => e.type === 'irisChatMessage');
+        assert.strictEqual(chatMsgs.length, 0, 'no irisChatMessage should exist for a failed send');
+
+        const attempts = events.filter(e => e.type === 'irisChatSendAttempt');
+        assert.strictEqual(attempts.length, 2, 'both attempt events should exist');
+    });
+
+    test('successful send: pending+sent attempt AND irisChatMessage event', async () => {
+        recorder.recordIrisChatSendAttempt('what is recursion?', 'pending');
+        recorder.recordIrisChatSendAttempt('what is recursion?', 'sent');
+        recorder.recordIrisChatSent('what is recursion?');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const attempts = events.filter(e => e.type === 'irisChatSendAttempt');
+        const chatMsgs = events.filter(
+            (e): e is IrisChatMessageEvent => e.type === 'irisChatMessage',
+        );
+
+        assert.strictEqual(attempts.length, 2, 'pending + sent attempt events');
+        assert.strictEqual(chatMsgs.length, 1, 'one irisChatMessage event');
+        assert.strictEqual(chatMsgs[0].direction, 'sent');
+        assert.strictEqual(chatMsgs[0].content, 'what is recursion?');
+    });
+
+    // ── H.2: Received message metadata ───────────────────────────────────
+
+    test('recordIrisChatReceived passes through messageId, sessionId, sentAt', async () => {
+        const sentAt = Date.now() - 1000;
+        recorder.recordIrisChatReceived('Great question!', 'msg-99', 'sess-7', sentAt);
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const received = events.filter(
+            (e): e is IrisChatMessageEvent =>
+                e.type === 'irisChatMessage' && e.direction === 'received',
+        );
+
+        assert.strictEqual(received.length, 1);
+        assert.strictEqual(received[0].content, 'Great question!');
+        assert.strictEqual(received[0].messageId, 'msg-99');
+        assert.strictEqual(received[0].sessionId, 'sess-7');
+        assert.strictEqual(received[0].sentAt, sentAt);
+    });
+
+    test('recordIrisChatReceived works without metadata (backwards-compat)', async () => {
+        recorder.recordIrisChatReceived('Simple reply');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const received = events.filter(
+            (e): e is IrisChatMessageEvent =>
+                e.type === 'irisChatMessage' && e.direction === 'received',
+        );
+
+        assert.strictEqual(received.length, 1);
+        assert.strictEqual(received[0].content, 'Simple reply');
+        assert.strictEqual(received[0].messageId, undefined);
+        assert.strictEqual(received[0].sessionId, undefined);
+        assert.strictEqual(received[0].sentAt, undefined);
+    });
+
+    test('recordIrisChatSent passes through messageId, sessionId, sentAt', async () => {
+        const sentAt = Date.now();
+        recorder.recordIrisChatSent('hello', 'msg-1', 'sess-3', sentAt);
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const sent = events.filter(
+            (e): e is IrisChatMessageEvent =>
+                e.type === 'irisChatMessage' && e.direction === 'sent',
+        );
+
+        assert.strictEqual(sent.length, 1);
+        assert.strictEqual(sent[0].messageId, 'msg-1');
+        assert.strictEqual(sent[0].sessionId, 'sess-3');
+        assert.strictEqual(sent[0].sentAt, sentAt);
+    });
+
+    // ── H.3: Feedback event ───────────────────────────────────────────────
+
+    test('recordIrisChatFeedback emits helpful=true event', async () => {
+        recorder.recordIrisChatFeedback('msg-55', true);
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const feedback = events.filter(
+            (e): e is IrisChatFeedbackEvent => e.type === 'irisChatFeedback',
+        );
+
+        assert.strictEqual(feedback.length, 1);
+        assert.strictEqual(feedback[0].messageId, 'msg-55');
+        assert.strictEqual(feedback[0].helpful, true);
+    });
+
+    test('recordIrisChatFeedback emits helpful=false event', async () => {
+        recorder.recordIrisChatFeedback('msg-66', false);
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const feedback = events.filter(
+            (e): e is IrisChatFeedbackEvent => e.type === 'irisChatFeedback',
+        );
+
+        assert.strictEqual(feedback.length, 1);
+        assert.strictEqual(feedback[0].helpful, false);
+    });
+
+    // ── H.4: Phase guard ─────────────────────────────────────────────────
+
+    test('recordIrisChatSendAttempt is a no-op when recorder is not in recording phase', async () => {
+        // End the session to put recorder back in idle
+        await recorder.endSession();
+        const chunksBefore = fs.appendedChunks.length;
+
+        recorder.recordIrisChatSendAttempt('ignored', 'pending');
+
+        assert.strictEqual(
+            fs.appendedChunks.length,
+            chunksBefore,
+            'no event should be appended when recorder is idle',
+        );
+    });
+
+    test('recordIrisChatFeedback is a no-op when recorder is not in recording phase', async () => {
+        await recorder.endSession();
+        const chunksBefore = fs.appendedChunks.length;
+
+        recorder.recordIrisChatFeedback('msg-x', true);
+
+        assert.strictEqual(
+            fs.appendedChunks.length,
+            chunksBefore,
+            'no event should be appended when recorder is idle',
+        );
+    });
+
+    // ── H.5: Existing recordIrisChatSent without metadata still works ─────
+
+    test('recordIrisChatSent without metadata is backwards-compatible', async () => {
+        recorder.recordIrisChatSent('plain message');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const sent = events.filter(
+            (e): e is IrisChatMessageEvent =>
+                e.type === 'irisChatMessage' && e.direction === 'sent',
+        );
+
+        assert.strictEqual(sent.length, 1);
+        assert.strictEqual(sent[0].content, 'plain message');
+        assert.strictEqual(sent[0].messageId, undefined);
+        assert.strictEqual(sent[0].sessionId, undefined);
+        assert.strictEqual(sent[0].sentAt, undefined);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/eventCollectors.test.ts
+++ b/extension/test/unit/services/telemetry/recording/eventCollectors.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for Block F — collectBuildResult
+ *
+ * Covers:
+ *   1. Feedback positive:false, text:'TestFoo', detailText:'AssertionError'
+ *      → failedTestDetails[0]={testName:'TestFoo', detail:'AssertionError'}
+ *      → failedTests[0]='AssertionError' (legacy)
+ *      → buildErrorFamilies[0]='build:TestFoo'
+ *   2. Feedback positive:undefined → no entries in failedTests or failedTestDetails (predicate consistency)
+ *   3. Feedback positive:true → not included in any list
+ *   4. exerciseId, participationId, submissionId are populated when all fields set
+ *   5. failedTestDetails is undefined when no failed tests
+ *   6. buildErrorFamilies cutoff: text longer than 200 chars is truncated at 200 (not 50)
+ *   7. Feedback positive:false, text undefined → testName='unknown' in failedTestDetails
+ *   8. Feedback positive:false, detailText undefined → detail='' in failedTestDetails, failedTests[0]=''
+ */
+
+import * as assert from 'assert';
+import { collectBuildResult } from '../../../../../src/extension/services/telemetry/recording/eventCollectors';
+import type { ResultDTO } from '../../../../../src/extension/domain';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeResult(overrides: Partial<ResultDTO> = {}): ResultDTO {
+    return {
+        id: 42,
+        successful: false,
+        testCaseCount: 5,
+        passedTestCaseCount: 3,
+        submission: { id: 101, buildFailed: false },
+        participation: { id: 9 },
+        ...overrides,
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+suite('collectBuildResult (Block F)', () => {
+    test('1. positive:false → failedTestDetails and failedTests populated', () => {
+        const result = makeResult({
+            feedbacks: [{ positive: false, text: 'TestFoo', detailText: 'AssertionError' }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.deepStrictEqual(event.failedTestDetails, [{ testName: 'TestFoo', detail: 'AssertionError' }]);
+        assert.deepStrictEqual(event.failedTests, ['AssertionError']);
+        assert.ok(event.buildErrorFamilies?.length === 1);
+        assert.ok(event.buildErrorFamilies![0].startsWith('build:TestFoo'));
+    });
+
+    test('2. positive:undefined → no entries in failedTests or failedTestDetails', () => {
+        const result = makeResult({
+            feedbacks: [{ positive: undefined, text: 'TestBar', detailText: 'some detail' }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.deepStrictEqual(event.failedTests, []);
+        assert.strictEqual(event.failedTestDetails, undefined);
+        assert.strictEqual(event.buildErrorFamilies, undefined);
+    });
+
+    test('3. positive:true → not included in any list', () => {
+        const result = makeResult({
+            feedbacks: [{ positive: true, text: 'TestPass', detailText: 'ok' }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.deepStrictEqual(event.failedTests, []);
+        assert.strictEqual(event.failedTestDetails, undefined);
+        assert.strictEqual(event.buildErrorFamilies, undefined);
+    });
+
+    test('4. exerciseId, participationId, submissionId populated', () => {
+        const result = makeResult();
+        const event = collectBuildResult(result, 7);
+
+        assert.strictEqual(event.exerciseId, 7);
+        assert.strictEqual(event.participationId, 9);
+        assert.strictEqual(event.submissionId, 101);
+    });
+
+    test('5. failedTestDetails is undefined when no failed tests', () => {
+        const result = makeResult({ feedbacks: [] });
+        const event = collectBuildResult(result, 5);
+
+        assert.strictEqual(event.failedTestDetails, undefined);
+    });
+
+    test('6. buildErrorFamilies text truncated at 200 chars (not 50)', () => {
+        const longText = 'A'.repeat(300);
+        const result = makeResult({
+            feedbacks: [{ positive: false, text: longText, detailText: 'detail' }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.ok(event.buildErrorFamilies?.length === 1);
+        // prefix 'build:' = 6 chars + 200 chars of text = 206
+        assert.strictEqual(event.buildErrorFamilies![0].length, 6 + 200);
+        assert.strictEqual(event.buildErrorFamilies![0], `build:${'A'.repeat(200)}`);
+    });
+
+    test('7. positive:false, text undefined → testName=unknown', () => {
+        const result = makeResult({
+            feedbacks: [{ positive: false, text: undefined, detailText: 'some error' }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.deepStrictEqual(event.failedTestDetails, [{ testName: 'unknown', detail: 'some error' }]);
+    });
+
+    test('8. positive:false, detailText undefined → detail and failedTests entry are empty string', () => {
+        const result = makeResult({
+            feedbacks: [{ positive: false, text: 'TestBaz', detailText: undefined }],
+        });
+        const event = collectBuildResult(result, 5);
+
+        assert.deepStrictEqual(event.failedTests, ['']);
+        assert.deepStrictEqual(event.failedTestDetails, [{ testName: 'TestBaz', detail: '' }]);
+    });
+
+    test('9. activeExerciseId undefined → exerciseId not set in event', () => {
+        const result = makeResult();
+        const event = collectBuildResult(result, undefined);
+
+        assert.strictEqual(event.exerciseId, undefined);
+        assert.strictEqual(event.participationId, 9);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
@@ -1,0 +1,818 @@
+/**
+ * Unit tests for SessionRecorder — Block AB+E
+ *
+ * Covers the lifecycle FSM, commit boundary, generation token, startup
+ * contributors, initial-state events, and consent-downgrade semantics.
+ *
+ * Tests drive the real SessionRecorder class with an injected
+ * RecordingStorageWriter backed by a controllable in-memory fake fs. VS Code
+ * listeners that fire during startup (`visibleTextEditors`, `terminals`,
+ * `activeTextEditor`) are read from the real `vscode` namespace — the tests
+ * make no assumptions about what is open at test time and assert only on the
+ * presence/ordering of marker events and lifecycle-relevant pieces of the
+ * stream.
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SessionRecorder } from '../../../../../src/extension/services/telemetry/recording/sessionRecorder';
+import type { RecordedEvent } from '../../../../../src/extension/services/telemetry/recording/types';
+import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+
+// ── Fake FS with full pause-control ───────────────────────────────────────
+
+/**
+ * In-memory RecordingFs with pause-on-demand for mkdir, writeFile and
+ * appendFile. Test setups arm a pause before triggering an operation and
+ * release it later to simulate concurrent events.
+ */
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    removedPaths: string[] = [];
+    syncChunks: string[] = [];
+    mkdirCalls = 0;
+
+    /** When true, the next writeFile call returns a promise that resolves via _releaseWriteFile(). */
+    private _pauseNextWriteFile = false;
+    private _writeFileGate: (() => void) | null = null;
+    private _appendGate: (() => void) | null = null;
+    private _pauseNextAppend = false;
+
+    /** Arm the next writeFile to block until releaseWriteFile() is called. */
+    armPauseNextWriteFile(): void {
+        this._pauseNextWriteFile = true;
+    }
+
+    /** Release a paused writeFile. No-op if not currently paused. */
+    releaseWriteFile(): void {
+        const gate = this._writeFileGate;
+        this._writeFileGate = null;
+        gate?.();
+    }
+
+    armPauseNextAppend(): void {
+        this._pauseNextAppend = true;
+    }
+
+    releaseAppend(): void {
+        const gate = this._appendGate;
+        this._appendGate = null;
+        gate?.();
+    }
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        this.mkdirCalls++;
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        if (this._pauseNextWriteFile) {
+            this._pauseNextWriteFile = false;
+            return new Promise<void>((resolve) => {
+                this._writeFileGate = () => {
+                    this.writtenFiles.push({ path: p, data });
+                    resolve();
+                };
+            });
+        }
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        if (this._pauseNextAppend) {
+            this._pauseNextAppend = false;
+            return new Promise<void>((resolve) => {
+                this._appendGate = () => {
+                    this.appendedChunks.push(data);
+                    resolve();
+                };
+            });
+        }
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, _opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push(p);
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of fakeFs.appendedChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed */
+            }
+        }
+    }
+    for (const chunk of fakeFs.syncChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed */
+            }
+        }
+    }
+    return events;
+}
+
+/** Create a fresh SessionRecorder + FakeFs pair, writer injected. */
+function makeRecorder(): { recorder: SessionRecorder; fs: FakeFs } {
+    const fs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(
+        fakeUri,
+        { hasTerminalShellExecution: false, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+    );
+    return { recorder, fs };
+}
+
+// ── Suite ────────────────────────────────────────────────────────────────
+
+suite('SessionRecorder (Block AB+E)', () => {
+    let recorder: SessionRecorder;
+    let fs: FakeFs;
+
+    setup(() => {
+        const ctx = makeRecorder();
+        recorder = ctx.recorder;
+        fs = ctx.fs;
+    });
+
+    teardown(async () => {
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Test: Basic start sequence ────────────────────────────────────────
+
+    test('startSession emits sessionStart, initial-state, startupPhaseComplete in order', async () => {
+        recorder.enable();
+        await recorder.startSession(42, 'p-1');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+
+        assert.ok(events.length > 0, 'expected at least one event');
+        assert.strictEqual(events[0].type, 'sessionStart', `first event should be sessionStart, got ${events[0].type}`);
+
+        const startupIdx = events.findIndex(e => e.type === 'startupPhaseComplete');
+        assert.ok(startupIdx > 0, 'startupPhaseComplete must appear after sessionStart');
+
+        const endIdx = events.findIndex(e => e.type === 'sessionEnd');
+        assert.ok(endIdx > startupIdx, 'sessionEnd must come after startupPhaseComplete');
+
+        // sessionStart carries schemaVersion: 2
+        const start = events[0] as { schemaVersion?: number };
+        assert.strictEqual(start.schemaVersion, 2);
+    });
+
+    // ── Test: sessionEnd is strictly the last event ───────────────────────
+
+    test('sessionEnd is strictly the last event in the stream', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+        recorder.recordIrisChatSent('hello');
+        recorder.recordIrisChatReceived('hi');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        assert.strictEqual(events[events.length - 1].type, 'sessionEnd');
+    });
+
+    // ── Test: Public record methods drop events after disable ─────────────
+
+    test('disable() immediately blocks further record() calls', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        recorder.disable(); // synchronous phase flip to 'disabling'
+
+        // These must be dropped:
+        recorder.recordIrisChatSent('should-not-appear');
+        recorder.recordIrisChatReceived('also-not');
+        recorder.recordEqSnapshot(0.5, 'sufficient', 'save');
+
+        // Let any queued lifecycle work drain.
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        const events = collectWrittenEvents(fs);
+        const chatMsgs = events.filter(e => e.type === 'irisChatMessage');
+        assert.strictEqual(chatMsgs.length, 0, 'no chat messages should reach disk after disable()');
+    });
+
+    // ── Test: post-commit disable produces consentChange + sessionEnd ─────
+
+    test('post-commit disable emits consentChange then sessionEnd, no startupPhaseComplete-after-consentChange', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        // Session is committed and running. Now revoke consent.
+        recorder.disable();
+
+        // Let _doDisable drain.
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        const consentIdx = types.lastIndexOf('consentChange');
+        const endIdx = types.lastIndexOf('sessionEnd');
+
+        assert.ok(consentIdx >= 0, `expected consentChange in stream, got types=${types.join(',')}`);
+        assert.ok(endIdx > consentIdx, 'sessionEnd must come after consentChange');
+
+        // No startupPhaseComplete after consentChange (the teardown path does not re-emit startup).
+        const postConsentTypes = types.slice(consentIdx + 1);
+        assert.ok(!postConsentTypes.includes('startupPhaseComplete'),
+            'startupPhaseComplete must not appear after consentChange');
+    });
+
+    // ── Test: multi-generation coalescing ─────────────────────────────────
+
+    test('three rapid startSession(A,B,C) calls produce at most one sessionStart per exercise', async () => {
+        recorder.enable();
+
+        // Fire three starts without awaiting the first two.
+        const a = recorder.startSession(100);
+        const b = recorder.startSession(101);
+        const c = recorder.startSession(102);
+
+        await Promise.all([a, b, c]);
+        // End the final session so everything flushes.
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const sessionStarts = events.filter(e => e.type === 'sessionStart') as Array<{ exerciseId: number }>;
+
+        // The last-requested start (exercise 102) MUST commit. Earlier requests
+        // are superseded before they reach commit-point, so they leave no
+        // sessionStart on disk.
+        const committedExerciseIds = sessionStarts.map(s => s.exerciseId);
+        assert.ok(committedExerciseIds.includes(102),
+            `expected exerciseId 102 to commit, got ${JSON.stringify(committedExerciseIds)}`);
+
+        // At most one sessionStart per exerciseId.
+        const uniqueIds = new Set(committedExerciseIds);
+        assert.strictEqual(uniqueIds.size, committedExerciseIds.length, 'no duplicate sessionStart per exercise');
+
+        // Each committed sessionStart is paired with a sessionEnd (we ended manually above).
+        const sessionEnds = events.filter(e => e.type === 'sessionEnd');
+        assert.strictEqual(sessionEnds.length, sessionStarts.length,
+            `expected ${sessionStarts.length} sessionEnd(s), got ${sessionEnds.length}`);
+    });
+
+    // ── Test: startSession after disable() is a no-op ─────────────────────
+
+    test('startSession() after disable() does not start a new session', async () => {
+        recorder.enable();
+        recorder.disable();
+
+        await recorder.startSession(7);
+
+        // Let everything settle.
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        const events = collectWrittenEvents(fs);
+        const sessionStarts = events.filter(e => e.type === 'sessionStart');
+        assert.strictEqual(sessionStarts.length, 0, 'no session should have started after disable()');
+    });
+
+    // ── Test: Startup contributors emit between sessionStart and startupPhaseComplete ──
+
+    test('registered startup contributor events appear between sessionStart and startupPhaseComplete', async () => {
+        recorder.enable();
+
+        const marker: RecordedEvent = {
+            type: 'eqEngineState',
+            timestamp: 1234,
+            snapshots: [],
+            currentEQ: 0.42,
+            pairCount: 5,
+            confidence: 'sufficient',
+        };
+
+        recorder.registerStartupContributor(() => [marker]);
+
+        await recorder.startSession(1);
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        const startIdx = types.indexOf('sessionStart');
+        const completeIdx = types.indexOf('startupPhaseComplete');
+        const markerIdx = events.findIndex(e => e.type === 'eqEngineState' && (e as { currentEQ: number }).currentEQ === 0.42);
+
+        assert.ok(startIdx >= 0);
+        assert.ok(completeIdx > startIdx);
+        assert.ok(markerIdx > startIdx && markerIdx < completeIdx,
+            `contributor event must be between sessionStart(${startIdx}) and startupPhaseComplete(${completeIdx}), got index ${markerIdx}`);
+    });
+
+    // ── Test: metadata.eventCount matches lines written ──────────────────
+
+    test('metadata.eventCount equals number of events in events.jsonl', async () => {
+        recorder.enable();
+        await recorder.startSession(77);
+        recorder.recordIrisChatSent('a');
+        recorder.recordIrisChatSent('b');
+        recorder.recordIrisChatSent('c');
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+
+        // Find the last metadata write.
+        const metadataWrite = [...fs.writtenFiles].reverse().find(f => f.path.endsWith('metadata.json'));
+        assert.ok(metadataWrite, 'metadata.json was not written');
+        const metadata = JSON.parse(metadataWrite.data) as { eventCount: number };
+
+        assert.strictEqual(metadata.eventCount, events.length,
+            `metadata.eventCount=${metadata.eventCount} but JSONL has ${events.length} events`);
+    });
+
+    // ── Test: _recordInternal phase gating (via public surface) ──────────
+
+    test('record() after session ends but before new session starts is a no-op', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+        await recorder.endSession();
+
+        const beforeLength = collectWrittenEvents(fs).length;
+
+        recorder.recordIrisChatSent('ghost');
+        recorder.recordEqSnapshot(0.1, 'sufficient', 'save');
+
+        const afterLength = collectWrittenEvents(fs).length;
+
+        assert.strictEqual(afterLength, beforeLength,
+            'no events should be written between sessions');
+    });
+
+    // ── Test: enable()/disable() is idempotent ───────────────────────────
+
+    test('enable() after enable() is a no-op', () => {
+        recorder.enable();
+        assert.strictEqual(recorder.isEnabled, true);
+        recorder.enable(); // should not throw
+        assert.strictEqual(recorder.isEnabled, true);
+    });
+
+    test('disable() after disable() is a no-op', () => {
+        recorder.enable();
+        recorder.disable();
+        recorder.disable(); // should not throw
+    });
+
+    // ── Test: Pre-commit disable (paused initSession) aborts cleanly ─────
+
+    test('disable() during paused initSession aborts without writing sessionStart', async () => {
+        recorder.enable();
+
+        // Arm: next writeFile (events.jsonl init inside initSession) will block
+        // until we call releaseWriteFile().
+        fs.armPauseNextWriteFile();
+
+        const startPromise = recorder.startSession(99);
+
+        // Yield so _doStart begins and reaches the paused writeFile.
+        for (let i = 0; i < 10; i++) { await Promise.resolve(); }
+
+        // Consent revoked while initSession is in flight. _requestedGeneration
+        // flips to -1; _phase to 'disabling'.
+        recorder.disable();
+
+        // Release the paused writeFile so _doStart advances to its pre-commit
+        // re-check — which must abort (no sessionStart written).
+        fs.releaseWriteFile();
+
+        // Await the start call (no-ops after abort) and the disable lifecycle.
+        try { await startPromise; } catch { /* ignore */ }
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        // Session never committed, so no sessionStart AND no consentChange/sessionEnd pair.
+        assert.ok(!types.includes('sessionStart'),
+            `pre-commit disable must not leak sessionStart. types=${types.join(',')}`);
+        assert.ok(!types.includes('consentChange'),
+            'pre-commit disable must not emit consentChange for an uncommitted session');
+        assert.ok(!types.includes('sessionEnd'),
+            'pre-commit disable must not emit sessionEnd for an uncommitted session');
+
+        // The writer was aborted → session directory was requested to be removed.
+        assert.ok(fs.removedPaths.length > 0, 'writer.abort() should have removed the session dir');
+    });
+
+    // ── Test: consent downgrade discards pending debounces (via disable) ──
+
+    test('consent-downgrade path does not re-emit startupPhaseComplete', async () => {
+        recorder.enable();
+        await recorder.startSession(5);
+
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        // There should be exactly one startupPhaseComplete in the stream
+        // (from the initial startSession), never a second one from teardown.
+        const completeCount = types.filter(t => t === 'startupPhaseComplete').length;
+        assert.strictEqual(completeCount, 1,
+            `expected exactly one startupPhaseComplete, got ${completeCount}`);
+    });
+
+    // ── Test: dispose drains buffered events ─────────────────────────────
+
+    test('dispose() with buffered events flushes everything before resolving', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        // Record a few events that are below the flush threshold.
+        recorder.recordIrisChatSent('msg-1');
+        recorder.recordIrisChatSent('msg-2');
+        recorder.recordIrisChatSent('msg-3');
+
+        await recorder.dispose();
+
+        const events = collectWrittenEvents(fs);
+        const chatMsgs = events.filter(e => e.type === 'irisChatMessage');
+        assert.strictEqual(chatMsgs.length, 3,
+            `expected 3 chat messages after dispose, got ${chatMsgs.length}`);
+
+        // sessionEnd came before the dispose-flush path.
+        const types = events.map(e => e.type);
+        assert.ok(types.includes('sessionEnd'), 'dispose() should end the active session');
+    });
+
+    // ── Test: Generation token monotonicity (regression for reuse bug) ────
+
+    test('disable → re-enable → start uses strictly larger generation (no reuse)', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        // Revoke consent: downgrades session 1 with consentChange + sessionEnd,
+        // which flushes the buffer.
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        recorder.enable();
+        await recorder.startSession(2);
+        await recorder.endSession();
+
+        const allEvents = collectWrittenEvents(fs);
+        const starts = allEvents.filter(e => e.type === 'sessionStart') as Array<{ exerciseId: number }>;
+        const ends = allEvents.filter(e => e.type === 'sessionEnd') as Array<{ exerciseId: number }>;
+        const consents = allEvents.filter(e => e.type === 'consentChange');
+
+        // Session 1 committed, then downgraded (consentChange + sessionEnd).
+        // Session 2 committed and ended regularly.
+        assert.deepStrictEqual(starts.map(s => s.exerciseId), [1, 2],
+            'two sessionStart events, one per exerciseId, in order');
+        assert.deepStrictEqual(ends.map(e => e.exerciseId), [1, 2],
+            'two sessionEnd events, one per exerciseId, in order');
+        assert.strictEqual(consents.length, 1,
+            'one consentChange from the disable that ended session 1');
+
+        // Inspect on-disk layout: both sessions wrote their own session dir.
+        const uniqueDirs = new Set(fs.writtenFiles.map(f => f.path.split('/').slice(0, -1).join('/')));
+        assert.ok(uniqueDirs.size >= 2, 'expected at least 2 session directories');
+    });
+
+    // ── Test: stale contributor from a previous generation is ignored ───
+
+    test('stale contributor that outlives its session does not leak events into a later one', async () => {
+        recorder.enable();
+
+        // A "misbehaving" contributor that caches the ctx and re-fires events
+        // for a previous session. We exercise the generation gate explicitly
+        // by calling recordViewNavigation() from inside the contributor,
+        // which uses _currentGeneration at call-time — in the current (good)
+        // implementation that is always the live generation, so this test
+        // really just anchors the monotonic-generation invariant: the pre-
+        // `-1` bug would have produced a `viewNavigation` event from
+        // generation 0 inside session 2's stream after a disable + re-enable
+        // cycle because _currentGeneration would also have been 0.
+        let firedCount = 0;
+        recorder.registerStartupContributor(() => {
+            firedCount++;
+            return [];
+        });
+
+        await recorder.startSession(10);
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        recorder.enable();
+        await recorder.startSession(11);
+        await recorder.endSession();
+
+        // Contributor fired once per committed session — not more, not less.
+        assert.strictEqual(firedCount, 2, `contributor fired ${firedCount} times, expected 2`);
+
+        // Both committed sessions exist, and each one is balanced.
+        const events = collectWrittenEvents(fs);
+        const starts = events.filter(e => e.type === 'sessionStart');
+        const ends = events.filter(e => e.type === 'sessionEnd');
+        assert.strictEqual(starts.length, 2);
+        assert.strictEqual(ends.length, 2);
+
+        // No crossover: the second session must not contain the first
+        // session's exerciseId (which would indicate generation leakage).
+        const startsTyped = starts as Array<{ exerciseId: number }>;
+        assert.deepStrictEqual(startsTyped.map(s => s.exerciseId), [10, 11]);
+    });
+
+    // ── Test: consent-downgrade discards pending debounce payloads ──────
+
+    test('consent-downgrade discards pending debounce payloads instead of flushing them', async () => {
+        recorder.enable();
+        await recorder.startSession(5);
+
+        // Directly prime _pendingSelectionPayloads (per-URI Map, Block J) via
+        // `as any` to simulate a debounce timer that is pending but has not
+        // yet fired when consent is revoked.
+        const fakeUri = 'file:///fake/Pending.java';
+        const pendingPayload: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: Date.now(),
+            uri: fakeUri,
+            selections: [{ startLine: 1, startCharacter: 0, endLine: 1, endCharacter: 5 }],
+            kind: undefined,
+        };
+        (recorder as any)._pendingSelectionPayloads.set(fakeUri, pendingPayload);
+
+        // Revoke consent — _doDisable must DISCARD, not flush, the pending payload.
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        // The pending selectionChange must NOT appear in the stream.
+        const selectionEvents = events.filter(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === fakeUri);
+        assert.strictEqual(selectionEvents.length, 0,
+            'pending debounce payload must be discarded (not flushed) on consent downgrade');
+
+        // The stream must still end with consentChange then sessionEnd.
+        const consentIdx = types.lastIndexOf('consentChange');
+        const endIdx = types.lastIndexOf('sessionEnd');
+        assert.ok(consentIdx >= 0, 'consentChange must appear in the stream');
+        assert.ok(endIdx > consentIdx, 'sessionEnd must come after consentChange');
+
+        // The recorder must have cleared all pending payloads.
+        assert.strictEqual((recorder as any)._pendingSelectionPayloads.size, 0,
+            '_pendingSelectionPayloads must be empty after disable()');
+        assert.strictEqual((recorder as any)._pendingVisibleRangePayloads.size, 0,
+            '_pendingVisibleRangePayloads must be empty after disable()');
+    });
+
+    // ── Test: record methods without recording phase are no-ops ──────────
+
+    test('recordPanelVisibility is a no-op when no session is active', async () => {
+        recorder.enable();
+
+        recorder.recordPanelVisibility('artemis', true);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const events = collectWrittenEvents(fs);
+        const panelEvents = events.filter(e => e.type === 'panelVisibility');
+        assert.strictEqual(panelEvents.length, 0,
+            'panelVisibility before startSession must not be recorded');
+    });
+
+    // ── Block J: Per-URI debounce tests ───────────────────────────────────
+
+    test('Block J — alternating selections on two URIs both appear in stream (no overwrite)', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uriA = 'file:///proj/A.java';
+        const uriB = 'file:///proj/B.java';
+
+        const payloadA: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: 1000,
+            uri: uriA,
+            selections: [{ startLine: 0, startCharacter: 0, endLine: 0, endCharacter: 3 }],
+            kind: undefined,
+        };
+        const payloadB: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: 2000,
+            uri: uriB,
+            selections: [{ startLine: 5, startCharacter: 0, endLine: 5, endCharacter: 7 }],
+            kind: undefined,
+        };
+
+        // Simulate two different URIs triggering in quick succession.
+        (recorder as any)._pendingSelectionPayloads.set(uriA, payloadA);
+        (recorder as any)._pendingSelectionPayloads.set(uriB, payloadB);
+
+        // Flush on session end must emit both.
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const selA = events.filter(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === uriA);
+        const selB = events.filter(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === uriB);
+
+        assert.strictEqual(selA.length, 1, 'selection event for URI A must appear exactly once');
+        assert.strictEqual(selB.length, 1, 'selection event for URI B must appear exactly once');
+    });
+
+    test('Block J — trigger-time payload is recorded, not post-trigger state', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uri = 'file:///proj/C.java';
+        const triggerTimePayload: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: 3000,
+            uri,
+            selections: [{ startLine: 10, startCharacter: 0, endLine: 10, endCharacter: 4 }],
+            kind: undefined,
+        };
+
+        // Prime the pending map as if the event listener serialized at trigger time.
+        (recorder as any)._pendingSelectionPayloads.set(uri, triggerTimePayload);
+
+        // Simulate a post-trigger state change: the map now holds a DIFFERENT payload
+        // for the same URI — but we captured triggerTimePayload already, so the
+        // timer closure (which holds a reference to triggerTimePayload) will compare
+        // correctly. To test the flush path here, we call _flushPendingDebouncesForEnd
+        // directly (the timer has not been set in this white-box test, so endSession
+        // is the flush path).
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const selEvents = events.filter(e =>
+            e.type === 'selectionChange' && (e as { uri?: string }).uri === uri
+        ) as Array<{ selections: Array<{ startLine: number }> }>;
+
+        assert.strictEqual(selEvents.length, 1, 'exactly one selectionChange for URI C');
+        assert.strictEqual(selEvents[0].selections[0].startLine, 10,
+            'recorded selection must reflect trigger-time payload (line 10), not a later state');
+    });
+
+    test('Block J — pending debounce at endSession appears before sessionEnd', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uri = 'file:///proj/D.java';
+        const payload: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: 4000,
+            uri,
+            selections: [{ startLine: 2, startCharacter: 0, endLine: 2, endCharacter: 1 }],
+            kind: undefined,
+        };
+
+        // Prime a pending payload that has not yet fired its timer.
+        (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const selIdx = events.findIndex(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === uri);
+        const endIdx = events.findIndex(e => e.type === 'sessionEnd');
+
+        assert.ok(selIdx >= 0, 'pending selectionChange must appear in the stream on endSession');
+        assert.ok(endIdx > selIdx, 'selectionChange must appear before sessionEnd');
+    });
+
+    test('Block J — pending debounce at disable() does NOT appear in stream', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uri = 'file:///proj/E.java';
+        const payload: RecordedEvent = {
+            type: 'selectionChange',
+            timestamp: 5000,
+            uri,
+            selections: [{ startLine: 3, startCharacter: 0, endLine: 3, endCharacter: 2 }],
+            kind: undefined,
+        };
+
+        (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+
+        // Consent revoked — pending payload must be discarded (Option A).
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const selEvents = events.filter(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === uri);
+        assert.strictEqual(selEvents.length, 0,
+            'pending debounce must be discarded (not flushed) when consent is revoked via disable()');
+    });
+
+    test('Block J — repeated triggers on same URI clear old timer, no memory leak', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uri = 'file:///proj/F.java';
+
+        // Simulate five rapid triggers on the same URI — only the last should remain pending.
+        for (let i = 0; i < 5; i++) {
+            const payload: RecordedEvent = {
+                type: 'selectionChange',
+                timestamp: 6000 + i,
+                uri,
+                selections: [{ startLine: i, startCharacter: 0, endLine: i, endCharacter: 1 }],
+                kind: undefined,
+            };
+            (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+        }
+
+        // After rapid triggers the map must still have exactly one entry for this URI.
+        assert.strictEqual(
+            (recorder as any)._pendingSelectionPayloads.size,
+            1,
+            'per-URI map must hold at most one pending payload per URI (no accumulation)',
+        );
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const selEvents = events.filter(e => e.type === 'selectionChange' && (e as { uri?: string }).uri === uri);
+        assert.strictEqual(selEvents.length, 1,
+            'exactly one selectionChange for F.java — the last trigger-time payload');
+    });
+
+    test('Block J — visible-range alternating on two URIs both appear in stream (no overwrite)', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uriA = 'file:///proj/G.java';
+        const uriB = 'file:///proj/H.java';
+
+        const payloadA: RecordedEvent = {
+            type: 'visibleRangeChange',
+            timestamp: 7000,
+            uri: uriA,
+            visibleRanges: [{ startLine: 0, startCharacter: 0, endLine: 20, endCharacter: 0 }],
+        };
+        const payloadB: RecordedEvent = {
+            type: 'visibleRangeChange',
+            timestamp: 8000,
+            uri: uriB,
+            visibleRanges: [{ startLine: 50, startCharacter: 0, endLine: 80, endCharacter: 0 }],
+        };
+
+        // Simulate two different URIs triggering visible-range changes in quick succession.
+        (recorder as any)._pendingVisibleRangePayloads.set(uriA, payloadA);
+        (recorder as any)._pendingVisibleRangePayloads.set(uriB, payloadB);
+
+        // Flush on session end must emit both.
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const vrA = events.filter(e => e.type === 'visibleRangeChange' && (e as { uri?: string }).uri === uriA);
+        const vrB = events.filter(e => e.type === 'visibleRangeChange' && (e as { uri?: string }).uri === uriB);
+
+        assert.strictEqual(vrA.length, 1, 'visibleRangeChange for URI G must appear exactly once');
+        assert.strictEqual(vrB.length, 1, 'visibleRangeChange for URI H must appear exactly once');
+    });
+
+    test('Block J — pending visible-range at disable() does NOT appear in stream', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const uri = 'file:///proj/I.java';
+        const payload: RecordedEvent = {
+            type: 'visibleRangeChange',
+            timestamp: 9000,
+            uri,
+            visibleRanges: [{ startLine: 10, startCharacter: 0, endLine: 30, endCharacter: 0 }],
+        };
+
+        (recorder as any)._pendingVisibleRangePayloads.set(uri, payload);
+
+        // Consent revoked — pending payload must be discarded (Option A).
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fs);
+        const vrEvents = events.filter(e => e.type === 'visibleRangeChange' && (e as { uri?: string }).uri === uri);
+        assert.strictEqual(vrEvents.length, 0,
+            'pending visibleRangeChange must be discarded (not flushed) when consent is revoked via disable()');
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/snapshotRetry.test.ts
+++ b/extension/test/unit/services/telemetry/recording/snapshotRetry.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Unit tests for Block G — Snapshot Retry with fileSnapshotError
+ *
+ * Covers:
+ *   - writeSnapshot() returns false on fs error, true on success
+ *   - First write failure: no fileSnapshot event, URI not in _snapshotedUris,
+ *     retry happens on next editor switch
+ *   - 3 consecutive failures: one fileSnapshotError event, no fileSnapshot event,
+ *     URI permanently marked (no further retry attempts)
+ *   - After fileSnapshotError: further editor switches to the same URI are no-ops
+ *   - _snapshotRetries is cleared on session end/start (via _resetSessionState)
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SessionRecorder } from '../../../../../src/extension/services/telemetry/recording/sessionRecorder';
+import type { RecordedEvent } from '../../../../../src/extension/services/telemetry/recording/types';
+import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+
+// ── Fake FS with per-path failure control ─────────────────────────────────────
+
+/**
+ * A RecordingFs where writeFile can be configured to fail for specific paths
+ * a given number of times, then succeed. Tracks all writeFile calls per path.
+ */
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    removedPaths: string[] = [];
+    syncChunks: string[] = [];
+
+    /** Map of path-suffix → remaining failure count */
+    private _failPaths = new Map<string, number>();
+
+    /**
+     * Make the next N writeFile calls that contain `pathFragment` in the path
+     * reject with an I/O error.
+     */
+    failWriteFileFor(pathFragment: string, times: number): void {
+        this._failPaths.set(pathFragment, times);
+    }
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        for (const [fragment, remaining] of this._failPaths) {
+            if (p.includes(fragment) && remaining > 0) {
+                this._failPaths.set(fragment, remaining - 1);
+                return Promise.reject(new Error(`fake fs error for ${fragment}`));
+            }
+        }
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, _opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push(p);
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of fakeFs.appendedChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed */
+            }
+        }
+    }
+    for (const chunk of fakeFs.syncChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed */
+            }
+        }
+    }
+    return events;
+}
+
+/** Create a fresh SessionRecorder + FakeFs pair with writer injected. */
+function makeRecorder(): { recorder: SessionRecorder; fs: FakeFs } {
+    const fs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(
+        fakeUri,
+        { hasTerminalShellExecution: false, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+    );
+    return { recorder, fs };
+}
+
+/**
+ * Directly call _snapshotDocument via (recorder as any) to simulate an
+ * editor switch that triggers a snapshot. This is the cleanest way to test
+ * the retry logic without spinning up VS Code's real text editor events.
+ */
+async function triggerSnapshot(
+    recorder: SessionRecorder,
+    uri: string,
+    content: string,
+    generation: number,
+): Promise<void> {
+    await (recorder as any)._snapshotDocument(uri, content, generation, false);
+}
+
+// ── Suite ────────────────────────────────────────────────────────────────────
+
+suite('SessionRecorder — Block G: Snapshot Retry', () => {
+    let recorder: SessionRecorder;
+    let fs: FakeFs;
+
+    setup(async () => {
+        const ctx = makeRecorder();
+        recorder = ctx.recorder;
+        fs = ctx.fs;
+        recorder.enable();
+        await recorder.startSession(42, 'p-1');
+    });
+
+    teardown(async () => {
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Test 1: writeSnapshot returns false on error, true on success ─────
+
+    test('writeSnapshot() returns false on fs error and true on success', async () => {
+        const ctx = makeRecorder();
+        const { fs: testFs } = ctx;
+        const writer = new RecordingStorageWriter('/fake-base', testFs, 'test-version');
+        await writer.initSession('test-session');
+
+        const URI_FRAGMENT = 'MyClass_';
+        testFs.failWriteFileFor(URI_FRAGMENT, 1);
+
+        // Make the path include our fragment via a matching URI
+        const failResult = await writer.writeSnapshot('file:///MyClass_fail.java', 'content');
+        assert.strictEqual(failResult, false, 'writeSnapshot must return false on fs error');
+
+        const successResult = await writer.writeSnapshot('file:///MyClass_fail.java', 'content');
+        assert.strictEqual(successResult, true, 'writeSnapshot must return true on success');
+
+        await writer.endSession();
+    });
+
+    // ── Test 2: First failure — no fileSnapshot, URI not in _snapshotedUris ──
+
+    test('first snapshot failure: no fileSnapshot event emitted, URI stays unsnapshotted', async () => {
+        const uri = 'file:///fake/Main.java';
+        // The sanitized filename will contain the sha1 hash prefix + "Main.java"
+        // We fail any writeFile that is not events.jsonl or metadata.json (i.e., snapshot files).
+        fs.failWriteFileFor('snapshots', 1);
+
+        const gen = (recorder as any)._currentGeneration as number;
+        await triggerSnapshot(recorder, uri, 'class Main {}', gen);
+
+        const events = collectWrittenEvents(fs);
+        const snapshots = events.filter(e => e.type === 'fileSnapshot') as Array<{ uri: string }>;
+        assert.strictEqual(snapshots.length, 0, 'no fileSnapshot should be emitted on first failure');
+
+        // URI must NOT be in _snapshotedUris so a retry can happen
+        const snapshotedUris = (recorder as any)._snapshotedUris as Set<string>;
+        assert.ok(!snapshotedUris.has(uri), 'URI must not be in _snapshotedUris after first failure');
+
+        // retry counter should be 1
+        const retries = (recorder as any)._snapshotRetries as Map<string, number>;
+        assert.strictEqual(retries.get(uri), 1, 'retry counter must be 1 after first failure');
+    });
+
+    // ── Test 3: Retry succeeds on second attempt ──────────────────────────
+
+    test('retry on second editor switch succeeds: one fileSnapshot event, URI marked as snapshotted', async () => {
+        const uri = 'file:///fake/Main.java';
+        // Fail only the first snapshot write
+        fs.failWriteFileFor('snapshots', 1);
+
+        const gen = (recorder as any)._currentGeneration as number;
+
+        // First attempt — fails
+        await triggerSnapshot(recorder, uri, 'class Main {}', gen);
+
+        const eventsAfterFailure = collectWrittenEvents(fs);
+        const snapshotsAfterFailure = eventsAfterFailure.filter(e => e.type === 'fileSnapshot');
+        assert.strictEqual(snapshotsAfterFailure.length, 0, 'no snapshot after first failure');
+
+        // URI is still not in _snapshotedUris — simulate next editor switch
+        const snapshotedUrisBefore = (recorder as any)._snapshotedUris as Set<string>;
+        assert.ok(!snapshotedUrisBefore.has(uri), 'URI must not be snapshotted yet, enabling retry');
+
+        // Second attempt — succeeds (fs is no longer failing)
+        await triggerSnapshot(recorder, uri, 'class Main {}', gen);
+
+        // Check in-memory state BEFORE endSession clears it via _resetSessionState().
+        const snapshotedUris = (recorder as any)._snapshotedUris as Set<string>;
+        assert.ok(snapshotedUris.has(uri), 'URI must be in _snapshotedUris after successful retry');
+
+        const retries = (recorder as any)._snapshotRetries as Map<string, number>;
+        assert.ok(!retries.has(uri), 'retry counter must be cleared after success');
+
+        // endSession flushes the buffer so the fileSnapshot event reaches appendedChunks.
+        await recorder.endSession();
+
+        const eventsAfterRetry = collectWrittenEvents(fs);
+        const snapshots = eventsAfterRetry.filter(e => e.type === 'fileSnapshot') as Array<{ uri: string }>;
+        assert.strictEqual(snapshots.length, 1, 'exactly one fileSnapshot after successful retry');
+        assert.strictEqual(snapshots[0].uri, uri);
+    });
+
+    // ── Test 4: 3 consecutive failures → one fileSnapshotError event ──────
+
+    test('3 consecutive failures: emits exactly one fileSnapshotError, URI permanently marked', async () => {
+        const uri = 'file:///fake/Heavy.java';
+        // Fail all 3 snapshot writes
+        fs.failWriteFileFor('snapshots', 3);
+
+        const gen = (recorder as any)._currentGeneration as number;
+
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+
+        // Check in-memory state BEFORE endSession clears it via _resetSessionState().
+        const snapshotedUris = (recorder as any)._snapshotedUris as Set<string>;
+        assert.ok(snapshotedUris.has(uri), 'URI must be in _snapshotedUris after max-retry failure');
+
+        const retries = (recorder as any)._snapshotRetries as Map<string, number>;
+        assert.ok(!retries.has(uri), 'retry counter must be cleared after max retries');
+
+        // endSession flushes the buffer so the fileSnapshotError event reaches appendedChunks.
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+
+        const snapshots = events.filter(e => e.type === 'fileSnapshot');
+        assert.strictEqual(snapshots.length, 0, 'no fileSnapshot should be emitted after 3 failures');
+
+        const errors = events.filter(e => e.type === 'fileSnapshotError') as Array<{ uri: string; reason: string }>;
+        assert.strictEqual(errors.length, 1, 'exactly one fileSnapshotError must be emitted');
+        assert.strictEqual(errors[0].uri, uri);
+        assert.strictEqual(errors[0].reason, 'snapshot-write-failed-after-3-retries');
+    });
+
+    // ── Test 5: After fileSnapshotError, further switches are no-ops ──────
+
+    test('after fileSnapshotError, further snapshot attempts for the same URI are no-ops', async () => {
+        const uri = 'file:///fake/Frozen.java';
+        // Fail all 3 writes to reach the error state
+        fs.failWriteFileFor('snapshots', 3);
+
+        const gen = (recorder as any)._currentGeneration as number;
+
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+
+        // URI is now in _snapshotedUris — any subsequent call from
+        // _captureFirstOpenSnapshot would be guarded by the `has(uri)` check.
+        // Verify the set membership BEFORE endSession clears it via _resetSessionState().
+        const snapshotedUrisBefore = (recorder as any)._snapshotedUris as Set<string>;
+        assert.ok(snapshotedUrisBefore.has(uri), 'URI should be permanently marked at this point');
+
+        // editorSwitch listener guard: _snapshotedUris.has(uri) must be true, blocking 4th attempt.
+        // This is the invariant that prevents further snapshot attempts for this URI.
+        assert.ok(snapshotedUrisBefore.has(uri),
+            'editorSwitch listener guard: _snapshotedUris.has(uri) must be true, blocking 4th attempt');
+
+        // endSession flushes the event buffer to disk so we can inspect it via collectWrittenEvents.
+        // The fileSnapshotError event is in the writer's buffer until the flush runs.
+        await recorder.endSession();
+
+        // Verify exactly one fileSnapshotError in the event stream, confirming:
+        //   (a) the error was emitted after the 3rd failure, and
+        //   (b) no duplicate error was produced (the URI was permanently marked).
+        const events = collectWrittenEvents(fs);
+        const errorsAfterEnd = events.filter(e => e.type === 'fileSnapshotError');
+        assert.strictEqual(errorsAfterEnd.length, 1,
+            'exactly one fileSnapshotError in the event stream — no duplicate error events');
+    });
+
+    // ── Test 6: _snapshotRetries cleared on new session ───────────────────
+
+    test('_snapshotRetries is cleared when a new session starts', async () => {
+        const uri = 'file:///fake/Transient.java';
+        // Fail once (but not max) to set a retry counter
+        fs.failWriteFileFor('snapshots', 1);
+
+        const gen = (recorder as any)._currentGeneration as number;
+        await triggerSnapshot(recorder, uri, 'content', gen);
+
+        const retriesBefore = (recorder as any)._snapshotRetries as Map<string, number>;
+        assert.strictEqual(retriesBefore.get(uri), 1, 'retry counter is 1 before session restart');
+
+        // End session and start a new one
+        await recorder.endSession();
+        await recorder.startSession(43, 'p-2');
+
+        const retriesAfter = (recorder as any)._snapshotRetries as Map<string, number>;
+        assert.strictEqual(retriesAfter.size, 0, '_snapshotRetries must be empty after new session starts');
+
+        await recorder.endSession();
+    });
+
+    // ── Test 7: fileSnapshotError appears before sessionEnd ───────────────
+
+    test('fileSnapshotError is written to the event stream (before sessionEnd)', async () => {
+        const uri = 'file:///fake/ErrOrder.java';
+        fs.failWriteFileFor('snapshots', 3);
+
+        const gen = (recorder as any)._currentGeneration as number;
+
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+        await triggerSnapshot(recorder, uri, 'content', gen);
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const types = events.map(e => e.type);
+
+        const errorIdx = types.indexOf('fileSnapshotError');
+        const endIdx = types.lastIndexOf('sessionEnd');
+
+        assert.ok(errorIdx >= 0, 'fileSnapshotError must appear in the event stream');
+        assert.ok(endIdx > errorIdx, 'sessionEnd must come after fileSnapshotError');
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/storageWriter.test.ts
+++ b/extension/test/unit/services/telemetry/recording/storageWriter.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Unit tests for RecordingStorageWriter — Block D
+ *
+ * Tests cover:
+ *   - Write-lane serialisation (no parallel appendFile calls)
+ *   - Atomic batch removal (failed write retains events)
+ *   - Event ordering across concurrent triggers
+ *   - dispose() sync-fallback (idle lane)
+ *   - dispose() async-drain (busy lane)
+ *   - Consecutive-error counter disables writer
+ *   - Threshold + timer flush debounce (no runaway queue)
+ *   - abort() removes session directory
+ *   - endSession() waits for in-flight flush and deferred flush (race fix)
+ *   - writeMetadata enrichment (schemaVersion, recorderVersion)
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordedEvent } from '../../../../../src/extension/services/telemetry/recording/types';
+
+// ── Fake FS ───────────────────────────────────────────────────────────────────
+
+/**
+ * A fully-controllable in-memory RecordingFs implementation.
+ * appendFile writes to the `appendedChunks` list; writeFile goes to `writtenFiles`.
+ */
+class FakeFs implements RecordingFs {
+    /** All chunks passed to appendFile(), in call order */
+    appendedChunks: string[] = [];
+
+    /** All args to rm() */
+    removedPaths: { path: string; recursive: boolean; force: boolean }[] = [];
+
+    /** All args to writeFile() */
+    writtenFiles: { path: string; data: string }[] = [];
+
+    /** Control: if set, the next N appendFile calls will reject with this error */
+    private _rejectNextN = 0;
+    private _rejectError: Error = new Error('fake io error');
+
+    /** Control: if set, next appendFile returns a promise that won't resolve until released */
+    private _pending: { resolve: () => void; reject: (e: Error) => void } | null = null;
+
+    /** All chunks passed to appendFileSync() */
+    syncChunks: string[] = [];
+
+    // ── Control methods ─────────────────────────────────────────────────
+
+    /** Make the next N appendFile calls reject */
+    failNextN(n: number, err?: Error): void {
+        this._rejectNextN = n;
+        if (err) { this._rejectError = err; }
+    }
+
+    /**
+     * Pause the next appendFile call. Returns a handle to release it.
+     * The promise is only resolved when `releaseHandle.resolve()` is called.
+     */
+    pauseNext(): { resolve(): void; reject(e: Error): void } {
+        const handle = { resolve: () => {}, reject: (_: Error) => {} };
+        this._pending = handle;
+        return handle;
+    }
+
+    // ── RecordingFs interface ────────────────────────────────────────────
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        if (this._rejectNextN > 0) {
+            this._rejectNextN--;
+            return Promise.reject(this._rejectError);
+        }
+        if (this._pending) {
+            const pending = this._pending;
+            this._pending = null;
+            return new Promise<void>((resolve, reject) => {
+                pending.resolve = () => { this.appendedChunks.push(data); resolve(); };
+                pending.reject = (e) => reject(e);
+            });
+        }
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push({ path: p, ...opts });
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(id: number): RecordedEvent {
+    return {
+        type: 'windowFocus',
+        timestamp: id,
+        focused: true,
+    } satisfies RecordedEvent;
+}
+
+/** Collect all JSONL events from the fake FS appendedChunks list */
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of fakeFs.appendedChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            events.push(JSON.parse(line) as RecordedEvent);
+        }
+    }
+    return events;
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+suite('RecordingStorageWriter (Block D)', () => {
+    let fakeFs: FakeFs;
+    let writer: RecordingStorageWriter;
+
+    const BASE_DIR = '/fake/base';
+    const SESSION_ID = 'test-session-001';
+    const SESSION_DIR = path.join(BASE_DIR, 'recordings', SESSION_ID);
+
+    setup(async () => {
+        fakeFs = new FakeFs();
+        writer = new RecordingStorageWriter(BASE_DIR, fakeFs, '2.0');
+        await writer.initSession(SESSION_ID);
+    });
+
+    teardown(async () => {
+        // Always stop internal timer. Dispose is idempotent.
+        try { await writer.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Test 1: Ordering under 100 parallel appendEvent calls ─────────────────
+
+    suite('Ordering', () => {
+        test('100 parallel appendEvent calls produce events in emit-order with no duplicates', async () => {
+            // Pause the first appendFile so some events arrive mid-flush.
+            // The handle's .resolve() is only wired up AFTER appendFile is called,
+            // so we must yield to the event loop before calling handle.resolve().
+            const handle = fakeFs.pauseNext();
+
+            // Emit first 20 events to trigger threshold flush
+            for (let i = 0; i < 20; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Yield so the lane's first flush actually calls appendFile (setting up handle.resolve)
+            await Promise.resolve();
+
+            // Emit 80 more while first flush is in flight
+            for (let i = 20; i < 100; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Let first flush complete (now handle.resolve is wired up)
+            handle.resolve();
+
+            // Drain all pending lane work
+            await writer.flush();
+
+            const written = collectWrittenEvents(fakeFs);
+
+            // All 100 events present
+            assert.strictEqual(written.length, 100, `Expected 100 events, got ${written.length}`);
+
+            // No duplicates
+            const timestamps = written.map(e => e.timestamp);
+            const unique = new Set(timestamps);
+            assert.strictEqual(unique.size, 100, 'Duplicate events detected');
+
+            // In emit order (timestamps 0..99 ascending)
+            for (let i = 0; i < 100; i++) {
+                assert.strictEqual(written[i].timestamp, i, `Event at index ${i} out of order`);
+            }
+        });
+    });
+
+    // ── Test 2: Failed write retains all events, ordering preserved on retry ───
+
+    suite('Retry on failure', () => {
+        test('failed appendFile retains batch; next flush writes old batch then new events in order', async () => {
+            // Add 5 events, then fail the first appendFile
+            for (let i = 0; i < 5; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            fakeFs.failNextN(1);
+
+            // First flush — resolves (log-and-resolve contract); buffer is NOT cleared
+            await writer.flush();
+
+            // No data should have been written (appendFile rejected)
+            assert.strictEqual(fakeFs.appendedChunks.length, 0, 'No chunks should be written on failed flush');
+
+            // Add 3 more events after the failed flush
+            for (let i = 5; i < 8; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Second flush — should write all 8 events (5 retained + 3 new)
+            await writer.flush();
+
+            const written = collectWrittenEvents(fakeFs);
+
+            // 8 events total (0 on first call due to rejection, 8 on second)
+            assert.strictEqual(written.length, 8, `Expected 8 events, got ${written.length}`);
+
+            // Order: 0-7 ascending
+            for (let i = 0; i < 8; i++) {
+                assert.strictEqual(written[i].timestamp, i, `Event at index ${i} out of order after retry`);
+            }
+        });
+    });
+
+    // ── Test 3: Dispose with idle lane → sync fallback ────────────────────────
+
+    suite('dispose() sync fallback (idle lane)', () => {
+        test('5 buffered events on idle lane are written via sync fallback', async () => {
+            // Drain any outstanding lane work from initSession
+            await writer.flush();
+
+            // Add 5 events (below threshold, no flush triggered)
+            for (let i = 100; i < 105; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Clear prior appendedChunks so we only check what dispose writes
+            fakeFs.appendedChunks = [];
+
+            await writer.dispose();
+
+            // Sync fallback should have been called
+            assert.strictEqual(fakeFs.syncChunks.length, 1, 'appendFileSync should be called once');
+            const syncEvents = fakeFs.syncChunks[0]
+                .split('\n')
+                .filter(Boolean)
+                .map(l => JSON.parse(l) as RecordedEvent);
+            assert.strictEqual(syncEvents.length, 5, 'Should have written 5 events via sync');
+            assert.strictEqual(syncEvents[0].timestamp, 100);
+            assert.strictEqual(syncEvents[4].timestamp, 104);
+        });
+    });
+
+    // ── Test 4: Dispose with busy lane → async drain, no duplicates ───────────
+
+    suite('dispose() async drain (busy lane)', () => {
+        test('active lane work + 5 buffered events: awaits lane then final flush, no duplicates', async () => {
+            // Pause the first appendFile to simulate a long-running flush
+            const handle = fakeFs.pauseNext();
+
+            // Trigger threshold flush with 20 events
+            for (let i = 0; i < 20; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Yield so the lane's first flush actually calls appendFile (wiring up handle.resolve)
+            await Promise.resolve();
+
+            // While first flush is in flight (lane busy), add 5 more events
+            for (let i = 20; i < 25; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Resolve the long write (now handle.resolve is wired up)
+            handle.resolve();
+
+            // dispose() should await the drain and then do a final flush
+            await writer.dispose();
+
+            // Sync fallback should NOT have been called (lane was busy)
+            assert.strictEqual(fakeFs.syncChunks.length, 0, 'appendFileSync should NOT be called when lane is busy');
+
+            // All 25 events must appear exactly once
+            const written = collectWrittenEvents(fakeFs);
+            assert.strictEqual(written.length, 25, `Expected 25 events, got ${written.length}`);
+
+            const timestamps = written.map(e => e.timestamp);
+            const unique = new Set(timestamps);
+            assert.strictEqual(unique.size, 25, 'Duplicate events found');
+
+            // First 20 in order, then next 5 in order
+            for (let i = 0; i < 25; i++) {
+                assert.strictEqual(written[i].timestamp, i, `Event at index ${i} out of order`);
+            }
+        });
+    });
+
+    // ── Test 5: Consecutive-error counter disables writer ────────────────────
+
+    suite('Consecutive-error disable', () => {
+        test('5 consecutive errors disable the writer and stop the timer', async () => {
+            // Force 5 failures — flush always resolves (log-and-resolve contract)
+            fakeFs.failNextN(5);
+
+            for (let run = 0; run < 5; run++) {
+                writer.appendEvent(makeEvent(run));
+                await writer.flush(); // always resolves, error is logged internally
+            }
+
+            // Writer should now be disabled; clear chunks to check no new writes happen
+            fakeFs.appendedChunks = [];
+
+            writer.appendEvent(makeEvent(999));
+            await writer.flush();
+
+            assert.strictEqual(
+                fakeFs.appendedChunks.length, 0,
+                'appendFile should not be called after writer is disabled',
+            );
+        });
+    });
+
+    // ── Test 6: Threshold + timer debounce — no runaway queue ────────────────
+
+    suite('Threshold flush debounce', () => {
+        test('timer flush and threshold flush during active flush produce at most 3 total flushes', async () => {
+            // Pause the first appendFile
+            const handle = fakeFs.pauseNext();
+
+            // Trigger first threshold flush (20 events)
+            for (let i = 0; i < 20; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Yield so the lane's first flush calls appendFile (wiring up handle.resolve)
+            await Promise.resolve();
+
+            // While first flush is in flight, trigger a second threshold hit
+            for (let i = 20; i < 40; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Also simulate a timer flush (same as manually calling flush)
+            const timerFlushPromise = writer.flush();
+
+            // Let first flush complete (now handle.resolve is wired up)
+            handle.resolve();
+
+            // Await everything
+            await timerFlushPromise;
+            await writer.flush(); // final drain
+
+            // Both threshold and timer debounce to a single deferred flush,
+            // so appendFile should be called exactly 2 times total:
+            // once for the initial 20 events, once for the deferred 20 events.
+            assert.strictEqual(
+                fakeFs.appendedChunks.length,
+                2,
+                `Expected exactly 2 appendFile calls, got ${fakeFs.appendedChunks.length}`,
+            );
+
+            // All 40 events present, no duplicates
+            const written = collectWrittenEvents(fakeFs);
+            assert.strictEqual(written.length, 40, `Expected 40 events, got ${written.length}`);
+            const unique = new Set(written.map(e => e.timestamp));
+            assert.strictEqual(unique.size, 40, 'Duplicate events detected');
+        });
+    });
+
+    // ── Test 7: abort() removes session directory ─────────────────────────────
+
+    suite('abort()', () => {
+        test('abort() removes session directory and stops timer', async () => {
+            await writer.abort();
+
+            assert.strictEqual(fakeFs.removedPaths.length, 1, 'fs.rm should be called once');
+            assert.strictEqual(fakeFs.removedPaths[0].path, SESSION_DIR, 'Should remove the session directory');
+            assert.strictEqual(fakeFs.removedPaths[0].recursive, true);
+            assert.strictEqual(fakeFs.removedPaths[0].force, true);
+        });
+
+        test('abort() clears the buffer so subsequent flush is a no-op', async () => {
+            for (let i = 0; i < 5; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            fakeFs.appendedChunks = [];
+
+            await writer.abort();
+
+            // After abort, flushing should be a no-op (no eventsPath)
+            await writer.flush();
+            assert.strictEqual(fakeFs.appendedChunks.length, 0, 'No appendFile after abort');
+        });
+    });
+
+    // ── Test 8: Delayed append + new events during delay + retry ordering ─────
+
+    suite('Ordering: delayed append with new events during delay', () => {
+        test('old batch written before new events even after a delayed flush', async () => {
+            // Emit 3 events
+            for (let i = 0; i < 3; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Pause the flush so new events arrive while it's in flight
+            const handle = fakeFs.pauseNext();
+
+            // Start flush (goes into lane) - this enqueues, then yields to let it call appendFile
+            const flushPromise = writer.flush();
+
+            // Yield so the lane actually calls appendFile (wiring up handle.resolve)
+            await Promise.resolve();
+
+            // New events arrive while flush is in flight
+            for (let i = 3; i < 6; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Complete the delayed flush (now handle.resolve is wired up)
+            handle.resolve();
+            await flushPromise;
+
+            // Final flush for the new events
+            await writer.flush();
+
+            const written = collectWrittenEvents(fakeFs);
+            assert.strictEqual(written.length, 6);
+
+            // Events 0-2 first (old batch), then 3-5 (new batch)
+            for (let i = 0; i < 6; i++) {
+                assert.strictEqual(written[i].timestamp, i, `Event at index ${i} out of order`);
+            }
+        });
+    });
+
+    // ── Test 9: endSession() with in-flight flush ─────────────────────────────
+
+    suite('endSession() with in-flight flush', () => {
+        test('endSession waits for in-flight flush and deferred flush to complete', async () => {
+            // Step 1: pause the first appendFile so a flush goes in-flight but does not finish.
+            const handle = fakeFs.pauseNext();
+
+            // Step 2: append 20 events to trigger a threshold flush.
+            for (let i = 0; i < 20; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Step 3: yield once so the lane starts and calls appendFile (wiring up handle.resolve).
+            await Promise.resolve();
+
+            // Step 4: add 5 more events while the first flush is in flight.
+            for (let i = 20; i < 25; i++) {
+                writer.appendEvent(makeEvent(i));
+            }
+
+            // Step 5: call endSession() — must not return until all flushes complete.
+            // We start endSession() before resolving the handle; it should block.
+            const endSessionPromise = writer.endSession();
+
+            // Step 6: resolve the paused appendFile handle so flush1 can finish.
+            handle.resolve();
+
+            // endSession() now drains, enqueues flush2 for the 5 buffered events,
+            // and drains again. Await it to confirm everything settled.
+            await endSessionPromise;
+
+            // Step 7: assert all 25 events were written in order, no duplicates.
+            const written = collectWrittenEvents(fakeFs);
+
+            assert.strictEqual(written.length, 25, `Expected 25 events, got ${written.length}`);
+
+            const timestamps = written.map(e => e.timestamp);
+            const unique = new Set(timestamps);
+            assert.strictEqual(unique.size, 25, 'Duplicate events detected');
+
+            for (let i = 0; i < 25; i++) {
+                assert.strictEqual(written[i].timestamp, i, `Event at index ${i} out of order`);
+            }
+        });
+    });
+
+    // ── Test 10: writeMetadata adds schemaVersion and recorderVersion ─────────
+
+    suite('writeMetadata enrichment', () => {
+        test('writes schemaVersion: 2 and recorderVersion: "2.0" into metadata', async () => {
+            await writer.writeMetadata({
+                sessionId: SESSION_ID,
+                exerciseId: 42,
+                participantId: undefined,
+                startTime: 1000,
+                endTime: 2000,
+                eventCount: 5,
+            });
+
+            // Find the metadata write (not the events.jsonl init write)
+            const metadataWrite = fakeFs.writtenFiles.find(
+                f => f.path.endsWith('metadata.json'),
+            );
+            assert.ok(metadataWrite, 'No metadata.json write found');
+            const written = JSON.parse(metadataWrite.data) as Record<string, unknown>;
+            assert.strictEqual(written['schemaVersion'], 2);
+            assert.strictEqual(written['recorderVersion'], '2.0');
+        });
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/uriFilter.test.ts
+++ b/extension/test/unit/services/telemetry/recording/uriFilter.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for uriFilter — Block I
+ *
+ * Covers:
+ *   1. Prefix-bug fix: /workspace/ex1 root does NOT accept /workspace/ex10/File.java
+ *   2. /workspace/ex1 root + /workspace/ex1/File.java → true
+ *   3. Exact root match: /workspace/ex1 root + /workspace/ex1 (root itself) → true
+ *   4. Blacklisted scheme: git:// → false
+ *   5. Non-file scheme: vscode-remote:// with file-path inside root → false (V1: file: only)
+ *   6. No exerciseRoot given, file:// URI → true
+ *   7. Blacklisted scheme: vscode-userdata: → false
+ *   8. shouldRecordUriString mirrors shouldRecordUri for string inputs
+ *   9. All blacklisted schemes are rejected
+ *  10. Non-file, non-blacklisted scheme (e.g. untitled:) → false (V1: file: only)
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { shouldRecordUri, shouldRecordUriString } from '../../../../../src/extension/services/telemetry/recording/uriFilter';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fileUri(fsPath: string): vscode.Uri {
+    return vscode.Uri.file(fsPath);
+}
+
+// ── shouldRecordUri ───────────────────────────────────────────────────────────
+
+suite('shouldRecordUri (Block I)', () => {
+    // ── Prefix-bug fix ────────────────────────────────────────────────────────
+
+    test('1. prefix-bug: /workspace/ex10/File.java must NOT match root /workspace/ex1', () => {
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex10/File.java');
+        assert.strictEqual(shouldRecordUri(uri, root), false,
+            '/workspace/ex10 starts with /workspace/ex1 lexically but is NOT under it');
+    });
+
+    test('2. /workspace/ex1/File.java is accepted under root /workspace/ex1', () => {
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex1/File.java');
+        assert.strictEqual(shouldRecordUri(uri, root), true);
+    });
+
+    test('3. exact root match: URI equal to root is accepted', () => {
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex1');
+        assert.strictEqual(shouldRecordUri(uri, root), true);
+    });
+
+    test('2b. deeply nested file is accepted under root', () => {
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex1/src/main/java/Main.java');
+        assert.strictEqual(shouldRecordUri(uri, root), true);
+    });
+
+    test('2c. sibling directory /workspace/ex1-extra is NOT accepted under root /workspace/ex1', () => {
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex1-extra/Main.java');
+        assert.strictEqual(shouldRecordUri(uri, root), false);
+    });
+
+    // ── Blacklisted schemes ───────────────────────────────────────────────────
+
+    test('4. git scheme is rejected', () => {
+        const uri = vscode.Uri.parse('git:/some/file.java');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('7. vscode-userdata scheme is rejected', () => {
+        const uri = vscode.Uri.parse('vscode-userdata:/settings.json');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9a. output scheme is rejected', () => {
+        const uri = vscode.Uri.parse('output:/extension-output');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9b. search-result scheme is rejected', () => {
+        const uri = vscode.Uri.parse('search-result:/result');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9c. vscode-scm scheme is rejected', () => {
+        const uri = vscode.Uri.parse('vscode-scm:/some/path');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9d. vscode-settings scheme is rejected', () => {
+        const uri = vscode.Uri.parse('vscode-settings:/settings');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9e. vscode-terminal scheme is rejected', () => {
+        const uri = vscode.Uri.parse('vscode-terminal:/term');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    test('9f. vscode-chat-input scheme is rejected', () => {
+        const uri = vscode.Uri.parse('vscode-chat-input:/chat');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    // ── Non-file, non-blacklisted schemes (V1: file: only) ───────────────────
+
+    test('5. vscode-remote scheme is rejected in V1 (file: scheme only)', () => {
+        // vscode-remote is not blacklisted but is not file: — V1 rejects it.
+        // Supporting remote URIs is a planned follow-up.
+        const root = fileUri('/workspace/ex1');
+        const uri  = vscode.Uri.parse('vscode-remote://ssh-remote+host/workspace/ex1/file.java');
+        assert.strictEqual(shouldRecordUri(uri, root), false,
+            'V1 only records file: scheme; vscode-remote is a future follow-up');
+    });
+
+    test('10. untitled scheme is rejected in V1', () => {
+        const uri = vscode.Uri.parse('untitled:Untitled-1');
+        assert.strictEqual(shouldRecordUri(uri), false);
+    });
+
+    // ── No exerciseRoot ───────────────────────────────────────────────────────
+
+    test('6. file:// URI is accepted when no exerciseRoot is given', () => {
+        const uri = fileUri('/workspace/ex1/Main.java');
+        assert.strictEqual(shouldRecordUri(uri), true);
+    });
+
+    test('6b. file:// URI at any path is accepted without exerciseRoot', () => {
+        const uri = fileUri('/tmp/random/path.txt');
+        assert.strictEqual(shouldRecordUri(uri), true);
+    });
+});
+
+// ── shouldRecordUriString ─────────────────────────────────────────────────────
+
+suite('shouldRecordUriString (Block I)', () => {
+    test('8a. prefix-bug: ex10 string not accepted under ex1 root string', () => {
+        const root = fileUri('/workspace/ex1').toString();
+        const uri  = fileUri('/workspace/ex10/File.java').toString();
+        assert.strictEqual(shouldRecordUriString(uri, root), false);
+    });
+
+    test('8b. file in ex1 subtree accepted', () => {
+        const root = fileUri('/workspace/ex1').toString();
+        const uri  = fileUri('/workspace/ex1/Main.java').toString();
+        assert.strictEqual(shouldRecordUriString(uri, root), true);
+    });
+
+    test('8c. git URI string is rejected', () => {
+        assert.strictEqual(shouldRecordUriString('git:/some/file.java'), false);
+    });
+
+    test('8d. no root: file URI string accepted', () => {
+        const uri = fileUri('/workspace/ex1/Main.java').toString();
+        assert.strictEqual(shouldRecordUriString(uri), true);
+    });
+
+    test('8e. vscode-userdata URI string is rejected', () => {
+        assert.strictEqual(shouldRecordUriString('vscode-userdata:/settings.json'), false);
+    });
+
+    test('8f. path.sep is correctly used — same result on current platform', () => {
+        // Regression guard: ensure that shouldRecordUri and shouldRecordUriString
+        // agree for the same input.
+        const root = fileUri('/workspace/ex1');
+        const uri  = fileUri('/workspace/ex1/sub/file.ts');
+        assert.strictEqual(
+            shouldRecordUri(uri, root),
+            shouldRecordUriString(uri.toString(), root.toString()),
+        );
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/workspaceEvents.test.ts
+++ b/extension/test/unit/services/telemetry/recording/workspaceEvents.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for Block K — workspace file events and document open/close
+ *
+ * The VS Code extension-host test environment does not expose a way to fire
+ * read-only `Event<T>` objects (e.g. `vscode.workspace.onDidCreateFiles`)
+ * programmatically from test code.  We therefore use the same white-box
+ * approach established in Block J: drive `_recordInternal` directly to
+ * verify the recorder correctly gates and writes events, and assert that the
+ * event types land in the stream with the expected fields.
+ *
+ * Covers:
+ *   1. fileCreate event lands in stream with correct uri
+ *   2. fileDelete event lands in stream with correct uri
+ *   3. fileRename event lands in stream with oldUri + newUri
+ *   4. textDocumentOpen event lands in stream with correct uri
+ *   5. textDocumentClose event lands in stream with correct uri
+ *   6. Events outside exerciseRoot are rejected by shouldRecordUri (unit-tested in uriFilter.test.ts;
+ *      recorded here as a white-box integration check via the phase gate)
+ *   7. All five new event types are gated by `_phase === 'recording'`: none reach disk when the
+ *      recorder is idle (before startSession)
+ *   8. All five new event types are gated by `_phase === 'recording'`: none reach disk after disable()
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SessionRecorder } from '../../../../../src/extension/services/telemetry/recording/sessionRecorder';
+import type { RecordedEvent } from '../../../../../src/extension/services/telemetry/recording/types';
+import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
+
+// ── Minimal in-memory FS ──────────────────────────────────────────────────
+
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    removedPaths: string[] = [];
+    syncChunks: string[] = [];
+    mkdirCalls = 0;
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        this.mkdirCalls++;
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, _opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push(p);
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of [...fakeFs.appendedChunks, ...fakeFs.syncChunks]) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try {
+                events.push(JSON.parse(line) as RecordedEvent);
+            } catch {
+                /* skip malformed */
+            }
+        }
+    }
+    return events;
+}
+
+function makeRecorder(): { recorder: SessionRecorder; fs: FakeFs } {
+    const fakeFs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fakeFs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(
+        fakeUri,
+        { hasTerminalShellExecution: false, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+    );
+    return { recorder, fs: fakeFs };
+}
+
+/** Inject a Block K event directly through the recorder's internal recording path. */
+function injectEvent(recorder: SessionRecorder, event: RecordedEvent): void {
+    (recorder as unknown as { _recordInternal(e: RecordedEvent, opts: object, gen: number): void })
+        ._recordInternal(event, {}, (recorder as unknown as { _currentGeneration: number })._currentGeneration);
+}
+
+const ROOT = vscode.Uri.file('/workspace/exercise1').toString();
+
+// ── Suite ────────────────────────────────────────────────────────────────
+
+suite('Block K — workspace file events (white-box)', () => {
+    let recorder: SessionRecorder;
+    let fakeFs: FakeFs;
+
+    setup(() => {
+        const ctx = makeRecorder();
+        recorder = ctx.recorder;
+        fakeFs = ctx.fs;
+    });
+
+    teardown(async () => {
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Test 1: fileCreate ───────────────────────────────────────────────
+
+    test('1. fileCreate event lands in stream with correct uri', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        const uri = vscode.Uri.file('/workspace/exercise1/src/NewFile.java').toString();
+        injectEvent(recorder, { type: 'fileCreate', timestamp: Date.now(), uri });
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        const creates = events.filter(e => e.type === 'fileCreate') as Array<{ uri: string }>;
+        assert.ok(creates.length > 0, 'expected at least one fileCreate event');
+        assert.ok(creates.some(e => e.uri === uri), `expected fileCreate with uri ${uri}`);
+    });
+
+    // ── Test 2: fileDelete ───────────────────────────────────────────────
+
+    test('2. fileDelete event lands in stream with correct uri', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        const uri = vscode.Uri.file('/workspace/exercise1/src/OldFile.java').toString();
+        injectEvent(recorder, { type: 'fileDelete', timestamp: Date.now(), uri });
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        const deletes = events.filter(e => e.type === 'fileDelete') as Array<{ uri: string }>;
+        assert.ok(deletes.length > 0, 'expected at least one fileDelete event');
+        assert.ok(deletes.some(e => e.uri === uri), `expected fileDelete with uri ${uri}`);
+    });
+
+    // ── Test 3: fileRename ───────────────────────────────────────────────
+
+    test('3. fileRename event lands in stream with oldUri and newUri', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        const oldUri = vscode.Uri.file('/workspace/exercise1/src/Foo.java').toString();
+        const newUri = vscode.Uri.file('/workspace/exercise1/src/Bar.java').toString();
+        injectEvent(recorder, { type: 'fileRename', timestamp: Date.now(), oldUri, newUri });
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        const renames = events.filter(e => e.type === 'fileRename') as Array<{ oldUri: string; newUri: string }>;
+        assert.ok(renames.length > 0, 'expected at least one fileRename event');
+        const ev = renames.find(e => e.oldUri === oldUri && e.newUri === newUri);
+        assert.ok(ev, `expected fileRename with oldUri=${oldUri} newUri=${newUri}`);
+    });
+
+    // ── Test 4: textDocumentOpen ─────────────────────────────────────────
+
+    test('4. textDocumentOpen event lands in stream with correct uri', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        const uri = vscode.Uri.file('/workspace/exercise1/src/Main.java').toString();
+        injectEvent(recorder, { type: 'textDocumentOpen', timestamp: Date.now(), uri });
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        const opens = events.filter(e => e.type === 'textDocumentOpen') as Array<{ uri: string }>;
+        assert.ok(opens.length > 0, 'expected at least one textDocumentOpen event');
+        assert.ok(opens.some(e => e.uri === uri), `expected textDocumentOpen with uri ${uri}`);
+    });
+
+    // ── Test 5: textDocumentClose ────────────────────────────────────────
+
+    test('5. textDocumentClose event lands in stream with correct uri', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        const uri = vscode.Uri.file('/workspace/exercise1/src/Main.java').toString();
+        injectEvent(recorder, { type: 'textDocumentClose', timestamp: Date.now(), uri });
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        const closes = events.filter(e => e.type === 'textDocumentClose') as Array<{ uri: string }>;
+        assert.ok(closes.length > 0, 'expected at least one textDocumentClose event');
+        assert.ok(closes.some(e => e.uri === uri), `expected textDocumentClose with uri ${uri}`);
+    });
+
+    // ── Test 6: Phase gate — all five types blocked before startSession ──
+
+    test('6. all five Block K event types are rejected when not in recording phase (idle)', () => {
+        recorder.enable();
+        // Phase is 'idle' — no session started yet. Injecting through _recordInternal
+        // should drop events because `_phase !== 'recording'`.
+        const uri = vscode.Uri.file('/workspace/exercise1/src/Test.java').toString();
+        const oldUri = uri;
+        const newUri = vscode.Uri.file('/workspace/exercise1/src/Test2.java').toString();
+
+        injectEvent(recorder, { type: 'fileCreate', timestamp: 1, uri });
+        injectEvent(recorder, { type: 'fileDelete', timestamp: 2, uri });
+        injectEvent(recorder, { type: 'fileRename', timestamp: 3, oldUri, newUri });
+        injectEvent(recorder, { type: 'textDocumentOpen', timestamp: 4, uri });
+        injectEvent(recorder, { type: 'textDocumentClose', timestamp: 5, uri });
+
+        const events = collectWrittenEvents(fakeFs);
+        const blockK = events.filter(e =>
+            e.type === 'fileCreate' ||
+            e.type === 'fileDelete' ||
+            e.type === 'fileRename' ||
+            e.type === 'textDocumentOpen' ||
+            e.type === 'textDocumentClose',
+        );
+        assert.strictEqual(blockK.length, 0,
+            `expected no Block K events before startSession, got: ${blockK.map(e => e.type).join(', ')}`);
+    });
+
+    // ── Test 7: Phase gate — all five types blocked after disable() ──────
+
+    test('7. all five Block K event types are blocked after disable()', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        // Disable synchronously — phase flips to 'disabling' immediately.
+        recorder.disable();
+
+        // At this point phase is 'disabling', so _recordInternal must drop events.
+        const uri = vscode.Uri.file('/workspace/exercise1/src/AfterDisable.java').toString();
+        const newUri = vscode.Uri.file('/workspace/exercise1/src/AfterDisable2.java').toString();
+
+        injectEvent(recorder, { type: 'fileCreate', timestamp: 10, uri });
+        injectEvent(recorder, { type: 'fileDelete', timestamp: 11, uri });
+        injectEvent(recorder, { type: 'fileRename', timestamp: 12, oldUri: uri, newUri });
+        injectEvent(recorder, { type: 'textDocumentOpen', timestamp: 13, uri });
+        injectEvent(recorder, { type: 'textDocumentClose', timestamp: 14, uri });
+
+        // Let lifecycle drain.
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        const events = collectWrittenEvents(fakeFs);
+        const blockK = events.filter(e =>
+            e.type === 'fileCreate' ||
+            e.type === 'fileDelete' ||
+            e.type === 'fileRename' ||
+            e.type === 'textDocumentOpen' ||
+            e.type === 'textDocumentClose',
+        );
+        assert.strictEqual(blockK.length, 0,
+            `expected no Block K events after disable(), got: ${blockK.map(e => e.type).join(', ')}`);
+    });
+
+    // ── Test 8: generation gate — stale callbacks from previous session ──
+
+    test('8. Block K events from a stale generation are not written to the new session', async () => {
+        recorder.enable();
+        await recorder.startSession(1, 'p1', ROOT);
+
+        // Capture the generation for session 1.
+        const staleGen: number = (recorder as unknown as { _currentGeneration: number })._currentGeneration;
+
+        // End session 1 and start session 2, so _currentGeneration advances.
+        await recorder.startSession(2, 'p1', ROOT);
+
+        // Inject events with the stale generation directly (mimics a late-firing async callback).
+        const recorder_ = recorder as unknown as {
+            _recordInternal(e: RecordedEvent, opts: object, gen: number): void;
+        };
+        const uri = vscode.Uri.file('/workspace/exercise1/src/Stale.java').toString();
+        recorder_._recordInternal({ type: 'fileCreate', timestamp: 99, uri }, {}, staleGen);
+
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fakeFs);
+        // The stale fileCreate (timestamp: 99) must not appear.
+        const staleCreates = events.filter(
+            e => e.type === 'fileCreate' && (e as { uri: string }).uri === uri,
+        );
+        assert.strictEqual(staleCreates.length, 0,
+            'stale fileCreate (wrong generation) must not appear in the new session');
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up PR stacked on #108. Adds the full test suite for the recorder robustness work (Blocks AB-K).

Split out to keep #108 focused on production changes and easier to review.

## Test files (9, +3213 LOC)

- `buildResultGuard.test.ts`
- `interventionService.test.ts`
- `recording/chatRecording.test.ts`
- `recording/eventCollectors.test.ts`
- `recording/sessionRecorder.test.ts`
- `recording/snapshotRetry.test.ts`
- `recording/storageWriter.test.ts`
- `recording/uriFilter.test.ts`
- `recording/workspaceEvents.test.ts`

## Merge order

1. Merge #108 first (production changes).
2. Retarget this PR to `dev` (GitHub auto-updates on merge).
3. Merge this PR.

## Test plan

- [ ] npm run test:unit passes
- [ ] CI green