### PR TITLE
fix(ws-statusbar): hide red "WS Disconnected" indicator when logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 ## [Unreleased]
 
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.
+- **WebSocket Status Bar**: No longer shows a misleading red "WS Disconnected" indicator while logged out (unless `artemis.showWebSocketStatusBar` is explicitly enabled).
 
 ## [0.4.4] - 2026-05-10
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -66,6 +66,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const updateAuthContext = async (isAuthenticated: boolean) => {
 		await vscode.commands.executeCommand('setContext', 'iris:authenticated', isAuthenticated);
+		websocketStatusBarService.setAuthenticated(isAuthenticated);
 		if (isAuthenticated) {
 			artemisApiService.resetAuthExpiredGuard();
 			void artemisWebsocketService.connect().catch(error => {
@@ -185,6 +186,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	try {
 		const isAuthenticated = await authManager.hasAuthToken();
 		await vscode.commands.executeCommand('setContext', 'iris:authenticated', isAuthenticated);
+		websocketStatusBarService.setAuthenticated(isAuthenticated);
 		if (isAuthenticated) {
 			void artemisWebsocketService.connect().catch(error => {
 				logger.error('Failed to connect to Artemis WebSocket on startup', LogCategory.WEBSOCKET, error);
@@ -193,6 +195,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	} catch (error) {
 		logger.error('Error checking initial auth state', LogCategory.AUTH, error);
 		await vscode.commands.executeCommand('setContext', 'iris:authenticated', false);
+		websocketStatusBarService.setAuthenticated(false);
 	}
 
 	// Session recorder wiring

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -8,9 +8,16 @@ import type { WebSocketDisplayStatus } from '../../../shared/messageContracts';
  * StatusBar item showing WebSocket connection status.
  *
  * Visibility rules:
- * - ALWAYS shown when disconnected or reconnecting
- * - Otherwise shown only when `artemis.showWebSocketStatusBar` is true
- * - After reconnection with setting off: 2s flash then hidden
+ * - When logged out: hidden unless `artemis.showWebSocketStatusBar` is true
+ *   (no WebSocket exists, so the default "needs attention on disconnect" rule
+ *   would surface a misleading red error indicator)
+ * - When logged in:
+ *   - ALWAYS shown when disconnected or reconnecting
+ *   - Otherwise shown only when `artemis.showWebSocketStatusBar` is true
+ *   - After reconnection with setting off: 2s flash then hidden
+ *
+ * Auth state is supplied externally via {@link setAuthenticated}; the service
+ * does not own auth lifecycle.
  *
  * Click action: always reconnect (reset + connect). No-op while connecting.
  */
@@ -21,6 +28,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
     private _stateSubscription?: vscode.Disposable;
     private _currentStatus: WebSocketDisplayStatus = 'disconnected';
     private _showStatusBar = false;
+    private _isAuthenticated = false;
     private _reconnectHideTimeout?: ReturnType<typeof setTimeout>;
 
     public static readonly COMMAND_ID = 'artemis.websocketStatusBarAction';
@@ -85,7 +93,31 @@ export class WebSocketStatusBarService implements vscode.Disposable {
         this._updateStatusBarItem();
     }
 
+    /**
+     * Sync authentication state. When toggled, re-applies visibility so the
+     * status bar can hide on logout (no WebSocket exists) and re-evaluate on
+     * login. Idempotent — no-op when the value matches the current state.
+     */
+    public setAuthenticated(value: boolean): void {
+        if (this._isAuthenticated === value) {
+            return;
+        }
+        this._isAuthenticated = value;
+        this._applyVisibility();
+    }
+
     private _applyVisibility(): void {
+        // Logged out: there is no WebSocket to surface a state for. Honor the
+        // explicit "always show" setting for diagnostics, otherwise hide.
+        if (!this._isAuthenticated) {
+            if (this._showStatusBar) {
+                this._statusBarItem.show();
+            } else {
+                this._statusBarItem.hide();
+            }
+            return;
+        }
+
         const needsAttention =
             this._currentStatus === 'disconnected'
             || this._currentStatus === 'reconnecting';

--- a/extension/test/unit/services/websocketStatusBar.test.ts
+++ b/extension/test/unit/services/websocketStatusBar.test.ts
@@ -111,9 +111,13 @@ suite('WebSocketStatusBarService', () => {
         capturedCommandHandler = undefined;
     });
 
-    // Helper to create the service and flush pending async operations
-    function createService(): WebSocketStatusBarService {
-        return new WebSocketStatusBarService(mockWsService as unknown as ArtemisWebsocketService);
+    // Helper to create the service. Defaults to authenticated=true so the
+    // existing logged-in visibility scenarios behave as before; pass false
+    // explicitly to exercise the logged-out gate.
+    function createService(authenticated = true): WebSocketStatusBarService {
+        const service = new WebSocketStatusBarService(mockWsService as unknown as ArtemisWebsocketService);
+        service.setAuthenticated(authenticated);
+        return service;
     }
 
     suite('visibility', () => {
@@ -345,6 +349,95 @@ suite('WebSocketStatusBarService', () => {
             } finally {
                 clock.restore();
             }
+        });
+    });
+
+    suite('authentication gate', () => {
+        test('logged out + setting off + state disconnected → hidden', () => {
+            configValues.showWebSocketStatusBar = false;
+
+            createService(false);
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            driveState('disconnected');
+
+            assert.ok(
+                mockStatusBarItem.hide.called,
+                'Status bar must be hidden when logged out and setting is off, even with disconnected state'
+            );
+            assert.ok(
+                !mockStatusBarItem.show.called,
+                'Status bar must NOT be shown when logged out and setting is off'
+            );
+        });
+
+        test('logged out + setting on + state disconnected → shown', () => {
+            configValues.showWebSocketStatusBar = true;
+
+            createService(false);
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            driveState('disconnected');
+
+            assert.ok(
+                mockStatusBarItem.show.called,
+                'Status bar must be shown when logged out but setting is explicitly on'
+            );
+        });
+
+        test('logged out → logged in transition re-applies visibility (logged-in rules return)', () => {
+            configValues.showWebSocketStatusBar = false;
+
+            const service = createService(false);
+            driveState('disconnected');
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            // Transition: user logs in
+            service.setAuthenticated(true);
+
+            // With setting off + logged in + state disconnected → needs attention → show
+            assert.ok(
+                mockStatusBarItem.show.called,
+                'After login, logged-in visibility rules must take over (disconnected → show)'
+            );
+        });
+
+        test('logged in → logged out transition re-applies visibility (statusbar hides)', () => {
+            configValues.showWebSocketStatusBar = false;
+
+            const service = createService(true);
+            driveState('disconnected');
+            assert.ok(mockStatusBarItem.show.called, 'precondition: bar visible while logged-in disconnected');
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            // Transition: user logs out
+            service.setAuthenticated(false);
+
+            assert.ok(
+                mockStatusBarItem.hide.called,
+                'After logout, status bar must hide (no WebSocket exists)'
+            );
+        });
+
+        test('setAuthenticated is idempotent (same value is a no-op)', () => {
+            configValues.showWebSocketStatusBar = false;
+
+            const service = createService(true);
+            driveState('disconnected');
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            // Same value as current → no visibility re-apply
+            service.setAuthenticated(true);
+
+            assert.ok(
+                !mockStatusBarItem.show.called && !mockStatusBarItem.hide.called,
+                'setAuthenticated with unchanged value must not trigger show/hide'
+            );
         });
     });
 


### PR DESCRIPTION
## Problem

When the user is logged out, the status bar surfaced a red `🔌 WS Disconnected` indicator suggesting a connection failure. In reality there is no WebSocket — `artemisWebsocketService` is intentionally not connected without credentials. The `getDisplayStatus()` override in `artemisWebsocketService.ts` correctly returns `'disconnected'` for the "client not actively trying" case, but the status bar then treats that as "needs attention" and forces visibility, regardless of the user's `artemis.showWebSocketStatusBar` setting.

Result: every fresh launch on the login screen shows a misleading red error indicator.

## Fix

`WebSocketStatusBarService` now accepts an external auth signal via `setAuthenticated(value)`. The visibility logic in `_applyVisibility()` gets an early return: when logged out, only the explicit `artemis.showWebSocketStatusBar = true` setting keeps the bar visible (for power-user diagnostics). Otherwise it hides.

`extension.ts` calls `setAuthenticated(...)` at the three auth entry points: `updateAuthContext`, the initial-auth try block, and the catch fallback.

## Behavior matrix

| Auth        | Setting | WS state                  | Status bar          |
|-------------|---------|---------------------------|---------------------|
| logged-out  | OFF     | any                       | **hide (new)**      |
| logged-out  | ON      | any                       | show                |
| logged-in   | OFF     | connected / connecting    | hide                |
| logged-in   | OFF     | disconnected / reconnecting | show              |
| logged-in   | OFF     | reconnected → connected   | 2 s flash, then hide |
| logged-in   | ON      | any                       | show                |

Logged-in behavior is unchanged; only the logged-out path was wrong.

## What is intentionally NOT touched

- **Chat-view banner** — the entire chat webview is gated on `iris:authenticated == true` (`package.json:157`), so the in-chat "WebSocket disconnected" banner never renders when logged out.
- **`getDisplayStatus()` itself** — the override is correct for the logged-in case; we only gate the UI surfaces on top of it.

## Test plan

- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm run test:unit` (exit 0)
- [x] `npm run test:react` (864 passed, 2 skipped)
- [x] `npx knip` (clean)
- [x] 5 new unit tests in `websocketStatusBar.test.ts` covering: hidden when logged-out + setting off, shown when logged-out + setting on, logout→login transition, login→logout transition, idempotent `setAuthenticated`
- [ ] Manual smoke in Extension Development Host: logged-out fresh start → no status bar; toggle setting on → red bar reappears; setting off → bar hides; login → normal logged-in behavior