### PR TITLE
ci(release): default release ref to main (was dev)

### DIFF
--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -8,13 +8,13 @@ on:
         required: true
         type: string
       ref:
-        description: 'Source branch to release from. Must be "dev" or "main".'
+        description: 'Source branch to release from. Default "main" (released code). Pick "dev" only for ad-hoc / hotfix releases of pre-merge work.'
         required: true
-        default: 'dev'
+        default: 'main'
         type: choice
         options:
-          - dev
           - main
+          - dev
       dry_run:
         description: 'Dry run: build + validate, skip publish/tag/release'
         required: true


### PR DESCRIPTION
Sets release workflow's ref input default to 'main' (was 'dev'). Reorders options so main appears first in the dropdown. Updates description to reflect main-first convention.

Part of the dev->main mirror sequence: this lands on dev first, then dev->main real-merge syncs both branches with the new default.