### PR TITLE
fix: clone 'Open Folder' opens local path instead of browser

### DIFF
--- a/extension/src/extension/controller/commands/repositoryCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCommands.ts
@@ -126,6 +126,7 @@ export class RepositoryCommandModule {
             [WebviewCmd.StartPractice]: this.handleStartPractice,
             [WebviewCmd.StartExercise]: this.handleStartExercise,
             [WebviewCmd.OpenRepository]: this.handleOpenRepository,
+            [WebviewCmd.OpenClonedRepository]: this.handleOpenClonedRepository,
             [WebviewCmd.ViewBuildLog]: this.handleViewBuildLog,
             [WebviewCmd.GoToSource]: this.handleGoToSource,
         };
@@ -338,7 +339,8 @@ export class RepositoryCommandModule {
 
             this.context.sendMessage({
                 type: ExtensionMsg.ShowClonedRepoNotice,
-                exerciseTitle: exerciseTitle
+                exerciseTitle: exerciseTitle,
+                participationId,
             });
 
             const openAction = await vscode.window.showInformationMessage(
@@ -749,6 +751,44 @@ export class RepositoryCommandModule {
         } catch (err: unknown) {
             logger.error('Failed to navigate to source error:', LogCategory.SUBMISSION, err);
             vscode.window.showErrorMessage('Failed to navigate to source error.');
+        }
+    };
+
+    private handleOpenClonedRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const { participationId } = getPayload<WebCmd<'openClonedRepository'>>(message);
+            const repoInfo = this.clonedRepositories.get(participationId);
+
+            if (!repoInfo) {
+                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
+                return;
+            }
+
+            try {
+                const stats = fs.statSync(repoInfo.path);
+                if (!stats.isDirectory()) {
+                    this.clonedRepositories.delete(participationId);
+                    vscode.window.showWarningMessage('Cloned repository path is not a directory.');
+                    return;
+                }
+            } catch {
+                this.clonedRepositories.delete(participationId);
+                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
+                return;
+            }
+
+            const repoUri = vscode.Uri.file(repoInfo.path);
+
+            const currentFolder = vscode.workspace.workspaceFolders?.[0];
+            if (currentFolder && currentFolder.uri.fsPath === repoInfo.path) {
+                await vscode.commands.executeCommand('workbench.view.explorer');
+                return;
+            }
+
+            await vscode.commands.executeCommand('vscode.openFolder', repoUri, true);
+        } catch (error: unknown) {
+            logger.error('Open cloned repository error:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage('Failed to open cloned repository.');
         }
     };
 

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -269,7 +269,7 @@ interface ExtensionMsgPayloads {
         dirtyFileCount: number;
         autoSaveEnabled: boolean;
     };
-    showClonedRepoNotice: { exerciseTitle: string };
+    showClonedRepoNotice: { exerciseTitle: string; participationId: number };
     gitCredentialsResult: {
         status: 'success' | 'error' | 'warning' | 'info';
         message: string;

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -44,6 +44,7 @@ export const WebviewCmd = {
     CloneRepository: 'cloneRepository',
     CopyAuthenticatedCloneUrl: 'copyAuthenticatedCloneUrl',
     OpenRepository: 'openRepository',
+    OpenClonedRepository: 'openClonedRepository',
     SubmitExercise: 'submitExercise',
     StartExercise: 'startExercise',
     StartPractice: 'startPractice',
@@ -137,6 +138,7 @@ interface WebviewCmdPayloads {
     cloneRepository: { participationId: number; repositoryUri: string; exerciseTitle: string };
     copyAuthenticatedCloneUrl: { participationId: number; repositoryUri: string };
     openRepository: { repositoryUri?: string };
+    openClonedRepository: { participationId: number };
     submitExercise: { participationId: number; exerciseId?: number; exerciseTitle?: string; commitMessage?: string };
     startExercise: { exerciseId: number };
     startPractice: { exerciseId: number; exerciseTitle?: string };
@@ -230,6 +232,7 @@ export const COMMANDS_REQUIRING_PAYLOAD = new Set<string>([
     WebviewCmd.RenderPlantUmlInline,
     WebviewCmd.ViewBuildLog,
     WebviewCmd.GoToSource,
+    WebviewCmd.OpenClonedRepository,
 ]);
 
 /** Auto-generated command messages */

--- a/extension/src/webview/hooks/useExerciseStatusMessages.ts
+++ b/extension/src/webview/hooks/useExerciseStatusMessages.ts
@@ -17,7 +17,7 @@ export function useExerciseStatusMessages(vscodeApi: VsCodeApi): void {
                 setRepoStatus({ isConnected: msg.isConnected, hasChanges: msg.hasChanges, isPracticeRepo: msg.isPracticeRepo });
                 break;
             case ExtensionMsg.ShowClonedRepoNotice:
-                setClonedNotice(msg.exerciseTitle);
+                setClonedNotice(msg.exerciseTitle, msg.participationId);
                 break;
             case ExtensionMsg.UpdateDirtyPagesStatus:
                 setDirtyPagesStatus({ hasDirtyPages: msg.hasDirtyPages, dirtyFileCount: msg.dirtyFileCount, autoSaveEnabled: msg.autoSaveEnabled });

--- a/extension/src/webview/stores/useExerciseDetailStore.ts
+++ b/extension/src/webview/stores/useExerciseDetailStore.ts
@@ -40,7 +40,7 @@ interface ExerciseDetailState {
 
     // Extension→Webview response state
     repoStatus: RepoStatus | null;
-    clonedNotice: string | null;
+    clonedNotice: { exerciseTitle: string; participationId: number } | null;
     dirtyPagesStatus: DirtyPagesStatus | null;
 
     // Actions
@@ -52,7 +52,7 @@ interface ExerciseDetailState {
     updateSubmission: (payload: SubmissionSummary) => void;
     updateSubmissionProcessing: (payload: PendingSubmissionInfo) => void;
     setRepoStatus: (status: RepoStatus) => void;
-    setClonedNotice: (exerciseTitle: string) => void;
+    setClonedNotice: (exerciseTitle: string, participationId: number) => void;
     setDirtyPagesStatus: (status: DirtyPagesStatus) => void;
     clearClonedNotice: () => void;
     clearPendingSubmission: () => void;
@@ -224,8 +224,8 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
                 set({ repoStatus: status }, false, 'setRepoStatus');
             },
 
-            setClonedNotice: (exerciseTitle) => {
-                set({ clonedNotice: exerciseTitle }, false, 'setClonedNotice');
+            setClonedNotice: (exerciseTitle, participationId) => {
+                set({ clonedNotice: { exerciseTitle, participationId } }, false, 'setClonedNotice');
             },
 
             setDirtyPagesStatus: (status) => {

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -250,7 +250,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
             {/* Cloned repo notice */}
             {clonedNotice && (
                 <div className={styles.banner} data-variant="info">
-                    <span>Repository cloned for "{clonedNotice}"</span>
+                    <span>Repository cloned for "{clonedNotice.exerciseTitle}"</span>
                     <button className={styles.bannerDismiss} onClick={clearClonedNotice}>×</button>
                 </div>
             )}
@@ -369,7 +369,10 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
                         postCommand(vscodeApi, 'openRepository', { repositoryUri });
                     }}
                     onOpenClonedRepository={() => {
-                        postCommand(vscodeApi, 'openRepository', { repositoryUri });
+                        if (clonedNotice) {
+                            postCommand(vscodeApi, 'openClonedRepository', { participationId: clonedNotice.participationId });
+                            clearClonedNotice();
+                        }
                     }}
                     onCheckWorkspace={() => {
                         postCommand(vscodeApi, 'checkRepositoryStatus');

--- a/extension/test/react/stores/useExerciseDetailStore.test.ts
+++ b/extension/test/react/stores/useExerciseDetailStore.test.ts
@@ -287,11 +287,11 @@ describe('useExerciseDetailStore', () => {
 
 		// Simulate receiving clonedNotice and dirtyPagesStatus from a previous exercise
 		act(() => {
-			result.current.setClonedNotice('Old Exercise');
+			result.current.setClonedNotice('Old Exercise', 42);
 			result.current.setDirtyPagesStatus({ hasDirtyPages: true, dirtyFileCount: 3, autoSaveEnabled: false });
 		});
 
-		expect(result.current.clonedNotice).toBe('Old Exercise');
+		expect(result.current.clonedNotice).toEqual({ exerciseTitle: 'Old Exercise', participationId: 42 });
 		expect(result.current.dirtyPagesStatus?.hasDirtyPages).toBe(true);
 
 		// Switch to a new exercise


### PR DESCRIPTION
## Summary

- Fixed the "Open now" button after cloning opening the browser instead of the local folder in VS Code
- Root cause: `onOpenClonedRepository` was sending the remote `repositoryUri` to `openRepository`, which fell back to `openExternal` (browser) when the workspace didn't match
- Added a dedicated `openClonedRepository` command that resolves the local clone path from the extension's in-memory cache by `participationId`, preserving the security boundary (webview never sees local file paths)
- Extended `ShowClonedRepoNotice` to include `participationId` so the "Open now" button works correctly even if the user switches participations between clone and click

Closes #116

## Test plan

- [ ] Clone a repository via the sidebar
- [ ] Verify the native VS Code "Open Folder" prompt still works correctly
- [ ] Click "Open now" in the webview banner after cloning
- [ ] Verify it opens the cloned folder in a new VS Code window (not the browser)
- [ ] If already in the cloned workspace, verify it reveals the Explorer instead
- [ ] Delete the cloned folder, then click "Open now" and verify a warning appears