### PR TITLE
chore(release): bump version to 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Artemis VS Code extension will be documented in this file.
 
+## [0.4.4] - 2026-05-10
+
+### Changed
+
+- Internal release pipeline: GitHub Actions workflow now publishes to both Open VSX Registry and VS Code Marketplace in parallel via a single `workflow_dispatch` run with manual approval gating. No user-facing changes.
+
 ## [0.4.3] - 2026-05-10
 
 ### Added

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-thaumantias",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-thaumantias",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@stomp/stompjs": "7.3.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Bump version + CHANGELOG entry for 0.4.4. CI/release-pipeline-only release; no user-facing changes since 0.4.3. Used to test the new dual-target (Open VSX + Marketplace) workflow end-to-end.