### PR TITLE
Revert "refactor(theia): drop printenv fallback (#118)"

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -11,7 +11,7 @@ import { ExerciseRegistry } from './extension/services/exerciseRegistry';
 import { CourseDataCache } from './extension/services/courseDataCache';
 import { createProviderRegistry } from './extension/services/ui';
 import { logger, LogCategory } from './extension/services/loggingService';
-import { VSCODE_CONFIG } from './extension/utils';
+import { VSCODE_CONFIG, resolveServerUrl } from './extension/utils';
 import { registerAllCommands } from './extension/activation/extensionCommands';
 import { wireSessionRecorder } from './extension/activation/sessionRecorderWiring';
 import { initializeTheiaContext, detectPlatformCapabilities, authenticateFromEnvironment, autoCloneIfNeeded } from './extension/theia';
@@ -155,15 +155,25 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// 401 handler: environment-aware auth teardown
 	if (theiaEnv.isTheia) {
-		// Theia tool tokens have a fixed 1-day lifetime and the operator
-		// injects credentials only once at session boot, so a 401 means the
-		// session is unrecoverable from inside the extension. Direct the
-		// student back to "Open Online IDE" to start a fresh session.
-		artemisApiService.onAuthExpired = () => {
-			void updateAuthContext(false);
-			vscode.window.showErrorMessage(
-				'Your session has expired. Please restart your workspace to re-authenticate.'
-			);
+		// Theia: attempt to re-read token from environment (orchestrator may have refreshed it)
+		artemisApiService.onAuthExpired = async () => {
+			const { readEnvVar } = await import('./extension/theia/index.js');
+			const freshToken = await readEnvVar('ARTEMIS_TOKEN');
+			const currentToken = await authManager.getStoredTokenValue();
+			if (freshToken && freshToken !== currentToken) {
+				logger.info('Theia token refreshed from environment, re-authenticating', LogCategory.AUTH);
+				const freshUrl = await readEnvVar('ARTEMIS_URL');
+				await authManager.storeArtemisCredentials(freshToken, freshUrl || resolveServerUrl(), false);
+				artemisApiService.resetAuthExpiredGuard();
+				void artemisWebsocketService.connect().catch(error => {
+					logger.error('WebSocket reconnect after token refresh failed', LogCategory.WEBSOCKET, error);
+				});
+			} else {
+				void updateAuthContext(false);
+				vscode.window.showErrorMessage(
+					'Your session has expired. Please restart your workspace to re-authenticate.'
+				);
+			}
 		};
 	} else {
 		// VS Code: interactive re-authentication via sidebar

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -595,9 +595,22 @@ function registerShowTheiaEnvironmentCommand(): vscode.Disposable {
         const theiaFlag = process.env.THEIA;
         const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
 
-        // Render an env-var value safely: tokens reduced to length, git URIs
-        // reduced to host+path so embedded credentials never leak into the UI.
-        const formatEnvValue = (key: string, value: string | undefined): string => {
+        const mask = (v: string | undefined): string =>
+            v ? `present (${v.length} chars)` : 'missing';
+
+        const gitUriDisplay = ((): string => {
+            if (!env.gitUri) { return 'missing'; }
+            try {
+                const u = new URL(env.gitUri);
+                return `present (host: ${u.host}, path: ${u.pathname})`;
+            } catch {
+                return 'present (unparseable)';
+            }
+        })();
+
+        const probe = await probeDataBridge();
+
+        const formatBridgeValue = (key: string, value: string | undefined): string => {
             if (!value) { return 'missing'; }
             if (key === 'ARTEMIS_TOKEN') { return `present (${value.length} chars)`; }
             if (key === 'GIT_URI') {
@@ -610,8 +623,6 @@ function registerShowTheiaEnvironmentCommand(): vscode.Disposable {
             }
             return value;
         };
-
-        const probe = await probeDataBridge();
 
         const probeLines: string[] = ['', '## Live data-bridge probe'];
         if (!probe.commandAvailable) {
@@ -632,7 +643,7 @@ function registerShowTheiaEnvironmentCommand(): vscode.Disposable {
                 `- Keys present in bridge: ${presentCount}/${KNOWN_BRIDGE_KEYS.length}`,
             );
             for (const key of KNOWN_BRIDGE_KEYS) {
-                probeLines.push(`- \`${key}\`: ${formatEnvValue(key, probe.values[key])}`);
+                probeLines.push(`- \`${key}\`: ${formatBridgeValue(key, probe.values[key])}`);
             }
         }
 
@@ -648,11 +659,11 @@ function registerShowTheiaEnvironmentCommand(): vscode.Disposable {
             `- \`process.env.THEIA\`: ${theiaFlag ?? '(unset)'}`,
             ``,
             `## Environment variables (snapshot at activation)`,
-            `- \`ARTEMIS_URL\`: ${formatEnvValue('ARTEMIS_URL', env.artemisUrl)}`,
-            `- \`ARTEMIS_TOKEN\`: ${formatEnvValue('ARTEMIS_TOKEN', env.artemisToken)}`,
-            `- \`GIT_URI\`: ${formatEnvValue('GIT_URI', env.gitUri)}`,
-            `- \`GIT_USER\`: ${formatEnvValue('GIT_USER', env.gitUser)}`,
-            `- \`GIT_MAIL\`: ${formatEnvValue('GIT_MAIL', env.gitMail)}`,
+            `- \`ARTEMIS_URL\`: ${env.artemisUrl ?? 'missing'}`,
+            `- \`ARTEMIS_TOKEN\`: ${mask(env.artemisToken)}`,
+            `- \`GIT_URI\`: ${gitUriDisplay}`,
+            `- \`GIT_USER\`: ${env.gitUser ?? 'missing'}`,
+            `- \`GIT_MAIL\`: ${env.gitMail ?? 'missing'}`,
             ...probeLines,
             ``,
             `## Workspace`,

--- a/extension/src/extension/theia/dataBridgeReader.ts
+++ b/extension/src/extension/theia/dataBridgeReader.ts
@@ -40,9 +40,8 @@ type KnownBridgeKey = (typeof KNOWN_BRIDGE_KEYS)[number];
  * data, which would cause a 10s blocking poll on every startup.
  *
  * Polls every 500ms until all requested keys are present, with a 10s timeout.
- * Returns `undefined` if data-bridge is unavailable or times out — the caller
- * treats this as "not running in Theia/EduIDE" and falls back to the
- * non-Theia default environment.
+ * Returns `undefined` if data-bridge is unavailable or times out, signaling
+ * the caller to fall back to process env reading.
  *
  * Pattern adapted from Scorpio's DataBridgeStrategy (env-strategy.ts).
  */
@@ -96,7 +95,7 @@ export async function readEnvVarsViaDataBridge<T extends string>(
     }
 
     logger.warn(
-        'DataBridge: timeout waiting for environment variables, treating session as non-Theia',
+        'DataBridge: timeout waiting for environment variables, falling back to process env',
         LogCategory.GENERAL,
     );
     return undefined;

--- a/extension/src/extension/theia/envVarReader.ts
+++ b/extension/src/extension/theia/envVarReader.ts
@@ -1,0 +1,45 @@
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+
+const execFileAsync = promisify(execFile);
+
+const ENV_READ_TIMEOUT_MS = 5_000;
+
+/**
+ * Reads an environment variable reliably across VS Code and Theia.
+ *
+ * In some Theia deployments, `process.env` is not populated with the host
+ * environment variables (Scorpio issue #124). This function uses `printenv`
+ * via child_process as the primary method and falls back to `process.env`.
+ */
+export async function readEnvVar(name: string): Promise<string | undefined> {
+    // Validate name to prevent command injection
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+        return undefined;
+    }
+
+    try {
+        const { stdout } = await execFileAsync('printenv', [name], {
+            timeout: ENV_READ_TIMEOUT_MS,
+        });
+        const value = stdout.trim();
+        return value || undefined;
+    } catch {
+        // printenv returns exit code 1 when the variable is not set,
+        // or may fail entirely — fall back to process.env
+        return process.env[name] || undefined;
+    }
+}
+
+/**
+ * Reads multiple environment variables in parallel.
+ * Returns a record mapping variable names to their values (or undefined).
+ */
+export async function readEnvVars<T extends string>(
+    names: readonly T[],
+): Promise<Record<T, string | undefined>> {
+    const entries = await Promise.all(
+        names.map(async (name) => [name, await readEnvVar(name)] as const),
+    );
+    return Object.fromEntries(entries) as Record<T, string | undefined>;
+}

--- a/extension/src/extension/theia/index.ts
+++ b/extension/src/extension/theia/index.ts
@@ -1,6 +1,7 @@
 export type { PlatformCapabilities } from './types';
 export { initializeTheiaContext, getTheiaEnvironment } from './theiaEnvironment';
 export { detectPlatformCapabilities } from './featureDetection';
+export { readEnvVar } from './envVarReader';
 export { probeDataBridge, KNOWN_BRIDGE_KEYS } from './dataBridgeReader';
 export { authenticateFromEnvironment } from './theiaAuthProvider';
 export { cloneRepositoryProgrammatic, autoCloneIfNeeded } from './theiaCloneService';

--- a/extension/src/extension/theia/theiaAuthProvider.ts
+++ b/extension/src/extension/theia/theiaAuthProvider.ts
@@ -2,18 +2,15 @@ import type { AuthManager } from '../services/auth/authManager';
 import type { TheiaEnvironment } from './types';
 
 /**
- * Authenticates the extension using bridge-provided credentials in Theia/EduIDE.
+ * Authenticates the extension using environment-provided credentials in Theia/EduIDE.
  *
  * Called during activation, before any UI is shown or interactive login is attempted.
- * The token is the raw JWT delivered by the EduIDE data-bridge — issued by Artemis
- * from the student's web session as a tool token (currently `tools: "SCORPIO"`,
- * see ls1intum/Artemis#12394 for the upcoming `ARTEMIS_EXTENSION` variant) and
- * capped at one day of validity.
- *
- * Stored in memory only (`persist=false`) because the token is ephemeral and the
- * bridge re-delivers it on every session boot.
+ * The token is the raw JWT from the ARTEMIS_TOKEN env var.
+ * Stored in memory only (persist=false) because ENV tokens are ephemeral.
  *
  * This follows the pattern established by Scorpio (Jandow 2024, Section 4.4.2).
+ * The Theia token is generated server-side by Artemis from the user's web session
+ * and has restricted scope (tools: "THEIA") with limited lifetime.
  */
 export async function authenticateFromEnvironment(
     authManager: AuthManager,

--- a/extension/src/extension/theia/theiaEnvironment.ts
+++ b/extension/src/extension/theia/theiaEnvironment.ts
@@ -1,10 +1,11 @@
+import * as vscode from 'vscode';
+import { readEnvVars } from './envVarReader';
 import { readEnvVarsViaDataBridge } from './dataBridgeReader';
 import { VSCODE_ENVIRONMENT, type TheiaEnvironment } from './types';
 
 /**
  * Environment variable names used for Theia/EduIDE integration.
- * The EduIDE operator POSTs these to the data-bridge after pod boot;
- * the bridge then exposes them via the `dataBridge.getEnv` command.
+ * These are set by the EduIDE container orchestrator before extension activation.
  */
 const THEIA_ENV_VARS = [
     'ARTEMIS_URL',
@@ -43,19 +44,36 @@ export function getTheiaEnvironment(): TheiaEnvironment {
  * Detects whether the extension is running inside a Theia-based IDE
  * and reads all relevant environment variables.
  *
- * The data-bridge is the sole source of truth: in EduIDE deployments the
- * orchestrator POSTs credentials into the bridge after pod boot, and the
- * bridge command is only registered when its activation gate
- * (`DATA_BRIDGE_ENABLED=1`) is set. On regular VS Code Desktop neither is
- * true, so the call returns undefined and detection cleanly resolves to
- * the non-Theia default.
+ * Detection uses functional prerequisites (presence of specific env vars)
+ * combined with a secondary UI-kind check to prevent false positives when
+ * a developer accidentally has ARTEMIS_URL in their shell profile.
+ *
+ * This function is async because env var reading may require exec() in
+ * Theia environments where process.env is unreliable.
  */
 async function detectTheiaEnvironment(): Promise<TheiaEnvironment> {
-    const env = await readEnvVarsViaDataBridge(THEIA_ENV_VARS);
+    // Try data-bridge first (EduIDE cloud deployments with late-arriving credentials).
+    // Returns undefined immediately if data-bridge extension is not installed (no overhead).
+    // Falls back to process env if data-bridge is unavailable or times out.
+    const env = await readEnvVarsViaDataBridge(THEIA_ENV_VARS)
+        ?? await readEnvVars(THEIA_ENV_VARS);
 
-    if (!env || !(env.ARTEMIS_TOKEN || env.ARTEMIS_URL)) {
+    const hasTheiaEnvVars = !!(env.ARTEMIS_TOKEN || env.ARTEMIS_URL);
+    const isWebUI = vscode.env.uiKind === vscode.UIKind.Web;
+    const dataBridgeEnabled = process.env.DATA_BRIDGE_ENABLED === '1'
+        || process.env.DATA_BRIDGE_ENABLED === 'true';
+
+    // Env vars alone in Desktop mode are likely accidental (e.g., shell profile).
+    // Require either a web UI host (Theia) or the DATA_BRIDGE_ENABLED flag
+    // (set by the EduIDE container orchestrator at boot).
+    const isTheia = hasTheiaEnvVars && (isWebUI || dataBridgeEnabled);
+
+    if (!isTheia) {
         return VSCODE_ENVIRONMENT;
     }
+
+    // Managed environment requires both URL and token for full automation
+    const isManagedEnvironment = !!(env.ARTEMIS_URL && env.ARTEMIS_TOKEN);
 
     return Object.freeze({
         isTheia: true,
@@ -64,6 +82,6 @@ async function detectTheiaEnvironment(): Promise<TheiaEnvironment> {
         gitUri: env.GIT_URI,
         gitUser: env.GIT_USER,
         gitMail: env.GIT_MAIL,
-        isManagedEnvironment: !!(env.ARTEMIS_URL && env.ARTEMIS_TOKEN),
+        isManagedEnvironment,
     });
 }

--- a/extension/src/extension/theia/types.ts
+++ b/extension/src/extension/theia/types.ts
@@ -1,29 +1,25 @@
 /**
  * Immutable record describing the Theia/EduIDE environment.
- * Populated once during activation from the values delivered by the EduIDE
- * data-bridge (`dataBridge.getEnv`) and passed through the service graph.
+ * Detected once during activation and passed through the service graph.
  * When `isTheia` is false, all other fields are undefined.
  */
 export interface TheiaEnvironment {
     /** Whether the extension is running inside a Theia-based IDE (e.g. EduIDE). */
     readonly isTheia: boolean;
-    /** Artemis server URL (bridge key `ARTEMIS_URL`). */
+    /** Artemis server URL from ARTEMIS_URL environment variable. */
     readonly artemisUrl: string | undefined;
-    /**
-     * Raw JWT issued by Artemis as a tool token (bridge key `ARTEMIS_TOKEN`),
-     * sent as `Authorization: Bearer` on outgoing requests in Theia mode.
-     */
+    /** Pre-authenticated JWT cookie string from ARTEMIS_TOKEN environment variable. */
     readonly artemisToken: string | undefined;
-    /** Git clone URI (bridge key `GIT_URI`). */
+    /** Git clone URI from GIT_URI environment variable. */
     readonly gitUri: string | undefined;
-    /** Git user name (bridge key `GIT_USER`). */
+    /** Git user name from GIT_USER environment variable. */
     readonly gitUser: string | undefined;
-    /** Git user email (bridge key `GIT_MAIL`). */
+    /** Git user email from GIT_MAIL environment variable. */
     readonly gitMail: string | undefined;
     /**
-     * True when both `ARTEMIS_URL` and `ARTEMIS_TOKEN` arrived through the
-     * bridge, i.e. the deployment is fully managed. In managed mode,
-     * settings like server URL are locked and interactive login is bypassed.
+     * True when all required environment variables for a managed Theia deployment
+     * are present (ARTEMIS_URL + ARTEMIS_TOKEN). In managed mode, settings like
+     * server URL are locked and interactive login is bypassed.
      */
     readonly isManagedEnvironment: boolean;
 }


### PR DESCRIPTION
## Summary
Reverts #118 — merged prematurely without explicit user approval and before codex review. Re-opening the original change as a fresh PR after codex review passes.

This revert is mechanical (\`git revert 9877f1e3\`); it restores \`envVarReader.ts\` and the printenv fallback path verbatim.

## Test plan
- [x] \`npm run check-types\` — clean
- [x] \`npm run lint\` — clean