### PR TITLE
fix(iris-context-picker): newest-first conversations, input-anchored dropdown, scroll shadows, aligned tag column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.
 - **WebSocket Status Bar**: No longer shows a misleading red "WS Disconnected" indicator while logged out (unless `artemis.showWebSocketStatusBar` is explicitly enabled).
+- **Iris Context Dropdown**: Conversations sort newest-first, the dropdown panel now spans exactly down to the chat input (no input controls peek through), scroll shadows appear when lists overflow, and exercise rows align consistently whether or not a course tag is shown.
 
 ## [0.4.4] - 2026-05-10
 

--- a/extension/src/extension/services/iris/chat/chatDiagnosticsService.ts
+++ b/extension/src/extension/services/iris/chat/chatDiagnosticsService.ts
@@ -65,6 +65,7 @@ export class ChatDiagnosticsService {
             snapshot.exercises.forEach((exercise, idx) => {
                 report += `  ${idx + 1}. [${exercise.id}] ${exercise.title}${exercise.isWorkspace ? ' ⭐' : ''}\n`;
                 report += `     Short Name: ${exercise.shortName ?? '—'}\n`;
+                report += `     Course ID: ${exercise.courseId ?? '—'}\n`;
                 if (exercise.releaseDate) {
                     report += `     Release: ${exercise.releaseDate}\n`;
                 }

--- a/extension/src/extension/services/iris/context/contextSnapshot.ts
+++ b/extension/src/extension/services/iris/context/contextSnapshot.ts
@@ -17,7 +17,9 @@ function isPastDeadline(ex: TrackedExercise, nowMs: number): boolean {
 export function buildContextSnapshot(state: StoredState): ContextSnapshot {
     const active = state.activeContext;
     const activeKey = active ? getContextKey(active.type, active.id) : null;
-    const sessions = activeKey ? [...(state.sessions[activeKey] ?? [])] : [];
+    const sessions = activeKey
+        ? [...(state.sessions[activeKey] ?? [])].sort((a, b) => b.lastActivity - a.lastActivity)
+        : [];
     const activeSession =
         sessions.find(session => session.id === state.activeSessionId) ?? sessions[0] ?? null;
 

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -28,6 +28,28 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     const [contextSwitching, setContextSwitching] = useState(false);
     const previousContextId = useRef<number | null>(null);
     const sideMenuRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const inputSectionRef = useRef<HTMLDivElement>(null);
+
+    // Publish the input section's measured height as a CSS variable so the
+    // ContextSelector dropdown can anchor its bottom edge to the actual layout
+    // (instead of a viewport-relative magic number). Without this the dropdown
+    // either falls short of the input or overshoots it depending on banner /
+    // referenced-file visibility.
+    useEffect(() => {
+        const inputEl = inputSectionRef.current;
+        const rootEl = containerRef.current;
+        if (!inputEl || !rootEl) {
+            return;
+        }
+        const update = () => {
+            rootEl.style.setProperty('--iris-input-height', `${inputEl.offsetHeight}px`);
+        };
+        update();
+        const ro = new ResizeObserver(update);
+        ro.observe(inputEl);
+        return () => ro.disconnect();
+    }, []);
 
     // Close side menu when clicking outside
     useClickOutside(sideMenuRef, sideMenuOpen, () => setSideMenuOpen(false));
@@ -280,7 +302,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     const irisLogoUri = document.getElementById('root')?.dataset.irisLogoUri;
 
     return (
-        <div className={styles.container}>
+        <div className={styles.container} ref={containerRef}>
             {/* Header */}
             <div className={styles.header}>
                 <div className={styles.headerLeft}>
@@ -448,7 +470,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             </div>
 
             {/* Input section */}
-            <div className={styles.inputSection}>
+            <div className={styles.inputSection} ref={inputSectionRef}>
                 {/* Referenced files */}
                 <ReferencedFiles
                     files={store.referencedFiles}

--- a/extension/src/webview/views/IrisChat/components/ContextSelector.module.css
+++ b/extension/src/webview/views/IrisChat/components/ContextSelector.module.css
@@ -83,7 +83,12 @@
     border: none;
     border-top: 1px solid var(--vscode-panel-border);
     box-shadow: none;
-    height: calc(100vh - 250px);
+    /*
+     * Height = viewport - chat header (~42px) - selector header (~48px) - actual input height.
+     * --iris-input-height is published by IrisChatView via a ResizeObserver on the
+     * input section; the 130px fallback matches the input's typical resting height.
+     */
+    height: calc(100vh - 90px - var(--iris-input-height, 130px));
     display: flex;
     flex-direction: column;
     z-index: 1000;
@@ -94,6 +99,17 @@
     flex: 1 1 0;
     min-height: 0;
     overflow-y: auto;
+    /*
+     * Pure-CSS scroll shadows (Lea Verou pattern): the two "local" gradients
+     * are anchored to the content and mask the corresponding "scroll" shadows
+     * (anchored to the viewport) when the user is at that edge. Result:
+     * shadows appear only when there is more content in that direction.
+     */
+    background:
+        linear-gradient(var(--theme-background) 30%, transparent) 0 0 / 100% 24px no-repeat local,
+        linear-gradient(transparent, var(--theme-background) 70%) 0 100% / 100% 24px no-repeat local,
+        radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.25), transparent) 0 0 / 100% 10px no-repeat,
+        radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.25), transparent) 0 100% / 100% 10px no-repeat;
 }
 
 .searchContainer {
@@ -199,6 +215,13 @@
     padding-left: 8px;
     flex-shrink: 0;
     color: var(--vscode-descriptionForeground);
+    /*
+     * Reserve a consistent slot so rows without a course tag align the same
+     * way as rows with one. Rows that would otherwise have no right-side
+     * content render an invisible tag with this minimum width.
+     */
+    min-width: 4em;
+    text-align: right;
 }
 
 .sessionItem {

--- a/extension/src/webview/views/IrisChat/components/ContextSelector.tsx
+++ b/extension/src/webview/views/IrisChat/components/ContextSelector.tsx
@@ -328,9 +328,13 @@ export function ContextSelector({
                                                 <span className={styles.itemText}>
                                                     {exercise.title}
                                                 </span>
-                                                {courseTag && (
-                                                    <span className={styles.itemTag}>{courseTag}</span>
-                                                )}
+                                                <span
+                                                    className={styles.itemTag}
+                                                    aria-hidden={courseTag ? undefined : true}
+                                                    style={courseTag ? undefined : { visibility: 'hidden' }}
+                                                >
+                                                    {courseTag ?? ' '}
+                                                </span>
                                             </button>
                                         );
                                     })}


### PR DESCRIPTION
## Summary

Four polish fixes to the Iris chat context picker, plus a small diagnostics tweak that helped diagnose #3 below.

1. **Conversations newest-first.** Sessions are now sorted by `lastActivity desc` at snapshot time. Avoids the "auto-scroll-to-bottom + top shadow" pattern that would have been needed if we kept oldest-first.
2. **Dropdown anchored to actual input section.** Replaced the brittle \`calc(100vh - 250px)\` magic number with \`calc(100vh - 90px - var(--iris-input-height))\`. The CSS variable is published by a \`ResizeObserver\` on the input section, so the dropdown never leaves the input's thumb / send buttons peeking through anymore.
3. **Course-tag column always reserved.** Exercises whose \`courseId\` points at a course that isn't in the registered courses list (e.g. archived course, older server state) used to render with no right-side content while siblings rendered a tag — visually inconsistent. The tag span is now always rendered (\`visibility: hidden\` when empty, \`min-width: 4em\`), so rows align.
4. **Scroll shadows top + bottom on all three lists.** Pure-CSS Lea Verou pattern using \`background-attachment: local/scroll\` — shadows only appear when there is more content in that direction. Zero JS, no scroll listener.
5. **Diagnostics report includes \`Course ID\` per exercise** so future "why no tag here?" cases can be triaged from the report alone.

## Test plan

- [x] \`npm run check-types\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test:react\` 864/864 pass
- [x] \`npm run test:unit\` exit code 0
- [x] \`npm run knip\` no new issues
- [x] Manual: conversations now appear newest-first, dropdown fully covers input region with no peek-through, scroll shadows visible when lists overflow, untagged exercise rows align with tagged ones.