### PR TITLE
feat(struggle): add showInterventions toggle to suppress UI surfaces

### DIFF
--- a/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
+++ b/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
@@ -23,25 +23,27 @@
 | `extension/src/extension/services/telemetry/types.ts` | Modify | Add `InterventionSuppressionReason` and `SuppressedInterventionPayload` |
 | `extension/src/extension/services/telemetry/recording/types.ts` | Modify | Add `'suppressed'` to `InterventionEvent.action`, add `suppressionReason`, add `ConfigurationSnapshotEvent` and `ConfigurationChangeEvent`, update `RecordedEvent` union |
 | `extension/src/extension/services/telemetry/interventionService.ts` | Modify | Extend `hideHint()` to reset `text` / `tooltip` / `backgroundColor` |
-| `extension/src/extension/services/telemetry/telemetryManager.ts` | Modify | Add `_showInterventions` field + `onDidSuppressIntervention` emitter; gate `_evaluateAndIntervene`; load + live-handle setting in `_loadConfiguration`; export `getShowInterventions()` for tests |
-| `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` | Modify | Add `'suppressed'` action to `recordIntervention`; add `recordConfigurationSnapshot` and `recordConfigurationChange` methods |
-| `extension/src/extension/activation/sessionRecorderWiring.ts` | Modify | Subscribe to `onDidSuppressIntervention` → `recordIntervention('suppressed', …)`; add startup contributor for `configurationSnapshot`; subscribe to `vscode.workspace.onDidChangeConfiguration` for the two struggle keys → `recordConfigurationChange` |
+| `extension/src/extension/services/telemetry/telemetryManager.ts` | Modify | Add `_showInterventions` field + `onDidSuppressIntervention` emitter; gate `_evaluateAndIntervene`; load + live-handle setting in `_loadConfiguration` |
+| `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` | Modify | Add `'suppressed'` action to `recordIntervention`; add `recordConfigurationSnapshot` and `recordConfigurationChange` |
+| `extension/src/extension/activation/sessionRecorderWiring.ts` | Modify | Subscribe to `onDidSuppressIntervention`; add startup contributor for `configurationSnapshot`; subscribe to `vscode.workspace.onDidChangeConfiguration` for the two struggle keys → `recordConfigurationChange` |
 | `extension/test/unit/services/telemetry/interventionService.test.ts` | Modify | Add tests for the extended `hideHint()` field-reset behaviour |
 | `extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts` | **Create** | Toggle on/off paths, event emission, no UI calls, no state advancement, type-guard fallback, live-toggle behaviour |
 | `extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts` | Modify | Add tests for `recordIntervention('suppressed', …)`, `recordConfigurationSnapshot`, `recordConfigurationChange` |
+| `extension/test/unit/activation/sessionRecorderWiring.test.ts` | **Create** | Integration tests: TelemetryManager + SessionRecorder + wiring drive suppression and config-change events end-to-end into the JSONL stream |
 
 ---
 
 ## Conventions & Reminders
 
 - **Branch:** Already created at `feat/intervention-ui-toggle` off `origin/dev` in worktree `~/claudeworktrees/MA-intervention-ui-toggle`.
-- **Run all commands from the worktree root:** `/Users/liamberger/claudeworktrees/MA-intervention-ui-toggle`. Tests live under `extension/`, so most npm commands run from `extension/`.
+- **Run all commands from the worktree root:** `/Users/liamberger/claudeworktrees/MA-intervention-ui-toggle`. Most npm commands run from `extension/`.
+- **NEVER invoke `vscode-test` without `compile-tests` first.** `vscode-test` runs the JS in `out/test/unit/**/*.test.js`. If you forget to compile, you may run *stale* tests (or none at all if the test file is newly created). Every test step in this plan uses the chain `npm run compile-tests && npx vscode-test --label unit --grep "…"`. Do not shortcut.
 - **Test runner:** vscode-test (Mocha) for unit tests under `extension/test/unit/`. Use `suite`/`test`/`setup`/`teardown` (Mocha BDD-not-installed). Assertions: node `assert`. Stubs/spies: `sinon`.
-- **Test file naming:** match the existing convention — see `interventionService.test.ts`, `sessionRecorder.test.ts`.
-- **Commit style:** match recent log on `dev` (Conventional Commits — `feat:`, `test:`, `docs:`, etc.). No Co-Authored-By line. No em dashes in commit messages.
+- **Whitebox access pattern:** Several tests in this plan reach into TS-`private` fields via `(tm as unknown as { _field: T })._field`. This works because TypeScript `private` is compile-time only; the field exists at runtime. If `TelemetryManager` later migrates to ECMAScript `#private` fields or renames `_evaluateAndIntervene`/`_decisionEngine`/`_showInterventions`/`_loadConfiguration`, these tests need updating. Note this in your code review.
+- **Commit style:** Conventional Commits (`feat:`, `test:`, `docs:`, etc.). No Co-Authored-By line. No em dashes anywhere.
 - **Commit cadence:** every task ends with a commit. Stage only the files actually changed; never `git add -A`.
-- **Lint/typecheck:** after edits, run `npm run check-types` and `npm run lint:src` from `extension/`. Final-final step before merging is `npm run compile`.
-- **First-time worktree setup:** before Task 1, run `npm install` inside `extension/` (the worktree has no `node_modules` yet). Verified-clean baseline: run `npm run check-types` and report success before starting.
+- **Lint/typecheck:** after edits, run `npm run check-types`. Final-final integration step uses `npm run lint` (lints both `src` and `test`) and `npm run package`.
+- **First-time worktree setup:** before Task 1, run `npm install` inside `extension/` (the worktree has no `node_modules` yet).
 
 ---
 
@@ -58,25 +60,33 @@ npm install 2>&1 | tee /tmp/intervention-toggle-install.log | tail -20
 
 Expected: install succeeds. If `npm install` fails, abort and report.
 
-- [ ] **Step 2: Verify clean type baseline**
+- [ ] **Step 2: Compile tests**
+
+```bash
+npm run compile-tests 2>&1 | tail -10
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Verify clean type baseline**
 
 ```bash
 npm run check-types 2>&1 | tee /tmp/intervention-toggle-baseline-types.txt | tail -10
 ```
 
-Expected: exit 0, no errors. (Worktree starts from `origin/dev`, which should be green.)
+Expected: exit 0.
 
-- [ ] **Step 3: Verify clean unit-test baseline (intervention area only)**
+- [ ] **Step 4: Verify clean unit-test baseline (intervention area)**
 
 ```bash
 npx vscode-test --label unit --grep "InterventionService" 2>&1 | tee /tmp/intervention-toggle-baseline-tests.txt | tail -30
 ```
 
-Expected: existing intervention tests pass. If any fail, report and stop — do not proceed with new work on a red baseline.
+Expected: existing intervention tests pass. If any fail, stop and report — do not proceed on a red baseline.
 
-- [ ] **Step 4: Commit nothing**
+- [ ] **Step 5: Commit nothing**
 
-This task makes no source changes; just confirms environment is ready. Skip commit.
+This task makes no source changes; just confirms environment is ready.
 
 ---
 
@@ -186,7 +196,7 @@ git commit -m "feat(constants): add SHOW_INTERVENTIONS_KEY for new struggle sett
 ## Task 3: Telemetry types — suppression payload
 
 **Files:**
-- Modify: `extension/src/extension/services/telemetry/types.ts` (after the `InterventionDecision` interface, near line 320 — locate by searching for the existing `InterventionBlockedReason` type)
+- Modify: `extension/src/extension/services/telemetry/types.ts` (after the `InterventionDismissReason` type definition near line 277)
 
 - [ ] **Step 1: Add the suppression-reason and payload types**
 
@@ -354,7 +364,7 @@ cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
 npm run check-types 2>&1 | tee /tmp/intervention-toggle-typecheck-task4.txt | tail -30
 ```
 
-Expected: errors in `sessionRecorderWiring.ts` and `sessionRecorder.ts` will surface only after Tasks 5–8 — at this stage only the type definitions changed, so type-check should still pass.
+Expected: pass. (The type definitions changed but no consumer call sites broke yet.)
 
 - [ ] **Step 5: Commit**
 
@@ -371,23 +381,24 @@ Schema-level changes only:
 
 ---
 
-## Task 5: Test — `hideHint()` resets text/tooltip/backgroundColor (TDD)
+## Task 5: Test — `hideHint()` resets text/tooltip/backgroundColor (TDD red)
 
 **Files:**
-- Test: `extension/test/unit/services/telemetry/interventionService.test.ts` (add new `suite` block at the bottom of the file)
+- Modify: `extension/test/unit/services/telemetry/interventionService.test.ts` (add `vscode` import + new `suite` block at the bottom)
 
-- [ ] **Step 1: Locate where the existing tests construct an `InterventionService`**
+- [ ] **Step 1: Add the `vscode` import**
 
-```bash
-cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-grep -n "new InterventionService\|createStatusBarItem" test/unit/services/telemetry/interventionService.test.ts | head -10
+The existing file imports only `assert`, `sinon`, and telemetry classes. At the top of the file, alongside those imports, add:
+
+```ts
+import * as vscode from 'vscode';
 ```
 
-Note the helper used to instantiate the service and to access the underlying status bar item (the file already stubs `vscode.window.createStatusBarItem`).
+(If the import is already present, skip this sub-step. Verify by grepping `^import \* as vscode` first.)
 
-- [ ] **Step 2: Add the new test suite at the end of `interventionService.test.ts`**
+- [ ] **Step 2: Append the new test suite at the end of the file**
 
-Append the following block after the existing suite, **without modifying** the existing tests:
+After the existing suite closes, append:
 
 ```ts
 suite('InterventionService.hideHint() — full status-bar reset', () => {
@@ -435,13 +446,14 @@ suite('InterventionService.hideHint() — full status-bar reset', () => {
 });
 ```
 
-If the existing test file already has a `setup` that stubs `createStatusBarItem`, reuse that pattern (do not double-stub). If the existing pattern is incompatible, mirror it exactly here so that all tests in the file use the same approach.
+If the existing test file already has a `setup` that stubs `createStatusBarItem`, mirror that exact pattern instead of double-stubbing.
 
-- [ ] **Step 3: Run the new test — expect failure**
+- [ ] **Step 3: Compile tests and run the new test — expect failure**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npx vscode-test --label unit --grep "hideHint() — full status-bar reset" 2>&1 | tee /tmp/intervention-toggle-task5-fail.txt | tail -20
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tee /tmp/intervention-toggle-task5-fail.txt | tail -20
 ```
 
 Expected: test fails because `hideHint()` does not currently reset `text` / `tooltip` / `backgroundColor`.
@@ -455,7 +467,7 @@ git commit -m "test(intervention): add failing test for hideHint full reset"
 
 ---
 
-## Task 6: Implement `hideHint()` reset
+## Task 6: Implement `hideHint()` reset (TDD green)
 
 **Files:**
 - Modify: `extension/src/extension/services/telemetry/interventionService.ts:254-261`
@@ -491,22 +503,23 @@ public hideHint(): void {
 }
 ```
 
-- [ ] **Step 2: Run the new test — expect pass**
+- [ ] **Step 2: Compile tests and run the new test — expect pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npx vscode-test --label unit --grep "hideHint() — full status-bar reset" 2>&1 | tail -15
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tail -15
 ```
 
 Expected: pass.
 
-- [ ] **Step 3: Run the full `InterventionService` suite — expect pass**
+- [ ] **Step 3: Run the full `InterventionService` suite — expect no regression**
 
 ```bash
 npx vscode-test --label unit --grep "InterventionService" 2>&1 | tail -20
 ```
 
-Expected: all existing intervention-service tests still pass (no regressions).
+Expected: all existing intervention-service tests still pass.
 
 - [ ] **Step 4: Commit**
 
@@ -516,19 +529,19 @@ git commit -m "feat(intervention): clear text/tooltip/backgroundColor in hideHin
 
 Prevents stale labels and warning-coloured backgrounds from bleeding
 through if the status bar item is later shown for an unrelated reason.
-Required precondition for the live UI-toggle off→hide path."
+Required precondition for the live UI-toggle off->hide path."
 ```
 
 ---
 
-## Task 7: TelemetryManager — toggle field, emitter, getter (foundational, no behaviour change yet)
+## Task 7: TelemetryManager — toggle field + emitter (foundational)
 
 **Files:**
-- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts` (around lines 1-25 for imports, 55-90 for fields/getters, 442-465 for `_loadConfiguration`)
+- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts` (imports near line 2; field block near line 57; getters near line 90; `dispose()` near line 162)
 
-- [ ] **Step 1: Add the type import**
+- [ ] **Step 1: Extend the type import**
 
-Open `telemetryManager.ts`. The existing type import (line 2) already pulls from `./types`. Append `SuppressedInterventionPayload` to the imported names:
+Open `telemetryManager.ts`. The existing import from `./types` (line 2) currently lists `StruggleContext, TriggerType, EQConfidence, EQState, RecommendedAction`. Replace with:
 
 ```ts
 import {
@@ -541,32 +554,24 @@ import {
 } from './types';
 ```
 
-- [ ] **Step 2: Add the new field, emitter, and event accessor**
+- [ ] **Step 2: Add the new field next to `_isEnabled`**
 
-Find the existing field block ending with `_debugMode: boolean = false;` (around line 63). Just below the existing intervention-event accessors (i.e. after `onDidBlockIntervention` getter at line 90), add:
+Around line 57, immediately after `private _isEnabled: boolean = true;`, add:
+
+```ts
+private _showInterventions: boolean = true;
+```
+
+- [ ] **Step 3: Add the suppression event emitter and accessor**
+
+Just below the existing `onDidBlockIntervention` getter (around line 90), add:
 
 ```ts
 private readonly _onDidSuppressIntervention = new vscode.EventEmitter<SuppressedInterventionPayload>();
 public readonly onDidSuppressIntervention = this._onDidSuppressIntervention.event;
 ```
 
-Add a new private field next to `_isEnabled` (around line 57):
-
-```ts
-private _showInterventions: boolean = true;
-```
-
-In `dispose()` (around line 162), append `this._onDidSuppressIntervention.dispose();` to the disposal list (model after the existing `_onDidCalculateEQ.dispose()` if present, or add it next to other disposable emitters).
-
-- [ ] **Step 3: Add a public read-accessor for tests**
-
-Below `public isEnabled(): boolean { return this._isEnabled; }` (around line 436), add:
-
-```ts
-public getShowInterventions(): boolean {
-    return this._showInterventions;
-}
-```
+Inside `dispose()` (around line 162-180), find the existing emitter-disposal block (look for `this._onDidCalculateEQ.dispose();`) and add `this._onDidSuppressIntervention.dispose();` right after it. If `_onDidCalculateEQ.dispose()` is not present in `dispose()`, dispose the new emitter at the end of the method, before the `_log('TelemetryManager disposed')` call.
 
 - [ ] **Step 4: Type-check**
 
@@ -575,7 +580,7 @@ cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
 npm run check-types 2>&1 | tail -10
 ```
 
-Expected: pass. (The new emitter is wired but not yet fired — behaviour unchanged.)
+Expected: pass. (Emitter declared but never fired — behaviour unchanged.)
 
 - [ ] **Step 5: Commit**
 
@@ -589,7 +594,7 @@ fired; setting not yet read. Behaviour unchanged."
 
 ---
 
-## Task 8: Test — toggle off → suppression event fires, no UI calls (TDD, red)
+## Task 8: Test — TelemetryManager toggle behaviour (TDD red)
 
 **Files:**
 - Create: `extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts`
@@ -603,14 +608,16 @@ Create `extension/test/unit/services/telemetry/telemetryManagerInterventionToggl
  * Unit tests for the artemis.struggleDetection.showInterventions toggle.
  *
  * Covers:
- *  T1. Toggle off → onDidSuppressIntervention fires once with original decision (shouldIntervene=true preserved).
- *  T2. Toggle off → no calls to vscode.window.showInformationMessage / showWarningMessage / statusBarItem.show().
- *  T3. Toggle off → no UI-delivery state advancement (lastInterventionTime=0, sessionInterventionCount=0).
+ *  T1. Toggle off → onDidSuppressIntervention fires once (decision unchanged);
+ *      onDidShowIntervention and onDidBlockIntervention do NOT fire.
+ *  T2. Toggle off → no calls to vscode.window.show*Message or statusBarItem.show.
+ *  T3. Toggle off → UI-delivery state does not advance.
  *  T4. Toggle off → suppression events are NOT rate-limited.
- *  T5. Toggle on (default) → existing show path still fires; no suppression event.
- *  T6. Live-toggle on→off with subtle hint visible → hideHint called; dismiss event with reason 'hidden' fires.
- *  T7. Live-toggle off→on → no spurious events.
- *  T8. Setting type guard: non-boolean value falls back to true.
+ *  T5. Toggle off → onDidCalculateEQ still fires.
+ *  T6. Toggle on (default) → existing show path runs; no suppression event.
+ *  T7. Live-toggle on→off with subtle visible → hideHint called; dismiss reason 'hidden'.
+ *  T8. Live-toggle off→on → no spurious events.
+ *  T9. Setting type guard: non-boolean falls back to true.
  */
 
 import * as assert from 'assert';
@@ -657,12 +664,14 @@ function stubGetConfiguration(values: ConfigStubValues): sinon.SinonStub {
  * Drive a synthetic eligible decision through TelemetryManager._evaluateAndIntervene.
  * Uses a controlled private accessor since _evaluateAndIntervene is private and
  * trigger-emitter wiring would couple this test to unrelated subsystems.
+ *
+ * Whitebox brittleness: depends on private field/method names
+ * `_decisionEngine` and `_evaluateAndIntervene`.
  */
 function driveEligibleDecision(
     tm: TelemetryManager,
     overrides: Partial<InterventionDecision> = {},
 ): void {
-    // Cast to expose the private method specifically for whitebox testing.
     type Internal = {
         _evaluateAndIntervene(triggerType: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained'): void;
         _decisionEngine: { evaluate: (...args: unknown[]) => InterventionDecision };
@@ -685,7 +694,7 @@ function driveEligibleDecision(
 }
 
 suite('TelemetryManager — intervention UI toggle', () => {
-    let getConfigStub: sinon.SinonStub;
+    let getConfigStub: sinon.SinonStub | undefined;
     let showInfoStub: sinon.SinonStub;
     let showWarnStub: sinon.SinonStub;
     let createStatusBarStub: sinon.SinonStub;
@@ -708,23 +717,30 @@ suite('TelemetryManager — intervention UI toggle', () => {
 
     teardown(() => {
         getConfigStub?.restore();
+        getConfigStub = undefined;
         showInfoStub.restore();
         showWarnStub.restore();
         createStatusBarStub.restore();
     });
 
-    test('T1: toggle off → suppression event fires with shouldIntervene=true preserved', () => {
+    test('T1: toggle off → suppression event fires; no show/block events', () => {
         getConfigStub = stubGetConfiguration({ showInterventions: false });
         const tm = new TelemetryManager();
-        const captured: SuppressedInterventionPayload[] = [];
-        tm.onDidSuppressIntervention(payload => captured.push(payload));
+        const suppressed: SuppressedInterventionPayload[] = [];
+        const shown: InterventionDecision[] = [];
+        const blocked: unknown[] = [];
+        tm.onDidSuppressIntervention(payload => suppressed.push(payload));
+        tm.onDidShowIntervention(d => shown.push(d));
+        tm.onDidBlockIntervention(p => blocked.push(p));
 
         driveEligibleDecision(tm, { level: 'subtle' });
 
-        assert.strictEqual(captured.length, 1);
-        assert.strictEqual(captured[0].reason, 'user-disabled');
-        assert.strictEqual(captured[0].decision.shouldIntervene, true);
-        assert.strictEqual(captured[0].decision.level, 'subtle');
+        assert.strictEqual(suppressed.length, 1, 'expected exactly one suppression event');
+        assert.strictEqual(suppressed[0].reason, 'user-disabled');
+        assert.strictEqual(suppressed[0].decision.shouldIntervene, true, 'decision.shouldIntervene must be preserved as true');
+        assert.strictEqual(suppressed[0].decision.level, 'subtle');
+        assert.strictEqual(shown.length, 0, 'onDidShowIntervention must not fire when suppressed');
+        assert.strictEqual(blocked.length, 0, 'onDidBlockIntervention must not fire when suppressed');
         tm.dispose();
     });
 
@@ -750,7 +766,6 @@ suite('TelemetryManager — intervention UI toggle', () => {
             driveEligibleDecision(tm, { level: 'notification' });
         }
 
-        // Whitebox: read intervention service state via the public getter chain.
         const internal = tm as unknown as { _interventionService: { getState(): { lastInterventionTime: number; sessionInterventionCount: number; lastDismissed: boolean; lastAccepted: boolean } } };
         const state = internal._interventionService.getState();
         assert.strictEqual(state.lastInterventionTime, 0, 'lastInterventionTime advanced');
@@ -774,7 +789,19 @@ suite('TelemetryManager — intervention UI toggle', () => {
         tm.dispose();
     });
 
-    test('T5: toggle on (default) → no suppression event; show path runs', () => {
+    test('T5: toggle off → onDidCalculateEQ still fires for the trigger', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const eqEvents: unknown[] = [];
+        tm.onDidCalculateEQ(e => eqEvents.push(e));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(eqEvents.length >= 1, true, 'onDidCalculateEQ must fire for trigger evaluation even when UI suppressed');
+        tm.dispose();
+    });
+
+    test('T6: toggle on (default) → no suppression event; show path runs', () => {
         getConfigStub = stubGetConfiguration({ showInterventions: true });
         const tm = new TelemetryManager();
         const captured: SuppressedInterventionPayload[] = [];
@@ -787,7 +814,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
         tm.dispose();
     });
 
-    test('T6: live-toggle on→off with subtle visible → hideHint called; dismiss reason hidden', () => {
+    test('T7: live-toggle on→off with subtle visible → hideHint called; dismiss reason hidden', () => {
         getConfigStub = stubGetConfiguration({ showInterventions: true });
         const tm = new TelemetryManager();
 
@@ -795,10 +822,10 @@ suite('TelemetryManager — intervention UI toggle', () => {
         const dismissals: Array<{ dismissReason: string }> = [];
         tm.onDidDismissIntervention(payload => dismissals.push(payload));
 
-        // Flip the stubbed config, then re-trigger config loading directly.
-        // We invoke _loadConfiguration() instead of firing a fake
-        // onDidChangeConfiguration event because TelemetryManager re-runs
-        // _loadConfiguration unconditionally on any matching event — calling
+        // Flip the stubbed config, then re-trigger configuration loading.
+        // We invoke _loadConfiguration directly (whitebox) instead of firing a
+        // fake ConfigurationChangeEvent: TelemetryManager re-runs
+        // _loadConfiguration unconditionally on a matching event, so calling
         // it directly is equivalent and avoids brittle event mocking.
         getConfigStub.restore();
         getConfigStub = stubGetConfiguration({ showInterventions: false });
@@ -810,7 +837,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
         tm.dispose();
     });
 
-    test('T7: live-toggle off→on → no spurious events', () => {
+    test('T8: live-toggle off→on → no spurious events', () => {
         getConfigStub = stubGetConfiguration({ showInterventions: false });
         const tm = new TelemetryManager();
         const suppressed: SuppressedInterventionPayload[] = [];
@@ -827,24 +854,26 @@ suite('TelemetryManager — intervention UI toggle', () => {
         tm.dispose();
     });
 
-    test('T8: type guard — non-boolean setting falls back to true', () => {
+    test('T9: type guard — non-boolean setting falls back to true', () => {
         getConfigStub = stubGetConfiguration({ showInterventions: 'not-a-boolean' });
         const tm = new TelemetryManager();
 
-        assert.strictEqual(tm.getShowInterventions(), true);
+        const internal = tm as unknown as { _showInterventions: boolean };
+        assert.strictEqual(internal._showInterventions, true);
         tm.dispose();
     });
 });
 ```
 
-- [ ] **Step 2: Run the new tests — expect failure**
+- [ ] **Step 2: Compile tests and run the new tests — expect failure**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task8-fail.txt | tail -60
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task8-fail.txt | tail -80
 ```
 
-Expected: every test fails (gate not implemented yet). T5 may pass; that is fine.
+Expected: every gate-dependent test (T1, T2, T3, T4, T7, T9) fails because the gate is not implemented yet. T5, T6, T8 may already pass; that is fine.
 
 - [ ] **Step 3: Commit (red tests)**
 
@@ -852,17 +881,18 @@ Expected: every test fails (gate not implemented yet). T5 may pass; that is fine
 git add extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
 git commit -m "test(telemetry): add failing tests for intervention UI toggle
 
-Covers suppression event semantics, no UI calls, no state advancement,
-non-rate-limited emission, live-toggle transitions, and type guard."
+Covers suppression-event semantics with no show/block emission, no UI
+calls, no state advancement, non-rate-limited emission, EQ event
+preservation, live-toggle transitions, and type guard."
 ```
 
 ---
 
-## Task 9: TelemetryManager — implement the gate + setting load
+## Task 9: TelemetryManager — implement the gate (TDD green)
 
 **Files:**
 - Modify: `extension/src/extension/services/telemetry/telemetryManager.ts:377-412` (`_evaluateAndIntervene`)
-- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts:442-465` (`_loadConfiguration`)
+- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts:442-466` (`_loadConfiguration`)
 
 - [ ] **Step 1: Replace the entire `_loadConfiguration` method**
 
@@ -893,7 +923,7 @@ private _loadConfiguration(): void {
         this._log('Struggle detection enabled');
     }
 
-    // Live transition on→off for the UI toggle: clear any visible hint so a
+    // Live transition on->off for the UI toggle: clear any visible hint so a
     // status-bar lightbulb / coloured remnant disappears immediately. We do
     // NOT log on every load (only on transitions) to avoid noise.
     if (previousShowInterventions && !this._showInterventions) {
@@ -974,16 +1004,17 @@ if (decision.shouldIntervene) {
 }
 ```
 
-- [ ] **Step 3: Run the toggle tests — expect pass**
+- [ ] **Step 3: Compile tests and run the toggle suite — expect pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run compile-tests 2>&1 | tail -5
 npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task9-pass.txt | tail -40
 ```
 
-Expected: all 8 tests pass. If any fail, inspect output and adjust the implementation (do **not** change the test assertions).
+Expected: all 9 tests (T1–T9) pass. If any fail, inspect the output and adjust the implementation. Do **not** modify the test assertions.
 
-- [ ] **Step 4: Run the broader telemetry suite — expect pass**
+- [ ] **Step 4: Run the broader telemetry suite — expect no regressions**
 
 ```bash
 npx vscode-test --label unit --grep "TelemetryManager|InterventionService" 2>&1 | tail -30
@@ -1005,12 +1036,105 @@ hideHint() so any visible status-bar hint disappears immediately."
 
 ---
 
-## Task 10: Recording — `recordIntervention('suppressed', …)` support
+## Task 10: Test — sessionRecorder for `'suppressed'` and config events (TDD red)
+
+**Files:**
+- Modify: `extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts` (append at end)
+
+- [ ] **Step 1: Append the new test suite using the existing harness helpers**
+
+The file already exposes a `makeRecorder()` factory and a `collectWrittenEvents(fakeFs)` helper that returns parsed `RecordedEvent[]` from a `FakeFs`. Append the following suite at the very bottom of `sessionRecorder.test.ts` (after the last existing `suite(...)` closes):
+
+```ts
+suite('SessionRecorder — intervention suppression and configuration provenance', () => {
+    test('recordIntervention with suppressed action persists suppressionReason', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordIntervention(
+            'suppressed', 'notification', true, 0.55, 'sufficient', 'execution-error',
+            { suppressionReason: 'user-disabled', rawWanted: true },
+        );
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const intervention = events.find(e => e.type === 'intervention') as InterventionEvent | undefined;
+        assert.ok(intervention, 'intervention event missing');
+        assert.strictEqual(intervention!.action, 'suppressed');
+        assert.strictEqual(intervention!.shouldIntervene, true);
+        assert.strictEqual(intervention!.suppressionReason, 'user-disabled');
+        assert.strictEqual(intervention!.rawWanted, true);
+        assert.strictEqual(intervention!.level, 'notification');
+        assert.strictEqual(intervention!.triggerType, 'execution-error');
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationSnapshot persists both keys', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationSnapshot(true, false);
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const snap = events.find(e => e.type === 'configurationSnapshot') as ConfigurationSnapshotEvent | undefined;
+        assert.ok(snap, 'configurationSnapshot missing');
+        assert.strictEqual(snap!.struggleDetectionEnabled, true);
+        assert.strictEqual(snap!.showInterventions, false);
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationChange persists only the changed key', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationChange({ showInterventions: false });
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
+        assert.ok(change, 'configurationChange missing');
+        assert.deepStrictEqual(change!.changes, { showInterventions: false });
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+});
+```
+
+If `InterventionEvent`, `ConfigurationSnapshotEvent`, or `ConfigurationChangeEvent` are not yet imported in this test file, add them to the existing `import type { … }` line at the top:
+
+```ts
+import type {
+    RecordedEvent,
+    InterventionEvent,
+    ConfigurationSnapshotEvent,
+    ConfigurationChangeEvent,
+} from '../../../../../src/extension/services/telemetry/recording/types';
+```
+
+(The path mirrors the existing `RecordedEvent` import in this file.)
+
+- [ ] **Step 2: Compile tests and run — expect failure**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tee /tmp/intervention-toggle-task10-fail.txt | tail -40
+```
+
+Expected behaviour: `compile-tests` may itself fail — `recordIntervention('suppressed', ...)` does not type-check yet, and `recordConfigurationSnapshot` / `recordConfigurationChange` do not exist. **Either** of these counts as "red". If `compile-tests` succeeds but tests fail at runtime, that is also red. Capture the output and proceed to Task 11.
+
+- [ ] **Step 3: Commit (red tests)**
+
+```bash
+git add extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+git commit -m "test(recording): add failing tests for suppressed action and config events"
+```
+
+---
+
+## Task 11: SessionRecorder — `'suppressed'` action support (TDD green for first test)
 
 **Files:**
 - Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts:300-329`
 
-- [ ] **Step 1: Widen the `action` parameter and accept `suppressionReason`**
+- [ ] **Step 1: Widen `recordIntervention` to accept the new action and reason**
 
 Replace the existing `recordIntervention` method:
 
@@ -1084,11 +1208,12 @@ recordIntervention(
 }
 ```
 
-- [ ] **Step 2: Type-check**
+- [ ] **Step 2: Compile tests; first test should now pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run check-types 2>&1 | tail -10
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "recordIntervention with suppressed action" 2>&1 | tail -15
 ```
 
 Expected: pass.
@@ -1102,14 +1227,14 @@ git commit -m "feat(recording): support 'suppressed' intervention action and rea
 
 ---
 
-## Task 11: Recording — `recordConfigurationSnapshot` and `recordConfigurationChange`
+## Task 12: SessionRecorder — config snapshot/change methods (TDD green for remaining tests)
 
 **Files:**
-- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` (add new methods near other `record*` methods, around line 350)
+- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` (insert near other `record*` methods, around line 350 after `recordPanelVisibility`)
 
 - [ ] **Step 1: Add the two new methods**
 
-Insert after `recordPanelVisibility` (around line 350):
+Insert after `recordPanelVisibility`:
 
 ```ts
 recordConfigurationSnapshot(struggleDetectionEnabled: boolean, showInterventions: boolean): void {
@@ -1139,14 +1264,21 @@ recordConfigurationChange(changes: {
 }
 ```
 
-- [ ] **Step 2: Type-check**
+- [ ] **Step 2: Compile tests and run the recording suite — expect pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run check-types 2>&1 | tail -10
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tail -30
 ```
 
-Expected: pass.
+Expected: all three tests in the new suite pass. Then check no regressions in the broader suite:
+
+```bash
+npx vscode-test --label unit --grep "SessionRecorder" 2>&1 | tail -30
+```
+
+Expected: no regressions.
 
 - [ ] **Step 3: Commit**
 
@@ -1157,7 +1289,263 @@ git commit -m "feat(recording): add configuration snapshot and change recorders"
 
 ---
 
-## Task 12: Recording wiring — subscribe to suppression and config-change
+## Task 13: Test — wiring integration (TDD red)
+
+**Files:**
+- Create: `extension/test/unit/activation/sessionRecorderWiring.test.ts`
+
+This task creates the first test file under `extension/test/unit/activation/`. The directory does not yet exist; `compile-tests` and `vscode-test` accept additional sub-directories under `test/unit/` automatically (the `.vscode-test.mjs` glob is `out/test/unit/**/*.test.js`).
+
+- [ ] **Step 1: Create the new wiring test file**
+
+Create `extension/test/unit/activation/sessionRecorderWiring.test.ts` with this content:
+
+```ts
+/**
+ * Integration tests for sessionRecorderWiring.
+ *
+ * Constructs a real TelemetryManager + SessionRecorder, calls wireSessionRecorder,
+ * drives suppression/config-change events, and asserts they reach the JSONL
+ * stream via the FakeFs.
+ *
+ * Whitebox brittleness note: stubs `vscode.workspace.onDidChangeConfiguration`
+ * to capture and synchronously invoke the listener that wiring registers.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { TelemetryManager } from '../../../src/extension/services/telemetry/telemetryManager';
+import { SessionRecorder } from '../../../src/extension/services/telemetry/recording/sessionRecorder';
+import { RecordingStorageWriter, type RecordingFs } from '../../../src/extension/services/telemetry/recording/storageWriter';
+import { wireSessionRecorder } from '../../../src/extension/activation/sessionRecorderWiring';
+import type { RecordedEvent, InterventionEvent, ConfigurationSnapshotEvent, ConfigurationChangeEvent } from '../../../src/extension/services/telemetry/recording/types';
+import type { ConsentService } from '../../../src/extension/services/auth';
+import type { ArtemisWebsocketService } from '../../../src/extension/services/websocket';
+import type { ArtemisWebviewProvider, ChatWebviewProvider } from '../../../src/extension/provider';
+import type { InterventionDecision } from '../../../src/extension/services/telemetry/types';
+
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    syncChunks: string[] = [];
+    mkdir(): Promise<string | undefined> { return Promise.resolve(undefined); }
+    writeFile(p: string, data: string): Promise<void> { this.writtenFiles.push({ path: p, data }); return Promise.resolve(); }
+    appendFile(_p: string, data: string): Promise<void> { this.appendedChunks.push(data); return Promise.resolve(); }
+    rm(): Promise<void> { return Promise.resolve(); }
+    appendFileSync(_p: string, data: string): void { this.syncChunks.push(data); }
+}
+
+function collectWrittenEvents(fs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of [...fs.appendedChunks, ...fs.syncChunks]) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip */ }
+        }
+    }
+    return events;
+}
+
+/** Stub the minimum of ConsentService that wireSessionRecorder reads. */
+function stubConsent(extended: boolean): ConsentService {
+    const onConsentChanged = new vscode.EventEmitter<'pending' | 'declined' | 'basic' | 'extended'>();
+    return {
+        get isExtendedCollectionEnabled() { return extended; },
+        onConsentChanged: onConsentChanged.event,
+    } as unknown as ConsentService;
+}
+
+/** Stub WebSocket service — wireSessionRecorder only registers/unregisters handlers. */
+function stubWebsocket(): ArtemisWebsocketService {
+    return {
+        registerMessageHandler: sinon.stub(),
+        unregisterMessageHandler: sinon.stub(),
+    } as unknown as ArtemisWebsocketService;
+}
+
+function stubWebviewProvider(): ArtemisWebviewProvider {
+    const onDidChangeViewNavigation = new vscode.EventEmitter<{ from: string; to: string }>();
+    const onDidChangePanelVisibility = new vscode.EventEmitter<boolean>();
+    return {
+        getCurrentVisibility: () => false,
+        onDidChangeViewNavigation: onDidChangeViewNavigation.event,
+        onDidChangePanelVisibility: onDidChangePanelVisibility.event,
+    } as unknown as ArtemisWebviewProvider;
+}
+
+function stubChatProvider(): ChatWebviewProvider {
+    const onDidSendIrisChatMessage = new vscode.EventEmitter<string>();
+    const onDidAttemptIrisChatSend = new vscode.EventEmitter<{ content: string; status: 'pending' | 'sent' | 'failed'; errorMessage?: string }>();
+    const onDidProvideIrisChatFeedback = new vscode.EventEmitter<{ messageId: string; helpful: boolean }>();
+    const onDidChangePanelVisibility = new vscode.EventEmitter<boolean>();
+    const onDidReceiveIrisChatMessage = new vscode.EventEmitter<{ content: string; messageId?: string; sessionId?: string; sentAt?: number }>();
+    return {
+        getCurrentVisibility: () => false,
+        getSelectedExerciseId: () => 42,
+        onDidSendIrisChatMessage: onDidSendIrisChatMessage.event,
+        onDidAttemptIrisChatSend: onDidAttemptIrisChatSend.event,
+        onDidProvideIrisChatFeedback: onDidProvideIrisChatFeedback.event,
+        onDidChangePanelVisibility: onDidChangePanelVisibility.event,
+        websocketMessageHandler: { onDidReceiveIrisChatMessage: onDidReceiveIrisChatMessage.event },
+    } as unknown as ChatWebviewProvider;
+}
+
+function makeWiringHarness(): {
+    telemetryManager: TelemetryManager;
+    recorder: SessionRecorder;
+    fs: FakeFs;
+    capturedConfigListener: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    onDidChangeConfigStub: sinon.SinonStub;
+    dispose: () => Promise<void>;
+} {
+    const fs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(fakeUri, undefined, undefined, writer);
+    const telemetryManager = new TelemetryManager();
+    let capturedConfigListener: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    const onDidChangeConfigStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
+        capturedConfigListener = listener;
+        return new vscode.Disposable(() => { /* noop */ });
+    });
+    const ctx = { globalStorageUri: fakeUri, subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const wiring = wireSessionRecorder({
+        context: ctx,
+        consentService: stubConsent(true),
+        artemisWebsocketService: stubWebsocket(),
+        telemetryManager,
+        artemisWebviewProvider: stubWebviewProvider(),
+        chatWebviewProvider: stubChatProvider(),
+        capabilities: undefined,
+        exerciseRegistry: undefined,
+    });
+    return {
+        telemetryManager,
+        recorder: wiring.sessionRecorder,
+        fs,
+        get capturedConfigListener() { return capturedConfigListener; },
+        onDidChangeConfigStub,
+        dispose: async () => {
+            wiring.disposable.dispose();
+            try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
+            telemetryManager.dispose();
+            onDidChangeConfigStub.restore();
+        },
+    };
+}
+
+suite('sessionRecorderWiring — suppression and configuration provenance', () => {
+    test('suppression event is recorded as action=suppressed', async () => {
+        const harness = makeWiringHarness();
+        try {
+            await harness.recorder.startSession(42);
+            // Drive a suppression event from the TelemetryManager side.
+            const decision: InterventionDecision = {
+                rawWanted: true,
+                shouldIntervene: true,
+                level: 'notification',
+                triggerType: 'execution-error',
+                eq: 0.55,
+                confidence: 'sufficient',
+            };
+            (harness.telemetryManager as unknown as { _onDidSuppressIntervention: vscode.EventEmitter<{ decision: InterventionDecision; reason: 'user-disabled' }> })
+                ._onDidSuppressIntervention.fire({ decision, reason: 'user-disabled' });
+            await harness.recorder.endSession();
+
+            const events = collectWrittenEvents(harness.fs);
+            const intervention = events.find(e => e.type === 'intervention') as InterventionEvent | undefined;
+            assert.ok(intervention, 'intervention event missing');
+            assert.strictEqual(intervention!.action, 'suppressed');
+            assert.strictEqual(intervention!.suppressionReason, 'user-disabled');
+            assert.strictEqual(intervention!.shouldIntervene, true);
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('configurationSnapshot is emitted at startup', async () => {
+        const harness = makeWiringHarness();
+        try {
+            await harness.recorder.startSession(42);
+            await harness.recorder.endSession();
+
+            const events = collectWrittenEvents(harness.fs);
+            const snap = events.find(e => e.type === 'configurationSnapshot') as ConfigurationSnapshotEvent | undefined;
+            assert.ok(snap, 'configurationSnapshot missing — startup contributor not registered?');
+            assert.strictEqual(typeof snap!.struggleDetectionEnabled, 'boolean');
+            assert.strictEqual(typeof snap!.showInterventions, 'boolean');
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('configurationChange is recorded when the listener fires', async () => {
+        const harness = makeWiringHarness();
+        try {
+            await harness.recorder.startSession(42);
+            assert.ok(harness.capturedConfigListener, 'wireSessionRecorder did not register an onDidChangeConfiguration listener');
+
+            // Stub workspace.getConfiguration to return values that DIFFER from what
+            // the listener cached at wiring time, so a change is detected.
+            const originalGet = vscode.workspace.getConfiguration;
+            const cfgStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+                const real = originalGet.call(vscode.workspace, section);
+                return {
+                    ...real,
+                    get: <T>(key: string, def?: T): T => {
+                        if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
+                            return false as unknown as T;
+                        }
+                        if (section === 'artemis.struggleDetection' && key === 'enabled') {
+                            return true as unknown as T;
+                        }
+                        return def as T;
+                    },
+                    inspect: real.inspect.bind(real),
+                    update: real.update.bind(real),
+                    has: real.has.bind(real),
+                } as unknown as vscode.WorkspaceConfiguration;
+            });
+            try {
+                harness.capturedConfigListener!({
+                    affectsConfiguration: (k: string) => k === 'artemis.struggleDetection',
+                } as vscode.ConfigurationChangeEvent);
+            } finally {
+                cfgStub.restore();
+            }
+            await harness.recorder.endSession();
+
+            const events = collectWrittenEvents(harness.fs);
+            const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
+            assert.ok(change, 'configurationChange missing');
+            assert.deepStrictEqual(change!.changes, { showInterventions: false });
+        } finally {
+            await harness.dispose();
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Compile tests and run — expect failure**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task13-fail.txt | tail -40
+```
+
+Expected: tests fail. Either compile fails (because `_onDidSuppressIntervention` not yet emitted in wiring, or wiring does not subscribe / register a config listener), or runtime fails because no `intervention`/`configurationSnapshot`/`configurationChange` event reaches the JSONL.
+
+- [ ] **Step 3: Commit (red tests)**
+
+```bash
+git add extension/test/unit/activation/sessionRecorderWiring.test.ts
+git commit -m "test(activation): add failing wiring tests for suppression and config provenance"
+```
+
+---
+
+## Task 14: Wiring — implement subscriptions and provenance (TDD green)
 
 **Files:**
 - Modify: `extension/src/extension/activation/sessionRecorderWiring.ts`
@@ -1178,15 +1566,21 @@ disposables.push(telemetryManager.onDidSuppressIntervention(({ decision, reason 
 
 - [ ] **Step 2: Add the configuration-snapshot startup contributor**
 
-After the existing panel-visibility startup contributor (around line 145-160), add a new startup contributor near the end of the contributor block:
+Add a new import at the top of the file alongside the existing imports:
+
+```ts
+import { VSCODE_CONFIG } from '../utils/constants';
+```
+
+After the existing panel-visibility startup contributor (around line 145-160), add a new startup contributor:
 
 ```ts
 // Configuration snapshot — captures struggle-detection setting values at
 // session start so analysis can classify control vs treatment sessions.
 disposables.push(sessionRecorder.registerStartupContributor((ctx): RecordedEvent[] => {
-    const struggleConfig = vscode.workspace.getConfiguration('artemis.struggleDetection');
-    const enabled = struggleConfig.get<boolean>('enabled', true);
-    const rawShow = struggleConfig.get<unknown>('showInterventions', true);
+    const struggleConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+    const enabled = struggleConfig.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
+    const rawShow = struggleConfig.get<unknown>(VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY, true);
     const showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
     return [{
         type: 'configurationSnapshot',
@@ -1204,25 +1598,24 @@ Inside `wireSessionRecorder`, before the `// Recording status bar button` commen
 ```ts
 // Runtime configuration changes for struggle-detection settings — recorded
 // so mid-session flips can be reconciled with intervention events by timestamp.
-let lastStruggleEnabled = (() => {
-    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
-    return cfg.get<boolean>('enabled', true);
-})();
-let lastShowInterventions = (() => {
-    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
-    const raw = cfg.get<unknown>('showInterventions', true);
+const readStruggleEnabled = (): boolean => {
+    const cfg = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+    return cfg.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
+};
+const readShowInterventions = (): boolean => {
+    const cfg = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+    const raw = cfg.get<unknown>(VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY, true);
     return typeof raw === 'boolean' ? raw : true;
-})();
+};
+let lastStruggleEnabled = readStruggleEnabled();
+let lastShowInterventions = readShowInterventions();
 
 disposables.push(vscode.workspace.onDidChangeConfiguration(event => {
-    if (!event.affectsConfiguration('artemis.struggleDetection')) {
+    if (!event.affectsConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION)) {
         return;
     }
-    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
-    const newEnabled = cfg.get<boolean>('enabled', true);
-    const rawShow = cfg.get<unknown>('showInterventions', true);
-    const newShow = typeof rawShow === 'boolean' ? rawShow : true;
-
+    const newEnabled = readStruggleEnabled();
+    const newShow = readShowInterventions();
     const changes: { struggleDetectionEnabled?: boolean; showInterventions?: boolean } = {};
     if (newEnabled !== lastStruggleEnabled) {
         changes.struggleDetectionEnabled = newEnabled;
@@ -1238,16 +1631,25 @@ disposables.push(vscode.workspace.onDidChangeConfiguration(event => {
 }));
 ```
 
-- [ ] **Step 4: Type-check**
+- [ ] **Step 4: Compile tests and run wiring suite — expect pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run check-types 2>&1 | tail -10
+npm run compile-tests 2>&1 | tail -5
+npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task14-pass.txt | tail -30
 ```
 
-Expected: pass.
+Expected: all three wiring tests pass.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Run full unit suite — expect no regressions**
+
+```bash
+npx vscode-test --label unit 2>&1 | tail -30
+```
+
+Expected: no regressions.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 git add extension/src/extension/activation/sessionRecorderWiring.ts
@@ -1263,105 +1665,7 @@ git commit -m "feat(recording): wire suppressed interventions and config provena
 
 ---
 
-## Task 13: Recording-layer tests
-
-**Files:**
-- Modify: `extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts` (append new `suite` block at end)
-
-- [ ] **Step 1: Append the new test suite using the existing harness helpers**
-
-The file already exposes a `makeRecorder()` factory and a `collectWrittenEvents(fakeFs)` helper that returns parsed `RecordedEvent[]` from the `FakeFs`. Append the following suite at the very bottom of `sessionRecorder.test.ts` (after the last existing `suite(...)` closes):
-
-```ts
-suite('SessionRecorder — intervention suppression and configuration provenance', () => {
-    test('recordIntervention with suppressed action persists suppressionReason', async () => {
-        const { recorder, fs } = makeRecorder();
-        recorder.enable();
-        await recorder.startSession(42);
-        recorder.recordIntervention(
-            'suppressed', 'notification', true, 0.55, 'sufficient', 'execution-error',
-            { suppressionReason: 'user-disabled', rawWanted: true },
-        );
-        await recorder.endSession();
-        const events = collectWrittenEvents(fs);
-        const intervention = events.find(e => e.type === 'intervention');
-        assert.ok(intervention, 'intervention event missing');
-        if (intervention.type !== 'intervention') {
-            throw new Error('unreachable');
-        }
-        assert.strictEqual(intervention.action, 'suppressed');
-        assert.strictEqual(intervention.shouldIntervene, true);
-        assert.strictEqual(intervention.suppressionReason, 'user-disabled');
-        assert.strictEqual(intervention.rawWanted, true);
-        assert.strictEqual(intervention.level, 'notification');
-        assert.strictEqual(intervention.triggerType, 'execution-error');
-        try { await recorder.dispose(); } catch { /* ignore */ }
-    });
-
-    test('recordConfigurationSnapshot persists both keys', async () => {
-        const { recorder, fs } = makeRecorder();
-        recorder.enable();
-        await recorder.startSession(42);
-        recorder.recordConfigurationSnapshot(true, false);
-        await recorder.endSession();
-        const events = collectWrittenEvents(fs);
-        const snap = events.find(e => e.type === 'configurationSnapshot');
-        assert.ok(snap, 'configurationSnapshot missing');
-        if (snap.type !== 'configurationSnapshot') {
-            throw new Error('unreachable');
-        }
-        assert.strictEqual(snap.struggleDetectionEnabled, true);
-        assert.strictEqual(snap.showInterventions, false);
-        try { await recorder.dispose(); } catch { /* ignore */ }
-    });
-
-    test('recordConfigurationChange persists only the changed key', async () => {
-        const { recorder, fs } = makeRecorder();
-        recorder.enable();
-        await recorder.startSession(42);
-        recorder.recordConfigurationChange({ showInterventions: false });
-        await recorder.endSession();
-        const events = collectWrittenEvents(fs);
-        const change = events.find(e => e.type === 'configurationChange');
-        assert.ok(change, 'configurationChange missing');
-        if (change.type !== 'configurationChange') {
-            throw new Error('unreachable');
-        }
-        assert.deepStrictEqual(change.changes, { showInterventions: false });
-        try { await recorder.dispose(); } catch { /* ignore */ }
-    });
-});
-```
-
-The `if (X.type !== 'Y') throw …` discriminator narrows the union type after `events.find` so the subsequent property access type-checks. (This pattern matches existing tests in the file — verify by skimming the surrounding code if the pattern looks unfamiliar.)
-
-- [ ] **Step 2: Run the new tests — expect pass**
-
-```bash
-cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tee /tmp/intervention-toggle-task13.txt | tail -40
-```
-
-Expected: all three tests pass.
-
-- [ ] **Step 3: Run the full recording suite — expect no regressions**
-
-```bash
-npx vscode-test --label unit --grep "SessionRecorder" 2>&1 | tail -30
-```
-
-Expected: no regressions.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
-git commit -m "test(recording): cover suppressed action and configuration events"
-```
-
----
-
-## Task 14: Final integration sweep — types, lint, full unit run
+## Task 15: Final integration sweep — types, lint (full), full unit run, package
 
 - [ ] **Step 1: Type-check**
 
@@ -1372,17 +1676,18 @@ npm run check-types 2>&1 | tail -10
 
 Expected: exit 0.
 
-- [ ] **Step 2: Lint**
+- [ ] **Step 2: Lint (src + test)**
 
 ```bash
-npm run lint:src 2>&1 | tee /tmp/intervention-toggle-final-lint.txt | tail -30
+npm run lint 2>&1 | tee /tmp/intervention-toggle-final-lint.txt | tail -30
 ```
 
-Expected: exit 0. If lint warnings appear in any file you modified, fix them in-place and amend the relevant commit (use `git commit --amend` only if the amend stays inside the same task scope; otherwise create a new fixup commit).
+Expected: exit 0. If lint warnings appear in any file you modified, fix them in-place.
 
 - [ ] **Step 3: Full unit-test run**
 
 ```bash
+npm run compile-tests 2>&1 | tail -5
 npx vscode-test --label unit 2>&1 | tee /tmp/intervention-toggle-final-tests.txt | tail -50
 ```
 
@@ -1409,11 +1714,11 @@ If everything was already green, skip the commit.
 
 ---
 
-## Task 15: Manual smoke test in Extension Development Host (UAT)
+## Task 16: Manual smoke test in Extension Development Host (UAT)
 
 **Files:** none (manual)
 
-This task confirms the toggle behaves correctly end-to-end in a live VS Code session. It is **not** automatable in the unit-test harness because it exercises the real `vscode.window` modal popups and Extension Settings UI.
+This task confirms the toggle behaves correctly end-to-end in a live VS Code session. It is **not** automatable in the unit-test harness because it exercises real `vscode.window` modal popups and the Settings UI.
 
 - [ ] **Step 1: Launch the Extension Development Host**
 
@@ -1456,14 +1761,14 @@ This task does not modify code.
 
 ## Done
 
-After Task 15:
-- All 14+ tasks committed on `feat/intervention-ui-toggle`
-- Unit tests green
-- Type-check + lint clean
+After Task 16:
+- All 15 functional tasks committed on `feat/intervention-ui-toggle`
+- Unit tests green (compile-tests + vscode-test)
+- Type-check + full lint clean
 - Production build succeeds
 - Manual smoke test signed off
 
 Next steps (handled outside this plan):
-- Open a PR against `dev` (per `.claude/CLAUDE.md`).
+- Open a PR against `dev` (per `extension/.claude/CLAUDE.md`).
 - Codex review of the diff before merge (per global CLAUDE.md).
 - After merge, push the same branch into the standalone `~/Documents/private/artemis-extension/` copy if needed for F5 work outside the MA project.

--- a/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
+++ b/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
@@ -1,0 +1,1469 @@
+# Intervention UI Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a VS Code setting `artemis.struggleDetection.showInterventions` (default `true`) that suppresses all intervention UI surfaces while preserving the trigger / EQ / decision pipeline. Suppressed events are recorded as a new `'suppressed'` action, and toggle state changes are persisted as new recording events for evaluation provenance.
+
+**Architecture:** A new `onDidSuppressIntervention` event on `TelemetryManager` fires (un-rate-limited, `decision.shouldIntervene === true` preserved) when the toggle is off and an eligible decision is produced. `InterventionService.show*EQ` methods are not called and decision-engine UI-delivery state (cooldown, session counters) does not advance. The recording layer gains a `'suppressed'` intervention action plus two new event types (`configurationSnapshot`, `configurationChange`) for session classification. `hideHint()` is extended to fully reset status-bar item fields so live toggling clears any visible UI cleanly.
+
+**Tech Stack:** TypeScript, VS Code Extension API, Mocha (vscode-test) + sinon for unit tests, esbuild bundler, npm.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md`
+
+**Worktree:** `/Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/` — branch `feat/intervention-ui-toggle` off `origin/dev`.
+
+---
+
+## File Inventory
+
+| Path (relative to worktree root) | Action | Responsibility |
+|---|---|---|
+| `extension/package.json` | Modify | Register `artemis.struggleDetection.showInterventions` configuration property |
+| `extension/src/extension/utils/constants.ts` | Modify | Add `SHOW_INTERVENTIONS_KEY` to `VSCODE_CONFIG.STRUGGLE_DETECTION` |
+| `extension/src/extension/services/telemetry/types.ts` | Modify | Add `InterventionSuppressionReason` and `SuppressedInterventionPayload` |
+| `extension/src/extension/services/telemetry/recording/types.ts` | Modify | Add `'suppressed'` to `InterventionEvent.action`, add `suppressionReason`, add `ConfigurationSnapshotEvent` and `ConfigurationChangeEvent`, update `RecordedEvent` union |
+| `extension/src/extension/services/telemetry/interventionService.ts` | Modify | Extend `hideHint()` to reset `text` / `tooltip` / `backgroundColor` |
+| `extension/src/extension/services/telemetry/telemetryManager.ts` | Modify | Add `_showInterventions` field + `onDidSuppressIntervention` emitter; gate `_evaluateAndIntervene`; load + live-handle setting in `_loadConfiguration`; export `getShowInterventions()` for tests |
+| `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` | Modify | Add `'suppressed'` action to `recordIntervention`; add `recordConfigurationSnapshot` and `recordConfigurationChange` methods |
+| `extension/src/extension/activation/sessionRecorderWiring.ts` | Modify | Subscribe to `onDidSuppressIntervention` → `recordIntervention('suppressed', …)`; add startup contributor for `configurationSnapshot`; subscribe to `vscode.workspace.onDidChangeConfiguration` for the two struggle keys → `recordConfigurationChange` |
+| `extension/test/unit/services/telemetry/interventionService.test.ts` | Modify | Add tests for the extended `hideHint()` field-reset behaviour |
+| `extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts` | **Create** | Toggle on/off paths, event emission, no UI calls, no state advancement, type-guard fallback, live-toggle behaviour |
+| `extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts` | Modify | Add tests for `recordIntervention('suppressed', …)`, `recordConfigurationSnapshot`, `recordConfigurationChange` |
+
+---
+
+## Conventions & Reminders
+
+- **Branch:** Already created at `feat/intervention-ui-toggle` off `origin/dev` in worktree `~/claudeworktrees/MA-intervention-ui-toggle`.
+- **Run all commands from the worktree root:** `/Users/liamberger/claudeworktrees/MA-intervention-ui-toggle`. Tests live under `extension/`, so most npm commands run from `extension/`.
+- **Test runner:** vscode-test (Mocha) for unit tests under `extension/test/unit/`. Use `suite`/`test`/`setup`/`teardown` (Mocha BDD-not-installed). Assertions: node `assert`. Stubs/spies: `sinon`.
+- **Test file naming:** match the existing convention — see `interventionService.test.ts`, `sessionRecorder.test.ts`.
+- **Commit style:** match recent log on `dev` (Conventional Commits — `feat:`, `test:`, `docs:`, etc.). No Co-Authored-By line. No em dashes in commit messages.
+- **Commit cadence:** every task ends with a commit. Stage only the files actually changed; never `git add -A`.
+- **Lint/typecheck:** after edits, run `npm run check-types` and `npm run lint:src` from `extension/`. Final-final step before merging is `npm run compile`.
+- **First-time worktree setup:** before Task 1, run `npm install` inside `extension/` (the worktree has no `node_modules` yet). Verified-clean baseline: run `npm run check-types` and report success before starting.
+
+---
+
+## Task 0: Setup & baseline
+
+**Files:** none (env preparation)
+
+- [ ] **Step 1: Install dependencies**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm install 2>&1 | tee /tmp/intervention-toggle-install.log | tail -20
+```
+
+Expected: install succeeds. If `npm install` fails, abort and report.
+
+- [ ] **Step 2: Verify clean type baseline**
+
+```bash
+npm run check-types 2>&1 | tee /tmp/intervention-toggle-baseline-types.txt | tail -10
+```
+
+Expected: exit 0, no errors. (Worktree starts from `origin/dev`, which should be green.)
+
+- [ ] **Step 3: Verify clean unit-test baseline (intervention area only)**
+
+```bash
+npx vscode-test --label unit --grep "InterventionService" 2>&1 | tee /tmp/intervention-toggle-baseline-tests.txt | tail -30
+```
+
+Expected: existing intervention tests pass. If any fail, report and stop — do not proceed with new work on a red baseline.
+
+- [ ] **Step 4: Commit nothing**
+
+This task makes no source changes; just confirms environment is ready. Skip commit.
+
+---
+
+## Task 1: Add the setting to package.json
+
+**Files:**
+- Modify: `extension/package.json` (within `contributes.configuration.properties`, alongside the existing `artemis.struggleDetection.enabled`)
+
+- [ ] **Step 1: Insert the new configuration property**
+
+Open `extension/package.json`. Find this block (around line 205):
+
+```jsonc
+"artemis.struggleDetection.enabled": {
+    "type": "boolean",
+    "default": true,
+    "description": "Enable struggle detection to receive helpful hints when you might be stuck on a problem"
+},
+```
+
+Add the following property **immediately after** that block (before the next property `artemis.startPage`):
+
+```jsonc
+"artemis.struggleDetection.showInterventions": {
+    "type": "boolean",
+    "default": true,
+    "markdownDescription": "Show help suggestions when struggle is detected (status bar hint and notification popups). When **disabled**, no UI prompts will appear during struggle, but data collection continues unchanged. Use this if you prefer to work without interruptions while still contributing to research data."
+},
+```
+
+Make sure the trailing comma on the previous block stays in place and that the new block ends with a comma before the next property.
+
+- [ ] **Step 2: Verify package.json is valid JSON**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Verify type-check still passes**
+
+```bash
+npm run check-types 2>&1 | tail -5
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/package.json
+git commit -m "feat(settings): add artemis.struggleDetection.showInterventions toggle
+
+Default true. Disabling suppresses intervention UI but keeps the
+telemetry pipeline observing and recording. Description explicitly
+states that data collection continues."
+```
+
+---
+
+## Task 2: Add the constant key
+
+**Files:**
+- Modify: `extension/src/extension/utils/constants.ts:33-37`
+
+- [ ] **Step 1: Add `SHOW_INTERVENTIONS_KEY` to the constants block**
+
+Open `extension/src/extension/utils/constants.ts`. Find:
+
+```ts
+STRUGGLE_DETECTION: {
+    SECTION: 'artemis.struggleDetection',
+    ENABLED_KEY: 'enabled',
+},
+```
+
+Replace with:
+
+```ts
+STRUGGLE_DETECTION: {
+    SECTION: 'artemis.struggleDetection',
+    ENABLED_KEY: 'enabled',
+    SHOW_INTERVENTIONS_KEY: 'showInterventions',
+},
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -5
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/src/extension/utils/constants.ts
+git commit -m "feat(constants): add SHOW_INTERVENTIONS_KEY for new struggle setting"
+```
+
+---
+
+## Task 3: Telemetry types — suppression payload
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/types.ts` (after the `InterventionDecision` interface, near line 320 — locate by searching for the existing `InterventionBlockedReason` type)
+
+- [ ] **Step 1: Add the suppression-reason and payload types**
+
+Open `extension/src/extension/services/telemetry/types.ts`. After the `InterventionDismissReason` definition (around line 277), add:
+
+```ts
+/**
+ * Reason a wanted intervention was suppressed without being delivered to the user.
+ * Currently only one reason exists; left as a union so future suppression sources
+ * (e.g. per-condition study mode) can extend it cleanly.
+ *
+ * Note: this is a SEPARATE concept from `InterventionBlockedReason`. Blocks come
+ * from engine-internal gates (cooldown, warmup, session-limit, low-confidence)
+ * and are rate-limited. Suppression comes from explicit user/config choice and
+ * is NOT rate-limited so the per-opportunity signal stays intact.
+ */
+export type InterventionSuppressionReason = 'user-disabled';
+
+/**
+ * Payload of `TelemetryManager.onDidSuppressIntervention`.
+ *
+ * `decision` is the original eligible decision with `shouldIntervene === true`.
+ * It must NOT be mutated to `false` — the recording must retain the per-opportunity
+ * eligibility signal for later analysis.
+ */
+export interface SuppressedInterventionPayload {
+    decision: InterventionDecision;
+    reason: InterventionSuppressionReason;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -5
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/types.ts
+git commit -m "feat(telemetry): add InterventionSuppressionReason and payload type
+
+Adds a new event payload distinct from InterventionBlockedReason, so
+user-driven UI suppression and engine-internal blocks stay semantically
+separate."
+```
+
+---
+
+## Task 4: Recording schema — `'suppressed'` action + new config events
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/recording/types.ts:190-208` (`InterventionEvent`)
+- Modify: `extension/src/extension/services/telemetry/recording/types.ts:307-336` (`RecordedEvent` union)
+- Modify: `extension/src/extension/services/telemetry/recording/types.ts` near line 125 (after `StartupPhaseCompleteEvent`)
+
+- [ ] **Step 1: Extend `InterventionEvent`**
+
+Replace the existing `InterventionEvent` interface (currently lines 190-208) with:
+
+```ts
+export interface InterventionEvent {
+    type: 'intervention';
+    timestamp: number;
+    action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed';
+    level: 'subtle' | 'notification' | 'proactive';
+    /** True for shown/accepted/dismissed/suppressed; false for blocked. */
+    shouldIntervene: boolean;
+    eq: number;
+    confidence: 'sufficient' | 'insufficient';
+    triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
+    /** Populated when action='blocked'. Identifies why the intervention was blocked. */
+    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+    /** Populated when action='suppressed'. Identifies the suppression source. */
+    suppressionReason?: 'user-disabled';
+    /** Populated when action='dismissed'. Identifies how the intervention was dismissed. */
+    dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+    /**
+     * Whether the EQ was above the severity threshold, regardless of confidence/guardrails.
+     * Populated when action='blocked' to explain the signal that was suppressed.
+     */
+    rawWanted?: boolean;
+}
+```
+
+- [ ] **Step 2: Add `ConfigurationSnapshotEvent` and `ConfigurationChangeEvent`**
+
+After the `StartupPhaseCompleteEvent` interface (around line 125), add:
+
+```ts
+/**
+ * Provenance event emitted once during the startup-contributor phase before
+ * `startupPhaseComplete`. Captures the values of struggle-detection settings
+ * at session start so analysis can classify control vs treatment sessions.
+ */
+export interface ConfigurationSnapshotEvent {
+    type: 'configurationSnapshot';
+    timestamp: number;
+    struggleDetectionEnabled: boolean;
+    showInterventions: boolean;
+}
+
+/**
+ * Provenance event emitted whenever one of the recorded struggle-detection
+ * settings changes mid-session. Each property is only present when its value
+ * changed in the triggering configuration event.
+ */
+export interface ConfigurationChangeEvent {
+    type: 'configurationChange';
+    timestamp: number;
+    changes: {
+        struggleDetectionEnabled?: boolean;
+        showInterventions?: boolean;
+    };
+}
+```
+
+- [ ] **Step 3: Add the new event types to the `RecordedEvent` union**
+
+Find the `RecordedEvent` union (around line 307). Insert `ConfigurationSnapshotEvent` and `ConfigurationChangeEvent` next to `ConsentChangeEvent` so all configuration-related events sit together. After change:
+
+```ts
+export type RecordedEvent =
+    | TextChangeEvent
+    | SaveEvent
+    | FileSwitchEvent
+    | DiagnosticsEvent
+    | BuildResultEvent
+    | WindowFocusEvent
+    | FileSnapshotEvent
+    | SessionStartEvent
+    | SessionEndEvent
+    | ConsentChangeEvent
+    | ConfigurationSnapshotEvent
+    | ConfigurationChangeEvent
+    | StartupPhaseCompleteEvent
+    | IrisChatMessageEvent
+    | IrisChatSendAttemptEvent
+    | IrisChatFeedbackEvent
+    | EqSnapshotEvent
+    | EqEngineStateEvent
+    | InterventionEvent
+    | ViewNavigationEvent
+    | PanelVisibilityEvent
+    | SelectionChangeEvent
+    | VisibleRangeChangeEvent
+    | TerminalCommandEvent
+    | TerminalOpenCloseEvent
+    | FileSnapshotErrorEvent
+    | FileCreateEvent
+    | FileDeleteEvent
+    | FileRenameEvent
+    | TextDocumentOpenEvent
+    | TextDocumentCloseEvent;
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tee /tmp/intervention-toggle-typecheck-task4.txt | tail -30
+```
+
+Expected: errors in `sessionRecorderWiring.ts` and `sessionRecorder.ts` will surface only after Tasks 5–8 — at this stage only the type definitions changed, so type-check should still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/recording/types.ts
+git commit -m "feat(recording): add 'suppressed' intervention action and config events
+
+Schema-level changes only:
+- InterventionEvent.action gains 'suppressed' with optional suppressionReason
+- New ConfigurationSnapshotEvent and ConfigurationChangeEvent for
+  control/treatment session classification provenance
+- RecordedEvent union widened accordingly"
+```
+
+---
+
+## Task 5: Test — `hideHint()` resets text/tooltip/backgroundColor (TDD)
+
+**Files:**
+- Test: `extension/test/unit/services/telemetry/interventionService.test.ts` (add new `suite` block at the bottom of the file)
+
+- [ ] **Step 1: Locate where the existing tests construct an `InterventionService`**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+grep -n "new InterventionService\|createStatusBarItem" test/unit/services/telemetry/interventionService.test.ts | head -10
+```
+
+Note the helper used to instantiate the service and to access the underlying status bar item (the file already stubs `vscode.window.createStatusBarItem`).
+
+- [ ] **Step 2: Add the new test suite at the end of `interventionService.test.ts`**
+
+Append the following block after the existing suite, **without modifying** the existing tests:
+
+```ts
+suite('InterventionService.hideHint() — full status-bar reset', () => {
+    let svc: InterventionService;
+    let statusBarItem: vscode.StatusBarItem;
+    let createStub: sinon.SinonStub;
+
+    setup(() => {
+        statusBarItem = {
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+            show: sinon.stub(),
+            hide: sinon.stub(),
+            dispose: sinon.stub(),
+            alignment: vscode.StatusBarAlignment.Right,
+            priority: 100,
+            color: undefined,
+            name: undefined,
+            id: 'mock',
+            accessibilityInformation: undefined,
+        } as unknown as vscode.StatusBarItem;
+        createStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem);
+        svc = new InterventionService();
+    });
+
+    teardown(() => {
+        svc.dispose();
+        createStub.restore();
+    });
+
+    test('hideHint clears text, tooltip, and backgroundColor', () => {
+        // Simulate state left behind by a notification/proactive flow.
+        statusBarItem.text = '$(warning) Help available!';
+        statusBarItem.tooltip = 'EQ: 80% — Iris detected struggle';
+        statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+
+        svc.hideHint();
+
+        assert.strictEqual(statusBarItem.text, '');
+        assert.strictEqual(statusBarItem.tooltip, undefined);
+        assert.strictEqual(statusBarItem.backgroundColor, undefined);
+    });
+});
+```
+
+If the existing test file already has a `setup` that stubs `createStatusBarItem`, reuse that pattern (do not double-stub). If the existing pattern is incompatible, mirror it exactly here so that all tests in the file use the same approach.
+
+- [ ] **Step 3: Run the new test — expect failure**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npx vscode-test --label unit --grep "hideHint() — full status-bar reset" 2>&1 | tee /tmp/intervention-toggle-task5-fail.txt | tail -20
+```
+
+Expected: test fails because `hideHint()` does not currently reset `text` / `tooltip` / `backgroundColor`.
+
+- [ ] **Step 4: Commit (red test)**
+
+```bash
+git add extension/test/unit/services/telemetry/interventionService.test.ts
+git commit -m "test(intervention): add failing test for hideHint full reset"
+```
+
+---
+
+## Task 6: Implement `hideHint()` reset
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/interventionService.ts:254-261`
+
+- [ ] **Step 1: Update `hideHint()`**
+
+Open `interventionService.ts`. Replace the existing `hideHint` implementation:
+
+```ts
+public hideHint(): void {
+    if (this._currentSubtleDecision !== undefined) {
+        this._emitDismiss(this._currentSubtleDecision, 'hidden');
+        this._currentSubtleDecision = undefined;
+    }
+    this._statusBarItem.command = 'iris.chatView.focus';
+    this._statusBarItem.hide();
+}
+```
+
+with:
+
+```ts
+public hideHint(): void {
+    if (this._currentSubtleDecision !== undefined) {
+        this._emitDismiss(this._currentSubtleDecision, 'hidden');
+        this._currentSubtleDecision = undefined;
+    }
+    this._statusBarItem.command = 'iris.chatView.focus';
+    this._statusBarItem.text = '';
+    this._statusBarItem.tooltip = undefined;
+    this._statusBarItem.backgroundColor = undefined;
+    this._statusBarItem.hide();
+}
+```
+
+- [ ] **Step 2: Run the new test — expect pass**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npx vscode-test --label unit --grep "hideHint() — full status-bar reset" 2>&1 | tail -15
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run the full `InterventionService` suite — expect pass**
+
+```bash
+npx vscode-test --label unit --grep "InterventionService" 2>&1 | tail -20
+```
+
+Expected: all existing intervention-service tests still pass (no regressions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/interventionService.ts
+git commit -m "feat(intervention): clear text/tooltip/backgroundColor in hideHint
+
+Prevents stale labels and warning-coloured backgrounds from bleeding
+through if the status bar item is later shown for an unrelated reason.
+Required precondition for the live UI-toggle off→hide path."
+```
+
+---
+
+## Task 7: TelemetryManager — toggle field, emitter, getter (foundational, no behaviour change yet)
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts` (around lines 1-25 for imports, 55-90 for fields/getters, 442-465 for `_loadConfiguration`)
+
+- [ ] **Step 1: Add the type import**
+
+Open `telemetryManager.ts`. The existing type import (line 2) already pulls from `./types`. Append `SuppressedInterventionPayload` to the imported names:
+
+```ts
+import {
+    StruggleContext,
+    TriggerType,
+    EQConfidence,
+    EQState,
+    RecommendedAction,
+    SuppressedInterventionPayload,
+} from './types';
+```
+
+- [ ] **Step 2: Add the new field, emitter, and event accessor**
+
+Find the existing field block ending with `_debugMode: boolean = false;` (around line 63). Just below the existing intervention-event accessors (i.e. after `onDidBlockIntervention` getter at line 90), add:
+
+```ts
+private readonly _onDidSuppressIntervention = new vscode.EventEmitter<SuppressedInterventionPayload>();
+public readonly onDidSuppressIntervention = this._onDidSuppressIntervention.event;
+```
+
+Add a new private field next to `_isEnabled` (around line 57):
+
+```ts
+private _showInterventions: boolean = true;
+```
+
+In `dispose()` (around line 162), append `this._onDidSuppressIntervention.dispose();` to the disposal list (model after the existing `_onDidCalculateEQ.dispose()` if present, or add it next to other disposable emitters).
+
+- [ ] **Step 3: Add a public read-accessor for tests**
+
+Below `public isEnabled(): boolean { return this._isEnabled; }` (around line 436), add:
+
+```ts
+public getShowInterventions(): boolean {
+    return this._showInterventions;
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -10
+```
+
+Expected: pass. (The new emitter is wired but not yet fired — behaviour unchanged.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/telemetryManager.ts
+git commit -m "feat(telemetry): add showInterventions field and onDidSuppressIntervention emitter
+
+Foundational scaffolding for the new UI-toggle gate. Emitter not yet
+fired; setting not yet read. Behaviour unchanged."
+```
+
+---
+
+## Task 8: Test — toggle off → suppression event fires, no UI calls (TDD, red)
+
+**Files:**
+- Create: `extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts`
+
+- [ ] **Step 1: Create the new test file**
+
+Create `extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts` with the following content:
+
+```ts
+/**
+ * Unit tests for the artemis.struggleDetection.showInterventions toggle.
+ *
+ * Covers:
+ *  T1. Toggle off → onDidSuppressIntervention fires once with original decision (shouldIntervene=true preserved).
+ *  T2. Toggle off → no calls to vscode.window.showInformationMessage / showWarningMessage / statusBarItem.show().
+ *  T3. Toggle off → no UI-delivery state advancement (lastInterventionTime=0, sessionInterventionCount=0).
+ *  T4. Toggle off → suppression events are NOT rate-limited.
+ *  T5. Toggle on (default) → existing show path still fires; no suppression event.
+ *  T6. Live-toggle on→off with subtle hint visible → hideHint called; dismiss event with reason 'hidden' fires.
+ *  T7. Live-toggle off→on → no spurious events.
+ *  T8. Setting type guard: non-boolean value falls back to true.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { TelemetryManager } from '../../../../src/extension/services/telemetry/telemetryManager';
+import type {
+    InterventionDecision,
+    SuppressedInterventionPayload,
+} from '../../../../src/extension/services/telemetry/types';
+
+interface ConfigStubValues {
+    enabled?: boolean;
+    showInterventions?: unknown;
+    developerMode?: boolean;
+}
+
+function stubGetConfiguration(values: ConfigStubValues): sinon.SinonStub {
+    const original = vscode.workspace.getConfiguration;
+    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+        const cfg = original.call(vscode.workspace, section);
+        return {
+            ...cfg,
+            get: <T>(key: string, defaultValue?: T): T => {
+                if (section === 'artemis.struggleDetection' && key === 'enabled') {
+                    return (values.enabled ?? true) as unknown as T;
+                }
+                if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
+                    return (values.showInterventions ?? true) as unknown as T;
+                }
+                if (section === 'artemis' && key === 'developerMode') {
+                    return (values.developerMode ?? false) as unknown as T;
+                }
+                return defaultValue as T;
+            },
+            inspect: cfg.inspect.bind(cfg),
+            update: cfg.update.bind(cfg),
+            has: cfg.has.bind(cfg),
+        } as unknown as vscode.WorkspaceConfiguration;
+    });
+}
+
+/**
+ * Drive a synthetic eligible decision through TelemetryManager._evaluateAndIntervene.
+ * Uses a controlled private accessor since _evaluateAndIntervene is private and
+ * trigger-emitter wiring would couple this test to unrelated subsystems.
+ */
+function driveEligibleDecision(
+    tm: TelemetryManager,
+    overrides: Partial<InterventionDecision> = {},
+): void {
+    // Cast to expose the private method specifically for whitebox testing.
+    type Internal = {
+        _evaluateAndIntervene(triggerType: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained'): void;
+        _decisionEngine: { evaluate: (...args: unknown[]) => InterventionDecision };
+    };
+    const internal = tm as unknown as Internal;
+    const stub = sinon.stub(internal._decisionEngine, 'evaluate').returns({
+        rawWanted: true,
+        shouldIntervene: true,
+        level: 'subtle',
+        triggerType: 'execution-error',
+        eq: 0.5,
+        confidence: 'sufficient',
+        ...overrides,
+    });
+    try {
+        internal._evaluateAndIntervene('execution-error');
+    } finally {
+        stub.restore();
+    }
+}
+
+suite('TelemetryManager — intervention UI toggle', () => {
+    let getConfigStub: sinon.SinonStub;
+    let showInfoStub: sinon.SinonStub;
+    let showWarnStub: sinon.SinonStub;
+    let createStatusBarStub: sinon.SinonStub;
+    let statusBarItem: { show: sinon.SinonStub; hide: sinon.SinonStub; dispose: sinon.SinonStub; text: string; tooltip: string | undefined; backgroundColor: vscode.ThemeColor | undefined; command: string | undefined };
+
+    setup(() => {
+        statusBarItem = {
+            show: sinon.stub(),
+            hide: sinon.stub(),
+            dispose: sinon.stub(),
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+        };
+        createStatusBarStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        showInfoStub = sinon.stub(vscode.window, 'showInformationMessage');
+        showWarnStub = sinon.stub(vscode.window, 'showWarningMessage');
+    });
+
+    teardown(() => {
+        getConfigStub?.restore();
+        showInfoStub.restore();
+        showWarnStub.restore();
+        createStatusBarStub.restore();
+    });
+
+    test('T1: toggle off → suppression event fires with shouldIntervene=true preserved', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const captured: SuppressedInterventionPayload[] = [];
+        tm.onDidSuppressIntervention(payload => captured.push(payload));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(captured.length, 1);
+        assert.strictEqual(captured[0].reason, 'user-disabled');
+        assert.strictEqual(captured[0].decision.shouldIntervene, true);
+        assert.strictEqual(captured[0].decision.level, 'subtle');
+        tm.dispose();
+    });
+
+    test('T2: toggle off → no UI surface calls', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+        driveEligibleDecision(tm, { level: 'notification' });
+        driveEligibleDecision(tm, { level: 'proactive' });
+
+        assert.strictEqual(showInfoStub.callCount, 0, 'showInformationMessage was called');
+        assert.strictEqual(showWarnStub.callCount, 0, 'showWarningMessage was called');
+        assert.strictEqual(statusBarItem.show.callCount, 0, 'statusBarItem.show was called');
+        tm.dispose();
+    });
+
+    test('T3: toggle off → UI-delivery state does not advance', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+
+        for (let i = 0; i < 5; i++) {
+            driveEligibleDecision(tm, { level: 'notification' });
+        }
+
+        // Whitebox: read intervention service state via the public getter chain.
+        const internal = tm as unknown as { _interventionService: { getState(): { lastInterventionTime: number; sessionInterventionCount: number; lastDismissed: boolean; lastAccepted: boolean } } };
+        const state = internal._interventionService.getState();
+        assert.strictEqual(state.lastInterventionTime, 0, 'lastInterventionTime advanced');
+        assert.strictEqual(state.sessionInterventionCount, 0, 'sessionInterventionCount advanced');
+        assert.strictEqual(state.lastDismissed, false);
+        assert.strictEqual(state.lastAccepted, false);
+        tm.dispose();
+    });
+
+    test('T4: toggle off → suppression events are not rate-limited', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const captured: SuppressedInterventionPayload[] = [];
+        tm.onDidSuppressIntervention(payload => captured.push(payload));
+
+        for (let i = 0; i < 5; i++) {
+            driveEligibleDecision(tm, { level: 'notification' });
+        }
+
+        assert.strictEqual(captured.length, 5);
+        tm.dispose();
+    });
+
+    test('T5: toggle on (default) → no suppression event; show path runs', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        const tm = new TelemetryManager();
+        const captured: SuppressedInterventionPayload[] = [];
+        tm.onDidSuppressIntervention(payload => captured.push(payload));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(captured.length, 0);
+        assert.strictEqual(statusBarItem.show.callCount >= 1, true, 'statusBarItem.show should fire for subtle path');
+        tm.dispose();
+    });
+
+    test('T6: live-toggle on→off with subtle visible → hideHint called; dismiss reason hidden', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        const tm = new TelemetryManager();
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+        const dismissals: Array<{ dismissReason: string }> = [];
+        tm.onDidDismissIntervention(payload => dismissals.push(payload));
+
+        // Flip the stubbed config, then re-trigger config loading directly.
+        // We invoke _loadConfiguration() instead of firing a fake
+        // onDidChangeConfiguration event because TelemetryManager re-runs
+        // _loadConfiguration unconditionally on any matching event — calling
+        // it directly is equivalent and avoids brittle event mocking.
+        getConfigStub.restore();
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
+
+        assert.strictEqual(statusBarItem.hide.callCount >= 1, true, 'statusBarItem.hide expected on transition');
+        assert.strictEqual(dismissals.length, 1, 'expected exactly one dismiss event');
+        assert.strictEqual(dismissals[0].dismissReason, 'hidden');
+        tm.dispose();
+    });
+
+    test('T7: live-toggle off→on → no spurious events', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const suppressed: SuppressedInterventionPayload[] = [];
+        const dismissals: unknown[] = [];
+        tm.onDidSuppressIntervention(p => suppressed.push(p));
+        tm.onDidDismissIntervention(p => dismissals.push(p));
+
+        getConfigStub.restore();
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
+
+        assert.strictEqual(suppressed.length, 0);
+        assert.strictEqual(dismissals.length, 0);
+        tm.dispose();
+    });
+
+    test('T8: type guard — non-boolean setting falls back to true', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: 'not-a-boolean' });
+        const tm = new TelemetryManager();
+
+        assert.strictEqual(tm.getShowInterventions(), true);
+        tm.dispose();
+    });
+});
+```
+
+- [ ] **Step 2: Run the new tests — expect failure**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task8-fail.txt | tail -60
+```
+
+Expected: every test fails (gate not implemented yet). T5 may pass; that is fine.
+
+- [ ] **Step 3: Commit (red tests)**
+
+```bash
+git add extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
+git commit -m "test(telemetry): add failing tests for intervention UI toggle
+
+Covers suppression event semantics, no UI calls, no state advancement,
+non-rate-limited emission, live-toggle transitions, and type guard."
+```
+
+---
+
+## Task 9: TelemetryManager — implement the gate + setting load
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts:377-412` (`_evaluateAndIntervene`)
+- Modify: `extension/src/extension/services/telemetry/telemetryManager.ts:442-465` (`_loadConfiguration`)
+
+- [ ] **Step 1: Replace the entire `_loadConfiguration` method**
+
+Open `telemetryManager.ts`. Replace the full body of `_loadConfiguration` (lines 442-466) with this exact code (note the `previousShowInterventions` capture and the new live-transition block; the rest mirrors the existing logic verbatim including the developer-mode log lines):
+
+```ts
+private _loadConfiguration(): void {
+    const struggleConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+    this._isEnabled = struggleConfig.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
+
+    const previousShowInterventions = this._showInterventions;
+    const rawShow = struggleConfig.get<unknown>(
+        VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY,
+        true,
+    );
+    this._showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
+
+    const wasDebugMode = this._debugMode;
+    const artemisConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
+    const developerMode = artemisConfig.get<boolean>(VSCODE_CONFIG.DEVELOPER_MODE_KEY, false);
+    this._debugMode = this._isEnabled && developerMode;
+
+    if (!this._isEnabled) {
+        this._interventionService.hideHint();
+        this._debugDashboard.stop();
+        this._log('Struggle detection disabled');
+    } else {
+        this._log('Struggle detection enabled');
+    }
+
+    // Live transition on→off for the UI toggle: clear any visible hint so a
+    // status-bar lightbulb / coloured remnant disappears immediately. We do
+    // NOT log on every load (only on transitions) to avoid noise.
+    if (previousShowInterventions && !this._showInterventions) {
+        this._interventionService.hideHint();
+        this._log('Intervention UI suppressed by user setting');
+    } else if (!previousShowInterventions && this._showInterventions) {
+        this._log('Intervention UI restored by user setting');
+    }
+
+    if (this._debugMode && !wasDebugMode) {
+        this._debugDashboard.start();
+        this._log('Developer mode ENABLED — showing live EQ in status bar');
+    } else if (!this._debugMode && wasDebugMode) {
+        this._debugDashboard.stop();
+        this._log('Developer mode DISABLED');
+    }
+}
+```
+
+- [ ] **Step 2: Update `_evaluateAndIntervene`**
+
+Replace the dispatch block in `_evaluateAndIntervene` (lines 389-411). Current code:
+
+```ts
+if (decision.shouldIntervene) {
+    switch (decision.level) {
+        case 'subtle':
+            this._interventionService.showSubtleHintEQ(decision);
+            break;
+        case 'notification':
+            void this._interventionService.showNotificationEQ(decision).catch((err: unknown) => {
+                logger.error('Failed to show notification intervention', LogCategory.TELEMETRY, err);
+            });
+            break;
+        case 'proactive':
+            void this._interventionService.showProactiveHelpEQ(decision).catch((err: unknown) => {
+                logger.error('Failed to show proactive intervention', LogCategory.TELEMETRY, err);
+            });
+            break;
+    }
+} else if (decision.rawWanted) {
+    this._interventionService.recordBlockedDecision(decision);
+}
+```
+
+Replace with:
+
+```ts
+if (decision.shouldIntervene) {
+    if (!this._showInterventions) {
+        // UI suppressed by user setting. Decision-engine UI-delivery state is
+        // intentionally NOT advanced (no _recordIntervention) because no UI was
+        // shown. The recording layer subscribes to onDidSuppressIntervention so
+        // every eligible opportunity is captured for evaluation.
+        this._onDidSuppressIntervention.fire({
+            decision,
+            reason: 'user-disabled',
+        });
+        return;
+    }
+    switch (decision.level) {
+        case 'subtle':
+            this._interventionService.showSubtleHintEQ(decision);
+            break;
+        case 'notification':
+            void this._interventionService.showNotificationEQ(decision).catch((err: unknown) => {
+                logger.error('Failed to show notification intervention', LogCategory.TELEMETRY, err);
+            });
+            break;
+        case 'proactive':
+            void this._interventionService.showProactiveHelpEQ(decision).catch((err: unknown) => {
+                logger.error('Failed to show proactive intervention', LogCategory.TELEMETRY, err);
+            });
+            break;
+    }
+} else if (decision.rawWanted) {
+    this._interventionService.recordBlockedDecision(decision);
+}
+```
+
+- [ ] **Step 3: Run the toggle tests — expect pass**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task9-pass.txt | tail -40
+```
+
+Expected: all 8 tests pass. If any fail, inspect output and adjust the implementation (do **not** change the test assertions).
+
+- [ ] **Step 4: Run the broader telemetry suite — expect pass**
+
+```bash
+npx vscode-test --label unit --grep "TelemetryManager|InterventionService" 2>&1 | tail -30
+```
+
+Expected: no regressions in existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/telemetryManager.ts
+git commit -m "feat(telemetry): suppress intervention UI when showInterventions is false
+
+Fires onDidSuppressIntervention with the original eligible decision
+(shouldIntervene preserved as true). Does not advance UI-delivery state
+because no intervention was shown. Live-toggle on->off triggers
+hideHint() so any visible status-bar hint disappears immediately."
+```
+
+---
+
+## Task 10: Recording — `recordIntervention('suppressed', …)` support
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts:300-329`
+
+- [ ] **Step 1: Widen the `action` parameter and accept `suppressionReason`**
+
+Replace the existing `recordIntervention` method:
+
+```ts
+recordIntervention(
+    action: 'shown' | 'accepted' | 'dismissed' | 'blocked',
+    level: 'subtle' | 'notification' | 'proactive',
+    shouldIntervene: boolean,
+    eq: number,
+    confidence: 'sufficient' | 'insufficient',
+    triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained',
+    opts?: {
+        blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+        dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+        rawWanted?: boolean;
+    },
+): void {
+    if (this._phase !== 'recording') {
+        return;
+    }
+    this._lifecycle.recordInternal({
+        type: 'intervention',
+        timestamp: Date.now(),
+        action,
+        level,
+        shouldIntervene,
+        eq,
+        confidence,
+        triggerType,
+        blockedReason: opts?.blockedReason,
+        dismissReason: opts?.dismissReason,
+        rawWanted: opts?.rawWanted,
+    }, {}, this._currentGeneration);
+}
+```
+
+with:
+
+```ts
+recordIntervention(
+    action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed',
+    level: 'subtle' | 'notification' | 'proactive',
+    shouldIntervene: boolean,
+    eq: number,
+    confidence: 'sufficient' | 'insufficient',
+    triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained',
+    opts?: {
+        blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+        suppressionReason?: 'user-disabled';
+        dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+        rawWanted?: boolean;
+    },
+): void {
+    if (this._phase !== 'recording') {
+        return;
+    }
+    this._lifecycle.recordInternal({
+        type: 'intervention',
+        timestamp: Date.now(),
+        action,
+        level,
+        shouldIntervene,
+        eq,
+        confidence,
+        triggerType,
+        blockedReason: opts?.blockedReason,
+        suppressionReason: opts?.suppressionReason,
+        dismissReason: opts?.dismissReason,
+        rawWanted: opts?.rawWanted,
+    }, {}, this._currentGeneration);
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -10
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+git commit -m "feat(recording): support 'suppressed' intervention action and reason"
+```
+
+---
+
+## Task 11: Recording — `recordConfigurationSnapshot` and `recordConfigurationChange`
+
+**Files:**
+- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` (add new methods near other `record*` methods, around line 350)
+
+- [ ] **Step 1: Add the two new methods**
+
+Insert after `recordPanelVisibility` (around line 350):
+
+```ts
+recordConfigurationSnapshot(struggleDetectionEnabled: boolean, showInterventions: boolean): void {
+    if (this._phase !== 'recording') {
+        return;
+    }
+    this._lifecycle.recordInternal({
+        type: 'configurationSnapshot',
+        timestamp: Date.now(),
+        struggleDetectionEnabled,
+        showInterventions,
+    }, {}, this._currentGeneration);
+}
+
+recordConfigurationChange(changes: {
+    struggleDetectionEnabled?: boolean;
+    showInterventions?: boolean;
+}): void {
+    if (this._phase !== 'recording') {
+        return;
+    }
+    this._lifecycle.recordInternal({
+        type: 'configurationChange',
+        timestamp: Date.now(),
+        changes,
+    }, {}, this._currentGeneration);
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -10
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+git commit -m "feat(recording): add configuration snapshot and change recorders"
+```
+
+---
+
+## Task 12: Recording wiring — subscribe to suppression and config-change
+
+**Files:**
+- Modify: `extension/src/extension/activation/sessionRecorderWiring.ts`
+
+- [ ] **Step 1: Add the suppression subscription**
+
+Open `sessionRecorderWiring.ts`. After the existing `onDidBlockIntervention` subscription block (lines 98-104), add:
+
+```ts
+disposables.push(telemetryManager.onDidSuppressIntervention(({ decision, reason }) => {
+    sessionRecorder.recordIntervention(
+        'suppressed', decision.level as 'subtle' | 'notification' | 'proactive',
+        decision.shouldIntervene, decision.eq, decision.confidence, decision.triggerType,
+        { suppressionReason: reason, rawWanted: decision.rawWanted },
+    );
+}));
+```
+
+- [ ] **Step 2: Add the configuration-snapshot startup contributor**
+
+After the existing panel-visibility startup contributor (around line 145-160), add a new startup contributor near the end of the contributor block:
+
+```ts
+// Configuration snapshot — captures struggle-detection setting values at
+// session start so analysis can classify control vs treatment sessions.
+disposables.push(sessionRecorder.registerStartupContributor((ctx): RecordedEvent[] => {
+    const struggleConfig = vscode.workspace.getConfiguration('artemis.struggleDetection');
+    const enabled = struggleConfig.get<boolean>('enabled', true);
+    const rawShow = struggleConfig.get<unknown>('showInterventions', true);
+    const showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
+    return [{
+        type: 'configurationSnapshot',
+        timestamp: ctx.timestamp,
+        struggleDetectionEnabled: enabled,
+        showInterventions,
+    }];
+}));
+```
+
+- [ ] **Step 3: Add the runtime configuration-change listener**
+
+Inside `wireSessionRecorder`, before the `// Recording status bar button` comment (around line 162), add a stateful listener that detects which struggle keys actually changed:
+
+```ts
+// Runtime configuration changes for struggle-detection settings — recorded
+// so mid-session flips can be reconciled with intervention events by timestamp.
+let lastStruggleEnabled = (() => {
+    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
+    return cfg.get<boolean>('enabled', true);
+})();
+let lastShowInterventions = (() => {
+    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
+    const raw = cfg.get<unknown>('showInterventions', true);
+    return typeof raw === 'boolean' ? raw : true;
+})();
+
+disposables.push(vscode.workspace.onDidChangeConfiguration(event => {
+    if (!event.affectsConfiguration('artemis.struggleDetection')) {
+        return;
+    }
+    const cfg = vscode.workspace.getConfiguration('artemis.struggleDetection');
+    const newEnabled = cfg.get<boolean>('enabled', true);
+    const rawShow = cfg.get<unknown>('showInterventions', true);
+    const newShow = typeof rawShow === 'boolean' ? rawShow : true;
+
+    const changes: { struggleDetectionEnabled?: boolean; showInterventions?: boolean } = {};
+    if (newEnabled !== lastStruggleEnabled) {
+        changes.struggleDetectionEnabled = newEnabled;
+        lastStruggleEnabled = newEnabled;
+    }
+    if (newShow !== lastShowInterventions) {
+        changes.showInterventions = newShow;
+        lastShowInterventions = newShow;
+    }
+    if (Object.keys(changes).length > 0) {
+        sessionRecorder.recordConfigurationChange(changes);
+    }
+}));
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -10
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/extension/activation/sessionRecorderWiring.ts
+git commit -m "feat(recording): wire suppressed interventions and config provenance
+
+- Subscribe to TelemetryManager.onDidSuppressIntervention and persist
+  events with action='suppressed' and rawWanted preserved.
+- Add a startup contributor that emits configurationSnapshot before
+  startupPhaseComplete so every session is classifiable.
+- Listen to onDidChangeConfiguration for the struggle keys and emit
+  configurationChange events with only the diffed values."
+```
+
+---
+
+## Task 13: Recording-layer tests
+
+**Files:**
+- Modify: `extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts` (append new `suite` block at end)
+
+- [ ] **Step 1: Append the new test suite using the existing harness helpers**
+
+The file already exposes a `makeRecorder()` factory and a `collectWrittenEvents(fakeFs)` helper that returns parsed `RecordedEvent[]` from the `FakeFs`. Append the following suite at the very bottom of `sessionRecorder.test.ts` (after the last existing `suite(...)` closes):
+
+```ts
+suite('SessionRecorder — intervention suppression and configuration provenance', () => {
+    test('recordIntervention with suppressed action persists suppressionReason', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordIntervention(
+            'suppressed', 'notification', true, 0.55, 'sufficient', 'execution-error',
+            { suppressionReason: 'user-disabled', rawWanted: true },
+        );
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const intervention = events.find(e => e.type === 'intervention');
+        assert.ok(intervention, 'intervention event missing');
+        if (intervention.type !== 'intervention') {
+            throw new Error('unreachable');
+        }
+        assert.strictEqual(intervention.action, 'suppressed');
+        assert.strictEqual(intervention.shouldIntervene, true);
+        assert.strictEqual(intervention.suppressionReason, 'user-disabled');
+        assert.strictEqual(intervention.rawWanted, true);
+        assert.strictEqual(intervention.level, 'notification');
+        assert.strictEqual(intervention.triggerType, 'execution-error');
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationSnapshot persists both keys', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationSnapshot(true, false);
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const snap = events.find(e => e.type === 'configurationSnapshot');
+        assert.ok(snap, 'configurationSnapshot missing');
+        if (snap.type !== 'configurationSnapshot') {
+            throw new Error('unreachable');
+        }
+        assert.strictEqual(snap.struggleDetectionEnabled, true);
+        assert.strictEqual(snap.showInterventions, false);
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationChange persists only the changed key', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationChange({ showInterventions: false });
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const change = events.find(e => e.type === 'configurationChange');
+        assert.ok(change, 'configurationChange missing');
+        if (change.type !== 'configurationChange') {
+            throw new Error('unreachable');
+        }
+        assert.deepStrictEqual(change.changes, { showInterventions: false });
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+});
+```
+
+The `if (X.type !== 'Y') throw …` discriminator narrows the union type after `events.find` so the subsequent property access type-checks. (This pattern matches existing tests in the file — verify by skimming the surrounding code if the pattern looks unfamiliar.)
+
+- [ ] **Step 2: Run the new tests — expect pass**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tee /tmp/intervention-toggle-task13.txt | tail -40
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 3: Run the full recording suite — expect no regressions**
+
+```bash
+npx vscode-test --label unit --grep "SessionRecorder" 2>&1 | tail -30
+```
+
+Expected: no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+git commit -m "test(recording): cover suppressed action and configuration events"
+```
+
+---
+
+## Task 14: Final integration sweep — types, lint, full unit run
+
+- [ ] **Step 1: Type-check**
+
+```bash
+cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
+npm run check-types 2>&1 | tail -10
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Lint**
+
+```bash
+npm run lint:src 2>&1 | tee /tmp/intervention-toggle-final-lint.txt | tail -30
+```
+
+Expected: exit 0. If lint warnings appear in any file you modified, fix them in-place and amend the relevant commit (use `git commit --amend` only if the amend stays inside the same task scope; otherwise create a new fixup commit).
+
+- [ ] **Step 3: Full unit-test run**
+
+```bash
+npx vscode-test --label unit 2>&1 | tee /tmp/intervention-toggle-final-tests.txt | tail -50
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Production build — sanity check**
+
+```bash
+npm run package 2>&1 | tail -10
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit (only if any fixups landed in Steps 2-4)**
+
+If lint or build flagged something requiring code changes that you fixed:
+
+```bash
+git add <only the files you changed>
+git commit -m "chore(intervention-toggle): post-implementation lint/build fixes"
+```
+
+If everything was already green, skip the commit.
+
+---
+
+## Task 15: Manual smoke test in Extension Development Host (UAT)
+
+**Files:** none (manual)
+
+This task confirms the toggle behaves correctly end-to-end in a live VS Code session. It is **not** automatable in the unit-test harness because it exercises the real `vscode.window` modal popups and Extension Settings UI.
+
+- [ ] **Step 1: Launch the Extension Development Host**
+
+Open the worktree in VS Code and press F5 to launch the Extension Development Host (the existing `.vscode/launch.json` should already be set up).
+
+- [ ] **Step 2: Verify the new setting is visible**
+
+In the EDH window, open Settings (Cmd+,) and search for `artemis.struggleDetection.showInterventions`. Verify:
+- It appears with the expected description.
+- It is checked by default (default `true`).
+
+- [ ] **Step 3: Verify "on" path still works**
+
+Authenticate to a test Artemis instance, open a programming exercise, and trigger struggle (e.g. cause repeated build errors). Verify status-bar lightbulb / notification appears as before.
+
+- [ ] **Step 4: Verify "off" path suppresses UI**
+
+Toggle the setting off. Trigger struggle the same way. Verify:
+- No status-bar lightbulb appears.
+- No info / warning popups appear.
+- The Iris Chat icon is unaffected.
+
+- [ ] **Step 5: Verify recording captures suppressed events**
+
+With the setting still off, finish the session and locate the recording JSONL under `globalStorageUri/recordings/<sessionId>/`. Open the JSONL and grep for `"action":"suppressed"` and `"type":"configurationSnapshot"`. Confirm both appear with sensible values.
+
+- [ ] **Step 6: Verify live-toggle works**
+
+Re-enable the setting mid-session: trigger struggle to confirm UI returns; toggle off again to confirm UI disappears.
+
+- [ ] **Step 7: Note any deviations**
+
+If any step fails, file a follow-up — do not silently fix during this task. The unit tests are the binding contract; the smoke test only checks integration.
+
+- [ ] **Step 8: Commit nothing**
+
+This task does not modify code.
+
+---
+
+## Done
+
+After Task 15:
+- All 14+ tasks committed on `feat/intervention-ui-toggle`
+- Unit tests green
+- Type-check + lint clean
+- Production build succeeds
+- Manual smoke test signed off
+
+Next steps (handled outside this plan):
+- Open a PR against `dev` (per `.claude/CLAUDE.md`).
+- Codex review of the diff before merge (per global CLAUDE.md).
+- After merge, push the same branch into the standalone `~/Documents/private/artemis-extension/` copy if needed for F5 work outside the MA project.

--- a/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
+++ b/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
@@ -1280,6 +1280,7 @@ This task creates the first test file under `extension/test/unit/activation/`. T
 
 - `wireSessionRecorder` constructs its own `SessionRecorderImpl` internally using `context.globalStorageUri`, so we cannot inject a `FakeFs` writer. Instead, the harness uses a **real temporary directory** as `globalStorageUri` and reads JSONL events back from disk after `endSession`.
 - The `vscode.workspace.getConfiguration` stub must be installed **before** `wireSessionRecorder` runs, because the wiring's runtime listener captures the initial config values at wiring time. Otherwise, the cached value may already match the test's "after" value (e.g. real config `showInterventions=false`), producing no diff and no event.
+- **Possible runtime hardening:** If a test fails at runtime with "command 'artemis.…' already registered" because the wired `RecordingStatusBarServiceImpl` re-registers a command across tests, add `sinon.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => {}));` inside `makeWiringHarness` (right next to the other stubs) and `.restore()` it in `dispose()`. Only add this if you actually hit the duplicate-registration error; otherwise leave it out to keep the harness minimal.
 
 - [ ] **Step 1: Create the new wiring test file**
 

--- a/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
+++ b/docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md
@@ -79,7 +79,7 @@ Expected: exit 0.
 - [ ] **Step 4: Verify clean unit-test baseline (intervention area)**
 
 ```bash
-npx vscode-test --label unit --grep "InterventionService" 2>&1 | tee /tmp/intervention-toggle-baseline-tests.txt | tail -30
+npm run compile-tests && npx vscode-test --label unit --grep "InterventionService" 2>&1 | tee /tmp/intervention-toggle-baseline-tests.txt | tail -30
 ```
 
 Expected: existing intervention tests pass. If any fail, stop and report — do not proceed on a red baseline.
@@ -452,8 +452,7 @@ If the existing test file already has a `setup` that stubs `createStatusBarItem`
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tee /tmp/intervention-toggle-task5-fail.txt | tail -20
+npm run compile-tests && npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tee /tmp/intervention-toggle-task5-fail.txt | tail -20
 ```
 
 Expected: test fails because `hideHint()` does not currently reset `text` / `tooltip` / `backgroundColor`.
@@ -507,8 +506,7 @@ public hideHint(): void {
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tail -15
+npm run compile-tests && npx vscode-test --label unit --grep "hideHint\\(\\) — full status-bar reset" 2>&1 | tail -15
 ```
 
 Expected: pass.
@@ -516,7 +514,7 @@ Expected: pass.
 - [ ] **Step 3: Run the full `InterventionService` suite — expect no regression**
 
 ```bash
-npx vscode-test --label unit --grep "InterventionService" 2>&1 | tail -20
+npm run compile-tests && npx vscode-test --label unit --grep "InterventionService" 2>&1 | tail -20
 ```
 
 Expected: all existing intervention-service tests still pass.
@@ -869,8 +867,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task8-fail.txt | tail -80
+npm run compile-tests && npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task8-fail.txt | tail -80
 ```
 
 Expected: every gate-dependent test (T1, T2, T3, T4, T7, T9) fails because the gate is not implemented yet. T5, T6, T8 may already pass; that is fine.
@@ -1008,8 +1005,7 @@ if (decision.shouldIntervene) {
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task9-pass.txt | tail -40
+npm run compile-tests && npx vscode-test --label unit --grep "intervention UI toggle" 2>&1 | tee /tmp/intervention-toggle-task9-pass.txt | tail -40
 ```
 
 Expected: all 9 tests (T1–T9) pass. If any fail, inspect the output and adjust the implementation. Do **not** modify the test assertions.
@@ -1017,7 +1013,7 @@ Expected: all 9 tests (T1–T9) pass. If any fail, inspect the output and adjust
 - [ ] **Step 4: Run the broader telemetry suite — expect no regressions**
 
 ```bash
-npx vscode-test --label unit --grep "TelemetryManager|InterventionService" 2>&1 | tail -30
+npm run compile-tests && npx vscode-test --label unit --grep "TelemetryManager|InterventionService" 2>&1 | tail -30
 ```
 
 Expected: no regressions in existing tests.
@@ -1114,8 +1110,7 @@ import type {
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tee /tmp/intervention-toggle-task10-fail.txt | tail -40
+npm run compile-tests && npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tee /tmp/intervention-toggle-task10-fail.txt | tail -40
 ```
 
 Expected behaviour: `compile-tests` may itself fail — `recordIntervention('suppressed', ...)` does not type-check yet, and `recordConfigurationSnapshot` / `recordConfigurationChange` do not exist. **Either** of these counts as "red". If `compile-tests` succeeds but tests fail at runtime, that is also red. Capture the output and proceed to Task 11.
@@ -1129,10 +1124,13 @@ git commit -m "test(recording): add failing tests for suppressed action and conf
 
 ---
 
-## Task 11: SessionRecorder — `'suppressed'` action support (TDD green for first test)
+## Task 11: SessionRecorder — implement all three new methods (TDD green for all recorder tests)
 
 **Files:**
-- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts:300-329`
+- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts:300-329` (`recordIntervention`)
+- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` (insert two new methods near line 350, after `recordPanelVisibility`)
+
+All three Task-10 tests can only go green together because `compile-tests` would still fail if `recordConfigurationSnapshot`/`recordConfigurationChange` are missing while their tests reference them. Implementing the three methods in one task keeps the TDD red→green cycle clean for the recorder layer.
 
 - [ ] **Step 1: Widen `recordIntervention` to accept the new action and reason**
 
@@ -1208,33 +1206,9 @@ recordIntervention(
 }
 ```
 
-- [ ] **Step 2: Compile tests; first test should now pass**
+- [ ] **Step 2: Add `recordConfigurationSnapshot` and `recordConfigurationChange`**
 
-```bash
-cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "recordIntervention with suppressed action" 2>&1 | tail -15
-```
-
-Expected: pass.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add extension/src/extension/services/telemetry/recording/sessionRecorder.ts
-git commit -m "feat(recording): support 'suppressed' intervention action and reason"
-```
-
----
-
-## Task 12: SessionRecorder — config snapshot/change methods (TDD green for remaining tests)
-
-**Files:**
-- Modify: `extension/src/extension/services/telemetry/recording/sessionRecorder.ts` (insert near other `record*` methods, around line 350 after `recordPanelVisibility`)
-
-- [ ] **Step 1: Add the two new methods**
-
-Insert after `recordPanelVisibility`:
+Insert after `recordPanelVisibility` (around line 350):
 
 ```ts
 recordConfigurationSnapshot(struggleDetectionEnabled: boolean, showInterventions: boolean): void {
@@ -1264,37 +1238,48 @@ recordConfigurationChange(changes: {
 }
 ```
 
-- [ ] **Step 2: Compile tests and run the recording suite — expect pass**
+- [ ] **Step 3: Compile tests and run the recording suite — expect pass**
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tail -30
+npm run compile-tests && npx vscode-test --label unit --grep "SessionRecorder — intervention suppression" 2>&1 | tail -30
 ```
 
-Expected: all three tests in the new suite pass. Then check no regressions in the broader suite:
+Expected: all three tests pass.
+
+- [ ] **Step 4: Run the broader recording suite — expect no regressions**
 
 ```bash
-npx vscode-test --label unit --grep "SessionRecorder" 2>&1 | tail -30
+npm run compile-tests && npx vscode-test --label unit --grep "SessionRecorder" 2>&1 | tail -30
 ```
 
 Expected: no regressions.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add extension/src/extension/services/telemetry/recording/sessionRecorder.ts
-git commit -m "feat(recording): add configuration snapshot and change recorders"
+git commit -m "feat(recording): support suppressed action and configuration provenance
+
+- recordIntervention accepts action='suppressed' with optional
+  suppressionReason='user-disabled'
+- New recordConfigurationSnapshot and recordConfigurationChange methods
+  for session-classification provenance"
 ```
 
 ---
 
-## Task 13: Test — wiring integration (TDD red)
+## Task 12: Test — wiring integration (TDD red)
 
 **Files:**
 - Create: `extension/test/unit/activation/sessionRecorderWiring.test.ts`
 
 This task creates the first test file under `extension/test/unit/activation/`. The directory does not yet exist; `compile-tests` and `vscode-test` accept additional sub-directories under `test/unit/` automatically (the `.vscode-test.mjs` glob is `out/test/unit/**/*.test.js`).
+
+**Important harness design notes:**
+
+- `wireSessionRecorder` constructs its own `SessionRecorderImpl` internally using `context.globalStorageUri`, so we cannot inject a `FakeFs` writer. Instead, the harness uses a **real temporary directory** as `globalStorageUri` and reads JSONL events back from disk after `endSession`.
+- The `vscode.workspace.getConfiguration` stub must be installed **before** `wireSessionRecorder` runs, because the wiring's runtime listener captures the initial config values at wiring time. Otherwise, the cached value may already match the test's "after" value (e.g. real config `showInterventions=false`), producing no diff and no event.
 
 - [ ] **Step 1: Create the new wiring test file**
 
@@ -1304,20 +1289,24 @@ Create `extension/test/unit/activation/sessionRecorderWiring.test.ts` with this 
 /**
  * Integration tests for sessionRecorderWiring.
  *
- * Constructs a real TelemetryManager + SessionRecorder, calls wireSessionRecorder,
- * drives suppression/config-change events, and asserts they reach the JSONL
- * stream via the FakeFs.
+ * Constructs a real TelemetryManager + (wireSessionRecorder-built) SessionRecorder
+ * pointing at a temp directory; drives suppression and config-change events,
+ * and asserts they reach the on-disk JSONL stream.
  *
- * Whitebox brittleness note: stubs `vscode.workspace.onDidChangeConfiguration`
- * to capture and synchronously invoke the listener that wiring registers.
+ * Whitebox brittleness:
+ *  - Fires TelemetryManager._onDidSuppressIntervention directly via cast.
+ *  - Stubs vscode.workspace.onDidChangeConfiguration to capture the listener.
+ *  - Stubs vscode.workspace.getConfiguration with mutable backing values.
  */
 
 import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { TelemetryManager } from '../../../src/extension/services/telemetry/telemetryManager';
 import { SessionRecorder } from '../../../src/extension/services/telemetry/recording/sessionRecorder';
-import { RecordingStorageWriter, type RecordingFs } from '../../../src/extension/services/telemetry/recording/storageWriter';
 import { wireSessionRecorder } from '../../../src/extension/activation/sessionRecorderWiring';
 import type { RecordedEvent, InterventionEvent, ConfigurationSnapshotEvent, ConfigurationChangeEvent } from '../../../src/extension/services/telemetry/recording/types';
 import type { ConsentService } from '../../../src/extension/services/auth';
@@ -1325,28 +1314,37 @@ import type { ArtemisWebsocketService } from '../../../src/extension/services/we
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '../../../src/extension/provider';
 import type { InterventionDecision } from '../../../src/extension/services/telemetry/types';
 
-class FakeFs implements RecordingFs {
-    appendedChunks: string[] = [];
-    writtenFiles: { path: string; data: string }[] = [];
-    syncChunks: string[] = [];
-    mkdir(): Promise<string | undefined> { return Promise.resolve(undefined); }
-    writeFile(p: string, data: string): Promise<void> { this.writtenFiles.push({ path: p, data }); return Promise.resolve(); }
-    appendFile(_p: string, data: string): Promise<void> { this.appendedChunks.push(data); return Promise.resolve(); }
-    rm(): Promise<void> { return Promise.resolve(); }
-    appendFileSync(_p: string, data: string): void { this.syncChunks.push(data); }
+interface MutableConfigState {
+    enabled: boolean;
+    showInterventions: unknown;   // unknown so tests can simulate non-boolean
+    developerMode: boolean;
 }
 
-function collectWrittenEvents(fs: FakeFs): RecordedEvent[] {
-    const events: RecordedEvent[] = [];
-    for (const chunk of [...fs.appendedChunks, ...fs.syncChunks]) {
-        for (const line of chunk.split('\n').filter(Boolean)) {
-            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip */ }
-        }
-    }
-    return events;
+function installConfigStub(state: MutableConfigState): sinon.SinonStub {
+    const original = vscode.workspace.getConfiguration;
+    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+        const real = original.call(vscode.workspace, section);
+        return {
+            ...real,
+            get: <T>(key: string, def?: T): T => {
+                if (section === 'artemis.struggleDetection' && key === 'enabled') {
+                    return state.enabled as unknown as T;
+                }
+                if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
+                    return state.showInterventions as T;
+                }
+                if (section === 'artemis' && key === 'developerMode') {
+                    return state.developerMode as unknown as T;
+                }
+                return def as T;
+            },
+            inspect: real.inspect.bind(real),
+            update: real.update.bind(real),
+            has: real.has.bind(real),
+        } as unknown as vscode.WorkspaceConfiguration;
+    });
 }
 
-/** Stub the minimum of ConsentService that wireSessionRecorder reads. */
 function stubConsent(extended: boolean): ConsentService {
     const onConsentChanged = new vscode.EventEmitter<'pending' | 'declined' | 'basic' | 'extended'>();
     return {
@@ -1355,7 +1353,6 @@ function stubConsent(extended: boolean): ConsentService {
     } as unknown as ConsentService;
 }
 
-/** Stub WebSocket service — wireSessionRecorder only registers/unregisters handlers. */
 function stubWebsocket(): ArtemisWebsocketService {
     return {
         registerMessageHandler: sinon.stub(),
@@ -1390,25 +1387,57 @@ function stubChatProvider(): ChatWebviewProvider {
     } as unknown as ChatWebviewProvider;
 }
 
-function makeWiringHarness(): {
+/** Read every events.jsonl file produced under tmpDir/recordings/<sessionId>/ and return the parsed events. */
+async function readAllRecordedEvents(tmpDir: string): Promise<RecordedEvent[]> {
+    const recordingsRoot = path.join(tmpDir, 'recordings');
+    const events: RecordedEvent[] = [];
+    let sessionDirs: string[];
+    try {
+        sessionDirs = await fs.readdir(recordingsRoot);
+    } catch {
+        return events; // recordings dir not created yet
+    }
+    for (const sessionId of sessionDirs) {
+        const eventsPath = path.join(recordingsRoot, sessionId, 'events.jsonl');
+        let content: string;
+        try {
+            content = await fs.readFile(eventsPath, 'utf-8');
+        } catch {
+            continue;
+        }
+        for (const line of content.split('\n').filter(Boolean)) {
+            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip malformed */ }
+        }
+    }
+    return events;
+}
+
+interface WiringHarness {
     telemetryManager: TelemetryManager;
     recorder: SessionRecorder;
-    fs: FakeFs;
-    capturedConfigListener: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
-    onDidChangeConfigStub: sinon.SinonStub;
+    tmpDir: string;
+    configState: MutableConfigState;
+    capturedConfigListener: () => ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
     dispose: () => Promise<void>;
-} {
-    const fs = new FakeFs();
-    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
-    const fakeUri = vscode.Uri.file('/fake-base');
-    const recorder = new SessionRecorder(fakeUri, undefined, undefined, writer);
-    const telemetryManager = new TelemetryManager();
-    let capturedConfigListener: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
-    const onDidChangeConfigStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
-        capturedConfigListener = listener;
+}
+
+async function makeWiringHarness(initial: MutableConfigState): Promise<WiringHarness> {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiring-test-'));
+    const configState: MutableConfigState = { ...initial };
+
+    // STEP 1: Install config stub BEFORE wireSessionRecorder runs.
+    const configStub = installConfigStub(configState);
+
+    // STEP 2: Stub onDidChangeConfiguration to capture the listener.
+    let captured: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    const onConfigStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
+        captured = listener;
         return new vscode.Disposable(() => { /* noop */ });
     });
-    const ctx = { globalStorageUri: fakeUri, subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+    // STEP 3: Construct manager and wiring.
+    const telemetryManager = new TelemetryManager();
+    const ctx = { globalStorageUri: vscode.Uri.file(tmpDir), subscriptions: [] } as unknown as vscode.ExtensionContext;
     const wiring = wireSessionRecorder({
         context: ctx,
         consentService: stubConsent(true),
@@ -1419,27 +1448,29 @@ function makeWiringHarness(): {
         capabilities: undefined,
         exerciseRegistry: undefined,
     });
+
     return {
         telemetryManager,
         recorder: wiring.sessionRecorder,
-        fs,
-        get capturedConfigListener() { return capturedConfigListener; },
-        onDidChangeConfigStub,
+        tmpDir,
+        configState,
+        capturedConfigListener: () => captured,
         dispose: async () => {
             wiring.disposable.dispose();
             try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
             telemetryManager.dispose();
-            onDidChangeConfigStub.restore();
+            onConfigStub.restore();
+            configStub.restore();
+            try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
         },
     };
 }
 
 suite('sessionRecorderWiring — suppression and configuration provenance', () => {
     test('suppression event is recorded as action=suppressed', async () => {
-        const harness = makeWiringHarness();
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
         try {
             await harness.recorder.startSession(42);
-            // Drive a suppression event from the TelemetryManager side.
             const decision: InterventionDecision = {
                 rawWanted: true,
                 shouldIntervene: true,
@@ -1452,7 +1483,7 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
                 ._onDidSuppressIntervention.fire({ decision, reason: 'user-disabled' });
             await harness.recorder.endSession();
 
-            const events = collectWrittenEvents(harness.fs);
+            const events = await readAllRecordedEvents(harness.tmpDir);
             const intervention = events.find(e => e.type === 'intervention') as InterventionEvent | undefined;
             assert.ok(intervention, 'intervention event missing');
             assert.strictEqual(intervention!.action, 'suppressed');
@@ -1464,58 +1495,38 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
     });
 
     test('configurationSnapshot is emitted at startup', async () => {
-        const harness = makeWiringHarness();
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: false, developerMode: false });
         try {
             await harness.recorder.startSession(42);
             await harness.recorder.endSession();
 
-            const events = collectWrittenEvents(harness.fs);
+            const events = await readAllRecordedEvents(harness.tmpDir);
             const snap = events.find(e => e.type === 'configurationSnapshot') as ConfigurationSnapshotEvent | undefined;
             assert.ok(snap, 'configurationSnapshot missing — startup contributor not registered?');
-            assert.strictEqual(typeof snap!.struggleDetectionEnabled, 'boolean');
-            assert.strictEqual(typeof snap!.showInterventions, 'boolean');
+            assert.strictEqual(snap!.struggleDetectionEnabled, true);
+            assert.strictEqual(snap!.showInterventions, false);
         } finally {
             await harness.dispose();
         }
     });
 
     test('configurationChange is recorded when the listener fires', async () => {
-        const harness = makeWiringHarness();
+        // Initial config: showInterventions=true. Listener caches that on construction.
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
         try {
             await harness.recorder.startSession(42);
-            assert.ok(harness.capturedConfigListener, 'wireSessionRecorder did not register an onDidChangeConfiguration listener');
+            const listener = harness.capturedConfigListener();
+            assert.ok(listener, 'wireSessionRecorder did not register an onDidChangeConfiguration listener');
 
-            // Stub workspace.getConfiguration to return values that DIFFER from what
-            // the listener cached at wiring time, so a change is detected.
-            const originalGet = vscode.workspace.getConfiguration;
-            const cfgStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
-                const real = originalGet.call(vscode.workspace, section);
-                return {
-                    ...real,
-                    get: <T>(key: string, def?: T): T => {
-                        if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
-                            return false as unknown as T;
-                        }
-                        if (section === 'artemis.struggleDetection' && key === 'enabled') {
-                            return true as unknown as T;
-                        }
-                        return def as T;
-                    },
-                    inspect: real.inspect.bind(real),
-                    update: real.update.bind(real),
-                    has: real.has.bind(real),
-                } as unknown as vscode.WorkspaceConfiguration;
-            });
-            try {
-                harness.capturedConfigListener!({
-                    affectsConfiguration: (k: string) => k === 'artemis.struggleDetection',
-                } as vscode.ConfigurationChangeEvent);
-            } finally {
-                cfgStub.restore();
-            }
+            // Mutate the backing state; the configStub's get() will now return false.
+            harness.configState.showInterventions = false;
+            listener!({
+                affectsConfiguration: (k: string) => k === 'artemis.struggleDetection',
+            } as vscode.ConfigurationChangeEvent);
+
             await harness.recorder.endSession();
 
-            const events = collectWrittenEvents(harness.fs);
+            const events = await readAllRecordedEvents(harness.tmpDir);
             const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
             assert.ok(change, 'configurationChange missing');
             assert.deepStrictEqual(change!.changes, { showInterventions: false });
@@ -1530,11 +1541,10 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task13-fail.txt | tail -40
+npm run compile-tests && npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task12-fail.txt | tail -40
 ```
 
-Expected: tests fail. Either compile fails (because `_onDidSuppressIntervention` not yet emitted in wiring, or wiring does not subscribe / register a config listener), or runtime fails because no `intervention`/`configurationSnapshot`/`configurationChange` event reaches the JSONL.
+Expected: tests fail. Either compile fails (because the wiring does not yet subscribe to `onDidSuppressIntervention` or register the config-snapshot startup contributor or the runtime config listener), or runtime fails because no `intervention`/`configurationSnapshot`/`configurationChange` event reaches the JSONL.
 
 - [ ] **Step 3: Commit (red tests)**
 
@@ -1545,7 +1555,7 @@ git commit -m "test(activation): add failing wiring tests for suppression and co
 
 ---
 
-## Task 14: Wiring — implement subscriptions and provenance (TDD green)
+## Task 13: Wiring — implement subscriptions and provenance (TDD green)
 
 **Files:**
 - Modify: `extension/src/extension/activation/sessionRecorderWiring.ts`
@@ -1635,8 +1645,7 @@ disposables.push(vscode.workspace.onDidChangeConfiguration(event => {
 
 ```bash
 cd /Users/liamberger/claudeworktrees/MA-intervention-ui-toggle/extension
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task14-pass.txt | tail -30
+npm run compile-tests && npx vscode-test --label unit --grep "sessionRecorderWiring — suppression" 2>&1 | tee /tmp/intervention-toggle-task13-pass.txt | tail -30
 ```
 
 Expected: all three wiring tests pass.
@@ -1644,7 +1653,7 @@ Expected: all three wiring tests pass.
 - [ ] **Step 5: Run full unit suite — expect no regressions**
 
 ```bash
-npx vscode-test --label unit 2>&1 | tail -30
+npm run compile-tests && npx vscode-test --label unit 2>&1 | tail -30
 ```
 
 Expected: no regressions.
@@ -1665,7 +1674,7 @@ git commit -m "feat(recording): wire suppressed interventions and config provena
 
 ---
 
-## Task 15: Final integration sweep — types, lint (full), full unit run, package
+## Task 14: Final integration sweep — types, lint (full), full unit run, package
 
 - [ ] **Step 1: Type-check**
 
@@ -1687,8 +1696,7 @@ Expected: exit 0. If lint warnings appear in any file you modified, fix them in-
 - [ ] **Step 3: Full unit-test run**
 
 ```bash
-npm run compile-tests 2>&1 | tail -5
-npx vscode-test --label unit 2>&1 | tee /tmp/intervention-toggle-final-tests.txt | tail -50
+npm run compile-tests && npx vscode-test --label unit 2>&1 | tee /tmp/intervention-toggle-final-tests.txt | tail -50
 ```
 
 Expected: all tests pass.
@@ -1714,7 +1722,7 @@ If everything was already green, skip the commit.
 
 ---
 
-## Task 16: Manual smoke test in Extension Development Host (UAT)
+## Task 15: Manual smoke test in Extension Development Host (UAT)
 
 **Files:** none (manual)
 
@@ -1761,8 +1769,8 @@ This task does not modify code.
 
 ## Done
 
-After Task 16:
-- All 15 functional tasks committed on `feat/intervention-ui-toggle`
+After Task 15:
+- All 14 functional tasks committed on `feat/intervention-ui-toggle`
 - Unit tests green (compile-tests + vscode-test)
 - Type-check + full lint clean
 - Production build succeeds

--- a/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
+++ b/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
@@ -8,24 +8,28 @@
 
 Add a user-facing setting that suppresses **all** struggle-detection UI surfaces (status-bar lightbulb, info notifications, warning notifications) while keeping the full telemetry / recording pipeline running unchanged.
 
-Use case: thesis evaluation needs a clean control condition — sessions where the system observes and records exactly as in the treatment condition, but the participant sees no AI-driven prompts.
+Use case: thesis evaluation needs a clean control condition. Sessions where the system observes and records the same trigger / EQ / decision signal as in the treatment condition, but the participant sees no AI-driven prompts.
 
 ## Non-Goals
 
 - Changing the behaviour of the existing `artemis.struggleDetection.enabled` setting (which kills the entire pipeline). It stays as-is.
-- Adding per-trigger or per-level granularity (e.g. "subtle yes, proactive no"). One toggle, all-or-nothing.
-- Changing how recording stores intervention events — only the surface that produces them changes.
+- Adding per-trigger or per-level granularity. One toggle, all-or-nothing.
 - Closing already-rendered VS Code modal popups when the toggle is flipped on→off mid-popup. VS Code's `showInformationMessage` / `showWarningMessage` API does not support programmatic dismissal; we accept this edge case.
+- Suppressing developer-mode UI (the EQ-score status bar item gated by `artemis.developerMode`). See **Participant Setup Note** below.
 
-## Decisions Reached During Brainstorming
+## Resolved Decisions
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| 1 | Suppress **all three** UI surfaces (status bar + info popup + warning popup). | Cleanest control condition for evaluation; "AI intervention off" should mean zero visible AI behaviour. |
-| 2 | Telemetry semantics: fire `onDidBlockIntervention` with **new** `blockedReason: 'user-disabled'` instead of `onDidShow*`. | Plain "fire show as if shown" was rejected because the absence of corresponding accept/dismiss events would make `sessionInterventionCount` saturate and the session-limit guardrail would silence further events after 3 phantom shows, breaking recording integrity. The blocked-decision pattern already exists for cooldown / warmup / session-limit / low-confidence — `user-disabled` slots into the same union cleanly. |
-| 3 | New setting `artemis.struggleDetection.showInterventions`, default `true`. | Sibling of existing `artemis.struggleDetection.enabled`. No breaking change. Description must explicitly state "Disabling does not stop data collection." so it cannot be confused with the existing kill-switch. |
-| 4 | Live-toggle: when toggle goes on→off and a status-bar hint is currently visible, hide it via `hideHint()`. Already-rendered modal popups stay until user reacts (VS Code limitation). | Status-bar item is programmatically controllable; modal popups are not. |
-| 5 | Gate at **TelemetryManager**, not InterventionService. | Keeps `InterventionService` UI-only with no config dependency. `TelemetryManager._evaluateAndIntervene` already orchestrates the show-vs-block decision; adding one more branch there is the natural spot. |
+| 1 | Suppress **all three** intervention UI surfaces (status bar lightbulb + info popup + warning popup). | Cleanest control condition. Developer-mode UI stays separate (see Participant Setup Note). |
+| 2 | Telemetry semantics: emit a **new** event `onDidSuppressIntervention` with the original `decision` (preserving `shouldIntervene === true`) and `reason: 'user-disabled'`. The recording layer persists this as `action: 'suppressed'` (a new action), not `'blocked'`. | The existing `recordBlockedDecision` rate-limits to one event per `(triggerType, blockedReason)` per 60 s, which would collapse repeated eligible opportunities into sparse events and bias the control condition relative to treatment. A separate, **un-rate-limited** event path preserves the per-opportunity signal. Reusing `'blocked'` would also conflate user-driven suppression with engine-internal gating (cooldown, warmup, etc.) — keeping them as distinct actions makes evaluation queries unambiguous. |
+| 3 | The emitter lives on `TelemetryManager`, not `InterventionService`. | Suppression is a manager-level orchestration decision (caused by config). `InterventionService` should remain UI-only. |
+| 4 | When toggle is off, **do not** call `_recordIntervention()`. State (cooldown, sessionInterventionCount, adaptive cadence) does not advance. | Advancing state would re-introduce the phantom-show / session-limit silencing that motivated rejecting the "fire onDidShow as if shown" alternative. The spec must therefore treat suppressed events as **eligible-suppressed opportunities**, not simulated treatment events. |
+| 5 | New setting `artemis.struggleDetection.showInterventions`, default `true`. | Sibling of existing `enabled` setting. No breaking change. Description must explicitly state "Disabling does not stop data collection." |
+| 6 | Live-toggle on→off with active status-bar item: call `hideHint()` and reset `text` / `tooltip` / `backgroundColor` to defaults. | `hideHint()` currently only hides + resets the command. Adding the field reset prevents stale state if future code re-shows the item. |
+| 7 | Gate the toggle in `TelemetryManager._evaluateAndIntervene`. | Keeps `InterventionService` UI-only; matches existing show/block dispatch pattern. |
+| 8 | Record toggle state at session start and on every change. | Required provenance for evaluation: without it, sessions with no suppressed events, warmup-only blocks, or mid-session flips cannot be reliably classified later. Implemented via two new recording event types: `configurationSnapshot` (emitted during the existing startup-contributor phase before `startupPhaseComplete`) and `configurationChange` (emitted on `vscode.workspace.onDidChangeConfiguration` for the relevant keys). |
+| 9 | Mid-session flips are not blocked. They are recorded with timestamps so analysis can exclude or segment contaminated sessions. | Blocking would be unexpectedly intrusive for normal users. Note also: accept/dismiss events that arrive after a flip can belong to UI shown before the flip — analysis must reconcile by timestamp. |
 
 ## Architecture
 
@@ -51,111 +55,217 @@ STRUGGLE_DETECTION: {
 }
 ```
 
-### Type extension
+### Type changes
 
-`extension/src/extension/services/telemetry/types.ts` — extend the union and update the JSDoc:
+#### `extension/src/extension/services/telemetry/types.ts`
+
+`InterventionBlockedReason` is **not** widened. The `'user-disabled'` reason lives on a different event channel and uses its own type:
 
 ```ts
 /**
- * Reason why an intervention was blocked (rawWanted=true but shouldIntervene=false).
- *
- * - 'cooldown'        — InterventionService internal cooldown (notification/proactive only)
- * - 'warmup'          — Exercise hasn't reached the 5-minute warmup yet
- * - 'session-limit'   — Max interventions per session exceeded
- * - 'low-confidence'  — EQ above threshold but confidence gate is 'insufficient'
- * - 'user-disabled'   — User has disabled UI interventions via settings; pipeline continues recording
+ * Reason a wanted intervention was suppressed without being delivered to the user.
+ * Currently only one reason exists; left as a union so future suppression sources
+ * (e.g. per-condition study mode) can extend it cleanly.
  */
-export type InterventionBlockedReason =
-    | 'cooldown'
-    | 'warmup'
-    | 'session-limit'
-    | 'low-confidence'
-    | 'user-disabled';
+export type InterventionSuppressionReason = 'user-disabled';
+
+/**
+ * Payload of `onDidSuppressIntervention`.
+ *
+ * `decision` is the original eligible decision with `shouldIntervene === true`.
+ * It is NOT mutated to `false` — the recording must retain the per-opportunity
+ * eligibility signal for later analysis.
+ */
+export interface SuppressedInterventionPayload {
+    decision: InterventionDecision;
+    reason: InterventionSuppressionReason;
+}
 ```
+
+#### `extension/src/extension/services/telemetry/recording/types.ts`
+
+`InterventionEvent` gains the `'suppressed'` action and a `suppressionReason` field:
+
+```ts
+export interface InterventionEvent {
+    type: 'intervention';
+    timestamp: number;
+    action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed';
+    level: 'subtle' | 'notification' | 'proactive';
+    shouldIntervene: boolean;          // true for shown/accepted/dismissed/suppressed; false for blocked
+    eq: number;
+    confidence: 'sufficient' | 'insufficient';
+    triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
+    /** Populated when action='blocked'. */
+    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+    /** Populated when action='suppressed'. */
+    suppressionReason?: 'user-disabled';
+    /** Populated when action='dismissed'. */
+    dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+    rawWanted?: boolean;
+}
+```
+
+Two new recording event types for configuration provenance:
+
+```ts
+export interface ConfigurationSnapshotEvent {
+    type: 'configurationSnapshot';
+    timestamp: number;
+    struggleDetectionEnabled: boolean;
+    showInterventions: boolean;
+}
+
+export interface ConfigurationChangeEvent {
+    type: 'configurationChange';
+    timestamp: number;
+    /** Each property is only present if it changed. */
+    changes: {
+        struggleDetectionEnabled?: boolean;
+        showInterventions?: boolean;
+    };
+}
+```
+
+Both new event types must be added to whatever discriminated-union list / type guard structure the recorder currently uses. (Implementation will check `recording/types.ts` and `sessionRecorder.ts` and update accordingly.)
 
 ### Gate logic
 
 `extension/src/extension/services/telemetry/telemetryManager.ts`:
 
-1. Add a new private field `_showInterventions: boolean = true`.
-2. Extend `_loadConfiguration()` to read `STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY` (default `true`) and store it on the field.
-3. In `_loadConfiguration()`, after the value is updated, if the new value is `false` and the InterventionService currently shows a subtle hint, call `_interventionService.hideHint()`. Reuse the existing pattern from the `!_isEnabled` branch.
-4. In `_evaluateAndIntervene`, change the dispatch branch:
+1. New private field `_showInterventions: boolean = true`.
+2. New event emitter `_onDidSuppressIntervention: vscode.EventEmitter<SuppressedInterventionPayload>` and public `onDidSuppressIntervention` accessor.
+3. `_loadConfiguration()` reads the setting with a runtime type guard:
 
-```ts
-if (decision.shouldIntervene) {
-    if (!this._showInterventions) {
-        // UI suppressed by user setting. Pipeline keeps observing & recording;
-        // record the suppressed decision as a blocked event for later analysis.
-        this._interventionService.recordBlockedDecision({
-            ...decision,
-            blockedReason: 'user-disabled',
-            shouldIntervene: false,
-        });
-        return;
-    }
-    switch (decision.level) {
-        case 'subtle': /* unchanged */
-        case 'notification': /* unchanged */
-        case 'proactive': /* unchanged */
-    }
-} else if (decision.rawWanted) {
-    this._interventionService.recordBlockedDecision(decision);
-}
-```
+   ```ts
+   const rawShow = struggleConfig.get<unknown>(
+       VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY,
+       true,
+   );
+   const previous = this._showInterventions;
+   this._showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
+   if (previous && !this._showInterventions) {
+       // Live transition on → off: hide any visible intervention UI.
+       this._interventionService.hideHint();
+   }
+   ```
 
-### Existing config-change wiring
+4. In `_evaluateAndIntervene`, replace the dispatch branch:
 
-`TelemetryManager` already subscribes to `vscode.workspace.onDidChangeConfiguration` (`telemetryManager.ts:151`) with a filter on `event.affectsConfiguration('artemis.struggleDetection')` — i.e. the whole section, not just the `enabled` key. The new `artemis.struggleDetection.showInterventions` key is therefore picked up automatically. **No filter change required.**
+   ```ts
+   if (decision.shouldIntervene) {
+       if (!this._showInterventions) {
+           this._onDidSuppressIntervention.fire({
+               decision, // unchanged: shouldIntervene === true preserved
+               reason: 'user-disabled',
+           });
+           return;
+       }
+       switch (decision.level) {
+           case 'subtle': /* unchanged */
+           case 'notification': /* unchanged */
+           case 'proactive': /* unchanged */
+       }
+   } else if (decision.rawWanted) {
+       this._interventionService.recordBlockedDecision(decision);
+   }
+   ```
+
+5. The existing `vscode.workspace.onDidChangeConfiguration` listener already filters on the whole `artemis.struggleDetection` section (`telemetryManager.ts:151`), so the new key is picked up automatically. **No filter change required.**
+
+### `InterventionService.hideHint()` enhancement
+
+`extension/src/extension/services/telemetry/interventionService.ts`:
+
+`hideHint()` currently emits a dismiss event (when a subtle hint is active), resets the command to `iris.chatView.focus`, and calls `statusBarItem.hide()`. It does **not** reset the status bar item's `text`, `tooltip`, or `backgroundColor`. Extend it to fully reset these fields so a stale label/colour cannot bleed through if future code shows the item again. Existing dismiss-event behaviour is preserved (no behavioural change for callers).
+
+### Recording layer
+
+`extension/src/extension/services/telemetry/recording/sessionRecorder.ts`:
+- Add a writer method for `ConfigurationSnapshotEvent` and `ConfigurationChangeEvent`.
+- Extend the intervention writer to accept `action='suppressed'` with `suppressionReason` and to keep `shouldIntervene: true`.
+
+`extension/src/extension/activation/sessionRecorderWiring.ts`:
+- Subscribe to `telemetryManager.onDidSuppressIntervention` and write a recording event with `action: 'suppressed'`, `suppressionReason: 'user-disabled'`, `shouldIntervene: true`.
+- Read the two struggle-detection settings during the startup-contributor phase and emit one `configurationSnapshot` event before `startupPhaseComplete`.
+- Subscribe to `vscode.workspace.onDidChangeConfiguration` for the two keys and emit `configurationChange` events on every flip.
 
 ## Data Flow With Toggle Off
 
 ```
-trigger event ──► EQ engine (records) ──► onDidCalculateEQ fires (records)
-                                       └─► decision engine evaluates
-                                              │
-                                              ├─ shouldIntervene=true:
-                                              │      _showInterventions=false?
-                                              │           ├─ yes ──► recordBlockedDecision('user-disabled')
-                                              │           └─ no  ──► show*EQ() → onDidShow / onDidAccept / onDidDismiss
-                                              │
-                                              └─ rawWanted=true, shouldIntervene=false:
-                                                     recordBlockedDecision(existing reason)
+trigger event ──► EQ engine (records as eqSnapshot/eqEngineState)
+                                       │
+                                       ▼
+                          decision engine evaluates
+                                       │
+        ┌──────────────────────────────┼──────────────────────────────┐
+        │                              │                              │
+   shouldIntervene=true            shouldIntervene=false          shouldIntervene=false
+   showInterventions=false         rawWanted=true                 rawWanted=false
+        │                          (engine block)                 (no signal)
+        │                              │                              │
+        ▼                              ▼                              ▼
+ onDidSuppressIntervention      recordBlockedDecision            (no event)
+ (un-rate-limited)              (rate-limited 60s per
+        │                        triggerType×reason)
+        ▼                              │
+ recording: action='suppressed'        ▼
+ shouldIntervene=true            recording: action='blocked'
+ suppressionReason='user-disabled' shouldIntervene=false
+                                  blockedReason=…
 ```
 
 Key invariants:
-- `onDidCalculateEQ` fires **identically** whether the toggle is on or off.
+- `eqSnapshot` and `eqEngineState` events fire **identically** whether the toggle is on or off.
 - The EQ engine, trigger emitters, and decision engine are not touched.
-- `recordBlockedDecision` is rate-limited per `(triggerType, blockedReason)` at 60 s by `InterventionService.BLOCK_EVENT_RATE_LIMIT_MS` — meaning the recording sees at most one `user-disabled` block per minute per trigger type. **This is acceptable for evaluation** because the same per-(trigger,reason) rate limit applies to all other blocked reasons; the recording is not biased between toggle-on and toggle-off conditions.
+- With UI disabled, suppressed events represent **eligible intervention opportunities after decision-engine and filter gates**, but **no UI-delivery state is advanced** because no intervention was actually shown. Cooldown timer, `sessionInterventionCount`, and adaptive cadence remain at their initial values for the session. Evaluation must treat these as `eligible-suppressed`, not `would-have-shown-and-respected-cooldown`.
+- Mid-session flips: any accept/dismiss events arriving after a `configurationChange` to off can refer to UI shown before the flip. Analysis must reconcile by timestamp.
 
 ## Error Handling
 
-No new failure modes. The setting read uses `getConfiguration().get<boolean>(key, true)` which never throws. If VS Code returns an unexpected non-boolean (impossible per the schema, but defensive), the default `true` applies — i.e. fail-open in favour of showing UI, which matches the existing pattern for `enabled`.
+The setting read uses a runtime type guard rather than relying on VS Code's typed `get<T>` fallback (which does not validate the underlying JSON value):
+
+```ts
+const raw = struggleConfig.get<unknown>(SHOW_INTERVENTIONS_KEY, true);
+this._showInterventions = typeof raw === 'boolean' ? raw : true;
+```
+
+If a user has manually corrupted their `settings.json` to put a non-boolean here, we fail open in favour of showing UI. This matches the conservative default for the existing `enabled` flag.
 
 ## Test Plan
 
-All new tests live in `extension/test/unit/services/telemetry/`. Existing files to extend:
+All new tests live under `extension/test/unit/services/telemetry/`. Approach to driving `TelemetryManager`: use the existing public trigger / `onNewResult` event surface where feasible; otherwise use a controlled private accessor (the existing `telemetryManagerCrossExercise.test.ts` should be inspected during implementation to pick the same pattern). The spec does not assume a pre-existing test pattern that exercises `_evaluateAndIntervene` directly.
 
-- `telemetryManager.test.ts` — new `describe` block: "intervention UI toggle".
-- `interventionService.test.ts` — no changes needed (the service is unchanged).
+### Functional tests
 
-### Test cases (Vitest / Mocha — match the existing harness)
+1. **Toggle off → suppression event with original decision preserved.** Drive a trigger that produces `shouldIntervene=true`. Assert `onDidSuppressIntervention` fires once with `reason='user-disabled'` and `decision.shouldIntervene === true` (original eligible decision, unchanged). Assert `onDidShowIntervention` does **not** fire and `onDidBlockIntervention` does **not** fire.
+2. **Toggle off → no UI calls at the VS Code API level.** Spy on `vscode.window.showInformationMessage`, `vscode.window.showWarningMessage`, and on the StatusBarItem instance methods (`.show`, `.hide`, the `text` setter if practical). Drive interventions for each level (subtle / notification / proactive). Assert the show methods and `statusBarItem.show()` are never called.
+3. **Toggle off → EQ + decision events still fire.** Same setup as (1). Assert `onDidCalculateEQ` fires with the expected source.
+4. **Toggle off → no decision-engine state advancement.** After driving N interventions with the toggle off, assert `interventionService.getState()` returns `{ lastInterventionTime: 0, sessionInterventionCount: 0, lastDismissed: false, lastAccepted: false }`.
+5. **Toggle off → suppression events are not rate-limited.** Drive multiple eligible interventions of the same trigger type within a 60-second window (using fake timers). Assert one `onDidSuppressIntervention` event fires per eligible decision, not collapsed.
+6. **Toggle on (default) → existing behaviour preserved.** Mirror of (1) with `showInterventions=true`. Assert `showSubtleHintEQ` is called and `onDidShowIntervention` fires.
+7. **Live-toggle on→off with subtle hint visible.** Render a subtle hint with toggle on; flip toggle off and trigger the config-change handler; assert `hideHint()` is called and emits `dismissReason='hidden'` (verified against the current `hideHint` implementation).
+8. **Live-toggle on→off with notification/proactive status-bar set.** Drive a notification or proactive flow so `statusBarItem.text` is `"$(lightbulb) Stuck? Let me help!"` or `"$(warning) Help available!"`; flip toggle off; assert `statusBarItem.hide()` is called and `text`/`backgroundColor` are reset to default values.
+9. **Live-toggle off→on.** Flip from off to on; assert no events fire as a side effect of the flip alone. Subsequent triggers follow the normal show path.
+10. **Setting type guard.** Stub `getConfiguration().get<unknown>()` to return a non-boolean (e.g. `"true"` string, `null`); assert `_showInterventions` falls back to `true`.
 
-1. **Toggle off → blocked event with `user-disabled` reason.** Configure `showInterventions=false`, drive a trigger that produces `shouldIntervene=true`, assert `onDidBlockIntervention` fires once with `blockedReason='user-disabled'` and `decision.shouldIntervene === false`. Assert `onDidShowIntervention` does **not** fire.
-2. **Toggle off → no UI calls.** Spy on `interventionService.showSubtleHintEQ`, `showNotificationEQ`, `showProactiveHelpEQ`. Drive interventions for each level. Assert all three spies have zero calls.
-3. **Toggle off → EQ + decision events still fire.** Same setup as (1). Assert `onDidCalculateEQ` fires with the expected source, and the decision-engine output is unchanged from the toggle-on case.
-4. **Toggle on (default) → existing behaviour preserved.** Sanity test that the new gate doesn't regress the default path. The simplest form is a mirror of test (1) with `showInterventions=true`, asserting `showSubtleHintEQ` is called.
-5. **Live-toggle on→off while subtle hint visible.** Render a subtle hint with toggle on; flip toggle off and trigger config-change handler; assert `hideHint()` is called and a dismiss event with reason `'session-end'` or `'hidden'` fires (whichever path `hideHint` already takes — verify against current implementation, do not change it).
-6. **Live-toggle off→on.** Flip from off to on; assert no spurious events fire. Subsequent triggers should follow the normal show path.
-7. **Type test (compile-time).** Ensure that `InterventionBlockedReason` includes `'user-disabled'` — covered automatically by typescript when test (1) types the assertion against the union.
-8. **Package manifest.** A schema/manifest unit test (if one exists in the repo — to be confirmed during implementation) asserts the new `artemis.struggleDetection.showInterventions` property exists with `type: boolean` and `default: true`. If no such test exists, skip — this is enforced at extension load time by VS Code.
+### Recording-layer tests
+
+11. **Suppressed intervention persisted.** Wire a real `sessionRecorder` to a `telemetryManager` with toggle off; drive an eligible intervention; assert the persisted recording entry has `type='intervention'`, `action='suppressed'`, `shouldIntervene=true`, `suppressionReason='user-disabled'`, and the correct `triggerType`/`level`/`eq`.
+12. **Configuration snapshot at startup.** Assert the recording contains a `configurationSnapshot` event with both `struggleDetectionEnabled` and `showInterventions` populated, emitted before `startupPhaseComplete`.
+13. **Configuration change recorded.** Flip the setting at runtime; assert a `configurationChange` event is appended with `changes.showInterventions: false` and a timestamp.
+
+### Type / manifest tests
+
+14. **Type test (compile-time).** `InterventionSuppressionReason` includes `'user-disabled'`; `InterventionEvent.action` includes `'suppressed'`. Both enforced by typescript when test (1) and (11) type their assertions against the unions.
+15. **Package manifest property exists.** If a manifest sanity test exists in the repo (to verify during implementation), assert `artemis.struggleDetection.showInterventions` is registered with `type: 'boolean'`, `default: true`. If no such test exists, skip — VS Code enforces this at extension load time.
+
+## Participant Setup Note
+
+The toggle suppresses **intervention** UI only. The developer-mode EQ-score status bar item is gated independently by `artemis.developerMode` (see `telemetryManager.ts:446`). Participants in the control condition must have `artemis.developerMode = false` (the default), otherwise an EQ score remains visible in the status bar. The participant-setup checklist for the study should explicitly include this.
 
 ## Out of Scope For This PR
 
-- Adding a quick-toggle command palette entry (`Iris: Toggle AI Interventions`). Could be a follow-up if user testing shows people don't find the setting.
-- Telemetry/analytics around how often the toggle is flipped. Not relevant for the evaluation use case.
-- A research-mode preset that bundles this with other "control condition" defaults. Out of scope.
-
-## Open Questions
-
-None remaining for this scope. All design questions raised during brainstorming have been resolved (see decisions table).
+- Quick-toggle command palette entry (`Iris: Toggle AI Interventions`). Could be a follow-up if user-testing reveals discoverability issues.
+- A research-mode preset that bundles this setting with other "control condition" defaults.
+- Hiding `artemis.developerMode` UI when this toggle is off. The two settings are intentionally orthogonal.

--- a/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
+++ b/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Add a user-facing setting that suppresses **all** struggle-detection UI surfaces (status-bar lightbulb, info notifications, warning notifications) while keeping the full telemetry / recording pipeline running unchanged.
+Add a user-facing setting that suppresses **all** struggle-detection UI surfaces (status-bar lightbulb, info notifications, warning notifications) while keeping the observation, EQ, trigger, decision, and recording pipeline active. UI delivery is replaced by explicit suppressed-opportunity recording. UI-delivery state (cooldown, session counters, adaptive cadence) does not advance.
 
 Use case: thesis evaluation needs a clean control condition. Sessions where the system observes and records the same trigger / EQ / decision signal as in the treatment condition, but the participant sees no AI-driven prompts.
 

--- a/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
+++ b/docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md
@@ -1,0 +1,161 @@
+# Intervention UI Toggle — Design
+
+**Date:** 2026-04-28
+**Branch:** `feat/intervention-ui-toggle`
+**Worktree:** `/Users/liamberger/claudeworktrees/MA-intervention-ui-toggle`
+
+## Goal
+
+Add a user-facing setting that suppresses **all** struggle-detection UI surfaces (status-bar lightbulb, info notifications, warning notifications) while keeping the full telemetry / recording pipeline running unchanged.
+
+Use case: thesis evaluation needs a clean control condition — sessions where the system observes and records exactly as in the treatment condition, but the participant sees no AI-driven prompts.
+
+## Non-Goals
+
+- Changing the behaviour of the existing `artemis.struggleDetection.enabled` setting (which kills the entire pipeline). It stays as-is.
+- Adding per-trigger or per-level granularity (e.g. "subtle yes, proactive no"). One toggle, all-or-nothing.
+- Changing how recording stores intervention events — only the surface that produces them changes.
+- Closing already-rendered VS Code modal popups when the toggle is flipped on→off mid-popup. VS Code's `showInformationMessage` / `showWarningMessage` API does not support programmatic dismissal; we accept this edge case.
+
+## Decisions Reached During Brainstorming
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Suppress **all three** UI surfaces (status bar + info popup + warning popup). | Cleanest control condition for evaluation; "AI intervention off" should mean zero visible AI behaviour. |
+| 2 | Telemetry semantics: fire `onDidBlockIntervention` with **new** `blockedReason: 'user-disabled'` instead of `onDidShow*`. | Plain "fire show as if shown" was rejected because the absence of corresponding accept/dismiss events would make `sessionInterventionCount` saturate and the session-limit guardrail would silence further events after 3 phantom shows, breaking recording integrity. The blocked-decision pattern already exists for cooldown / warmup / session-limit / low-confidence — `user-disabled` slots into the same union cleanly. |
+| 3 | New setting `artemis.struggleDetection.showInterventions`, default `true`. | Sibling of existing `artemis.struggleDetection.enabled`. No breaking change. Description must explicitly state "Disabling does not stop data collection." so it cannot be confused with the existing kill-switch. |
+| 4 | Live-toggle: when toggle goes on→off and a status-bar hint is currently visible, hide it via `hideHint()`. Already-rendered modal popups stay until user reacts (VS Code limitation). | Status-bar item is programmatically controllable; modal popups are not. |
+| 5 | Gate at **TelemetryManager**, not InterventionService. | Keeps `InterventionService` UI-only with no config dependency. `TelemetryManager._evaluateAndIntervene` already orchestrates the show-vs-block decision; adding one more branch there is the natural spot. |
+
+## Architecture
+
+### Setting
+
+`extension/package.json` `contributes.configuration.properties`:
+
+```jsonc
+"artemis.struggleDetection.showInterventions": {
+    "type": "boolean",
+    "default": true,
+    "markdownDescription": "Show help suggestions when struggle is detected (status bar hint and notification popups). When **disabled**, no UI prompts will appear during struggle, but data collection continues unchanged. Use this if you prefer to work without interruptions while still contributing to research data."
+}
+```
+
+`extension/src/extension/utils/constants.ts` — extend `VSCODE_CONFIG.STRUGGLE_DETECTION`:
+
+```ts
+STRUGGLE_DETECTION: {
+    SECTION: 'artemis.struggleDetection',
+    ENABLED_KEY: 'enabled',
+    SHOW_INTERVENTIONS_KEY: 'showInterventions',
+}
+```
+
+### Type extension
+
+`extension/src/extension/services/telemetry/types.ts` — extend the union and update the JSDoc:
+
+```ts
+/**
+ * Reason why an intervention was blocked (rawWanted=true but shouldIntervene=false).
+ *
+ * - 'cooldown'        — InterventionService internal cooldown (notification/proactive only)
+ * - 'warmup'          — Exercise hasn't reached the 5-minute warmup yet
+ * - 'session-limit'   — Max interventions per session exceeded
+ * - 'low-confidence'  — EQ above threshold but confidence gate is 'insufficient'
+ * - 'user-disabled'   — User has disabled UI interventions via settings; pipeline continues recording
+ */
+export type InterventionBlockedReason =
+    | 'cooldown'
+    | 'warmup'
+    | 'session-limit'
+    | 'low-confidence'
+    | 'user-disabled';
+```
+
+### Gate logic
+
+`extension/src/extension/services/telemetry/telemetryManager.ts`:
+
+1. Add a new private field `_showInterventions: boolean = true`.
+2. Extend `_loadConfiguration()` to read `STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY` (default `true`) and store it on the field.
+3. In `_loadConfiguration()`, after the value is updated, if the new value is `false` and the InterventionService currently shows a subtle hint, call `_interventionService.hideHint()`. Reuse the existing pattern from the `!_isEnabled` branch.
+4. In `_evaluateAndIntervene`, change the dispatch branch:
+
+```ts
+if (decision.shouldIntervene) {
+    if (!this._showInterventions) {
+        // UI suppressed by user setting. Pipeline keeps observing & recording;
+        // record the suppressed decision as a blocked event for later analysis.
+        this._interventionService.recordBlockedDecision({
+            ...decision,
+            blockedReason: 'user-disabled',
+            shouldIntervene: false,
+        });
+        return;
+    }
+    switch (decision.level) {
+        case 'subtle': /* unchanged */
+        case 'notification': /* unchanged */
+        case 'proactive': /* unchanged */
+    }
+} else if (decision.rawWanted) {
+    this._interventionService.recordBlockedDecision(decision);
+}
+```
+
+### Existing config-change wiring
+
+`TelemetryManager` already subscribes to `vscode.workspace.onDidChangeConfiguration` (`telemetryManager.ts:151`) with a filter on `event.affectsConfiguration('artemis.struggleDetection')` — i.e. the whole section, not just the `enabled` key. The new `artemis.struggleDetection.showInterventions` key is therefore picked up automatically. **No filter change required.**
+
+## Data Flow With Toggle Off
+
+```
+trigger event ──► EQ engine (records) ──► onDidCalculateEQ fires (records)
+                                       └─► decision engine evaluates
+                                              │
+                                              ├─ shouldIntervene=true:
+                                              │      _showInterventions=false?
+                                              │           ├─ yes ──► recordBlockedDecision('user-disabled')
+                                              │           └─ no  ──► show*EQ() → onDidShow / onDidAccept / onDidDismiss
+                                              │
+                                              └─ rawWanted=true, shouldIntervene=false:
+                                                     recordBlockedDecision(existing reason)
+```
+
+Key invariants:
+- `onDidCalculateEQ` fires **identically** whether the toggle is on or off.
+- The EQ engine, trigger emitters, and decision engine are not touched.
+- `recordBlockedDecision` is rate-limited per `(triggerType, blockedReason)` at 60 s by `InterventionService.BLOCK_EVENT_RATE_LIMIT_MS` — meaning the recording sees at most one `user-disabled` block per minute per trigger type. **This is acceptable for evaluation** because the same per-(trigger,reason) rate limit applies to all other blocked reasons; the recording is not biased between toggle-on and toggle-off conditions.
+
+## Error Handling
+
+No new failure modes. The setting read uses `getConfiguration().get<boolean>(key, true)` which never throws. If VS Code returns an unexpected non-boolean (impossible per the schema, but defensive), the default `true` applies — i.e. fail-open in favour of showing UI, which matches the existing pattern for `enabled`.
+
+## Test Plan
+
+All new tests live in `extension/test/unit/services/telemetry/`. Existing files to extend:
+
+- `telemetryManager.test.ts` — new `describe` block: "intervention UI toggle".
+- `interventionService.test.ts` — no changes needed (the service is unchanged).
+
+### Test cases (Vitest / Mocha — match the existing harness)
+
+1. **Toggle off → blocked event with `user-disabled` reason.** Configure `showInterventions=false`, drive a trigger that produces `shouldIntervene=true`, assert `onDidBlockIntervention` fires once with `blockedReason='user-disabled'` and `decision.shouldIntervene === false`. Assert `onDidShowIntervention` does **not** fire.
+2. **Toggle off → no UI calls.** Spy on `interventionService.showSubtleHintEQ`, `showNotificationEQ`, `showProactiveHelpEQ`. Drive interventions for each level. Assert all three spies have zero calls.
+3. **Toggle off → EQ + decision events still fire.** Same setup as (1). Assert `onDidCalculateEQ` fires with the expected source, and the decision-engine output is unchanged from the toggle-on case.
+4. **Toggle on (default) → existing behaviour preserved.** Sanity test that the new gate doesn't regress the default path. The simplest form is a mirror of test (1) with `showInterventions=true`, asserting `showSubtleHintEQ` is called.
+5. **Live-toggle on→off while subtle hint visible.** Render a subtle hint with toggle on; flip toggle off and trigger config-change handler; assert `hideHint()` is called and a dismiss event with reason `'session-end'` or `'hidden'` fires (whichever path `hideHint` already takes — verify against current implementation, do not change it).
+6. **Live-toggle off→on.** Flip from off to on; assert no spurious events fire. Subsequent triggers should follow the normal show path.
+7. **Type test (compile-time).** Ensure that `InterventionBlockedReason` includes `'user-disabled'` — covered automatically by typescript when test (1) types the assertion against the union.
+8. **Package manifest.** A schema/manifest unit test (if one exists in the repo — to be confirmed during implementation) asserts the new `artemis.struggleDetection.showInterventions` property exists with `type: boolean` and `default: true`. If no such test exists, skip — this is enforced at extension load time by VS Code.
+
+## Out of Scope For This PR
+
+- Adding a quick-toggle command palette entry (`Iris: Toggle AI Interventions`). Could be a follow-up if user testing shows people don't find the setting.
+- Telemetry/analytics around how often the toggle is flipped. Not relevant for the evaluation use case.
+- A research-mode preset that bundles this with other "control condition" defaults. Out of scope.
+
+## Open Questions
+
+None remaining for this scope. All design questions raised during brainstorming have been resolved (see decisions table).

--- a/extension/package.json
+++ b/extension/package.json
@@ -207,6 +207,11 @@
           "default": true,
           "description": "Enable struggle detection to receive helpful hints when you might be stuck on a problem"
         },
+        "artemis.struggleDetection.showInterventions": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show help suggestions when struggle is detected (status bar hint and notification popups). When **disabled**, no UI prompts will appear during struggle, but data collection continues unchanged. Use this if you prefer to work without interruptions while still contributing to research data."
+        },
         "artemis.startPage": {
           "type": "string",
           "enum": [

--- a/extension/src/extension/activation/sessionRecorderWiring.ts
+++ b/extension/src/extension/activation/sessionRecorderWiring.ts
@@ -7,6 +7,7 @@ import type { RecordedEvent } from '../services/telemetry/recording/types';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '../provider';
 import type { PlatformCapabilities } from '../theia';
 import type { ExerciseRegistry } from '../services/exerciseRegistry';
+import { VSCODE_CONFIG } from '../utils/constants';
 
 interface RecorderWiringDeps {
     context: vscode.ExtensionContext;
@@ -102,6 +103,13 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
             { blockedReason: decision.blockedReason, rawWanted: true },
         );
     }));
+    disposables.push(telemetryManager.onDidSuppressIntervention(({ decision, reason }) => {
+        sessionRecorder.recordIntervention(
+            'suppressed', decision.level as 'subtle' | 'notification' | 'proactive',
+            decision.shouldIntervene, decision.eq, decision.confidence, decision.triggerType,
+            { suppressionReason: reason, rawWanted: decision.rawWanted },
+        );
+    }));
 
     // Provider navigation/visibility events
     disposables.push(artemisWebviewProvider.onDidChangeViewNavigation(({ from, to }) => {
@@ -157,6 +165,55 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
                 visible: chatWebviewProvider.getCurrentVisibility(),
             },
         ];
+    }));
+
+    // Configuration snapshot — captures struggle-detection setting values at
+    // session start so analysis can classify control vs treatment sessions.
+    disposables.push(sessionRecorder.registerStartupContributor((ctx): RecordedEvent[] => {
+        const struggleConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+        const enabled = struggleConfig.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
+        const rawShow = struggleConfig.get<unknown>(VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY, true);
+        const showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
+        return [{
+            type: 'configurationSnapshot',
+            timestamp: ctx.timestamp,
+            struggleDetectionEnabled: enabled,
+            showInterventions,
+        }];
+    }));
+
+    // Runtime configuration changes for struggle-detection settings — recorded
+    // so mid-session flips can be reconciled with intervention events by timestamp.
+    const readStruggleEnabled = (): boolean => {
+        const cfg = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+        return cfg.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
+    };
+    const readShowInterventions = (): boolean => {
+        const cfg = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
+        const raw = cfg.get<unknown>(VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY, true);
+        return typeof raw === 'boolean' ? raw : true;
+    };
+    let lastStruggleEnabled = readStruggleEnabled();
+    let lastShowInterventions = readShowInterventions();
+
+    disposables.push(vscode.workspace.onDidChangeConfiguration(event => {
+        if (!event.affectsConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION)) {
+            return;
+        }
+        const newEnabled = readStruggleEnabled();
+        const newShow = readShowInterventions();
+        const changes: { struggleDetectionEnabled?: boolean; showInterventions?: boolean } = {};
+        if (newEnabled !== lastStruggleEnabled) {
+            changes.struggleDetectionEnabled = newEnabled;
+            lastStruggleEnabled = newEnabled;
+        }
+        if (newShow !== lastShowInterventions) {
+            changes.showInterventions = newShow;
+            lastShowInterventions = newShow;
+        }
+        if (Object.keys(changes).length > 0) {
+            sessionRecorder.recordConfigurationChange(changes);
+        }
     }));
 
     // Recording status bar button

--- a/extension/src/extension/services/telemetry/interventionService.ts
+++ b/extension/src/extension/services/telemetry/interventionService.ts
@@ -257,6 +257,9 @@ export class InterventionService implements vscode.Disposable, SessionResettable
             this._currentSubtleDecision = undefined;
         }
         this._statusBarItem.command = 'iris.chatView.focus';
+        this._statusBarItem.text = '';
+        this._statusBarItem.tooltip = undefined;
+        this._statusBarItem.backgroundColor = undefined;
         this._statusBarItem.hide();
     }
 

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -298,7 +298,7 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
     }
 
     recordIntervention(
-        action: 'shown' | 'accepted' | 'dismissed' | 'blocked',
+        action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed',
         level: 'subtle' | 'notification' | 'proactive',
         shouldIntervene: boolean,
         eq: number,
@@ -306,6 +306,7 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
         triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained',
         opts?: {
             blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+            suppressionReason?: 'user-disabled';
             dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
             rawWanted?: boolean;
         },
@@ -323,6 +324,7 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
             confidence,
             triggerType,
             blockedReason: opts?.blockedReason,
+            suppressionReason: opts?.suppressionReason,
             dismissReason: opts?.dismissReason,
             rawWanted: opts?.rawWanted,
         }, {}, this._currentGeneration);
@@ -349,6 +351,32 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
             timestamp: Date.now(),
             panel,
             visible,
+        }, {}, this._currentGeneration);
+    }
+
+    recordConfigurationSnapshot(struggleDetectionEnabled: boolean, showInterventions: boolean): void {
+        if (this._phase !== 'recording') {
+            return;
+        }
+        this._lifecycle.recordInternal({
+            type: 'configurationSnapshot',
+            timestamp: Date.now(),
+            struggleDetectionEnabled,
+            showInterventions,
+        }, {}, this._currentGeneration);
+    }
+
+    recordConfigurationChange(changes: {
+        struggleDetectionEnabled?: boolean;
+        showInterventions?: boolean;
+    }): void {
+        if (this._phase !== 'recording') {
+            return;
+        }
+        this._lifecycle.recordInternal({
+            type: 'configurationChange',
+            timestamp: Date.now(),
+            changes,
         }, {}, this._currentGeneration);
     }
 

--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -124,6 +124,32 @@ export interface StartupPhaseCompleteEvent {
     timestamp: number;
 }
 
+/**
+ * Provenance event emitted once during the startup-contributor phase before
+ * `startupPhaseComplete`. Captures the values of struggle-detection settings
+ * at session start so analysis can classify control vs treatment sessions.
+ */
+export interface ConfigurationSnapshotEvent {
+    type: 'configurationSnapshot';
+    timestamp: number;
+    struggleDetectionEnabled: boolean;
+    showInterventions: boolean;
+}
+
+/**
+ * Provenance event emitted whenever one of the recorded struggle-detection
+ * settings changes mid-session. Each property is only present when its value
+ * changed in the triggering configuration event.
+ */
+export interface ConfigurationChangeEvent {
+    type: 'configurationChange';
+    timestamp: number;
+    changes: {
+        struggleDetectionEnabled?: boolean;
+        showInterventions?: boolean;
+    };
+}
+
 export interface IrisChatMessageEvent {
     type: 'irisChatMessage';
     timestamp: number;
@@ -190,14 +216,17 @@ export interface EqEngineStateEvent {
 export interface InterventionEvent {
     type: 'intervention';
     timestamp: number;
-    action: 'shown' | 'accepted' | 'dismissed' | 'blocked';
+    action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed';
     level: 'subtle' | 'notification' | 'proactive';
+    /** True for shown/accepted/dismissed/suppressed; false for blocked. */
     shouldIntervene: boolean;
     eq: number;
     confidence: 'sufficient' | 'insufficient';
     triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
     /** Populated when action='blocked'. Identifies why the intervention was blocked. */
     blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+    /** Populated when action='suppressed'. Identifies the suppression source. */
+    suppressionReason?: 'user-disabled';
     /** Populated when action='dismissed'. Identifies how the intervention was dismissed. */
     dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
     /**
@@ -315,6 +344,8 @@ export type RecordedEvent =
     | SessionStartEvent
     | SessionEndEvent
     | ConsentChangeEvent
+    | ConfigurationSnapshotEvent
+    | ConfigurationChangeEvent
     | StartupPhaseCompleteEvent
     | IrisChatMessageEvent
     | IrisChatSendAttemptEvent

--- a/extension/src/extension/services/telemetry/telemetryManager.ts
+++ b/extension/src/extension/services/telemetry/telemetryManager.ts
@@ -393,7 +393,17 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         const decision = this._decisionEngine.evaluate(eq, confidence, triggerType, state);
 
         if (decision.shouldIntervene) {
-            // Dispatch intervention
+            if (!this._showInterventions) {
+                // UI suppressed by user setting. Decision-engine UI-delivery state is
+                // intentionally NOT advanced (no _recordIntervention) because no UI was
+                // shown. The recording layer subscribes to onDidSuppressIntervention so
+                // every eligible opportunity is captured for evaluation.
+                this._onDidSuppressIntervention.fire({
+                    decision,
+                    reason: 'user-disabled',
+                });
+                return;
+            }
             switch (decision.level) {
                 case 'subtle':
                     this._interventionService.showSubtleHintEQ(decision);
@@ -449,6 +459,13 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         const struggleConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.STRUGGLE_DETECTION.SECTION);
         this._isEnabled = struggleConfig.get<boolean>(VSCODE_CONFIG.STRUGGLE_DETECTION.ENABLED_KEY, true);
 
+        const previousShowInterventions = this._showInterventions;
+        const rawShow = struggleConfig.get<unknown>(
+            VSCODE_CONFIG.STRUGGLE_DETECTION.SHOW_INTERVENTIONS_KEY,
+            true,
+        );
+        this._showInterventions = typeof rawShow === 'boolean' ? rawShow : true;
+
         const wasDebugMode = this._debugMode;
         const artemisConfig = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
         const developerMode = artemisConfig.get<boolean>(VSCODE_CONFIG.DEVELOPER_MODE_KEY, false);
@@ -460,6 +477,16 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
             this._log('Struggle detection disabled');
         } else {
             this._log('Struggle detection enabled');
+        }
+
+        // Live transition on->off for the UI toggle: clear any visible hint so a
+        // status-bar lightbulb / coloured remnant disappears immediately. We do
+        // NOT log on every load (only on transitions) to avoid noise.
+        if (previousShowInterventions && !this._showInterventions) {
+            this._interventionService.hideHint();
+            this._log('Intervention UI suppressed by user setting');
+        } else if (!previousShowInterventions && this._showInterventions) {
+            this._log('Intervention UI restored by user setting');
         }
 
         if (this._debugMode && !wasDebugMode) {

--- a/extension/src/extension/services/telemetry/telemetryManager.ts
+++ b/extension/src/extension/services/telemetry/telemetryManager.ts
@@ -5,6 +5,7 @@ import {
     EQConfidence,
     EQState,
     RecommendedAction,
+    SuppressedInterventionPayload,
 } from './types';
 import type { SessionResettable, SessionStartContext } from './types';
 import { DiagnosticPersistenceService } from './diagnosticPersistenceService';
@@ -55,6 +56,7 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
     // State
     private _websocketService: ArtemisWebsocketService | undefined;
     private _isEnabled: boolean = true;
+    private _showInterventions: boolean = true;
     private readonly _sessionServices: SessionResettable[];
     private _activeExerciseId: number | undefined;
     private _lastTriggerType: TriggerType | undefined;
@@ -88,6 +90,9 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
     public get onDidBlockIntervention() {
         return this._interventionService.onDidBlockIntervention;
     }
+
+    private readonly _onDidSuppressIntervention = new vscode.EventEmitter<SuppressedInterventionPayload>();
+    public readonly onDidSuppressIntervention = this._onDidSuppressIntervention.event;
 
     constructor(exerciseRegistry?: ExerciseRegistry) {
         this._exerciseRegistry = exerciseRegistry;
@@ -174,6 +179,7 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         }
 
         this._onDidCalculateEQ.dispose();
+        this._onDidSuppressIntervention.dispose();
     }
 
     // ==================== WebSocket Message Handler ====================

--- a/extension/src/extension/services/telemetry/types.ts
+++ b/extension/src/extension/services/telemetry/types.ts
@@ -277,6 +277,30 @@ export type InterventionBlockedReason = 'cooldown' | 'warmup' | 'session-limit' 
 export type InterventionDismissReason = 'user-action' | 'hidden' | 'replaced' | 'session-end';
 
 /**
+ * Reason a wanted intervention was suppressed without being delivered to the user.
+ * Currently only one reason exists; left as a union so future suppression sources
+ * (e.g. per-condition study mode) can extend it cleanly.
+ *
+ * Note: this is a SEPARATE concept from `InterventionBlockedReason`. Blocks come
+ * from engine-internal gates (cooldown, warmup, session-limit, low-confidence)
+ * and are rate-limited. Suppression comes from explicit user/config choice and
+ * is NOT rate-limited so the per-opportunity signal stays intact.
+ */
+export type InterventionSuppressionReason = 'user-disabled';
+
+/**
+ * Payload of `TelemetryManager.onDidSuppressIntervention`.
+ *
+ * `decision` is the original eligible decision with `shouldIntervene === true`.
+ * It must NOT be mutated to `false` — the recording must retain the per-opportunity
+ * eligibility signal for later analysis.
+ */
+export interface SuppressedInterventionPayload {
+    decision: InterventionDecision;
+    reason: InterventionSuppressionReason;
+}
+
+/**
  * Decision output from the intervention decision engine
  */
 export interface InterventionDecision {

--- a/extension/src/extension/utils/constants.ts
+++ b/extension/src/extension/utils/constants.ts
@@ -33,6 +33,7 @@ export const VSCODE_CONFIG = {
     STRUGGLE_DETECTION: {
         SECTION: 'artemis.struggleDetection',
         ENABLED_KEY: 'enabled',
+        SHOW_INTERVENTIONS_KEY: 'showInterventions',
     },
 } as const;
 

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -32,9 +32,9 @@ interface MutableConfigState {
     developerMode: boolean;
 }
 
-function installConfigStub(state: MutableConfigState): sinon.SinonStub {
+function installConfigStub(sandbox: sinon.SinonSandbox, state: MutableConfigState): sinon.SinonStub {
     const original = vscode.workspace.getConfiguration;
-    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+    return sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
         const real = original.call(vscode.workspace, section);
         return {
             ...real,
@@ -65,10 +65,10 @@ function stubConsent(extended: boolean): ConsentService {
     } as unknown as ConsentService;
 }
 
-function stubWebsocket(): ArtemisWebsocketService {
+function stubWebsocket(sandbox: sinon.SinonSandbox): ArtemisWebsocketService {
     return {
-        registerMessageHandler: sinon.stub(),
-        unregisterMessageHandler: sinon.stub(),
+        registerMessageHandler: sandbox.stub(),
+        unregisterMessageHandler: sandbox.stub(),
     } as unknown as ArtemisWebsocketService;
 }
 
@@ -133,27 +133,45 @@ interface WiringHarness {
     dispose: () => Promise<void>;
 }
 
-async function makeWiringHarness(initial: MutableConfigState): Promise<WiringHarness> {
+/**
+ * Build a wiring harness against a per-suite sandbox. The sandbox owns every
+ * stub so a thrown error mid-construction (or a forgotten dispose call) cannot
+ * leak `getConfiguration` / `registerCommand` wraps into the next test —
+ * `sandbox.restore()` in teardown rolls them all back unconditionally.
+ */
+async function makeWiringHarness(
+    sandbox: sinon.SinonSandbox,
+    initial: MutableConfigState,
+): Promise<WiringHarness> {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiring-test-'));
     const configState: MutableConfigState = { ...initial };
 
-    // STEP 1: Install config stub BEFORE wireSessionRecorder runs.
-    const configStub = installConfigStub(configState);
+    installConfigStub(sandbox, configState);
 
-    // STEP 2: Stub onDidChangeConfiguration to capture the listener.
     let captured: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
-    const onConfigStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
+    sandbox.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
         captured = listener;
         return new vscode.Disposable(() => { /* noop */ });
     });
 
-    // STEP 3: Construct manager and wiring.
+    // The extension under test is already activated by the test runner and has
+    // registered `artemis.toggleRecording`. Stub registerCommand so the wiring's
+    // RecordingStatusBarService does not collide with that pre-existing
+    // registration. Same story for createStatusBarItem (avoid duplicating the
+    // real status bar item).
+    sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+    sandbox.stub(vscode.window, 'createStatusBarItem').returns({
+        text: '', tooltip: undefined, backgroundColor: undefined, command: undefined,
+        show: sandbox.stub(), hide: sandbox.stub(), dispose: sandbox.stub(),
+        alignment: vscode.StatusBarAlignment.Right, priority: 99,
+    } as unknown as vscode.StatusBarItem);
+
     const telemetryManager = new TelemetryManager();
     const ctx = { globalStorageUri: vscode.Uri.file(tmpDir), subscriptions: [] } as unknown as vscode.ExtensionContext;
     const wiring = wireSessionRecorder({
         context: ctx,
         consentService: stubConsent(true),
-        artemisWebsocketService: stubWebsocket(),
+        artemisWebsocketService: stubWebsocket(sandbox),
         telemetryManager,
         artemisWebviewProvider: stubWebviewProvider(),
         chatWebviewProvider: stubChatProvider(),
@@ -171,16 +189,25 @@ async function makeWiringHarness(initial: MutableConfigState): Promise<WiringHar
             wiring.disposable.dispose();
             try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
             telemetryManager.dispose();
-            onConfigStub.restore();
-            configStub.restore();
             try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+            // Stubs are restored centrally via the suite-level sandbox in teardown.
         },
     };
 }
 
 suite('sessionRecorderWiring — suppression and configuration provenance', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
     test('suppression event is recorded as action=suppressed', async () => {
-        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
+        const harness = await makeWiringHarness(sandbox, { enabled: true, showInterventions: true, developerMode: false });
         try {
             await harness.recorder.startSession(42);
             const decision: InterventionDecision = {
@@ -207,7 +234,7 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
     });
 
     test('configurationSnapshot is emitted at startup', async () => {
-        const harness = await makeWiringHarness({ enabled: true, showInterventions: false, developerMode: false });
+        const harness = await makeWiringHarness(sandbox, { enabled: true, showInterventions: false, developerMode: false });
         try {
             await harness.recorder.startSession(42);
             await harness.recorder.endSession();
@@ -224,7 +251,7 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
 
     test('configurationChange is recorded when the listener fires', async () => {
         // Initial config: showInterventions=true. Listener caches that on construction.
-        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
+        const harness = await makeWiringHarness(sandbox, { enabled: true, showInterventions: true, developerMode: false });
         try {
             await harness.recorder.startSession(42);
             const listener = harness.capturedConfigListener();

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration tests for sessionRecorderWiring.
+ *
+ * Constructs a real TelemetryManager + (wireSessionRecorder-built) SessionRecorder
+ * pointing at a temp directory; drives suppression and config-change events,
+ * and asserts they reach the on-disk JSONL stream.
+ *
+ * Whitebox brittleness:
+ *  - Fires TelemetryManager._onDidSuppressIntervention directly via cast.
+ *  - Stubs vscode.workspace.onDidChangeConfiguration to capture the listener.
+ *  - Stubs vscode.workspace.getConfiguration with mutable backing values.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { TelemetryManager } from '../../../src/extension/services/telemetry/telemetryManager';
+import { SessionRecorder } from '../../../src/extension/services/telemetry/recording/sessionRecorder';
+import { wireSessionRecorder } from '../../../src/extension/activation/sessionRecorderWiring';
+import type { RecordedEvent, InterventionEvent, ConfigurationSnapshotEvent, ConfigurationChangeEvent } from '../../../src/extension/services/telemetry/recording/types';
+import type { ConsentService } from '../../../src/extension/services/auth';
+import type { ArtemisWebsocketService } from '../../../src/extension/services/websocket';
+import type { ArtemisWebviewProvider, ChatWebviewProvider } from '../../../src/extension/provider';
+import type { InterventionDecision } from '../../../src/extension/services/telemetry/types';
+
+interface MutableConfigState {
+    enabled: boolean;
+    showInterventions: unknown;   // unknown so tests can simulate non-boolean
+    developerMode: boolean;
+}
+
+function installConfigStub(state: MutableConfigState): sinon.SinonStub {
+    const original = vscode.workspace.getConfiguration;
+    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+        const real = original.call(vscode.workspace, section);
+        return {
+            ...real,
+            get: <T>(key: string, def?: T): T => {
+                if (section === 'artemis.struggleDetection' && key === 'enabled') {
+                    return state.enabled as unknown as T;
+                }
+                if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
+                    return state.showInterventions as T;
+                }
+                if (section === 'artemis' && key === 'developerMode') {
+                    return state.developerMode as unknown as T;
+                }
+                return def as T;
+            },
+            inspect: real.inspect.bind(real),
+            update: real.update.bind(real),
+            has: real.has.bind(real),
+        } as unknown as vscode.WorkspaceConfiguration;
+    });
+}
+
+function stubConsent(extended: boolean): ConsentService {
+    const onConsentChanged = new vscode.EventEmitter<'pending' | 'declined' | 'basic' | 'extended'>();
+    return {
+        get isExtendedCollectionEnabled() { return extended; },
+        onConsentChanged: onConsentChanged.event,
+    } as unknown as ConsentService;
+}
+
+function stubWebsocket(): ArtemisWebsocketService {
+    return {
+        registerMessageHandler: sinon.stub(),
+        unregisterMessageHandler: sinon.stub(),
+    } as unknown as ArtemisWebsocketService;
+}
+
+function stubWebviewProvider(): ArtemisWebviewProvider {
+    const onDidChangeViewNavigation = new vscode.EventEmitter<{ from: string; to: string }>();
+    const onDidChangePanelVisibility = new vscode.EventEmitter<boolean>();
+    return {
+        getCurrentVisibility: () => false,
+        onDidChangeViewNavigation: onDidChangeViewNavigation.event,
+        onDidChangePanelVisibility: onDidChangePanelVisibility.event,
+    } as unknown as ArtemisWebviewProvider;
+}
+
+function stubChatProvider(): ChatWebviewProvider {
+    const onDidSendIrisChatMessage = new vscode.EventEmitter<string>();
+    const onDidAttemptIrisChatSend = new vscode.EventEmitter<{ content: string; status: 'pending' | 'sent' | 'failed'; errorMessage?: string }>();
+    const onDidProvideIrisChatFeedback = new vscode.EventEmitter<{ messageId: string; helpful: boolean }>();
+    const onDidChangePanelVisibility = new vscode.EventEmitter<boolean>();
+    const onDidReceiveIrisChatMessage = new vscode.EventEmitter<{ content: string; messageId?: string; sessionId?: string; sentAt?: number }>();
+    return {
+        getCurrentVisibility: () => false,
+        getSelectedExerciseId: () => 42,
+        onDidSendIrisChatMessage: onDidSendIrisChatMessage.event,
+        onDidAttemptIrisChatSend: onDidAttemptIrisChatSend.event,
+        onDidProvideIrisChatFeedback: onDidProvideIrisChatFeedback.event,
+        onDidChangePanelVisibility: onDidChangePanelVisibility.event,
+        websocketMessageHandler: { onDidReceiveIrisChatMessage: onDidReceiveIrisChatMessage.event },
+    } as unknown as ChatWebviewProvider;
+}
+
+/** Read every events.jsonl file produced under tmpDir/recordings/<sessionId>/ and return the parsed events. */
+async function readAllRecordedEvents(tmpDir: string): Promise<RecordedEvent[]> {
+    const recordingsRoot = path.join(tmpDir, 'recordings');
+    const events: RecordedEvent[] = [];
+    let sessionDirs: string[];
+    try {
+        sessionDirs = await fs.readdir(recordingsRoot);
+    } catch {
+        return events; // recordings dir not created yet
+    }
+    for (const sessionId of sessionDirs) {
+        const eventsPath = path.join(recordingsRoot, sessionId, 'events.jsonl');
+        let content: string;
+        try {
+            content = await fs.readFile(eventsPath, 'utf-8');
+        } catch {
+            continue;
+        }
+        for (const line of content.split('\n').filter(Boolean)) {
+            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip malformed */ }
+        }
+    }
+    return events;
+}
+
+interface WiringHarness {
+    telemetryManager: TelemetryManager;
+    recorder: SessionRecorder;
+    tmpDir: string;
+    configState: MutableConfigState;
+    capturedConfigListener: () => ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    dispose: () => Promise<void>;
+}
+
+async function makeWiringHarness(initial: MutableConfigState): Promise<WiringHarness> {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiring-test-'));
+    const configState: MutableConfigState = { ...initial };
+
+    // STEP 1: Install config stub BEFORE wireSessionRecorder runs.
+    const configStub = installConfigStub(configState);
+
+    // STEP 2: Stub onDidChangeConfiguration to capture the listener.
+    let captured: ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    const onConfigStub = sinon.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((listener: (e: vscode.ConfigurationChangeEvent) => void) => {
+        captured = listener;
+        return new vscode.Disposable(() => { /* noop */ });
+    });
+
+    // STEP 3: Construct manager and wiring.
+    const telemetryManager = new TelemetryManager();
+    const ctx = { globalStorageUri: vscode.Uri.file(tmpDir), subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const wiring = wireSessionRecorder({
+        context: ctx,
+        consentService: stubConsent(true),
+        artemisWebsocketService: stubWebsocket(),
+        telemetryManager,
+        artemisWebviewProvider: stubWebviewProvider(),
+        chatWebviewProvider: stubChatProvider(),
+        capabilities: undefined,
+        exerciseRegistry: undefined,
+    });
+
+    return {
+        telemetryManager,
+        recorder: wiring.sessionRecorder,
+        tmpDir,
+        configState,
+        capturedConfigListener: () => captured,
+        dispose: async () => {
+            wiring.disposable.dispose();
+            try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
+            telemetryManager.dispose();
+            onConfigStub.restore();
+            configStub.restore();
+            try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        },
+    };
+}
+
+suite('sessionRecorderWiring — suppression and configuration provenance', () => {
+    test('suppression event is recorded as action=suppressed', async () => {
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
+        try {
+            await harness.recorder.startSession(42);
+            const decision: InterventionDecision = {
+                rawWanted: true,
+                shouldIntervene: true,
+                level: 'notification',
+                triggerType: 'execution-error',
+                eq: 0.55,
+                confidence: 'sufficient',
+            };
+            (harness.telemetryManager as unknown as { _onDidSuppressIntervention: vscode.EventEmitter<{ decision: InterventionDecision; reason: 'user-disabled' }> })
+                ._onDidSuppressIntervention.fire({ decision, reason: 'user-disabled' });
+            await harness.recorder.endSession();
+
+            const events = await readAllRecordedEvents(harness.tmpDir);
+            const intervention = events.find(e => e.type === 'intervention') as InterventionEvent | undefined;
+            assert.ok(intervention, 'intervention event missing');
+            assert.strictEqual(intervention!.action, 'suppressed');
+            assert.strictEqual(intervention!.suppressionReason, 'user-disabled');
+            assert.strictEqual(intervention!.shouldIntervene, true);
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('configurationSnapshot is emitted at startup', async () => {
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: false, developerMode: false });
+        try {
+            await harness.recorder.startSession(42);
+            await harness.recorder.endSession();
+
+            const events = await readAllRecordedEvents(harness.tmpDir);
+            const snap = events.find(e => e.type === 'configurationSnapshot') as ConfigurationSnapshotEvent | undefined;
+            assert.ok(snap, 'configurationSnapshot missing — startup contributor not registered?');
+            assert.strictEqual(snap!.struggleDetectionEnabled, true);
+            assert.strictEqual(snap!.showInterventions, false);
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('configurationChange is recorded when the listener fires', async () => {
+        // Initial config: showInterventions=true. Listener caches that on construction.
+        const harness = await makeWiringHarness({ enabled: true, showInterventions: true, developerMode: false });
+        try {
+            await harness.recorder.startSession(42);
+            const listener = harness.capturedConfigListener();
+            assert.ok(listener, 'wireSessionRecorder did not register an onDidChangeConfiguration listener');
+
+            // Mutate the backing state; the configStub's get() will now return false.
+            harness.configState.showInterventions = false;
+            listener!({
+                affectsConfiguration: (k: string) => k === 'artemis.struggleDetection',
+            } as vscode.ConfigurationChangeEvent);
+
+            await harness.recorder.endSession();
+
+            const events = await readAllRecordedEvents(harness.tmpDir);
+            const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
+            assert.ok(change, 'configurationChange missing');
+            assert.deepStrictEqual(change!.changes, { showInterventions: false });
+        } finally {
+            await harness.dispose();
+        }
+    });
+});

--- a/extension/test/unit/services/telemetry/interventionService.test.ts
+++ b/extension/test/unit/services/telemetry/interventionService.test.ts
@@ -566,17 +566,18 @@ suite('Block C — TelemetryManager dispatch routing', () => {
 suite('InterventionService.hideHint() — full status-bar reset', () => {
     let svc: InterventionService;
     let statusBarItem: vscode.StatusBarItem;
-    let createStub: sinon.SinonStub;
+    let sandbox: sinon.SinonSandbox;
 
     setup(() => {
+        sandbox = sinon.createSandbox();
         statusBarItem = {
             text: '',
             tooltip: undefined,
             backgroundColor: undefined,
             command: undefined,
-            show: sinon.stub(),
-            hide: sinon.stub(),
-            dispose: sinon.stub(),
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            dispose: sandbox.stub(),
             alignment: vscode.StatusBarAlignment.Right,
             priority: 100,
             color: undefined,
@@ -584,13 +585,13 @@ suite('InterventionService.hideHint() — full status-bar reset', () => {
             id: 'mock',
             accessibilityInformation: undefined,
         } as unknown as vscode.StatusBarItem;
-        createStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem);
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem);
         svc = new InterventionService();
     });
 
     teardown(() => {
         svc.dispose();
-        createStub.restore();
+        sandbox.restore();
     });
 
     test('hideHint clears text, tooltip, and backgroundColor', () => {

--- a/extension/test/unit/services/telemetry/interventionService.test.ts
+++ b/extension/test/unit/services/telemetry/interventionService.test.ts
@@ -21,6 +21,7 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { InterventionService } from '../../../../src/extension/services/telemetry/interventionService';
 import { InterventionDecisionEngine } from '../../../../src/extension/services/telemetry/decision/interventionDecisionEngine';
 import { InterventionFilter } from '../../../../src/extension/services/telemetry/interventionFilter';
@@ -559,5 +560,49 @@ suite('Block C — TelemetryManager dispatch routing', () => {
 
         assert.strictEqual(blocks.length, 1);
         assert.strictEqual(blocks[0].blockedReason, 'low-confidence');
+    });
+});
+
+suite('InterventionService.hideHint() — full status-bar reset', () => {
+    let svc: InterventionService;
+    let statusBarItem: vscode.StatusBarItem;
+    let createStub: sinon.SinonStub;
+
+    setup(() => {
+        statusBarItem = {
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+            show: sinon.stub(),
+            hide: sinon.stub(),
+            dispose: sinon.stub(),
+            alignment: vscode.StatusBarAlignment.Right,
+            priority: 100,
+            color: undefined,
+            name: undefined,
+            id: 'mock',
+            accessibilityInformation: undefined,
+        } as unknown as vscode.StatusBarItem;
+        createStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem);
+        svc = new InterventionService();
+    });
+
+    teardown(() => {
+        svc.dispose();
+        createStub.restore();
+    });
+
+    test('hideHint clears text, tooltip, and backgroundColor', () => {
+        // Simulate state left behind by a notification/proactive flow.
+        statusBarItem.text = '$(warning) Help available!';
+        statusBarItem.tooltip = 'EQ: 80% — Iris detected struggle';
+        statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+
+        svc.hideHint();
+
+        assert.strictEqual(statusBarItem.text, '');
+        assert.strictEqual(statusBarItem.tooltip, undefined);
+        assert.strictEqual(statusBarItem.backgroundColor, undefined);
     });
 });

--- a/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
@@ -16,7 +16,12 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { SessionRecorder } from '../../../../../src/extension/services/telemetry/recording/sessionRecorder';
-import type { RecordedEvent } from '../../../../../src/extension/services/telemetry/recording/types';
+import type {
+    RecordedEvent,
+    InterventionEvent,
+    ConfigurationSnapshotEvent,
+    ConfigurationChangeEvent,
+} from '../../../../../src/extension/services/telemetry/recording/types';
 import { RecordingStorageWriter } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
 import type { RecordingFs } from '../../../../../src/extension/services/telemetry/recording/storageWriter';
 
@@ -814,5 +819,55 @@ suite('SessionRecorder (Block AB+E)', () => {
         const vrEvents = events.filter(e => e.type === 'visibleRangeChange' && (e as { uri?: string }).uri === uri);
         assert.strictEqual(vrEvents.length, 0,
             'pending visibleRangeChange must be discarded (not flushed) when consent is revoked via disable()');
+    });
+});
+
+suite('SessionRecorder — intervention suppression and configuration provenance', () => {
+    test('recordIntervention with suppressed action persists suppressionReason', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordIntervention(
+            'suppressed', 'notification', true, 0.55, 'sufficient', 'execution-error',
+            { suppressionReason: 'user-disabled', rawWanted: true },
+        );
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const intervention = events.find(e => e.type === 'intervention') as InterventionEvent | undefined;
+        assert.ok(intervention, 'intervention event missing');
+        assert.strictEqual(intervention!.action, 'suppressed');
+        assert.strictEqual(intervention!.shouldIntervene, true);
+        assert.strictEqual(intervention!.suppressionReason, 'user-disabled');
+        assert.strictEqual(intervention!.rawWanted, true);
+        assert.strictEqual(intervention!.level, 'notification');
+        assert.strictEqual(intervention!.triggerType, 'execution-error');
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationSnapshot persists both keys', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationSnapshot(true, false);
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const snap = events.find(e => e.type === 'configurationSnapshot') as ConfigurationSnapshotEvent | undefined;
+        assert.ok(snap, 'configurationSnapshot missing');
+        assert.strictEqual(snap!.struggleDetectionEnabled, true);
+        assert.strictEqual(snap!.showInterventions, false);
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    test('recordConfigurationChange persists only the changed key', async () => {
+        const { recorder, fs } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(42);
+        recorder.recordConfigurationChange({ showInterventions: false });
+        await recorder.endSession();
+        const events = collectWrittenEvents(fs);
+        const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
+        assert.ok(change, 'configurationChange missing');
+        assert.deepStrictEqual(change!.changes, { showInterventions: false });
+        try { await recorder.dispose(); } catch { /* ignore */ }
     });
 });

--- a/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
@@ -29,9 +29,9 @@ interface ConfigStubValues {
     developerMode?: boolean;
 }
 
-function stubGetConfiguration(values: ConfigStubValues): sinon.SinonStub {
+function stubGetConfiguration(sandbox: sinon.SinonSandbox, values: ConfigStubValues): sinon.SinonStub {
     const original = vscode.workspace.getConfiguration;
-    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+    return sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
         const cfg = original.call(vscode.workspace, section);
         return {
             ...cfg,
@@ -89,10 +89,8 @@ function driveEligibleDecision(
 
 suite('TelemetryManager — intervention UI toggle', () => {
     let sandbox: sinon.SinonSandbox;
-    let getConfigStub: sinon.SinonStub | undefined;
     let showInfoStub: sinon.SinonStub;
     let showWarnStub: sinon.SinonStub;
-    let createStatusBarStub: sinon.SinonStub;
     let statusBarItem: { show: sinon.SinonStub; hide: sinon.SinonStub; dispose: sinon.SinonStub; text: string; tooltip: string | undefined; backgroundColor: vscode.ThemeColor | undefined; command: string | undefined };
 
     setup(() => {
@@ -106,19 +104,32 @@ suite('TelemetryManager — intervention UI toggle', () => {
             backgroundColor: undefined,
             command: undefined,
         };
-        createStatusBarStub = sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
         showInfoStub = sandbox.stub(vscode.window, 'showInformationMessage');
         showWarnStub = sandbox.stub(vscode.window, 'showWarningMessage');
     });
 
     teardown(() => {
-        getConfigStub?.restore();
-        getConfigStub = undefined;
         sandbox.restore();
     });
 
+    /**
+     * Re-stubbing `vscode.workspace.getConfiguration` requires restoring the
+     * existing stub first; sinon throws "already wrapped" otherwise. The
+     * sandbox itself doesn't allow targeted restore, so we walk its fakes to
+     * find the active getConfiguration wrap and restore just that one.
+     */
+    function reStubGetConfiguration(values: ConfigStubValues): void {
+        const desc = Object.getOwnPropertyDescriptor(vscode.workspace, 'getConfiguration');
+        const current = desc?.value as { restore?: () => void } | undefined;
+        if (current?.restore) {
+            current.restore();
+        }
+        stubGetConfiguration(sandbox, values);
+    }
+
     test('T1: toggle off → suppression event fires; no show/block events', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
         const suppressed: SuppressedInterventionPayload[] = [];
         const shown: InterventionDecision[] = [];
@@ -139,7 +150,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T2: toggle off → no UI surface calls', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
 
         driveEligibleDecision(tm, { level: 'subtle' });
@@ -153,7 +164,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T3: toggle off → UI-delivery state does not advance', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
 
         for (let i = 0; i < 5; i++) {
@@ -170,7 +181,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T4: toggle off → suppression events are not rate-limited', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
         const captured: SuppressedInterventionPayload[] = [];
         tm.onDidSuppressIntervention(payload => captured.push(payload));
@@ -184,7 +195,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T5: toggle off → onDidCalculateEQ still fires for the trigger', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
         const eqEvents: unknown[] = [];
         tm.onDidCalculateEQ(e => eqEvents.push(e));
@@ -196,7 +207,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T6: toggle on (default) → no suppression event; show path runs', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        stubGetConfiguration(sandbox, { showInterventions: true });
         const tm = new TelemetryManager();
         const captured: SuppressedInterventionPayload[] = [];
         tm.onDidSuppressIntervention(payload => captured.push(payload));
@@ -209,7 +220,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T7: live-toggle on→off with subtle visible → hideHint called; dismiss reason hidden', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        stubGetConfiguration(sandbox, { showInterventions: true });
         const tm = new TelemetryManager();
 
         driveEligibleDecision(tm, { level: 'subtle' });
@@ -221,8 +232,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
         // fake ConfigurationChangeEvent: TelemetryManager re-runs
         // _loadConfiguration unconditionally on a matching event, so calling
         // it directly is equivalent and avoids brittle event mocking.
-        getConfigStub.restore();
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        reStubGetConfiguration({ showInterventions: false });
         (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
 
         assert.strictEqual(statusBarItem.hide.callCount >= 1, true, 'statusBarItem.hide expected on transition');
@@ -232,15 +242,14 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T8: live-toggle off→on → no spurious events', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        stubGetConfiguration(sandbox, { showInterventions: false });
         const tm = new TelemetryManager();
         const suppressed: SuppressedInterventionPayload[] = [];
         const dismissals: unknown[] = [];
         tm.onDidSuppressIntervention(p => suppressed.push(p));
         tm.onDidDismissIntervention(p => dismissals.push(p));
 
-        getConfigStub.restore();
-        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        reStubGetConfiguration({ showInterventions: true });
         (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
 
         assert.strictEqual(suppressed.length, 0);
@@ -249,7 +258,7 @@ suite('TelemetryManager — intervention UI toggle', () => {
     });
 
     test('T9: type guard — non-boolean setting falls back to true', () => {
-        getConfigStub = stubGetConfiguration({ showInterventions: 'not-a-boolean' });
+        stubGetConfiguration(sandbox, { showInterventions: 'not-a-boolean' });
         const tm = new TelemetryManager();
 
         const internal = tm as unknown as { _showInterventions: boolean };

--- a/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the artemis.struggleDetection.showInterventions toggle.
+ *
+ * Covers:
+ *  T1. Toggle off → onDidSuppressIntervention fires once (decision unchanged);
+ *      onDidShowIntervention and onDidBlockIntervention do NOT fire.
+ *  T2. Toggle off → no calls to vscode.window.show*Message or statusBarItem.show.
+ *  T3. Toggle off → UI-delivery state does not advance.
+ *  T4. Toggle off → suppression events are NOT rate-limited.
+ *  T5. Toggle off → onDidCalculateEQ still fires.
+ *  T6. Toggle on (default) → existing show path runs; no suppression event.
+ *  T7. Live-toggle on→off with subtle visible → hideHint called; dismiss reason 'hidden'.
+ *  T8. Live-toggle off→on → no spurious events.
+ *  T9. Setting type guard: non-boolean falls back to true.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { TelemetryManager } from '../../../../src/extension/services/telemetry/telemetryManager';
+import type {
+    InterventionDecision,
+    SuppressedInterventionPayload,
+} from '../../../../src/extension/services/telemetry/types';
+
+interface ConfigStubValues {
+    enabled?: boolean;
+    showInterventions?: unknown;
+    developerMode?: boolean;
+}
+
+function stubGetConfiguration(values: ConfigStubValues): sinon.SinonStub {
+    const original = vscode.workspace.getConfiguration;
+    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+        const cfg = original.call(vscode.workspace, section);
+        return {
+            ...cfg,
+            get: <T>(key: string, defaultValue?: T): T => {
+                if (section === 'artemis.struggleDetection' && key === 'enabled') {
+                    return (values.enabled ?? true) as unknown as T;
+                }
+                if (section === 'artemis.struggleDetection' && key === 'showInterventions') {
+                    return (values.showInterventions ?? true) as unknown as T;
+                }
+                if (section === 'artemis' && key === 'developerMode') {
+                    return (values.developerMode ?? false) as unknown as T;
+                }
+                return defaultValue as T;
+            },
+            inspect: cfg.inspect.bind(cfg),
+            update: cfg.update.bind(cfg),
+            has: cfg.has.bind(cfg),
+        } as unknown as vscode.WorkspaceConfiguration;
+    });
+}
+
+/**
+ * Drive a synthetic eligible decision through TelemetryManager._evaluateAndIntervene.
+ * Uses a controlled private accessor since _evaluateAndIntervene is private and
+ * trigger-emitter wiring would couple this test to unrelated subsystems.
+ *
+ * Whitebox brittleness: depends on private field/method names
+ * `_decisionEngine` and `_evaluateAndIntervene`.
+ */
+function driveEligibleDecision(
+    tm: TelemetryManager,
+    overrides: Partial<InterventionDecision> = {},
+): void {
+    type Internal = {
+        _evaluateAndIntervene(triggerType: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained'): void;
+        _decisionEngine: { evaluate: (...args: unknown[]) => InterventionDecision };
+    };
+    const internal = tm as unknown as Internal;
+    const stub = sinon.stub(internal._decisionEngine, 'evaluate').returns({
+        rawWanted: true,
+        shouldIntervene: true,
+        level: 'subtle',
+        triggerType: 'execution-error',
+        eq: 0.5,
+        confidence: 'sufficient',
+        ...overrides,
+    });
+    try {
+        internal._evaluateAndIntervene('execution-error');
+    } finally {
+        stub.restore();
+    }
+}
+
+suite('TelemetryManager — intervention UI toggle', () => {
+    let getConfigStub: sinon.SinonStub | undefined;
+    let showInfoStub: sinon.SinonStub;
+    let showWarnStub: sinon.SinonStub;
+    let createStatusBarStub: sinon.SinonStub;
+    let statusBarItem: { show: sinon.SinonStub; hide: sinon.SinonStub; dispose: sinon.SinonStub; text: string; tooltip: string | undefined; backgroundColor: vscode.ThemeColor | undefined; command: string | undefined };
+
+    setup(() => {
+        statusBarItem = {
+            show: sinon.stub(),
+            hide: sinon.stub(),
+            dispose: sinon.stub(),
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+        };
+        createStatusBarStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        showInfoStub = sinon.stub(vscode.window, 'showInformationMessage');
+        showWarnStub = sinon.stub(vscode.window, 'showWarningMessage');
+    });
+
+    teardown(() => {
+        getConfigStub?.restore();
+        getConfigStub = undefined;
+        showInfoStub.restore();
+        showWarnStub.restore();
+        createStatusBarStub.restore();
+    });
+
+    test('T1: toggle off → suppression event fires; no show/block events', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const suppressed: SuppressedInterventionPayload[] = [];
+        const shown: InterventionDecision[] = [];
+        const blocked: unknown[] = [];
+        tm.onDidSuppressIntervention(payload => suppressed.push(payload));
+        tm.onDidShowIntervention(d => shown.push(d));
+        tm.onDidBlockIntervention(p => blocked.push(p));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(suppressed.length, 1, 'expected exactly one suppression event');
+        assert.strictEqual(suppressed[0].reason, 'user-disabled');
+        assert.strictEqual(suppressed[0].decision.shouldIntervene, true, 'decision.shouldIntervene must be preserved as true');
+        assert.strictEqual(suppressed[0].decision.level, 'subtle');
+        assert.strictEqual(shown.length, 0, 'onDidShowIntervention must not fire when suppressed');
+        assert.strictEqual(blocked.length, 0, 'onDidBlockIntervention must not fire when suppressed');
+        tm.dispose();
+    });
+
+    test('T2: toggle off → no UI surface calls', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+        driveEligibleDecision(tm, { level: 'notification' });
+        driveEligibleDecision(tm, { level: 'proactive' });
+
+        assert.strictEqual(showInfoStub.callCount, 0, 'showInformationMessage was called');
+        assert.strictEqual(showWarnStub.callCount, 0, 'showWarningMessage was called');
+        assert.strictEqual(statusBarItem.show.callCount, 0, 'statusBarItem.show was called');
+        tm.dispose();
+    });
+
+    test('T3: toggle off → UI-delivery state does not advance', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+
+        for (let i = 0; i < 5; i++) {
+            driveEligibleDecision(tm, { level: 'notification' });
+        }
+
+        const internal = tm as unknown as { _interventionService: { getState(): { lastInterventionTime: number; sessionInterventionCount: number; lastDismissed: boolean; lastAccepted: boolean } } };
+        const state = internal._interventionService.getState();
+        assert.strictEqual(state.lastInterventionTime, 0, 'lastInterventionTime advanced');
+        assert.strictEqual(state.sessionInterventionCount, 0, 'sessionInterventionCount advanced');
+        assert.strictEqual(state.lastDismissed, false);
+        assert.strictEqual(state.lastAccepted, false);
+        tm.dispose();
+    });
+
+    test('T4: toggle off → suppression events are not rate-limited', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const captured: SuppressedInterventionPayload[] = [];
+        tm.onDidSuppressIntervention(payload => captured.push(payload));
+
+        for (let i = 0; i < 5; i++) {
+            driveEligibleDecision(tm, { level: 'notification' });
+        }
+
+        assert.strictEqual(captured.length, 5);
+        tm.dispose();
+    });
+
+    test('T5: toggle off → onDidCalculateEQ still fires for the trigger', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const eqEvents: unknown[] = [];
+        tm.onDidCalculateEQ(e => eqEvents.push(e));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(eqEvents.length >= 1, true, 'onDidCalculateEQ must fire for trigger evaluation even when UI suppressed');
+        tm.dispose();
+    });
+
+    test('T6: toggle on (default) → no suppression event; show path runs', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        const tm = new TelemetryManager();
+        const captured: SuppressedInterventionPayload[] = [];
+        tm.onDidSuppressIntervention(payload => captured.push(payload));
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+
+        assert.strictEqual(captured.length, 0);
+        assert.strictEqual(statusBarItem.show.callCount >= 1, true, 'statusBarItem.show should fire for subtle path');
+        tm.dispose();
+    });
+
+    test('T7: live-toggle on→off with subtle visible → hideHint called; dismiss reason hidden', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        const tm = new TelemetryManager();
+
+        driveEligibleDecision(tm, { level: 'subtle' });
+        const dismissals: Array<{ dismissReason: string }> = [];
+        tm.onDidDismissIntervention(payload => dismissals.push(payload));
+
+        // Flip the stubbed config, then re-trigger configuration loading.
+        // We invoke _loadConfiguration directly (whitebox) instead of firing a
+        // fake ConfigurationChangeEvent: TelemetryManager re-runs
+        // _loadConfiguration unconditionally on a matching event, so calling
+        // it directly is equivalent and avoids brittle event mocking.
+        getConfigStub.restore();
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
+
+        assert.strictEqual(statusBarItem.hide.callCount >= 1, true, 'statusBarItem.hide expected on transition');
+        assert.strictEqual(dismissals.length, 1, 'expected exactly one dismiss event');
+        assert.strictEqual(dismissals[0].dismissReason, 'hidden');
+        tm.dispose();
+    });
+
+    test('T8: live-toggle off→on → no spurious events', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: false });
+        const tm = new TelemetryManager();
+        const suppressed: SuppressedInterventionPayload[] = [];
+        const dismissals: unknown[] = [];
+        tm.onDidSuppressIntervention(p => suppressed.push(p));
+        tm.onDidDismissIntervention(p => dismissals.push(p));
+
+        getConfigStub.restore();
+        getConfigStub = stubGetConfiguration({ showInterventions: true });
+        (tm as unknown as { _loadConfiguration(): void })._loadConfiguration();
+
+        assert.strictEqual(suppressed.length, 0);
+        assert.strictEqual(dismissals.length, 0);
+        tm.dispose();
+    });
+
+    test('T9: type guard — non-boolean setting falls back to true', () => {
+        getConfigStub = stubGetConfiguration({ showInterventions: 'not-a-boolean' });
+        const tm = new TelemetryManager();
+
+        const internal = tm as unknown as { _showInterventions: boolean };
+        assert.strictEqual(internal._showInterventions, true);
+        tm.dispose();
+    });
+});

--- a/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
@@ -88,6 +88,7 @@ function driveEligibleDecision(
 }
 
 suite('TelemetryManager — intervention UI toggle', () => {
+    let sandbox: sinon.SinonSandbox;
     let getConfigStub: sinon.SinonStub | undefined;
     let showInfoStub: sinon.SinonStub;
     let showWarnStub: sinon.SinonStub;
@@ -95,26 +96,25 @@ suite('TelemetryManager — intervention UI toggle', () => {
     let statusBarItem: { show: sinon.SinonStub; hide: sinon.SinonStub; dispose: sinon.SinonStub; text: string; tooltip: string | undefined; backgroundColor: vscode.ThemeColor | undefined; command: string | undefined };
 
     setup(() => {
+        sandbox = sinon.createSandbox();
         statusBarItem = {
-            show: sinon.stub(),
-            hide: sinon.stub(),
-            dispose: sinon.stub(),
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            dispose: sandbox.stub(),
             text: '',
             tooltip: undefined,
             backgroundColor: undefined,
             command: undefined,
         };
-        createStatusBarStub = sinon.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
-        showInfoStub = sinon.stub(vscode.window, 'showInformationMessage');
-        showWarnStub = sinon.stub(vscode.window, 'showWarningMessage');
+        createStatusBarStub = sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        showInfoStub = sandbox.stub(vscode.window, 'showInformationMessage');
+        showWarnStub = sandbox.stub(vscode.window, 'showWarningMessage');
     });
 
     teardown(() => {
         getConfigStub?.restore();
         getConfigStub = undefined;
-        showInfoStub.restore();
-        showWarnStub.restore();
-        createStatusBarStub.restore();
+        sandbox.restore();
     });
 
     test('T1: toggle off → suppression event fires; no show/block events', () => {


### PR DESCRIPTION
## Summary
- Adds **\`artemis.struggleDetection.showInterventions\`** (boolean, default \`true\`). When \`false\`, all intervention UI surfaces (subtle hint, notification, proactive popup) are suppressed while the telemetry pipeline keeps running unchanged.
- Suppressed decisions are recorded as \`{type:"intervention", action:"suppressed", suppressionReason:"user-disabled", rawWanted:true}\` so sessions remain control/treatment-classifiable for evaluation.
- Live-toggle: flipping \`on→off\` while a subtle hint is visible calls \`hideHint()\` with \`dismissReason:"hidden"\`.
- Each session emits a \`configurationSnapshot\` event before \`startupPhaseComplete\`, plus \`configurationChange\` events when the listener fires (diff-only payload).

## Implementation
- **Setting + constants** — \`package.json\`, \`SHOW_INTERVENTIONS_KEY\`
- **Telemetry layer** — \`InterventionSuppressionReason\`, \`SuppressedInterventionPayload\`, \`onDidSuppressIntervention\` emitter, gate in \`_evaluateAndIntervene\`, live-transition logic in \`_loadConfiguration\`
- **Recording layer** — new \`'suppressed'\` action variant, \`configurationSnapshot\` + \`configurationChange\` event types, \`recordConfigurationChange()\` API
- **Activation/wiring** — \`sessionRecorderWiring\` subscribes to suppression event, registers startup contributor for snapshot, listens to \`onDidChangeConfiguration\` with diff detection
- **Bugfix** — \`InterventionService.hideHint()\` now resets \`text\`/\`tooltip\`/\`backgroundColor\` (was leaving ghost state)

## Test plan
- [x] \`npm run check-types\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:unit\` — 718/718 passing (T1-T9 toggle scenarios + 3 wiring integration tests + recorder unit tests)
- [x] **Manual smoke test in Extension Development Host:**
  - [x] Setting visible in Settings UI with default \`true\`
  - [x] Default ON: status-bar lightbulb + proactive notification fire as before
  - [x] Toggle OFF: \`Intervention UI suppressed by user setting\` logged, no UI appears even with EQ=0.93 and triggers firing
  - [x] Recording shows \`configurationSnapshot\` with \`showInterventions:false\` and 2 \`action:"suppressed"\` events (idle + selection-maintained triggers, both \`level:"proactive"\`, \`rawWanted:true\`)

## Spec / plan
- \`docs/superpowers/specs/2026-04-28-intervention-ui-toggle-design.md\`
- \`docs/superpowers/plans/2026-04-28-intervention-ui-toggle.md\`