### PR TITLE
ci: opt JS actions into Node 24 (silence June 2026 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+# Opt JS actions into Node 24 ahead of GitHub's June 2026 default flip.
+# Drop this once the default flip happens and all third-party actions ship
+# Node-24-native versions.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   security-events: write
 
+# Opt JS actions into Node 24 ahead of GitHub's June 2026 default flip.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   analyze:
     name: Analyze JavaScript/TypeScript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+# Opt JS actions into Node 24 ahead of GitHub's June 2026 default flip.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   dependency-review:
     name: Review

--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -24,6 +24,12 @@ on:
 permissions:
   contents: read
 
+# Opt JS actions into Node 24 ahead of GitHub's June 2026 default flip.
+# Drop this once the default flip happens and all third-party actions ship
+# Node-24-native versions.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: release-openvsx
   cancel-in-progress: false


### PR DESCRIPTION
GitHub forces JS actions to Node 24 default on 2026-06-02. Several pinned actions still bundle Node 20 (checkout v4.3.1, setup-node v4.4.0, download-artifact v5.0.0). Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` workflow-level env var per GitHub's recommended early-opt-in path. Drop the env var in a follow-up after 2026-06-02.