### PR TITLE
fix(ci): clear knip unused-exports failures on dev

### DIFF
--- a/extension/knip.json
+++ b/extension/knip.json
@@ -3,7 +3,6 @@
   "entry": [
     "src/extension.ts",
     "src/webview/index.tsx",
-    "esbuild.js",
     "test/**/*.{ts,tsx}",
     ".mocharc.ui.yml",
     ".vscode-test.mjs"

--- a/extension/src/extension/theia/dataBridgeReader.ts
+++ b/extension/src/extension/theia/dataBridgeReader.ts
@@ -24,7 +24,7 @@ export const KNOWN_BRIDGE_KEYS = [
     'TEMPLATE',
 ] as const;
 
-export type KnownBridgeKey = (typeof KNOWN_BRIDGE_KEYS)[number];
+type KnownBridgeKey = (typeof KNOWN_BRIDGE_KEYS)[number];
 
 /**
  * Reads environment variables via the EduIDE data-bridge companion extension.
@@ -101,7 +101,7 @@ export async function readEnvVarsViaDataBridge<T extends string>(
     return undefined;
 }
 
-export interface DataBridgeProbeResult {
+interface DataBridgeProbeResult {
     /** Whether the `dataBridge.getEnv` command is registered (extension installed + active). */
     readonly commandAvailable: boolean;
     /** Whether `DATA_BRIDGE_ENABLED` env var is set (the bridge's own activation gate). */

--- a/extension/src/extension/theia/index.ts
+++ b/extension/src/extension/theia/index.ts
@@ -3,6 +3,5 @@ export { initializeTheiaContext, getTheiaEnvironment } from './theiaEnvironment'
 export { detectPlatformCapabilities } from './featureDetection';
 export { readEnvVar } from './envVarReader';
 export { probeDataBridge, KNOWN_BRIDGE_KEYS } from './dataBridgeReader';
-export type { DataBridgeProbeResult, KnownBridgeKey } from './dataBridgeReader';
 export { authenticateFromEnvironment } from './theiaAuthProvider';
 export { cloneRepositoryProgrammatic, autoCloneIfNeeded } from './theiaCloneService';

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -20,7 +20,7 @@ import type { ExtMsg, WebSocketDisplayStatus } from '../../shared/messageContrac
 type ChatWebSocketStatus = WebSocketDisplayStatus | 'unknown';
 
 
-export interface MessageLoadResult {
+interface MessageLoadResult {
     localSessionId: string;
     status: 'success' | 'error';
 }


### PR DESCRIPTION
## Summary

The CI \`TypeScript, Lint & Tests / Dead code analysis\` step (\`npm run knip\`) has been red on every push to \`dev\` since 55091f00. This PR clears the three offending exports plus one redundant config entry.

## Changes

- **\`useChatStore.ts\`**: \`MessageLoadResult\` was exported but only consumed in the same file (as the type of an internal store field). Demoted to file-private interface.
- **\`theia/dataBridgeReader.ts\`**: \`KnownBridgeKey\` and \`DataBridgeProbeResult\` were exported (and re-exported through \`theia/index.ts\`) but every call site relies on TypeScript inference for the public-API surface. Demoted to file-private; dropped the barrel re-exports.
- **\`knip.json\`**: removed the redundant \`esbuild.js\` entry pattern (knip auto-detects build configs; the entry was flagged as a configuration hint).

## Test plan

- [x] \`npm run check-types\` passes
- [x] \`npm run lint:src\` passes
- [x] \`npm run knip\` exits 0 with **no** unused-exports or configuration hints
- [ ] CI \`Dead code analysis\` step turns green

## Notes

- This branches off \`dev\` directly (commit b3...) and is independent of #118 (\`refactor/theia-bridge-only\`). The \`KnownBridgeKey\`/\`DataBridgeProbeResult\` un-export change is the same change that lives in #118's commit \`c0b9bcb1\`. Whichever PR merges first, the other will be a no-op on those two files.
- Do not merge yet — review only.