### PR TITLE
ci: bulletproof pipeline (parallel jobs, ci-gate, CODEOWNERS, security workflows)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for paths that form the CI / release trust boundary.
+# PRs touching these paths require approval from one of the listed admins.
+# Other PRs do not require a code-owner review.
+
+/.github/                       @krusche @FelixTJDietrich @Predixx
+/scripts/                       @krusche @FelixTJDietrich @Predixx
+/extension/package.json         @krusche @FelixTJDietrich @Predixx
+/extension/package-lock.json    @krusche @FelixTJDietrich @Predixx
+/CHANGELOG.md                   @krusche @FelixTJDietrich @Predixx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,43 +3,109 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [dev]
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:
     working-directory: extension
 
 jobs:
-  check:
-    name: TypeScript, Lint & Tests
+  typecheck:
+    name: Type check
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - run: npm run check-types
 
-      - name: Install dependencies
-        run: npm ci
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - run: npm run lint
 
-      - name: Type check
-        run: npm run check-types
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - run: npx vitest run
 
-      - name: Lint
-        run: npm run lint
+  knip:
+    name: Dead code (knip)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - run: npm run knip
 
-      - name: Tests
-        run: npx vitest run
+  build:
+    name: Build & VSIX package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - run: npm run package
+      - run: npx @vscode/vsce package --no-dependencies
 
-      - name: Dead code analysis
-        run: npm run knip
-
-      - name: Build extension
-        run: npm run package
-
-      - name: Package VSIX
-        run: npx @vscode/vsce package --no-dependencies
+  ci-gate:
+    name: CI gate
+    needs: [typecheck, lint, test, knip, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    if: always()
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "Job results: $NEEDS"
+          if echo "$NEEDS" | jq -e '[.[] | .result] | any(. != "success")' > /dev/null; then
+            echo "::error::One or more required CI jobs did not succeed"
+            exit 1
+          fi
+          echo "All CI jobs passed."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: github/codeql-action/init@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: never

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -5,7 +5,8 @@
     "src/webview/index.tsx",
     "test/**/*.{ts,tsx}",
     ".mocharc.ui.yml",
-    ".vscode-test.mjs"
+    ".vscode-test.mjs",
+    "esbuild.js"
   ],
   "project": [
     "src/**/*.{ts,tsx}",

--- a/extension/src/extension/theia/dataBridgeReader.ts
+++ b/extension/src/extension/theia/dataBridgeReader.ts
@@ -35,7 +35,7 @@ type KnownBridgeKey = (typeof KNOWN_BRIDGE_KEYS)[number];
  * broken EduIDE pod silently boot in Desktop-Cookie mode, which is the wrong
  * failure mode (auth would attempt the wrong scheme; auto-clone would not run).
  */
-export type ReadEnvResult<T extends string> =
+type ReadEnvResult<T extends string> =
     | { kind: 'no-bridge' }
     | { kind: 'success'; env: Record<T, string | undefined> }
     | { kind: 'failure'; reason: 'command-missing' | 'timeout' | 'invalid-response'; details?: string };


### PR DESCRIPTION
## Summary

First of two bootstrap PRs to make the CI pipeline tamper-proof. This one lands the new workflows + CODEOWNERS on `dev`. A second PR will mirror the same files onto `main`. After both are merged, branch protection on `main` and `dev` will be tightened to require the new `CI gate` check.

### What changes

- **`ci.yml`**: split the single sequential `check` job into 5 parallel jobs (`typecheck`, `lint`, `test`, `knip`, `build`) with per-job timeouts, plus a stable aggregator job named **`CI gate`** that explicitly verifies each `needs` result (refuses to pass on `skipped`/`cancelled`/`failed`). Pinned actions to SHA with version comments (Renovate-compatible). Locked default workflow permissions to `contents: read`. Added concurrency group that cancels superseded PR runs but never push runs to `dev`/`main`. Added `push` trigger for `main` so future merges produce the `CI gate` status check on `main`.
- **`dependency-review.yml`** (new): advisory check on PRs, fails on high-severity vulnerabilities introduced by the PR. `comment-summary-in-pr: never` keeps `permissions` minimal.
- **`codeql.yml`** (new): JavaScript/TypeScript security analysis on push to `main`/`dev`, on PRs to `main`, and weekly. Results in Security tab.
- **`CODEOWNERS`** (new): protects `.github/`, `/scripts/`, `package.json`, `package-lock.json`, `CHANGELOG.md` so workflow/release tampering requires admin approval. Normal code PRs still need 0 reviews.

### Why

Today the required status check on `main` is the job name `"TypeScript, Lint & Tests"`. Renaming the job silently breaks the gate, and the workflow file itself is editable in any PR with no review. Once branch protection is updated (next step, separate API call), the new `CI gate` is bound to `app_id: 15368` (GitHub Actions) and changes to workflow files require admin sign-off via CODEOWNERS.

### Out of scope

Deploy/release automation, `VSCE_PAT` migration, tag protection rules, the 267-commit `dev`<->`main` drift, Open VSX, marketplace publishing changes.

## Test plan

- [ ] All 5 parallel jobs (`typecheck`, `lint`, `test`, `knip`, `build`) run and pass on this PR
- [ ] `CI gate` job runs after them and reports green
- [ ] `Dependency Review` workflow runs and is green
- [ ] `CodeQL` workflow runs (only triggers on PRs to `main`, so will not run here -- will be exercised once on `main`)
- [ ] After merge: `CI gate` status check is observable on `dev`'s commit history (precondition for adding it to branch protection)