### PR TITLE
fix(iris): preserve user-selected context against workspace re-detection

### DIFF
--- a/extension/src/extension/services/iris/chatContextManager.ts
+++ b/extension/src/extension/services/iris/chatContextManager.ts
@@ -48,8 +48,16 @@ function shouldOverrideWithWorkspace(
     active: ActiveContext | null,
     detected: TrackedExercise,
 ): boolean {
-    const isDifferentExercise = !active || active.id !== detected.id;
-    return isDifferentExercise || active!.source !== 'user-selected';
+    if (!active) {
+        return true;
+    }
+    // An explicit user choice (e.g. "Ask Iris about this exercise") must never
+    // be silently overwritten by background workspace re-detection — that
+    // produces the "I clicked B but the chat shows A" bug.
+    if (active.source === 'user-selected') {
+        return false;
+    }
+    return active.id !== detected.id;
 }
 
 export type ChatContextReason =

--- a/extension/test/unit/services/chatContextManager.test.ts
+++ b/extension/test/unit/services/chatContextManager.test.ts
@@ -332,16 +332,56 @@ suite('ChatContextManager Test Suite', () => {
             assert.strictEqual(snapshot.activeContext?.id, 999);
         });
 
-        test('should override with workspace exercise when different exercise active', () => {
+        test('should NOT override an explicit user-selected exercise when workspace detection runs for a different id', () => {
+            // Reproduces the bug where clicking "Ask Iris about exercise B"
+            // was silently overwritten by background workspace re-detection of
+            // exercise A on the next chat-view-visible event.
             contextStore.setActiveContext({
                 type: 'exercise',
                 id: 999,
-                title: 'Other',
+                title: 'User-Picked Exercise',
                 source: 'user-selected',
                 locked: false,
                 selectedAt: Date.now(),
             });
 
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 123,
+                title: 'Workspace Exercise',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.id, 999, 'user-selected exercise must be preserved');
+            assert.strictEqual(snapshot.activeContext?.source, 'user-selected');
+        });
+
+        test('should override with workspace exercise when active is system-default and outdated', () => {
+            // Legitimate override case: no explicit user choice, just a stale
+            // auto-pick. Workspace detection is allowed to take over.
+            contextStore.setActiveContext({
+                type: 'exercise',
+                id: 999,
+                title: 'Auto-picked Exercise',
+                source: 'system-default',
+                locked: false,
+                selectedAt: Date.now(),
+            });
+
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 123,
+                title: 'Workspace Exercise',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.id, 123);
+            assert.strictEqual(snapshot.activeContext?.source, 'workspace-detected');
+        });
+
+        test('should override with workspace exercise when no active context exists', () => {
             chatContextManager.registerExerciseAndAutoSelect({
                 id: 123,
                 title: 'Workspace Exercise',


### PR DESCRIPTION
## Summary
Clicking **Ask Iris about exercise B** was silently overwritten by background workspace re-detection of exercise A. The chat header briefly showed B, then jumped back to A and loaded A's sessions — the click looked broken.

Verified with diagnostic logging in a real reproduction:

\`\`\`
[diag] switchContext: id=17469 reason=user-selected      ← user click
setActiveContext called with: id=17469 source=user-selected   ← correct
[diag] _detectWorkspaceExercise triggered                 ← race
[diag] registerExerciseAndAutoSelect: id=19570 source=workspace-detected
[diag] override-check: active.id=17469 active.source=user-selected detected.id=19570 -> override=true   ← bug
setActiveContext called with: id=19570 source=workspace-detected   ← user click overwritten
\`\`\`

## Root cause
\`shouldOverrideWithWorkspace\` in \`chatContextManager.ts\`:

\`\`\`ts
const isDifferentExercise = !active || active.id !== detected.id;
return isDifferentExercise || active!.source !== 'user-selected';
\`\`\`

The \`||\` short-circuits on \`isDifferentExercise=true\`, so the \`'user-selected'\` source check is unreachable when the IDs differ.

## Fix
Treat \`'user-selected'\` as a hard signal:

\`\`\`ts
if (!active) return true;                            // no active → take workspace
if (active.source === 'user-selected') return false; // never override an explicit user choice
return active.id !== detected.id;                    // override only if outdated
\`\`\`

Workspace detection still wins when there's no active context or when the current pick is \`system-default\` / \`workspace-detected\` — those are the legitimate auto-correction cases.

## Behavior change for users
- An explicit \"Ask Iris about <exercise>\" click is now sticky and survives subsequent chat-view-visibility events.
- To switch to the workspace exercise the user clicks the workspace context explicitly (the \"Switch to Workspace\" path that already exists).
- The persisted user-selected context survives across VS Code restarts (was already the case via \`loadState\`).

## Tests
- Existing test \`should override with workspace exercise when different exercise active\` was codifying the buggy behavior (asserting that user-selected gets overwritten). Renamed and flipped to assert preservation.
- Added \`should override with workspace exercise when active is system-default and outdated\` — covers the legitimate override case.
- Added \`should override with workspace exercise when no active context exists\` — confirms initial-load behavior is unchanged.

## Test plan
- [x] \`npm run check-types\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:unit\` exit 0 (all unit tests pass)
- [ ] Manual smoke: log in, open a course, click \"Ask Iris\" on a non-workspace exercise — chat shows that exercise, doesn't jump back to the workspace one.

## Independent of #122
This fix lives on its own branch off \`dev\`. It's orthogonal to the ContextStore split refactor — the bug exists with or without #122. Once both merge, no rebase conflict expected (different files).