### PR TITLE
chore(changelog): promote Unreleased to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Artemis VS Code extension will be documented in this file.
 
-## [Unreleased]
+## [0.4.3] - 2026-05-10
 
 ### Added
 


### PR DESCRIPTION
Promotes the existing `[Unreleased]` heading to `[0.4.3] - 2026-05-10` so the release workflow's CHANGELOG verification passes. No content changes.