### PR TITLE
fix(iris): adapt API client to unified session endpoints (Artemis #12504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.
 - **WebSocket Status Bar**: No longer shows a misleading red "WS Disconnected" indicator while logged out (unless `artemis.showWebSocketStatusBar` is explicitly enabled).
 - **Iris Context Dropdown**: Conversations sort newest-first, the dropdown panel now spans exactly down to the chat input (no input controls peek through), scroll shadows appear when lists overflow, and exercise rows align consistently whether or not a course tag is shown.
+- **Iris API**: Adapted to Artemis PR #12504 (unified chat session endpoints). The extension now uses `/api/iris/chat/sessions{,/current}?mode=…&entityId=…` and `/api/iris/chat/{courseId}/sessions/overview` instead of the legacy per-context routes. Course resolution for exercise contexts is extracted into a shared helper.
 
 ## [0.4.4] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.
 - **WebSocket Status Bar**: No longer shows a misleading red "WS Disconnected" indicator while logged out (unless `artemis.showWebSocketStatusBar` is explicitly enabled).
 - **Iris Context Dropdown**: Conversations sort newest-first, the dropdown panel now spans exactly down to the chat input (no input controls peek through), scroll shadows appear when lists overflow, and exercise rows align consistently whether or not a course tag is shown.
-- **Iris API**: Adapted to Artemis PR #12504 (unified chat session endpoints). The extension now uses `/api/iris/chat/sessions{,/current}?mode=…&entityId=…` and `/api/iris/chat/{courseId}/sessions/overview` instead of the legacy per-context routes. Course resolution for exercise contexts is extracted into a shared helper.
+- **Iris Chat**: Updated to the unified Iris API in Artemis 9.2+ so chat keeps working after the upstream session-endpoint consolidation.
 
 ## [0.4.4] - 2026-05-10
 

--- a/docs/superpowers/plans/2026-05-13-iris-api-unified-sessions.md
+++ b/docs/superpowers/plans/2026-05-13-iris-api-unified-sessions.md
@@ -1,0 +1,1137 @@
+# Iris API Migration to Unified Sessions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the artemis-extension Iris API client to Artemis develop after PR #12504 unified the per-context chat session endpoints into one mode-aware surface.
+
+**Architecture:** Three layers — strict DTO types, three thin HTTP primitives in `ArtemisApiService`, and a composition layer in `sessionSyncUtils` that orchestrates overview → filter → per-session messages. A shared `courseIdResolver` extracts the existing per-call-site resolution logic. The seven old per-context methods are deleted; all four callers (two service files, two test suites) migrate. End state: no reference to legacy URL patterns or method names anywhere under `extension/`.
+
+**Tech Stack:** TypeScript, Mocha via `vscode-test --label unit` (tests are pre-compiled to `out/` by `npm run compile-tests`), sinon stubs, eslint, tsc.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-iris-api-unified-sessions-design.md` (commit `10b32d55`, codex-approved after 2 rounds).
+
+**Conventions used throughout this plan:**
+- All paths are repo-relative.
+- `npm` scripts run inside `extension/` — every test command is `(cd extension && npm run compile-tests && npm run test:unit -- --grep "...")`. The `compile-tests` step is non-optional: `test:unit` executes compiled JS in `out/`, so skipping `compile-tests` runs stale code.
+- `git` commands run from repo root. Never chain `git` after `cd extension`.
+- Branch: `fix/iris-api-unified-sessions`. Small, atomic commits per task.
+
+---
+
+## File map
+
+```
+M  extension/src/shared/types/apiResponses.ts                                     (Task 1)
+A  extension/src/extension/services/iris/context/contextChatMode.ts               (Task 2)
+A  extension/test/unit/services/iris/context/contextChatMode.test.ts              (Task 2)
+A  extension/src/extension/services/iris/context/courseIdResolver.ts              (Task 3)
+A  extension/test/unit/services/iris/context/courseIdResolver.test.ts             (Task 3)
+M  extension/src/extension/services/iris/chat/chatSessionService.ts               (Task 3, 5)
+M  extension/src/extension/api/artemisApi.ts                                      (Task 4, 8)
+M  extension/test/unit/api/artemisApi.test.ts                                     (Task 4, 8)
+A  extension/test/unit/services/iris/context/sessionSyncUtils.test.ts             (Task 5)
+M  extension/src/extension/services/iris/context/sessionSyncUtils.ts              (Task 5)
+M  extension/src/extension/services/iris/chat/chatDiagnosticsService.ts           (Task 5)
+M  extension/test/unit/services/chatSessionService.test.ts                        (Task 5)
+M  extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts  (Task 6)
+M  extension/test/unit/services/websocket.test.ts                                 (Task 6)
+M  extension/test/e2e/uncommittedChanges.e2e.test.ts                              (Task 7)
+M  CHANGELOG.md                                                                   (Task 9)
+```
+
+---
+
+### Task 1: Add new TypeScript types
+
+**Files:**
+- Modify: `extension/src/shared/types/apiResponses.ts`
+
+- [ ] **Step 1.1: Edit `extension/src/shared/types/apiResponses.ts`** — replace the `IrisChatSession` block (lines 113-119) with the following, and add the new sibling types directly below it:
+
+```ts
+export type IrisChatMode =
+    | 'PROGRAMMING_EXERCISE_CHAT'
+    | 'TEXT_EXERCISE_CHAT'
+    | 'COURSE_CHAT'
+    | 'LECTURE_CHAT';
+
+/** Detail DTO returned by /api/iris/chat/sessions/current, /sessions, and /{courseId}/session/{sessionId}. */
+export interface IrisChatSession {
+    id: number;
+    mode?: IrisChatMode;
+    entityId?: number;
+    userId?: number;
+    title?: string;
+    creationDate?: string;
+    messages?: IrisChatMessage[];
+    [key: string]: unknown;
+}
+
+/** Listing DTO returned by /api/iris/chat/{courseId}/sessions/overview. No messages. */
+export interface IrisChatSessionSummary {
+    id: number;
+    entityId: number;
+    entityName?: string;
+    title?: string;
+    creationDate: string;
+    lastActivityDate?: string;
+    mode: IrisChatMode;
+    [key: string]: unknown;
+}
+```
+
+- [ ] **Step 1.2: Run typecheck**
+
+```bash
+cd extension && npm run check-types
+```
+
+Expected: PASS. The change is additive (`mode`, `entityId`, `userId` are optional new fields; existing index signature already permitted them).
+
+- [ ] **Step 1.3: Commit (from repo root)**
+
+```bash
+git add extension/src/shared/types/apiResponses.ts
+git commit -m "feat(iris): add IrisChatMode and IrisChatSessionSummary types"
+```
+
+---
+
+### Task 2: `contextChatMode` helper
+
+**Files:**
+- Create: `extension/src/extension/services/iris/context/contextChatMode.ts`
+- Create: `extension/test/unit/services/iris/context/contextChatMode.test.ts`
+
+- [ ] **Step 2.1: Ensure the new test directory exists**
+
+```bash
+mkdir -p extension/test/unit/services/iris/context
+```
+
+- [ ] **Step 2.2: Write the failing test** — create `extension/test/unit/services/iris/context/contextChatMode.test.ts`:
+
+```ts
+import * as assert from 'assert';
+import { contextToIrisMode } from '../../../../../src/extension/services/iris/context/contextChatMode';
+
+suite('contextToIrisMode', () => {
+    test('maps course → COURSE_CHAT', () => {
+        assert.strictEqual(contextToIrisMode('course'), 'COURSE_CHAT');
+    });
+
+    test('maps exercise → PROGRAMMING_EXERCISE_CHAT', () => {
+        assert.strictEqual(contextToIrisMode('exercise'), 'PROGRAMMING_EXERCISE_CHAT');
+    });
+});
+```
+
+- [ ] **Step 2.3: Run compile + test, expect failure**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "contextToIrisMode"
+```
+
+Expected: FAIL at the `compile-tests` step with a "Cannot find module" error for `contextChatMode` (or, on systems that skip strict resolution, at the Mocha layer). Either failure mode is acceptable — it proves the module is absent.
+
+- [ ] **Step 2.4: Create `extension/src/extension/services/iris/context/contextChatMode.ts`**:
+
+```ts
+import type { ChatContextType } from '../../../../shared/types/context';
+import type { IrisChatMode } from '../../../../shared/types/apiResponses';
+
+/**
+ * Maps the extension's ChatContextType to the Artemis IrisChatMode enum
+ * expected by the unified /api/iris/chat endpoints. Single source of truth.
+ */
+export function contextToIrisMode(type: ChatContextType): IrisChatMode {
+    return type === 'course' ? 'COURSE_CHAT' : 'PROGRAMMING_EXERCISE_CHAT';
+}
+```
+
+- [ ] **Step 2.5: Run compile + test, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "contextToIrisMode"
+```
+
+Expected: 2/2 passing.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add extension/src/extension/services/iris/context/contextChatMode.ts \
+        extension/test/unit/services/iris/context/contextChatMode.test.ts
+git commit -m "feat(iris): add contextToIrisMode helper"
+```
+
+---
+
+### Task 3: Extract `courseIdResolver`
+
+Lift the existing private `resolveCourseIdForExercise` (chatSessionService.ts lines 103-129) into a shared module. Behavior preserved exactly so existing `IrisChatSessionService` tests keep passing.
+
+**Files:**
+- Create: `extension/src/extension/services/iris/context/courseIdResolver.ts`
+- Create: `extension/test/unit/services/iris/context/courseIdResolver.test.ts`
+- Modify: `extension/src/extension/services/iris/chat/chatSessionService.ts`
+
+- [ ] **Step 3.1: Write the failing tests** — create `extension/test/unit/services/iris/context/courseIdResolver.test.ts`:
+
+```ts
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { resolveCourseIdFromContext } from '../../../../../src/extension/services/iris/context/courseIdResolver';
+import type { ActiveContext } from '../../../../../src/shared/types/context';
+
+function makeContextStore(overrides: any = {}): any {
+    return {
+        getExerciseById: sinon.stub().returns(undefined),
+        registerExercise: sinon.stub(),
+        ...overrides,
+    };
+}
+
+function makeApi(overrides: any = {}): any {
+    return {
+        getExerciseDetails: sinon.stub().rejects(new Error('not stubbed')),
+        ...overrides,
+    };
+}
+
+const courseContext: ActiveContext = {
+    type: 'course', id: 42, title: 'C', source: 'user-selected', locked: false, selectedAt: 0,
+};
+const exerciseContext: ActiveContext = {
+    type: 'exercise', id: 123, title: 'E', source: 'user-selected', locked: false, selectedAt: 0,
+};
+
+suite('resolveCourseIdFromContext', () => {
+    test('course context returns its own id', async () => {
+        const id = await resolveCourseIdFromContext(courseContext, makeContextStore(), makeApi());
+        assert.strictEqual(id, 42);
+    });
+
+    test('exercise context with courseId returns it directly', async () => {
+        const ctx = { ...exerciseContext, courseId: 7 };
+        const id = await resolveCourseIdFromContext(ctx, makeContextStore(), makeApi());
+        assert.strictEqual(id, 7);
+    });
+
+    test('falls back to contextStore when context has no courseId', async () => {
+        const store = makeContextStore({
+            getExerciseById: sinon.stub().withArgs(123).returns({ id: 123, title: 'E', courseId: 9 }),
+        });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, makeApi());
+        assert.strictEqual(id, 9);
+    });
+
+    test('falls back to getExerciseDetails and registers exercise on success', async () => {
+        const store = makeContextStore();
+        const api = makeApi({
+            getExerciseDetails: sinon.stub().withArgs(123).resolves({ exercise: { course: { id: 11 } } }),
+        });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, 11);
+        assert.ok((store.registerExercise as sinon.SinonStub).calledOnceWith(
+            sinon.match({ id: 123, courseId: 11 }),
+        ));
+    });
+
+    test('returns undefined when nothing resolves', async () => {
+        const store = makeContextStore();
+        const api = makeApi({ getExerciseDetails: sinon.stub().resolves({}) });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, undefined);
+    });
+
+    test('returns undefined when getExerciseDetails throws', async () => {
+        const store = makeContextStore();
+        const api = makeApi({ getExerciseDetails: sinon.stub().rejects(new Error('boom')) });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, undefined);
+    });
+});
+```
+
+- [ ] **Step 3.2: Run compile + tests, expect failure**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "resolveCourseIdFromContext"
+```
+
+Expected: FAIL — module missing.
+
+- [ ] **Step 3.3: Create `extension/src/extension/services/iris/context/courseIdResolver.ts`**:
+
+```ts
+import type { ActiveContext } from '../../../../shared/types/context';
+import { logger, LogCategory } from '../../loggingService';
+import type { ArtemisApiService } from '../../../api';
+import type { ContextStore } from './contextStore';
+
+/**
+ * Resolves the courseId for an ActiveContext, walking:
+ *   1. context.courseId (or context.id when type === 'course')
+ *   2. contextStore.getExerciseById(...).courseId
+ *   3. api.getExerciseDetails(...).exercise.course.id (registers the exercise back into the store on success)
+ *
+ * Returns undefined if all three paths fail. Mirrors the legacy private
+ * resolveCourseIdForExercise from chatSessionService.ts so behavior is preserved
+ * across both the IrisChatSessionService and sessionSyncUtils call sites.
+ */
+export async function resolveCourseIdFromContext(
+    context: ActiveContext,
+    contextStore: ContextStore,
+    api: ArtemisApiService | undefined,
+): Promise<number | undefined> {
+    if (context.type === 'course') {
+        return context.id;
+    }
+    if (context.courseId) {
+        return context.courseId;
+    }
+    const tracked = contextStore.getExerciseById(context.id);
+    if (tracked?.courseId) {
+        return tracked.courseId;
+    }
+    if (!api) {
+        return undefined;
+    }
+    try {
+        const details = await api.getExerciseDetails(context.id);
+        const resolved = details?.exercise?.course?.id;
+        if (resolved) {
+            contextStore.registerExercise({
+                id: context.id,
+                title: context.title,
+                shortName: context.shortName,
+                courseId: resolved,
+            });
+        }
+        return resolved;
+    } catch (error) {
+        logger.warn('Failed to resolve course from exercise details:', LogCategory.IRIS_CHAT, error);
+        return undefined;
+    }
+}
+```
+
+- [ ] **Step 3.4: Run compile + tests, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "resolveCourseIdFromContext"
+```
+
+Expected: 6/6 passing.
+
+- [ ] **Step 3.5: Delegate `chatSessionService.resolveCourseIdForExercise` to the shared helper** — in `extension/src/extension/services/iris/chat/chatSessionService.ts`:
+
+  Add the import alongside other `../context/` imports near the top:
+
+```ts
+import { resolveCourseIdFromContext } from '../context/courseIdResolver';
+```
+
+  Replace the body of the private method (lines 103-129) with:
+
+```ts
+private async resolveCourseIdForExercise(context: ActiveContext): Promise<number | undefined> {
+    return resolveCourseIdFromContext(context, this.deps.contextStore, this.deps.artemisApiService);
+}
+```
+
+- [ ] **Step 3.6: Run compile + IrisChatSessionService suite, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "IrisChatSessionService"
+```
+
+Expected: all previously-passing tests still pass.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add extension/src/extension/services/iris/context/courseIdResolver.ts \
+        extension/test/unit/services/iris/context/courseIdResolver.test.ts \
+        extension/src/extension/services/iris/chat/chatSessionService.ts
+git commit -m "refactor(iris): extract resolveCourseIdFromContext into shared module"
+```
+
+---
+
+### Task 4: Add new API primitives
+
+Adds the three new methods to `ArtemisApiService` *alongside* the old ones. Old methods stay for now so callers and their tests keep building. Deletion is Task 8.
+
+**Files:**
+- Modify: `extension/src/extension/api/artemisApi.ts`
+- Modify: `extension/test/unit/api/artemisApi.test.ts`
+
+- [ ] **Step 4.1: Write the failing tests** — append the following three tests inside the `Artemis API Service` `suite(...)` block in `extension/test/unit/api/artemisApi.test.ts`:
+
+```ts
+test('should get current chat session via unified endpoint', async () => {
+    const entityId = 42;
+    global.fetch = async (url: any, options: any) => {
+        assert.ok(url.includes('/api/iris/chat/sessions/current'));
+        assert.ok(url.includes('mode=COURSE_CHAT'));
+        assert.ok(url.includes(`entityId=${entityId}`));
+        assert.strictEqual(options.method, 'POST');
+        return { ok: true, status: 200, json: async () => ({ id: 123 }) } as any;
+    };
+    const session = await apiService.getCurrentChat('COURSE_CHAT', entityId);
+    assert.strictEqual(session.id, 123);
+});
+
+test('should create chat session via unified endpoint', async () => {
+    const entityId = 99;
+    global.fetch = async (url: any, options: any) => {
+        assert.ok(url.includes('/api/iris/chat/sessions'));
+        assert.ok(!url.includes('/sessions/current'));
+        assert.ok(url.includes('mode=PROGRAMMING_EXERCISE_CHAT'));
+        assert.ok(url.includes(`entityId=${entityId}`));
+        assert.strictEqual(options.method, 'POST');
+        return { ok: true, status: 200, json: async () => ({ id: 7 }) } as any;
+    };
+    const session = await apiService.createChatSession('PROGRAMMING_EXERCISE_CHAT', entityId);
+    assert.strictEqual(session.id, 7);
+});
+
+test('should list chat sessions for course via overview endpoint', async () => {
+    const courseId = 5;
+    const mockSummaries = [
+        { id: 1, entityId: 5, mode: 'COURSE_CHAT', creationDate: '2026-05-13T00:00:00Z' },
+        { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: '2026-05-13T01:00:00Z' },
+    ];
+    global.fetch = async (url: any, options: any) => {
+        assert.ok(url.includes(`/api/iris/chat/${courseId}/sessions/overview`));
+        assert.ok(!options?.method || options.method === 'GET');
+        return { ok: true, status: 200, json: async () => mockSummaries } as any;
+    };
+    const summaries = await apiService.listChatSessionsForCourse(courseId);
+    assert.deepStrictEqual(summaries, mockSummaries);
+});
+```
+
+- [ ] **Step 4.2: Run compile + tests, expect failure**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "unified endpoint|overview endpoint"
+```
+
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 4.3: Add the three primitives** in `extension/src/extension/api/artemisApi.ts`. First, extend the type import line to include `IrisChatMode` and `IrisChatSessionSummary` from `apiResponses`. Then insert the new methods near the existing Iris block (just below `markMessageHelpful`):
+
+```ts
+// Unified Iris chat session endpoints (Artemis develop, PR #12504).
+async getCurrentChat(mode: IrisChatMode, entityId: number): Promise<IrisChatSession> {
+    const params = new URLSearchParams({ mode, entityId: String(entityId) });
+    const response = await this.makeRequest(
+        `/api/iris/chat/sessions/current?${params.toString()}`,
+        { method: 'POST' },
+    );
+    return response.json() as Promise<IrisChatSession>;
+}
+
+async createChatSession(mode: IrisChatMode, entityId: number): Promise<IrisChatSession> {
+    const params = new URLSearchParams({ mode, entityId: String(entityId) });
+    const response = await this.makeRequest(
+        `/api/iris/chat/sessions?${params.toString()}`,
+        { method: 'POST' },
+    );
+    return response.json() as Promise<IrisChatSession>;
+}
+
+async listChatSessionsForCourse(courseId: number): Promise<IrisChatSessionSummary[]> {
+    const response = await this.makeRequest(`/api/iris/chat/${courseId}/sessions/overview`);
+    return response.json() as Promise<IrisChatSessionSummary[]>;
+}
+```
+
+- [ ] **Step 4.4: Run compile + tests, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "unified endpoint|overview endpoint"
+```
+
+Expected: 3/3 passing.
+
+  Also confirm the rest of the API suite still passes:
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "Artemis API Service"
+```
+
+Expected: all previously-passing tests still pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add extension/src/extension/api/artemisApi.ts \
+        extension/test/unit/api/artemisApi.test.ts
+git commit -m "feat(iris-api): add unified chat session primitives"
+```
+
+---
+
+### Task 5: Rewrite `sessionSyncUtils` + migrate all consumers of the old composite
+
+This task is intentionally larger than the others: the new function signature, production call sites, and the entire `chatSessionService.test.ts` stub set must all flip together to keep a green build. **Single commit at the end.**
+
+**Files:**
+- Create: `extension/test/unit/services/iris/context/sessionSyncUtils.test.ts`
+- Modify: `extension/src/extension/services/iris/context/sessionSyncUtils.ts`
+- Modify: `extension/src/extension/services/iris/chat/chatSessionService.ts` (caller at line 449)
+- Modify: `extension/src/extension/services/iris/chat/chatDiagnosticsService.ts` (caller at line 134)
+- Modify: `extension/test/unit/services/chatSessionService.test.ts` (~20 stubs migrated)
+
+- [ ] **Step 5.1: Write the failing tests** — create `extension/test/unit/services/iris/context/sessionSyncUtils.test.ts`:
+
+```ts
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { fetchSessionsWithMessages } from '../../../../../src/extension/services/iris/context/sessionSyncUtils';
+import type { ActiveContext } from '../../../../../src/shared/types/context';
+
+function makeApi(stubs: Partial<Record<string, sinon.SinonStub>> = {}): any {
+    return {
+        listChatSessionsForCourse: sinon.stub().resolves([]),
+        getChatMessages: sinon.stub().resolves([]),
+        getExerciseDetails: sinon.stub().rejects(new Error('not stubbed')),
+        ...stubs,
+    };
+}
+
+function makeStore(stubs: Partial<Record<string, sinon.SinonStub>> = {}): any {
+    return {
+        getExerciseById: sinon.stub().returns(undefined),
+        registerExercise: sinon.stub(),
+        ...stubs,
+    };
+}
+
+const exerciseCtx: ActiveContext = {
+    type: 'exercise', id: 123, courseId: 42, title: 'E', source: 'user-selected', locked: false, selectedAt: 0,
+};
+const courseCtx: ActiveContext = {
+    type: 'course', id: 42, title: 'C', source: 'user-selected', locked: false, selectedAt: 0,
+};
+
+suite('fetchSessionsWithMessages', () => {
+    test('filters summaries by mode + entityId before fetching messages', async () => {
+        const summaries = [
+            { id: 1, entityId: 42, mode: 'COURSE_CHAT',                creationDate: 't1' },
+            { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+            { id: 3, entityId: 999, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't3' },
+            { id: 4, entityId: 123, mode: 'LECTURE_CHAT',              creationDate: 't4' },
+        ];
+        const getChatMessages = sinon.stub().resolves([{ id: 100, sender: 'USER' }]);
+        const api = makeApi({
+            listChatSessionsForCourse: sinon.stub().withArgs(42).resolves(summaries),
+            getChatMessages,
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), exerciseCtx);
+
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].id, 2);
+        assert.ok(getChatMessages.calledOnceWith(2));
+        assert.ok(getChatMessages.neverCalledWith(1));
+        assert.ok(getChatMessages.neverCalledWith(3));
+        assert.ok(getChatMessages.neverCalledWith(4));
+    });
+
+    test('course context uses its own id as courseId and filters by COURSE_CHAT', async () => {
+        const summaries = [
+            { id: 10, entityId: 42, mode: 'COURSE_CHAT',                creationDate: 't1' },
+            { id: 11, entityId: 7,  mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+        ];
+        const listStub = sinon.stub().resolves(summaries);
+        const api = makeApi({ listChatSessionsForCourse: listStub });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), courseCtx);
+
+        assert.ok(listStub.calledOnceWith(42));
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].id, 10);
+    });
+
+    test('resolves courseId from contextStore when context.courseId is missing', async () => {
+        const ctx: ActiveContext = { ...exerciseCtx, courseId: undefined };
+        const listStub = sinon.stub().resolves([]);
+        const store = makeStore({
+            getExerciseById: sinon.stub().withArgs(123).returns({ id: 123, title: 'E', courseId: 77 }),
+        });
+        const api = makeApi({ listChatSessionsForCourse: listStub });
+
+        await fetchSessionsWithMessages(api, store, ctx);
+
+        assert.ok(listStub.calledOnceWith(77));
+    });
+
+    test('returns [] when courseId is fully unresolvable', async () => {
+        const ctx: ActiveContext = { ...exerciseCtx, courseId: undefined };
+        const listStub = sinon.stub().resolves([]);
+        const api = makeApi({
+            listChatSessionsForCourse: listStub,
+            getExerciseDetails: sinon.stub().resolves({}),
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), ctx);
+
+        assert.deepStrictEqual(result, []);
+        assert.ok(listStub.notCalled);
+    });
+
+    test('per-session fetch failure yields a session with empty messages', async () => {
+        const summaries = [
+            { id: 1, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't1' },
+            { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+        ];
+        const getChatMessages = sinon.stub();
+        getChatMessages.withArgs(1).rejects(new Error('boom'));
+        getChatMessages.withArgs(2).resolves([{ id: 999, sender: 'USER' }]);
+        const api = makeApi({
+            listChatSessionsForCourse: sinon.stub().resolves(summaries),
+            getChatMessages,
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), exerciseCtx);
+
+        assert.strictEqual(result.length, 2);
+        assert.deepStrictEqual(result.find(s => s.id === 1)?.messages, []);
+        assert.strictEqual(result.find(s => s.id === 2)?.messages?.length, 1);
+    });
+});
+```
+
+- [ ] **Step 5.2: Run compile + sessionSyncUtils tests, expect failure**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "fetchSessionsWithMessages"
+```
+
+Expected: FAIL — the new signature isn't implemented (or, more precisely, the current `(api, context)` function is called with three args).
+
+- [ ] **Step 5.3: Rewrite `extension/src/extension/services/iris/context/sessionSyncUtils.ts`** — replace the file contents with:
+
+```ts
+import { ArtemisApiService } from '../../../api';
+import { ContextStore } from './contextStore';
+import { contextToIrisMode } from './contextChatMode';
+import { resolveCourseIdFromContext } from './courseIdResolver';
+import { extractIrisMessageContent } from '../chat/messageUtils';
+import { logger, LogCategory } from '../../loggingService';
+import type { ActiveContext, IrisChatSession, IrisChatMessage } from '../../../types';
+import type { ExtensionToWebviewMessage } from '../../../../shared/messageContracts';
+
+/**
+ * Shared dependency bag for Iris services. Bundles common params so
+ * constructors stay short and wiring is DRY.
+ */
+export interface IrisServiceDeps {
+    contextStore: ContextStore;
+    artemisApiService: ArtemisApiService | undefined;
+    postMessage: (message: ExtensionToWebviewMessage) => void;
+    postSnapshot: () => void;
+}
+
+/**
+ * Lists Iris chat sessions for the given context and hydrates each with messages.
+ *
+ * The unified /api/iris/chat/{courseId}/sessions/overview endpoint returns
+ * lightweight summaries across all modes for the course. We filter to the
+ * relevant mode + entityId before fanning out to /api/iris/sessions/{id}/messages
+ * so unrelated sessions are never fetched.
+ */
+export async function fetchSessionsWithMessages(
+    api: ArtemisApiService,
+    contextStore: ContextStore,
+    context: ActiveContext,
+): Promise<IrisChatSession[]> {
+    const courseId = await resolveCourseIdFromContext(context, contextStore, api);
+    if (courseId === undefined) {
+        logger.warn(
+            `Cannot list sessions: unable to resolve courseId for context ${context.type}:${context.id}`,
+            LogCategory.IRIS_CHAT,
+        );
+        return [];
+    }
+    const mode = contextToIrisMode(context.type);
+    const summaries = await api.listChatSessionsForCourse(courseId);
+    const filtered = summaries.filter(s => s.mode === mode && s.entityId === context.id);
+
+    return Promise.all(filtered.map(async (summary) => {
+        const base = {
+            id: summary.id,
+            title: summary.title,
+            creationDate: summary.creationDate,
+            mode: summary.mode,
+            entityId: summary.entityId,
+        };
+        try {
+            const messages = await api.getChatMessages(summary.id);
+            return { ...base, messages };
+        } catch (error) {
+            logger.warn(
+                `Failed to fetch messages for session ${summary.id}: ${error}`,
+                LogCategory.API,
+            );
+            return { ...base, messages: [] };
+        }
+    }));
+}
+
+/**
+ * Sorts sessions newest-first, extracts preview from first user message,
+ * and imports each session into the context store.
+ *
+ * Returns the number of sessions actually imported. Empty server sessions
+ * (no messages) are skipped — callers rely on this count to decide whether
+ * to fall back to creating a fresh session.
+ *
+ * NOTE: createSessionWithDetails() prepends sessions. Since we iterate
+ * newest-first and prepend each time, the stored array ends up oldest-first.
+ * Existing behavior, preserved intentionally.
+ */
+export function importSessionsToStore(
+    sessions: IrisChatSession[],
+    contextStore: ContextStore,
+): number {
+    if (sessions.length === 0) {
+        return 0;
+    }
+
+    sessions.sort((a, b) => {
+        const timeA = a.creationDate ? new Date(a.creationDate).getTime() : 0;
+        const timeB = b.creationDate ? new Date(b.creationDate).getTime() : 0;
+        return timeB - timeA;
+    });
+
+    let imported = 0;
+    for (const session of sessions) {
+        const messageCount = session.messages?.length || 0;
+        if (messageCount === 0) {
+            continue;
+        }
+
+        const createdAt = session.creationDate ? new Date(session.creationDate).getTime() : Date.now();
+
+        let preview = 'New conversation';
+        if (session.messages && session.messages.length > 0) {
+            const firstUserMsg = session.messages.find((m: IrisChatMessage) => m.sender === 'USER');
+            if (firstUserMsg) {
+                const content = extractIrisMessageContent(firstUserMsg.content);
+                if (content && content !== 'undefined' && content !== 'null') {
+                    preview = content.substring(0, 50);
+                }
+            }
+        }
+
+        logger.info(`Importing session ${session.id}: ${messageCount} messages, preview: "${preview}"`, LogCategory.IRIS_CHAT);
+
+        contextStore.createSessionWithDetails(
+            preview,
+            messageCount,
+            createdAt,
+            session.id,
+            session.messages || [],
+            typeof session.title === 'string' ? session.title : undefined,
+        );
+        imported++;
+    }
+
+    return imported;
+}
+```
+
+- [ ] **Step 5.4: Update the two production call sites**
+
+  In `extension/src/extension/services/iris/chat/chatSessionService.ts:449`:
+
+```ts
+const sessions = await fetchSessionsWithMessages(this.deps.artemisApiService!, this.deps.contextStore, targetContext);
+```
+
+  In `extension/src/extension/services/iris/chat/chatDiagnosticsService.ts:134`:
+
+```ts
+const artemisSessionsListFromServer = await fetchSessionsWithMessages(this._artemisApiService, this._contextStore, activeContext);
+```
+
+- [ ] **Step 5.5: Migrate every stub in `extension/test/unit/services/chatSessionService.test.ts`**
+
+  The existing stubs target `getCourseChatSessionsWithMessages` / `getExerciseChatSessionsWithMessages` / `getExerciseChatSessions`. After Task 5.3, the internal path is `listChatSessionsForCourse` → filter → per-summary `getChatMessages`. Migrate per the patterns below.
+
+  **Pattern A — replace a "with messages" stub:**
+
+  Old:
+  ```ts
+  mockApiService.getCourseChatSessionsWithMessages.resolves([
+      { id: 1, messages: [{ id: 100, sender: 'USER', content: [{ textContent: 'hi', type: 'text' }] }], creationDate: '2026-01-01' },
+  ]);
+  ```
+
+  New:
+  ```ts
+  mockApiService.listChatSessionsForCourse.resolves([
+      { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2026-01-01' },
+  ]);
+  mockApiService.getChatMessages.withArgs(1).resolves([
+      { id: 100, sender: 'USER', content: [{ textContent: 'hi', type: 'text' }] },
+  ]);
+  ```
+
+  For exercise contexts use `mode: 'PROGRAMMING_EXERCISE_CHAT'` and `entityId: <exercise id, typically 123>`. Make sure the `ActiveContext` fixture sets `courseId` so the resolver succeeds (e.g. `{ type: 'exercise', id: 123, courseId: 42, ... }`).
+
+  **Pattern B — assertion fixes:**
+
+  - `mockApiService.getCourseChatSessionsWithMessages.calledOnceWith(courseId)` → `mockApiService.listChatSessionsForCourse.calledOnceWith(courseId)`.
+  - `mockApiService.getExerciseChatSessionsWithMessages.calledOnceWith(exerciseId)` → `mockApiService.listChatSessionsForCourse.calledOnceWith(courseId)`. Note: the new method takes **courseId**, not exerciseId — drop the exerciseId assertion or replace with `entityId` checks on the summary returned.
+  - `mockApiService.getExerciseChatSessions.notCalled` → drop (covered by `listChatSessionsForCourse.notCalled`).
+  - `mockApiService.getCourseChatSessionsWithMessages.notCalled` → `mockApiService.listChatSessionsForCourse.notCalled`.
+
+  **Pattern C — rejection / fake / multiple-call semantics:**
+
+  - `mockApiService.getCourseChatSessionsWithMessages.rejects(...)` → `mockApiService.listChatSessionsForCourse.rejects(...)`.
+  - `mockApiService.getCourseChatSessionsWithMessages.callsFake(async () => {...})` → `mockApiService.listChatSessionsForCourse.callsFake(...)`.
+
+  **Pattern D — dual `getChatMessages` semantics (important):**
+
+  In the new code path, `getChatMessages` is called twice per session: once during the import phase (inside `fetchSessionsWithMessages`) and again later during active-session hydration. Tests that previously distinguished those phases via different mock methods must now distinguish via call order.
+
+  Specifically, around `chatSessionService.test.ts:810`, `'emits LoadMessagesError after posting snapshot so the webview accepts the error'` expects the LATER fetch to fail. A naive `getChatMessages.rejects(...)` would now cause the IMPORT phase to swallow the failure, the test never reaches `LoadMessagesError`. Use call-order discrimination:
+
+  ```ts
+  const failingSessionFetch = mockApiService.getChatMessages.withArgs(<sessionId>);
+  failingSessionFetch.onFirstCall().resolves([
+      { id: 999, sender: 'USER', content: [{ textContent: 'previous turn', type: 'text' }] },
+  ]);
+  failingSessionFetch.onSecondCall().rejects(new Error('Server error during hydration'));
+  ```
+
+  The first call satisfies the import phase (so the session gets imported as expected). The second call is the active-session hydration that the test is actually asserting against.
+
+  Apply the same `onFirstCall()/onSecondCall()` pattern to any test that previously assumed the import returned messages but later hydration failed (or vice versa). Around line 685 (the `LoadMessages` success path) the import returns messages and the hydration also returns messages — there `withArgs(id).resolves([...])` is sufficient because both calls get the same answer.
+
+- [ ] **Step 5.6: Compile + run all affected suites, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "fetchSessionsWithMessages|IrisChatSessionService"
+```
+
+Expected: all tests pass (5 new + the entire IrisChatSessionService suite).
+
+- [ ] **Step 5.7: Commit (single atomic commit covering all four files)**
+
+```bash
+git add extension/test/unit/services/iris/context/sessionSyncUtils.test.ts \
+        extension/src/extension/services/iris/context/sessionSyncUtils.ts \
+        extension/src/extension/services/iris/chat/chatSessionService.ts \
+        extension/src/extension/services/iris/chat/chatDiagnosticsService.ts \
+        extension/test/unit/services/chatSessionService.test.ts
+git commit -m "refactor(iris): orchestrate sessions via unified overview + per-session messages"
+```
+
+---
+
+### Task 6: Migrate `irisWebSocketSessionClient` + its tests
+
+**Files:**
+- Modify: `extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts`
+- Modify: `extension/test/unit/services/websocket.test.ts`
+
+- [ ] **Step 6.1: Update production code**
+
+  In `extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts`, add at the top alongside other context-module imports:
+
+```ts
+import { contextToIrisMode } from '../context/contextChatMode';
+```
+
+  Replace the get-current branch (around lines 102-108):
+
+  Old:
+  ```ts
+  if (context.type === 'course') {
+      session = await this._artemisApiService.getCurrentCourseChat(context.id);
+  } else if (context.type === 'exercise') {
+      session = await this._artemisApiService.getCurrentExerciseChat(context.id);
+  }
+  ```
+
+  New:
+  ```ts
+  const mode = contextToIrisMode(context.type);
+  session = await this._artemisApiService.getCurrentChat(mode, context.id);
+  ```
+
+  Replace the create branch (around lines 121-128):
+
+  Old:
+  ```ts
+  if (context.type === 'course') {
+      newSession = await this._artemisApiService.createCourseChatSession(context.id);
+  } else if (context.type === 'exercise') {
+      newSession = await this._artemisApiService.createExerciseChatSession(context.id);
+  }
+  ```
+
+  New (reuse `mode` from outer scope if available; otherwise recompute):
+  ```ts
+  const mode = contextToIrisMode(context.type);
+  newSession = await this._artemisApiService.createChatSession(mode, context.id);
+  ```
+
+- [ ] **Step 6.2: Migrate test stubs in `extension/test/unit/services/websocket.test.ts`**
+
+  Lines 539-540, 663-664, and 834 currently stub the old methods:
+
+  Old (apply at every occurrence):
+  ```ts
+  apiService.getCurrentExerciseChat.resolves({ id: 123 });
+  apiService.getCurrentCourseChat.resolves({ id: 456 });
+  ```
+
+  New:
+  ```ts
+  apiService.getCurrentChat
+      .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 123 } as any);
+  apiService.getCurrentChat
+      .withArgs('COURSE_CHAT', sinon.match.any).resolves({ id: 456 } as any);
+  ```
+
+  And at line 665:
+
+  Old:
+  ```ts
+  apiService.createExerciseChatSession.resolves({ id: 789 });
+  ```
+
+  New:
+  ```ts
+  apiService.createChatSession
+      .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 789 } as any);
+  ```
+
+  (`as any` is acceptable because the old stubs already used `{ id: N }` without the full `IrisChatSession` shape; the production code only reads `.id`.)
+
+- [ ] **Step 6.3: Compile + run affected suites, expect PASS**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit -- --grep "WebSocket|IrisWebSocketSessionClient"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts \
+        extension/test/unit/services/websocket.test.ts
+git commit -m "refactor(iris): dispatch WebSocket session client via contextToIrisMode"
+```
+
+---
+
+### Task 7: Migrate the e2e helper
+
+The existing helper omits `method` on the current-session fetch (defaults to GET) — a latent bug masked by the old endpoint. The new endpoint is strictly `@PostMapping`. Both URLs become the unified form.
+
+**Files:**
+- Modify: `extension/test/e2e/uncommittedChanges.e2e.test.ts` (lines 133-160 area)
+
+- [ ] **Step 7.1: Rewrite the `getOrCreateSession` helper body**
+
+  Replace the function body with:
+
+```ts
+async getOrCreateSession(exerciseId: number): Promise<number | null> {
+    logger.info(`[E2E] Getting/creating Iris session for exercise ${exerciseId}...`, LogCategory.TEST);
+
+    const params = new URLSearchParams({
+        mode: 'PROGRAMMING_EXERCISE_CHAT',
+        entityId: String(exerciseId),
+    });
+
+    // Try to get current session
+    let response = await fetch(
+        `${this.baseUrl}/api/iris/chat/sessions/current?${params.toString()}`,
+        { method: 'POST', headers: this.getHeaders() },
+    );
+
+    if (response.ok) {
+        const data = await response.json() as { id: number };
+        logger.info(`[E2E] Found existing session: ${data.id}`, LogCategory.TEST);
+        return data.id;
+    }
+
+    // Create new session
+    response = await fetch(
+        `${this.baseUrl}/api/iris/chat/sessions?${params.toString()}`,
+        { method: 'POST', headers: this.getHeaders() },
+    );
+
+    if (response.ok) {
+        const data = await response.json() as { id: number };
+        logger.info(`[E2E] Created new session: ${data.id}`, LogCategory.TEST);
+        return data.id;
+    }
+    // Keep any existing tail of the function (return null / error log) unchanged.
+}
+```
+
+  e2e is not part of `npm run test:unit` (it requires a live Artemis server). Typecheck is sufficient.
+
+- [ ] **Step 7.2: Run typecheck**
+
+```bash
+cd extension && npm run check-types
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add extension/test/e2e/uncommittedChanges.e2e.test.ts
+git commit -m "test(e2e): point uncommittedChanges helper at unified Iris API"
+```
+
+---
+
+### Task 8: Delete the seven old API methods and their tests
+
+By this point every caller has been migrated. Old methods are dead weight.
+
+**Files:**
+- Modify: `extension/src/extension/api/artemisApi.ts`
+- Modify: `extension/test/unit/api/artemisApi.test.ts`
+
+- [ ] **Step 8.1: Delete the seven methods from `extension/src/extension/api/artemisApi.ts`**
+
+  Remove (identify by name; each is a small block):
+
+  - `getCurrentCourseChat`
+  - `getCurrentExerciseChat`
+  - `getExerciseChatSessions`
+  - `getCourseChatSessionsWithMessages`
+  - `getExerciseChatSessionsWithMessages`
+  - `createCourseChatSession`
+  - `createExerciseChatSession`
+
+- [ ] **Step 8.2: Delete the corresponding test cases from `extension/test/unit/api/artemisApi.test.ts`**
+
+  Remove the `test('should ...')` blocks whose fetch assertions reference `course-chat/`, `programming-exercise-chat/`, or `chat-history/`. After this, only the three new tests from Task 4 plus the unchanged message/setting tests remain in the Iris section.
+
+- [ ] **Step 8.3: Run typecheck**
+
+```bash
+cd extension && npm run check-types
+```
+
+Expected: PASS. If a reference remains, fix the missed caller before continuing.
+
+- [ ] **Step 8.4: Compile + run the full unit suite**
+
+```bash
+cd extension && npm run compile-tests && npm run test:unit
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add extension/src/extension/api/artemisApi.ts \
+        extension/test/unit/api/artemisApi.test.ts
+git commit -m "refactor(iris-api): remove legacy per-context session methods"
+```
+
+---
+
+### Task 9: Final acceptance + CHANGELOG + PR
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 9.1: Verify no legacy endpoint strings remain under `extension/`**
+
+```bash
+cd extension && ! grep -rn 'course-chat/\|programming-exercise-chat/\|chat-history/' src test
+```
+
+Expected: command exits 0 (the `!` flips a "no matches" exit-1 from `grep` into success). Any match means the command exits non-zero — investigate and fix before continuing.
+
+- [ ] **Step 9.2: Verify no legacy method names remain under `extension/`**
+
+```bash
+cd extension && ! grep -rn 'getCurrentCourseChat\|getCurrentExerciseChat\|getExerciseChatSessions\|getCourseChatSessionsWithMessages\|getExerciseChatSessionsWithMessages\|createCourseChatSession\|createExerciseChatSession' src test
+```
+
+Expected: exits 0.
+
+- [ ] **Step 9.3: Full quality gate — lint, typecheck, full unit suite, knip**
+
+```bash
+cd extension && npm run lint && npm run check-types && npm run compile-tests && npm run test:unit && npm run knip
+```
+
+Expected: all pass.
+
+- [ ] **Step 9.4: Add CHANGELOG entry** — open `CHANGELOG.md` (repo root) and insert under `[Unreleased]`:
+
+```
+- **Iris API**: Adapted to Artemis PR #12504 (unified chat session endpoints). The
+  extension now uses `/api/iris/chat/sessions{,/current}?mode=…&entityId=…` and
+  `/api/iris/chat/{courseId}/sessions/overview` instead of the legacy per-context
+  routes. Course resolution for exercise contexts is extracted into a shared helper.
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(changelog): note Iris API migration to unified sessions"
+```
+
+- [ ] **Step 9.6: Push and open PR (from repo root)**
+
+```bash
+git push -u origin fix/iris-api-unified-sessions
+gh pr create --base dev --title "fix(iris): adapt API client to unified session endpoints (Artemis #12504)" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces 7 per-context Iris session methods with 3 unified primitives (`getCurrentChat`, `createChatSession`, `listChatSessionsForCourse`) targeting Artemis develop after [PR #12504](https://github.com/ls1intum/Artemis/pull/12504).
+- Extracts `resolveCourseIdFromContext` and `contextToIrisMode` as shared helpers so both `IrisChatSessionService` and `sessionSyncUtils` share resolution semantics.
+- Filters the new course-scoped overview by mode + entityId before fanning out to per-session message fetches, so unrelated sessions are never fetched.
+
+Spec: `docs/superpowers/specs/2026-05-13-iris-api-unified-sessions-design.md` (codex-approved, 2 rounds).
+Plan: `docs/superpowers/plans/2026-05-13-iris-api-unified-sessions.md` (codex-approved).
+
+## Test plan
+
+- [x] `npm run lint && npm run check-types && npm run compile-tests && npm run test:unit && npm run knip` clean
+- [ ] Manual smoke against a Helios test server: open chat in course context, open in exercise context, send messages, see WebSocket replies, reopen and verify history.
+- [ ] Note: e2e (`uncommittedChanges.e2e.test.ts`) requires a live Artemis develop server; verify before merge.
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec sections each map to a task:
+
+- **Types** (Task 1) — `IrisChatMode`, `IrisChatSession`, `IrisChatSessionSummary` with `[key: string]: unknown` index signatures.
+- **API primitives** (Tasks 4, 8) — three thin methods added, seven legacy methods deleted.
+- **Composition layer** (Task 5) — `fetchSessionsWithMessages(api, contextStore, context)` with filter-before-fetch + the entire `chatSessionService.test.ts` stub migration in the same atomic commit.
+- **Helpers** (Tasks 2, 3) — `contextToIrisMode` and `resolveCourseIdFromContext` with focused tests.
+- **Callers** (Tasks 5, 6) — `chatSessionService`, `chatDiagnosticsService`, `irisWebSocketSessionClient`.
+- **Tests** (Tasks 4, 5, 6, 7, 8) — every affected suite migrated; one new dedicated suite.
+- **Acceptance** (Task 9) — two grep guards (with `!` to flip semantics), lint, typecheck, full unit suite, knip, CHANGELOG.
+
+Build-stays-green discipline: new API methods added in Task 4 *alongside* old; production rewrite and the stub migration that depends on it ship together in Task 5; old methods deleted only in Task 8 after every caller has switched. Each numbered task ends on a green build.

--- a/docs/superpowers/specs/2026-05-13-iris-api-unified-sessions-design.md
+++ b/docs/superpowers/specs/2026-05-13-iris-api-unified-sessions-design.md
@@ -1,0 +1,303 @@
+# Iris API Migration to Unified Sessions (PR #12504) — Design
+
+## Goal
+
+Adapt the artemis-extension Iris API client and consumers to Artemis `develop` after PR [#12504](https://github.com/ls1intum/Artemis/pull/12504) (`Iris: Unify chat session types`, merged 2026-05-11). The pre-PR per-context REST endpoints are gone; the unified endpoints under `/api/iris/chat/sessions{,/current}` with `mode` + `entityId` query parameters replace them. The list endpoint shape also changed (lightweight summaries instead of full sessions with messages).
+
+## Scope decision
+
+**Full switch, no backwards compatibility layer.** Target is Artemis `develop` (test servers). Production Artemis `main` will run the old API for a few more weeks; the extension is temporarily incompatible with it during that window. Rationale: thesis evaluation happens against Helios/develop. Once `develop→main` lands upstream, the extension automatically becomes compatible again.
+
+Explicitly out of scope: feature detection, dual-API runtime support, env-flagged variant selection.
+
+## Architecture
+
+Three layers, each with one clear responsibility.
+
+### 1. Types — `extension/src/shared/types/apiResponses.ts`
+
+Replace the loose `IrisChatSession` with two strict DTOs mirroring the server side:
+
+```ts
+export type IrisChatMode =
+    | 'PROGRAMMING_EXERCISE_CHAT'
+    | 'TEXT_EXERCISE_CHAT'
+    | 'COURSE_CHAT'
+    | 'LECTURE_CHAT';
+
+/** Detail DTO returned by current/create/getById endpoints. */
+export interface IrisChatSession {
+    id: number;
+    mode?: IrisChatMode;
+    entityId?: number;
+    userId?: number;
+    title?: string;
+    creationDate?: string;
+    messages?: IrisChatMessage[];
+    [key: string]: unknown;
+}
+
+/** List DTO returned by /sessions/overview. No messages. */
+export interface IrisChatSessionSummary {
+    id: number;
+    entityId: number;
+    entityName?: string;
+    title?: string;
+    creationDate: string;
+    lastActivityDate?: string;
+    mode: IrisChatMode;
+    [key: string]: unknown;
+}
+```
+
+The full `IrisChatMode` enum is exported even though only `COURSE_CHAT` and `PROGRAMMING_EXERCISE_CHAT` are dispatched today. Keeps types honest with the server; adding lectures / text exercises later won't re-touch this module.
+
+`latestSuggestions` (`String`) and `citationInfo` (`List<IrisCitationMetaDTO>`) exist on the server but are unused by the extension. They are absorbed by the `[key: string]: unknown` index signature, which also keeps the client resilient against future server-side additions.
+
+### 2. API client — `extension/src/extension/api/artemisApi.ts`
+
+Delete seven methods (`getCurrentCourseChat`, `getCurrentExerciseChat`, `getExerciseChatSessions`, `getCourseChatSessionsWithMessages`, `getExerciseChatSessionsWithMessages`, `createCourseChatSession`, `createExerciseChatSession`). Replace with three HTTP-thin primitives:
+
+```ts
+async getCurrentChat(mode: IrisChatMode, entityId: number): Promise<IrisChatSession>
+// POST /api/iris/chat/sessions/current?mode={mode}&entityId={entityId}
+
+async createChatSession(mode: IrisChatMode, entityId: number): Promise<IrisChatSession>
+// POST /api/iris/chat/sessions?mode={mode}&entityId={entityId}
+
+async listChatSessionsForCourse(courseId: number): Promise<IrisChatSessionSummary[]>
+// GET /api/iris/chat/{courseId}/sessions/overview
+```
+
+The methods do not compose multiple HTTP calls. Existing `getChatMessages`, `sendChatMessage`, `markMessageHelpful`, `checkIrisHealth`, `getIrisCourseChatSettings`, `getProfileInfo` are untouched — the underlying endpoints are unchanged.
+
+### 3. Composition + helpers — `extension/src/extension/services/iris/context/`
+
+Three changes.
+
+**`contextChatMode.ts` (new):** single-line context→mode mapping helper.
+
+```ts
+import type { ChatContextType } from '../../../../shared/types/context';
+import type { IrisChatMode } from '../../../../shared/types/apiResponses';
+
+export function contextToIrisMode(type: ChatContextType): IrisChatMode {
+    return type === 'course' ? 'COURSE_CHAT' : 'PROGRAMMING_EXERCISE_CHAT';
+}
+```
+
+Single source of truth for the mapping, importable from anywhere.
+
+**`courseIdResolver.ts` (new):** extracted from `chatSessionService.resolveCourseIdForExercise`. The existing private method walks three sources (`context.courseId` → `contextStore.getExerciseById` → API `getExerciseDetails`) and registers the exercise back into the store. Migrating it out as a pure function makes it reusable from `sessionSyncUtils` without coupling.
+
+```ts
+export async function resolveCourseIdFromContext(
+    context: ActiveContext,
+    contextStore: ContextStore,
+    api: ArtemisApiService,
+): Promise<number | undefined> {
+    if (context.type === 'course') {
+        return context.id;
+    }
+    if (context.courseId) {
+        return context.courseId;
+    }
+    const tracked = contextStore.getExerciseById(context.id);
+    if (tracked?.courseId) {
+        return tracked.courseId;
+    }
+    try {
+        const details = await api.getExerciseDetails(context.id);
+        const resolved = details?.exercise?.course?.id;
+        if (resolved) {
+            contextStore.registerExercise({
+                id: context.id,
+                title: context.title,
+                shortName: context.shortName,
+                courseId: resolved,
+            });
+        }
+        return resolved;
+    } catch (error) {
+        logger.warn('Failed to resolve course from exercise details:', LogCategory.IRIS_CHAT, error);
+        return undefined;
+    }
+}
+```
+
+`chatSessionService.ts` then drops its private `resolveCourseIdForExercise` and delegates to the shared helper — same behavior, one source of truth.
+
+**`sessionSyncUtils.ts`:** `fetchSessionsWithMessages` is rewritten to take a `ContextStore` (for the resolver) and to orchestrate overview → filter → per-session messages:
+
+```ts
+export async function fetchSessionsWithMessages(
+    api: ArtemisApiService,
+    contextStore: ContextStore,
+    context: ActiveContext,
+): Promise<IrisChatSession[]> {
+    const courseId = await resolveCourseIdFromContext(context, contextStore, api);
+    if (courseId === undefined) {
+        logger.warn(
+            `Cannot list sessions: unable to resolve courseId for context ${context.type}:${context.id}`,
+            LogCategory.IRIS_CHAT,
+        );
+        return [];
+    }
+    const mode = contextToIrisMode(context.type);
+    const summaries = await api.listChatSessionsForCourse(courseId);
+    const filtered = summaries.filter(s => s.mode === mode && s.entityId === context.id);
+
+    return Promise.all(
+        filtered.map(async (summary) => {
+            try {
+                const messages = await api.getChatMessages(summary.id);
+                return {
+                    id: summary.id,
+                    title: summary.title,
+                    creationDate: summary.creationDate,
+                    mode: summary.mode,
+                    entityId: summary.entityId,
+                    messages,
+                };
+            } catch (error) {
+                logger.warn(
+                    `Failed to fetch messages for session ${summary.id}: ${error}`,
+                    LogCategory.API,
+                );
+                return {
+                    id: summary.id,
+                    title: summary.title,
+                    creationDate: summary.creationDate,
+                    mode: summary.mode,
+                    entityId: summary.entityId,
+                    messages: [],
+                };
+            }
+        }),
+    );
+}
+```
+
+Filter happens *before* the per-session message fetch — unrelated course/exercise sessions are not fetched.
+
+`importSessionsToStore` consumes `id`, `title`, `creationDate`, `messages` — all still present, so no changes needed there.
+
+Both call sites of `fetchSessionsWithMessages` (`chatSessionService.ts:449`, `chatDiagnosticsService.ts:134`) are updated to pass `contextStore` alongside `api` and `context`.
+
+### 4. WebSocket session client — `extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts`
+
+The four call sites (lines 103, 105, 122, 124) collapse into two via `contextToIrisMode`:
+
+```ts
+// Before: if context.type === 'course' { getCurrentCourseChat } else { getCurrentExerciseChat }
+const mode = contextToIrisMode(context.type);
+session = await this._artemisApiService.getCurrentChat(mode, context.id);
+
+// Before: similar fork for createXxxChatSession
+newSession = await this._artemisApiService.createChatSession(mode, context.id);
+```
+
+## Data flow
+
+For `fetchSessionsWithMessages` on an exercise context with two prior chats:
+
+```
+ActiveContext{type=exercise, id=123, courseId=42}
+  ↓
+GET /api/iris/chat/42/sessions/overview
+  ↓ returns N summaries across all modes
+filter: mode==PROGRAMMING_EXERCISE_CHAT && entityId==123  → 2 summaries
+  ↓
+parallel: GET /api/iris/sessions/{id}/messages for each
+  ↓
+2 IrisChatSession objects with messages
+```
+
+For `getCurrentChat` on a course context:
+
+```
+ActiveContext{type=course, id=42}
+  ↓ contextToIrisMode → COURSE_CHAT
+POST /api/iris/chat/sessions/current?mode=COURSE_CHAT&entityId=42
+  ↓
+IrisChatSession (with messages already embedded by the server)
+```
+
+The WebSocket topic `/user/topic/iris/{sessionId}` is unchanged; subscription logic stays as is.
+
+## Error handling
+
+- `getCurrentChat` / `createChatSession`: bubble HTTP errors up unchanged (existing `makeRequest` behavior, `ApiError` thrown on non-2xx).
+- `listChatSessionsForCourse`: bubble up — caller is `fetchSessionsWithMessages`, which defensively logs and returns `[]` on missing `courseId` only (not on HTTP failure).
+- Per-session message fetch in `fetchSessionsWithMessages`: existing behavior preserved — per-summary try/catch, log warning, return empty `messages` for that session only.
+- `sendChatMessage`'s 400-retry-without-uncommittedFiles fallback stays unchanged.
+
+## Testing strategy
+
+The old method names are stubbed in three unit suites and used in one e2e helper. All must migrate.
+
+**`extension/test/unit/api/artemisApi.test.ts`:**
+
+- Replace each test that hits an old URL (`course-chat`, `programming-exercise-chat`, `chat-history`) with one that asserts the new URL + query params (`mode=…&entityId=…`).
+- Add a test for `listChatSessionsForCourse` that asserts URL shape and parses summary DTOs.
+- Drop tests covering deleted composite methods (`getExerciseChatSessionsWithMessages` is no longer in this layer; its behavior moves to `sessionSyncUtils.test.ts`).
+
+**`extension/test/unit/services/chatSessionService.test.ts`** (heavily impacted — ~20+ stubs of old methods):
+
+- Rewrite stubs of `getCourseChatSessionsWithMessages` / `getExerciseChatSessionsWithMessages` to stub the new composition path. Since `fetchSessionsWithMessages` is invoked inside `loadAllSessionsForContext`, the cleanest stubbing is at the API primitive level: stub `listChatSessionsForCourse` returning summaries and `getChatMessages` returning the per-session messages.
+- Migrate the `mockApiService.getExerciseChatSessions.notCalled` assertion to `listChatSessionsForCourse.notCalled` (line 354).
+- Drop assertions on `getCourseChatSessionsWithMessages.calledOnceWith(courseId)` and replace with `listChatSessionsForCourse.calledOnceWith(courseId)`.
+
+**`extension/test/unit/services/websocket.test.ts`** (5 stubs at lines 539, 540, 663, 664, 665, 834):
+
+- Replace `apiService.getCurrentExerciseChat.resolves(...)` / `apiService.getCurrentCourseChat.resolves(...)` with `apiService.getCurrentChat.resolves(...)`. Same for `createExerciseChatSession` → `createChatSession`.
+
+**`extension/test/e2e/uncommittedChanges.e2e.test.ts`** (`ArtemisTestClient.getOrCreateSession`, lines 137-155):
+
+- The current-session call must become `POST /api/iris/chat/sessions/current?mode=PROGRAMMING_EXERCISE_CHAT&entityId={exerciseId}` with an explicit `method: 'POST'` (the current code at line 137 omits the method, defaulting to GET — that was a latent bug masked by the old endpoint, the new endpoint is strictly `@PostMapping`).
+- The create call becomes `POST /api/iris/chat/sessions?mode=PROGRAMMING_EXERCISE_CHAT&entityId={exerciseId}`.
+
+**New** (`extension/test/unit/services/iris/context/sessionSyncUtils.test.ts`):
+
+- `fetchSessionsWithMessages` with a mocked `ArtemisApiService` + `ContextStore`:
+    - Verifies summaries are filtered by mode + `entityId` *before* messages are fetched (assert `getChatMessages` is only called for matching summaries).
+    - Verifies messages are fetched per filtered session.
+    - Verifies the resolver positive path: exercise context with no `context.courseId` but a `contextStore.getExerciseById(...)?.courseId` resolves and `listChatSessionsForCourse(resolvedCourseId)` is called with the resolved value (separate sub-case for `getExerciseDetails` fallback).
+    - Verifies fully unresolvable `courseId` returns `[]` and does not call `listChatSessionsForCourse`.
+    - Verifies per-session fetch failure yields a session with empty `messages` rather than failing the whole batch.
+
+## Files touched
+
+```
+M  extension/src/shared/types/apiResponses.ts
+M  extension/src/extension/api/artemisApi.ts
+A  extension/src/extension/services/iris/context/contextChatMode.ts
+A  extension/src/extension/services/iris/context/courseIdResolver.ts
+M  extension/src/extension/services/iris/context/sessionSyncUtils.ts
+M  extension/src/extension/services/iris/chat/chatSessionService.ts
+M  extension/src/extension/services/iris/chat/chatDiagnosticsService.ts
+M  extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
+M  extension/test/unit/api/artemisApi.test.ts
+M  extension/test/unit/services/chatSessionService.test.ts
+M  extension/test/unit/services/websocket.test.ts
+A  extension/test/unit/services/iris/context/sessionSyncUtils.test.ts
+M  extension/test/e2e/uncommittedChanges.e2e.test.ts
+M  CHANGELOG.md
+```
+
+## Out of scope
+
+- Refactoring `ArtemisApiService` beyond the Iris session methods.
+- Backwards compatibility with the old Artemis API.
+- Migration of lecture / text-exercise modes (extension only tracks `exercise` / `course` contexts; adding them is a separate feature).
+- Changes to the WebSocket subscription path or message API.
+- `getProfileInfo`, `checkIrisHealth`, `getIrisCourseChatSettings` (unchanged endpoints).
+
+## Acceptance
+
+- Extension's Iris chat works against an Artemis `develop` deployment (Helios test server): open chat in course context, open chat in exercise context, send messages, see WebSocket replies, re-open and see history restored.
+- All previously passing unit + e2e tests pass after migration of stubs and URLs.
+- New `sessionSyncUtils` test passes, including the explicit filter-before-fetch assertion.
+- Lint + typecheck clean.
+- No reference to any old endpoint string (`course-chat/`, `programming-exercise-chat/`, `chat-history/`) remains under `extension/`.
+- No reference to any old method name (`getCurrentCourseChat`, `getCurrentExerciseChat`, `getExerciseChatSessions`, `getCourseChatSessionsWithMessages`, `getExerciseChatSessionsWithMessages`, `createCourseChatSession`, `createExerciseChatSession`) remains under `extension/`.

--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -393,65 +393,6 @@ export class ArtemisApiService {
         return response.json() as Promise<IrisSettingsResponse>;
     }
 
-    // Get or create current chat session for a course
-    async getCurrentCourseChat(courseId: number): Promise<IrisChatSession> {
-        const response = await this.makeRequest(
-            `/api/iris/course-chat/${courseId}/sessions/current`,
-            { method: 'POST' }
-        );
-        return response.json() as Promise<IrisChatSession>;
-    }
-
-    // Get or create current chat session for an exercise
-    async getCurrentExerciseChat(exerciseId: number): Promise<IrisChatSession> {
-        const response = await this.makeRequest(
-            `/api/iris/programming-exercise-chat/${exerciseId}/sessions/current`,
-            { method: 'POST' }
-        );
-        return response.json() as Promise<IrisChatSession>;
-    }
-
-    // Get all chat sessions for an exercise (metadata only, lightweight)
-    async getExerciseChatSessions(exerciseId: number): Promise<IrisChatSession[]> {
-        const response = await this.makeRequest(`/api/iris/programming-exercise-chat/${exerciseId}/sessions`);
-        return response.json() as Promise<IrisChatSession[]>;
-    }
-
-    // Get all chat sessions for a course WITH messages (heavy operation)
-    // Uses the chat-history endpoint which returns full session data
-    async getCourseChatSessionsWithMessages(courseId: number): Promise<IrisChatSession[]> {
-        const response = await this.makeRequest(`/api/iris/chat-history/${courseId}/sessions`);
-        return response.json() as Promise<IrisChatSession[]>;
-    }
-
-    // Get all chat sessions for an exercise WITH messages (heavy operation)
-    // This fetches session list first, then fetches messages for each session
-    async getExerciseChatSessionsWithMessages(exerciseId: number): Promise<IrisChatSession[]> {
-        // First get the session list (metadata only)
-        const sessions = await this.getExerciseChatSessions(exerciseId);
-
-        // Then fetch messages for each session
-        const sessionsWithMessages = await Promise.all(
-            sessions.map(async (session) => {
-                try {
-                    const messages = await this.getChatMessages(session.id);
-                    return {
-                        ...session,
-                        messages: messages
-                    };
-                } catch (error) {
-                    logger.warn(`Failed to fetch messages for session ${session.id}: ${error}`, LogCategory.API);
-                    return {
-                        ...session,
-                        messages: []
-                    };
-                }
-            })
-        );
-
-        return sessionsWithMessages;
-    }
-
     // Get messages for a chat session
     async getChatMessages(sessionId: number): Promise<IrisChatMessage[]> {
         const response = await this.makeRequest(`/api/iris/sessions/${sessionId}/messages`);
@@ -516,24 +457,6 @@ export class ArtemisApiService {
             }
             throw error;
         }
-    }
-
-    // Create a new chat session for a course
-    async createCourseChatSession(courseId: number): Promise<IrisChatSession> {
-        const response = await this.makeRequest(
-            `/api/iris/course-chat/${courseId}/sessions`,
-            { method: 'POST' }
-        );
-        return response.json() as Promise<IrisChatSession>;
-    }
-
-    // Create a new chat session for an exercise
-    async createExerciseChatSession(exerciseId: number): Promise<IrisChatSession> {
-        const response = await this.makeRequest(
-            `/api/iris/programming-exercise-chat/${exerciseId}/sessions`,
-            { method: 'POST' }
-        );
-        return response.json() as Promise<IrisChatSession>;
     }
 
     // Mark a message as helpful

--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -12,7 +12,7 @@ import type {
 import type {
     CourseDashboardResponse, CourseDashboardEntry, CourseDashboardCourse,
     ExerciseDetailsResponse, ResultSummary, IrisChatSession, IrisChatMessage, IrisSettingsResponse,
-    ExamSummary, StudentExam,
+    ExamSummary, StudentExam, IrisChatMode, IrisChatSessionSummary,
 } from '../types';
 import { logger, LogCategory } from '../services/loggingService';
 
@@ -545,6 +545,30 @@ export class ArtemisApiService {
                 body: JSON.stringify(helpful)
             }
         );
+    }
+
+    // Unified Iris chat session endpoints (Artemis develop, PR #12504).
+    async getCurrentChat(mode: IrisChatMode, entityId: number): Promise<IrisChatSession> {
+        const params = new URLSearchParams({ mode, entityId: String(entityId) });
+        const response = await this.makeRequest(
+            `/api/iris/chat/sessions/current?${params.toString()}`,
+            { method: 'POST' },
+        );
+        return response.json() as Promise<IrisChatSession>;
+    }
+
+    async createChatSession(mode: IrisChatMode, entityId: number): Promise<IrisChatSession> {
+        const params = new URLSearchParams({ mode, entityId: String(entityId) });
+        const response = await this.makeRequest(
+            `/api/iris/chat/sessions?${params.toString()}`,
+            { method: 'POST' },
+        );
+        return response.json() as Promise<IrisChatSession>;
+    }
+
+    async listChatSessionsForCourse(courseId: number): Promise<IrisChatSessionSummary[]> {
+        const response = await this.makeRequest(`/api/iris/chat/${courseId}/sessions/overview`);
+        return response.json() as Promise<IrisChatSessionSummary[]>;
     }
 
     // Get exam sidebar data for a specific course (student-accessible).

--- a/extension/src/extension/services/iris/chat/chatDiagnosticsService.ts
+++ b/extension/src/extension/services/iris/chat/chatDiagnosticsService.ts
@@ -131,7 +131,7 @@ export class ChatDiagnosticsService {
 
         report += '🌐 FETCHING SESSIONS FROM ARTEMIS...\n\n';
 
-        const artemisSessionsListFromServer = await fetchSessionsWithMessages(this._artemisApiService, activeContext);
+        const artemisSessionsListFromServer = await fetchSessionsWithMessages(this._artemisApiService, this._contextStore, activeContext);
 
         report += `📊 TOTAL SESSIONS FOUND: ${artemisSessionsListFromServer.length}\n`;
         report += `   (All sessions are for ${activeContext.type} ${activeContext.id}: ${activeContext.title})\n`;

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -423,7 +423,7 @@ export class IrisChatSessionService {
         targetContext: ActiveContext,
         loadToken: number,
     ): Promise<number> {
-        const sessions = await fetchSessionsWithMessages(this.deps.artemisApiService!, targetContext);
+        const sessions = await fetchSessionsWithMessages(this.deps.artemisApiService!, this.deps.contextStore, targetContext);
 
         logger.info(`Fetched ${sessions.length} session(s) with messages from Artemis`, LogCategory.IRIS_CHAT);
 

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -5,6 +5,7 @@ import { logger, LogCategory } from '../../loggingService';
 import { ExtensionMsg } from '../../../../shared/messageContracts';
 import { fetchSessionsWithMessages, importSessionsToStore } from '../context/sessionSyncUtils';
 import type { IrisServiceDeps } from '../context/sessionSyncUtils';
+import { resolveCourseIdFromContext } from '../context/courseIdResolver';
 
 /**
  * Orchestrates Iris chat session lifecycle (create, load, switch).
@@ -101,31 +102,7 @@ export class IrisChatSessionService {
     }
 
     private async resolveCourseIdForExercise(context: ActiveContext): Promise<number | undefined> {
-        if (context.courseId) {
-            return context.courseId;
-        }
-
-        const tracked = this.deps.contextStore.getExerciseById(context.id);
-        if (tracked?.courseId) {
-            return tracked.courseId;
-        }
-
-        try {
-            const exerciseDetails = await this.deps.artemisApiService?.getExerciseDetails(context.id);
-            const resolvedCourseId = exerciseDetails?.exercise?.course?.id;
-            if (resolvedCourseId) {
-                this.deps.contextStore.registerExercise({
-                    id: context.id,
-                    title: context.title,
-                    shortName: context.shortName,
-                    courseId: resolvedCourseId,
-                });
-            }
-            return resolvedCourseId;
-        } catch (error) {
-            logger.warn('Failed to resolve course from exercise details:', LogCategory.IRIS_CHAT, error);
-            return undefined;
-        }
+        return resolveCourseIdFromContext(context, this.deps.contextStore, this.deps.artemisApiService);
     }
 
     // ── System-driven: load sessions on context switch ─────────────────

--- a/extension/src/extension/services/iris/context/contextChatMode.ts
+++ b/extension/src/extension/services/iris/context/contextChatMode.ts
@@ -1,0 +1,10 @@
+import type { ChatContextType } from '../../../../shared/types/context';
+import type { IrisChatMode } from '../../../../shared/types/apiResponses';
+
+/**
+ * Maps the extension's ChatContextType to the Artemis IrisChatMode enum
+ * expected by the unified /api/iris/chat endpoints. Single source of truth.
+ */
+export function contextToIrisMode(type: ChatContextType): IrisChatMode {
+    return type === 'course' ? 'COURSE_CHAT' : 'PROGRAMMING_EXERCISE_CHAT';
+}

--- a/extension/src/extension/services/iris/context/courseIdResolver.ts
+++ b/extension/src/extension/services/iris/context/courseIdResolver.ts
@@ -1,0 +1,50 @@
+import type { ActiveContext } from '../../../../shared/types/context';
+import { logger, LogCategory } from '../../loggingService';
+import type { ArtemisApiService } from '../../../api';
+import type { ContextStore } from './contextStore';
+
+/**
+ * Resolves the courseId for an ActiveContext, walking:
+ *   1. context.courseId (or context.id when type === 'course')
+ *   2. contextStore.getExerciseById(...).courseId
+ *   3. api.getExerciseDetails(...).exercise.course.id (registers the exercise back into the store on success)
+ *
+ * Returns undefined if all three paths fail. Mirrors the legacy private
+ * resolveCourseIdForExercise from chatSessionService.ts so behavior is preserved
+ * across both the IrisChatSessionService and sessionSyncUtils call sites.
+ */
+export async function resolveCourseIdFromContext(
+    context: ActiveContext,
+    contextStore: ContextStore,
+    api: ArtemisApiService | undefined,
+): Promise<number | undefined> {
+    if (context.type === 'course') {
+        return context.id;
+    }
+    if (context.courseId) {
+        return context.courseId;
+    }
+    const tracked = contextStore.getExerciseById(context.id);
+    if (tracked?.courseId) {
+        return tracked.courseId;
+    }
+    if (!api) {
+        return undefined;
+    }
+    try {
+        const details = await api.getExerciseDetails(context.id);
+        const resolved = details?.exercise?.course?.id;
+        if (resolved) {
+            contextStore.registerExercise({
+                id: context.id,
+                title: context.title,
+                shortName: context.shortName,
+                courseId: resolved,
+            });
+        }
+        return resolved;
+    } catch (error) {
+        logger.warn('Failed to resolve course from exercise details:', LogCategory.IRIS_CHAT, error);
+        return undefined;
+    }
+}

--- a/extension/src/extension/services/iris/context/sessionSyncUtils.ts
+++ b/extension/src/extension/services/iris/context/sessionSyncUtils.ts
@@ -1,13 +1,15 @@
 import { ArtemisApiService } from '../../../api';
 import { ContextStore } from './contextStore';
+import { contextToIrisMode } from './contextChatMode';
+import { resolveCourseIdFromContext } from './courseIdResolver';
 import { extractIrisMessageContent } from '../chat/messageUtils';
 import { logger, LogCategory } from '../../loggingService';
 import type { ActiveContext, IrisChatSession, IrisChatMessage } from '../../../types';
 import type { ExtensionToWebviewMessage } from '../../../../shared/messageContracts';
 
 /**
- * Shared dependency bag for Iris services.
- * Bundles common params so constructors stay short and wiring is DRY.
+ * Shared dependency bag for Iris services. Bundles common params so
+ * constructors stay short and wiring is DRY.
  */
 export interface IrisServiceDeps {
     contextStore: ContextStore;
@@ -17,20 +19,49 @@ export interface IrisServiceDeps {
 }
 
 /**
- * Fetches all sessions with messages for the given context.
- * Delegates to the existing API methods that handle the fetch-metadata → fetch-messages dance.
+ * Lists Iris chat sessions for the given context and hydrates each with messages.
+ *
+ * The unified /api/iris/chat/{courseId}/sessions/overview endpoint returns
+ * lightweight summaries across all modes for the course. We filter to the
+ * relevant mode + entityId before fanning out to /api/iris/sessions/{id}/messages
+ * so unrelated sessions are never fetched.
  */
 export async function fetchSessionsWithMessages(
     api: ArtemisApiService,
-    context: ActiveContext
+    contextStore: ContextStore,
+    context: ActiveContext,
 ): Promise<IrisChatSession[]> {
-    if (context.type === 'course') {
-        return api.getCourseChatSessionsWithMessages(context.id);
-    } else if (context.type === 'exercise') {
-        return api.getExerciseChatSessionsWithMessages(context.id);
+    const courseId = await resolveCourseIdFromContext(context, contextStore, api);
+    if (courseId === undefined) {
+        logger.warn(
+            `Cannot list sessions: unable to resolve courseId for context ${context.type}:${context.id}`,
+            LogCategory.IRIS_CHAT,
+        );
+        return [];
     }
-    logger.info(`Unsupported context type: ${context.type}`, LogCategory.IRIS_CHAT);
-    return [];
+    const mode = contextToIrisMode(context.type);
+    const summaries = await api.listChatSessionsForCourse(courseId);
+    const filtered = summaries.filter(s => s.mode === mode && s.entityId === context.id);
+
+    return Promise.all(filtered.map(async (summary) => {
+        const base = {
+            id: summary.id,
+            title: summary.title,
+            creationDate: summary.creationDate,
+            mode: summary.mode,
+            entityId: summary.entityId,
+        };
+        try {
+            const messages = await api.getChatMessages(summary.id);
+            return { ...base, messages };
+        } catch (error) {
+            logger.warn(
+                `Failed to fetch messages for session ${summary.id}: ${error}`,
+                LogCategory.API,
+            );
+            return { ...base, messages: [] };
+        }
+    }));
 }
 
 /**
@@ -39,16 +70,15 @@ export async function fetchSessionsWithMessages(
  *
  * Returns the number of sessions actually imported. Empty server sessions
  * (no messages) are skipped — callers rely on this count to decide whether
- * to fall back to creating a fresh session, so it must reflect what is
- * really in the store, not the raw server payload size.
+ * to fall back to creating a fresh session.
  *
  * NOTE: createSessionWithDetails() prepends sessions. Since we iterate
  * newest-first and prepend each time, the stored array ends up oldest-first.
- * This is existing behavior — preserving it intentionally.
+ * Existing behavior, preserved intentionally.
  */
 export function importSessionsToStore(
     sessions: IrisChatSession[],
-    contextStore: ContextStore
+    contextStore: ContextStore,
 ): number {
     if (sessions.length === 0) {
         return 0;
@@ -57,21 +87,18 @@ export function importSessionsToStore(
     sessions.sort((a, b) => {
         const timeA = a.creationDate ? new Date(a.creationDate).getTime() : 0;
         const timeB = b.creationDate ? new Date(b.creationDate).getTime() : 0;
-        return timeB - timeA; // newest first
+        return timeB - timeA;
     });
 
     let imported = 0;
     for (const session of sessions) {
         const messageCount = session.messages?.length || 0;
-
-        // Skip empty sessions — they were created but never used
         if (messageCount === 0) {
             continue;
         }
 
         const createdAt = session.creationDate ? new Date(session.creationDate).getTime() : Date.now();
 
-        // Extract preview from first user message using shared content extractor
         let preview = 'New conversation';
         if (session.messages && session.messages.length > 0) {
             const firstUserMsg = session.messages.find((m: IrisChatMessage) => m.sender === 'USER');

--- a/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
+++ b/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
@@ -3,6 +3,7 @@ import { ArtemisApiService } from '../../../api';
 import { ArtemisWebsocketService } from '../../websocket/artemisWebsocketService';
 import { ActiveContext, type IrisChatMessage } from '../../../types';
 import { logger, LogLevel } from '../../loggingService';
+import { contextToIrisMode } from '../context/contextChatMode';
 
 /** WebSocket message structure for Iris chat */
 interface IrisWebSocketMessage {
@@ -98,14 +99,8 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
             sessionId = storedSessionId;
         } else {
             logger.session('Fetching current session from Artemis');
-            let session;
-            if (context.type === 'course') {
-                session = await this._artemisApiService.getCurrentCourseChat(context.id);
-            } else if (context.type === 'exercise') {
-                session = await this._artemisApiService.getCurrentExerciseChat(context.id);
-            } else {
-                throw new Error(`Unsupported context type: ${context.type}`);
-            }
+            const mode = contextToIrisMode(context.type);
+            const session = await this._artemisApiService.getCurrentChat(mode, context.id);
             sessionId = session.id;
         }
 
@@ -117,14 +112,8 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
     public async createNewSession(context: ActiveContext): Promise<number> {
         logger.session(`Creating NEW Iris session for ${context.type} ${context.id}`);
 
-        let newSession;
-        if (context.type === 'course') {
-            newSession = await this._artemisApiService.createCourseChatSession(context.id);
-        } else if (context.type === 'exercise') {
-            newSession = await this._artemisApiService.createExerciseChatSession(context.id);
-        } else {
-            throw new Error(`Unsupported context type: ${context.type}`);
-        }
+        const mode = contextToIrisMode(context.type);
+        const newSession = await this._artemisApiService.createChatSession(mode, context.id);
 
         this._currentArtemisSessionId = newSession.id;
         await this._subscribeIfConnected(newSession.id);

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -110,11 +110,33 @@ export interface FeedbackSummary {
     [key: string]: unknown;
 }
 
+export type IrisChatMode =
+    | 'PROGRAMMING_EXERCISE_CHAT'
+    | 'TEXT_EXERCISE_CHAT'
+    | 'COURSE_CHAT'
+    | 'LECTURE_CHAT';
+
+/** Detail DTO returned by /api/iris/chat/sessions/current, /sessions, and /{courseId}/session/{sessionId}. */
 export interface IrisChatSession {
     id: number;
+    mode?: IrisChatMode;
+    entityId?: number;
+    userId?: number;
     title?: string;
     creationDate?: string;
     messages?: IrisChatMessage[];
+    [key: string]: unknown;
+}
+
+/** Listing DTO returned by /api/iris/chat/{courseId}/sessions/overview. No messages. */
+export interface IrisChatSessionSummary {
+    id: number;
+    entityId: number;
+    entityName?: string;
+    title?: string;
+    creationDate: string;
+    lastActivityDate?: string;
+    mode: IrisChatMode;
     [key: string]: unknown;
 }
 

--- a/extension/test/e2e/uncommittedChanges.e2e.test.ts
+++ b/extension/test/e2e/uncommittedChanges.e2e.test.ts
@@ -133,10 +133,15 @@ class ArtemisTestClient extends ArtemisTestClientBase {
     async getOrCreateSession(exerciseId: number): Promise<number | null> {
         logger.info(`[E2E] Getting/creating Iris session for exercise ${exerciseId}...`, LogCategory.TEST);
 
+        const params = new URLSearchParams({
+            mode: 'PROGRAMMING_EXERCISE_CHAT',
+            entityId: String(exerciseId),
+        });
+
         // Try to get current session
         let response = await fetch(
-            `${this.baseUrl}/api/iris/programming-exercise-chat/${exerciseId}/sessions/current`,
-            { headers: this.getHeaders() }
+            `${this.baseUrl}/api/iris/chat/sessions/current?${params.toString()}`,
+            { method: 'POST', headers: this.getHeaders() },
         );
 
         if (response.ok) {
@@ -147,11 +152,8 @@ class ArtemisTestClient extends ArtemisTestClientBase {
 
         // Create new session
         response = await fetch(
-            `${this.baseUrl}/api/iris/programming-exercise-chat/${exerciseId}/sessions`,
-            {
-                method: 'POST',
-                headers: this.getHeaders(),
-            }
+            `${this.baseUrl}/api/iris/chat/sessions?${params.toString()}`,
+            { method: 'POST', headers: this.getHeaders() },
         );
 
         if (response.ok) {

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -653,6 +653,48 @@ suite('Artemis API Service Test Suite', () => {
         await apiService.sendChatMessage(sessionId, content);
     });
 
+    test('should get current chat session via unified endpoint', async () => {
+        const entityId = 42;
+        global.fetch = async (url: any, options: any) => {
+            assert.ok(url.includes('/api/iris/chat/sessions/current'));
+            assert.ok(url.includes('mode=COURSE_CHAT'));
+            assert.ok(url.includes(`entityId=${entityId}`));
+            assert.strictEqual(options.method, 'POST');
+            return { ok: true, status: 200, json: async () => ({ id: 123 }) } as any;
+        };
+        const session = await apiService.getCurrentChat('COURSE_CHAT', entityId);
+        assert.strictEqual(session.id, 123);
+    });
+
+    test('should create chat session via unified endpoint', async () => {
+        const entityId = 99;
+        global.fetch = async (url: any, options: any) => {
+            assert.ok(url.includes('/api/iris/chat/sessions'));
+            assert.ok(!url.includes('/sessions/current'));
+            assert.ok(url.includes('mode=PROGRAMMING_EXERCISE_CHAT'));
+            assert.ok(url.includes(`entityId=${entityId}`));
+            assert.strictEqual(options.method, 'POST');
+            return { ok: true, status: 200, json: async () => ({ id: 7 }) } as any;
+        };
+        const session = await apiService.createChatSession('PROGRAMMING_EXERCISE_CHAT', entityId);
+        assert.strictEqual(session.id, 7);
+    });
+
+    test('should list chat sessions for course via overview endpoint', async () => {
+        const courseId = 5;
+        const mockSummaries = [
+            { id: 1, entityId: 5, mode: 'COURSE_CHAT', creationDate: '2026-05-13T00:00:00Z' },
+            { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: '2026-05-13T01:00:00Z' },
+        ];
+        global.fetch = async (url: any, options: any) => {
+            assert.ok(url.includes(`/api/iris/chat/${courseId}/sessions/overview`));
+            assert.ok(!options?.method || options.method === 'GET');
+            return { ok: true, status: 200, json: async () => mockSummaries } as any;
+        };
+        const summaries = await apiService.listChatSessionsForCourse(courseId);
+        assert.deepStrictEqual(summaries, mockSummaries);
+    });
+
     test('should throw when authentication succeeds without cookie', async () => {
         let storeCalled = false;
         (authManager as any).storeArtemisCredentials = async () => {

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -334,21 +334,6 @@ suite('Artemis API Service Test Suite', () => {
         await apiService.getIrisCourseChatSettings(courseId);
     });
 
-    test('should get current course chat session', async () => {
-        const courseId = 1;
-        global.fetch = async (url: any, options: any) => {
-            assert.ok(url.includes(`/api/iris/course-chat/${courseId}/sessions/current`));
-            assert.strictEqual(options.method, 'POST');
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({ id: 123 }),
-            } as any;
-        };
-
-        await apiService.getCurrentCourseChat(courseId);
-    });
-
     test('should get chat messages', async () => {
         const sessionId = 123;
         const mockMessages = [{ id: 1, content: 'Hello' }];
@@ -466,70 +451,6 @@ suite('Artemis API Service Test Suite', () => {
         assert.strictEqual(submission, null);
     });
 
-    test('should get exercise chat sessions', async () => {
-        const exerciseId = 1;
-        const mockSessions = [{ id: 1 }];
-        global.fetch = async (url: any) => {
-            assert.ok(url.includes(`/api/iris/programming-exercise-chat/${exerciseId}/sessions`));
-            return {
-                ok: true,
-                status: 200,
-                json: async () => mockSessions,
-            } as any;
-        };
-
-        const sessions = await apiService.getExerciseChatSessions(exerciseId);
-        assert.deepStrictEqual(sessions, mockSessions);
-    });
-
-    test('should get course chat sessions with messages', async () => {
-        const courseId = 1;
-        const mockSessions = [{ id: 1, messages: [] }];
-        global.fetch = async (url: any) => {
-            assert.ok(url.includes(`/api/iris/chat-history/${courseId}/sessions`));
-            return {
-                ok: true,
-                status: 200,
-                json: async () => mockSessions,
-            } as any;
-        };
-
-        const sessions = await apiService.getCourseChatSessionsWithMessages(courseId);
-        assert.deepStrictEqual(sessions, mockSessions);
-    });
-
-    test('should create course chat session', async () => {
-        const courseId = 1;
-        global.fetch = async (url: any, options: any) => {
-            assert.ok(url.includes(`/api/iris/course-chat/${courseId}/sessions`));
-            assert.strictEqual(options.method, 'POST');
-            return {
-                ok: true,
-                status: 201,
-                json: async () => ({ id: 1 }),
-            } as any;
-        };
-
-        const session = await apiService.createCourseChatSession(courseId);
-        assert.strictEqual(session.id, 1);
-    });
-
-    test('should create exercise chat session', async () => {
-        const exerciseId = 1;
-        global.fetch = async (url: any, options: any) => {
-            assert.ok(url.includes(`/api/iris/programming-exercise-chat/${exerciseId}/sessions`));
-            assert.strictEqual(options.method, 'POST');
-            return {
-                ok: true,
-                status: 201,
-                json: async () => ({ id: 1 }),
-            } as any;
-        };
-
-        const session = await apiService.createExerciseChatSession(exerciseId);
-        assert.strictEqual(session.id, 1);
-    });
-
     test('should mark message helpful', async () => {
         const sessionId = 1;
         const messageId = 1;
@@ -573,60 +494,6 @@ suite('Artemis API Service Test Suite', () => {
         const token = await apiService.getOrCreateVcsAccessToken(participationId);
         assert.strictEqual(attempt, 2);
         assert.strictEqual(token, createdToken);
-    });
-
-    test('should get current exercise chat session', async () => {
-        const exerciseId = 77;
-        global.fetch = async (url: any, options: any) => {
-            assert.ok(url.includes(`/api/iris/programming-exercise-chat/${exerciseId}/sessions/current`));
-            assert.strictEqual(options.method, 'POST');
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({ id: 555 })
-            } as any;
-        };
-
-        const session = await apiService.getCurrentExerciseChat(exerciseId);
-        assert.strictEqual(session.id, 555);
-    });
-
-    test('should fetch exercise chat sessions with messages', async () => {
-        const exerciseId = 77;
-        const sessions = [{ id: 1 }, { id: 2 }];
-        const messages: Record<number, any[]> = {
-            1: [{ id: 'm1' }],
-            2: [{ id: 'm2' }]
-        };
-
-        global.fetch = async (url: any) => {
-            if (url.includes(`/api/iris/programming-exercise-chat/${exerciseId}/sessions`)) {
-                return {
-                    ok: true,
-                    status: 200,
-                    json: async () => sessions
-                } as any;
-            }
-            if (url.includes('/api/iris/sessions/1/messages')) {
-                return {
-                    ok: true,
-                    status: 200,
-                    json: async () => messages[1]
-                } as any;
-            }
-            if (url.includes('/api/iris/sessions/2/messages')) {
-                return {
-                    ok: true,
-                    status: 200,
-                    json: async () => messages[2]
-                } as any;
-            }
-            return { ok: true, status: 200, json: async () => [] } as any;
-        };
-
-        const result = await apiService.getExerciseChatSessionsWithMessages(exerciseId);
-        assert.deepStrictEqual(result[0].messages, messages[result[0].id]);
-        assert.deepStrictEqual(result[1].messages, messages[result[1].id]);
     });
 
     test('should include auth headers and payload when sending chat message', async () => {

--- a/extension/test/unit/services/chatSessionService.test.ts
+++ b/extension/test/unit/services/chatSessionService.test.ts
@@ -350,8 +350,7 @@ suite('IrisChatSessionService Test Suite', () => {
         test('should not load sessions when no active context', async () => {
             await chatSessionService.loadAllSessionsForContext();
 
-            assert.ok(mockApiService.getCourseChatSessionsWithMessages.notCalled);
-            assert.ok(mockApiService.getExerciseChatSessions.notCalled);
+            assert.ok(mockApiService.listChatSessionsForCourse.notCalled);
         });
 
         test('should not load sessions when API service is not available', async () => {
@@ -423,18 +422,27 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Hello' }] }] },
-                { id: 2, creationDate: '2024-01-02T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Hi there' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+                { id: 2, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-02T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hello' }] },
+            ]);
+            mockApiService.getChatMessages.withArgs(2).resolves([
+                { id: 200, sender: 'USER', content: [{ textContent: 'Hi there' }] },
             ]);
 
             // Stub initializeSession for the _loadIrisMessages call
-            mockIrisWebSocketSessionClient.initializeSession.resolves(1);
-            mockApiService.getChatMessages.resolves([]);
+            mockIrisWebSocketSessionClient.initializeSession.resolves(2);
+            // Second call for hydration of the active session
+            mockApiService.getChatMessages.withArgs(2).resolves([
+                { id: 200, sender: 'USER', content: [{ textContent: 'Hi there' }] },
+            ]);
 
             await chatSessionService.loadAllSessionsForContext();
 
-            assert.ok(mockApiService.getCourseChatSessionsWithMessages.calledOnceWith(101));
+            assert.ok(mockApiService.listChatSessionsForCourse.calledOnceWith(101));
             assert.ok(onPostSnapshotSpy.called);
 
             const snapshot = contextStore.snapshot();
@@ -458,16 +466,18 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getExerciseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Question' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Question' }] },
             ]);
 
             mockIrisWebSocketSessionClient.initializeSession.resolves(1);
-            mockApiService.getChatMessages.resolves([]);
 
             await chatSessionService.loadAllSessionsForContext();
 
-            assert.ok(mockApiService.getExerciseChatSessionsWithMessages.calledOnceWith(123));
+            assert.ok(mockApiService.listChatSessionsForCourse.calledOnceWith(101));
         });
 
         test('should create new session when no sessions exist', async () => {
@@ -486,7 +496,7 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([]);
+            mockApiService.listChatSessionsForCourse.resolves([]);
 
             // Stub createNewSession for the fallback
             mockIrisWebSocketSessionClient.createNewSession.resolves(42);
@@ -520,18 +530,27 @@ suite('IrisChatSessionService Test Suite', () => {
             // Use non-empty sessions — empty ones are intentionally skipped
             // by importSessionsToStore (they would not contribute to the
             // session list, breaking the assertion below).
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Q1' }] }] },
-                { id: 2, creationDate: '2024-01-03T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Q2' }] }] }, // Newest
-                { id: 3, creationDate: '2024-01-02T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Q3' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+                { id: 2, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-03T10:00:00Z' }, // Newest
+                { id: 3, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-02T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 10, sender: 'USER', content: [{ textContent: 'Q1' }] },
+            ]);
+            mockApiService.getChatMessages.withArgs(2).resolves([
+                { id: 20, sender: 'USER', content: [{ textContent: 'Q2' }] },
+            ]);
+            mockApiService.getChatMessages.withArgs(3).resolves([
+                { id: 30, sender: 'USER', content: [{ textContent: 'Q3' }] },
             ]);
 
             mockIrisWebSocketSessionClient.initializeSession.resolves(2);
             // Match the imported session's messageCount=1 so the stale
             // session-id cleanup branch in initializeIrisSessionAndLoadMessages
             // does not strip the active session's artemisSessionId.
-            mockApiService.getChatMessages.resolves([
-                { id: 1, sender: 'USER', content: [{ textContent: 'Q2' }], sentAt: '2024-01-03T10:00:00Z' } as never
+            mockApiService.getChatMessages.withArgs(2).resolves([
+                { id: 20, sender: 'USER', content: [{ textContent: 'Q2' }], sentAt: '2024-01-03T10:00:00Z' } as never
             ]);
 
             await chatSessionService.loadAllSessionsForContext();
@@ -560,7 +579,7 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getCourseChatSessionsWithMessages.callsFake(async () => {
+            mockApiService.listChatSessionsForCourse.callsFake(async () => {
                 // Change context during loading
                 const context2: ActiveContext = {
                     type: 'exercise',
@@ -597,7 +616,7 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getCourseChatSessionsWithMessages.rejects(new Error('API Error'));
+            mockApiService.listChatSessionsForCourse.rejects(new Error('API Error'));
 
             mockIrisWebSocketSessionClient.createNewSession.resolves(42);
 
@@ -635,15 +654,18 @@ suite('IrisChatSessionService Test Suite', () => {
             // Non-empty server session — empty ones are skipped by
             // importSessionsToStore, which would defeat the assertion that
             // the API session ends up in the store.
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Hi' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hi' }] },
             ]);
 
             mockIrisWebSocketSessionClient.initializeSession.resolves(1);
             // Return a message matching the imported session so the stale
             // cleanup branch does not strip the artemisSessionId.
-            mockApiService.getChatMessages.resolves([
-                { id: 1, sender: 'USER', content: [{ textContent: 'Hi' }], sentAt: '2024-01-01T10:00:00Z' } as never
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hi' }], sentAt: '2024-01-01T10:00:00Z' } as never
             ]);
 
             await chatSessionService.loadAllSessionsForContext();
@@ -672,7 +694,7 @@ suite('IrisChatSessionService Test Suite', () => {
                 settings: { enabled: true }
             });
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([]);
+            mockApiService.listChatSessionsForCourse.resolves([]);
             mockIrisWebSocketSessionClient.createNewSession.resolves(42);
 
             await chatSessionService.loadAllSessionsForContext();
@@ -698,11 +720,15 @@ suite('IrisChatSessionService Test Suite', () => {
             contextStore.setActiveContext(context);
 
             mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 7, creationDate: '2024-02-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Hello' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 7, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-02-01T10:00:00Z' },
+            ]);
+            // First call: import phase (in fetchSessionsWithMessages)
+            // Second call: hydration phase (in initializeIrisSessionAndLoadMessages)
+            mockApiService.getChatMessages.withArgs(7).resolves([
+                { id: 70, sender: 'USER', content: [{ textContent: 'Hello' }] },
             ]);
             mockIrisWebSocketSessionClient.initializeSession.resolves(7);
-            mockApiService.getChatMessages.resolves([]);
 
             await chatSessionService.loadAllSessionsForContext();
 
@@ -749,10 +775,13 @@ suite('IrisChatSessionService Test Suite', () => {
             contextStore.setActiveContext(context);
 
             mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [] },
-                { id: 2, creationDate: '2024-01-02T10:00:00Z', messages: [] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+                { id: 2, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-02T10:00:00Z' },
             ]);
+            // Both sessions return empty messages — import phase yields [], skipped by importSessionsToStore
+            mockApiService.getChatMessages.withArgs(1).resolves([]);
+            mockApiService.getChatMessages.withArgs(2).resolves([]);
             mockIrisWebSocketSessionClient.createNewSession.resolves(99);
 
             await chatSessionService.loadAllSessionsForContext();
@@ -782,16 +811,23 @@ suite('IrisChatSessionService Test Suite', () => {
             contextStore.setActiveContext(context);
 
             mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'A' }] }] },
-                { id: 2, creationDate: '2024-01-02T10:00:00Z', messages: [] },
-                { id: 3, creationDate: '2024-01-03T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'B' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+                { id: 2, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-02T10:00:00Z' },
+                { id: 3, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-03T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 10, sender: 'USER', content: [{ textContent: 'A' }] },
+            ]);
+            mockApiService.getChatMessages.withArgs(2).resolves([]);
+            mockApiService.getChatMessages.withArgs(3).resolves([
+                { id: 30, sender: 'USER', content: [{ textContent: 'B' }] },
             ]);
             mockIrisWebSocketSessionClient.initializeSession.resolves(3);
             // Match the active (newest, id=3) session's content to keep its
             // artemisSessionId mapping after hydration.
-            mockApiService.getChatMessages.resolves([
-                { id: 1, sender: 'USER', content: [{ textContent: 'B' }], sentAt: '2024-01-03T10:00:00Z' } as never
+            mockApiService.getChatMessages.withArgs(3).resolves([
+                { id: 30, sender: 'USER', content: [{ textContent: 'B' }], sentAt: '2024-01-03T10:00:00Z' } as never
             ]);
 
             await chatSessionService.loadAllSessionsForContext();
@@ -823,12 +859,18 @@ suite('IrisChatSessionService Test Suite', () => {
             contextStore.setActiveContext(context);
 
             mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 5, creationDate: '2024-01-05T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'X' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 5, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-05T10:00:00Z' },
             ]);
-            // Simulate server failure during message hydration.
+            // Pattern D: first call satisfies import phase so session gets imported;
+            // second call is the active-session hydration in initializeIrisSessionAndLoadMessages,
+            // which is what this test is asserting against.
+            const failingSessionFetch = mockApiService.getChatMessages.withArgs(5);
+            failingSessionFetch.onFirstCall().resolves([
+                { id: 50, sender: 'USER', content: [{ textContent: 'X' }] },
+            ]);
+            failingSessionFetch.onSecondCall().rejects(new Error('Server error during hydration'));
             mockIrisWebSocketSessionClient.initializeSession.resolves(5);
-            mockApiService.getChatMessages.rejects(new Error('boom'));
 
             await chatSessionService.loadAllSessionsForContext();
 
@@ -983,12 +1025,14 @@ suite('IrisChatSessionService Test Suite', () => {
             };
             contextStore.setActiveContext(context);
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([
-                { id: 1, creationDate: '2024-01-01T10:00:00Z', messages: [{ sender: 'USER', content: [{ textContent: 'Hi' }] }] }
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hi' }] },
             ]);
 
             mockIrisWebSocketSessionClient.initializeSession.resolves(1);
-            mockApiService.getChatMessages.resolves([]);
 
             const count = await chatSessionService.resetAndReloadSessions();
 
@@ -1015,7 +1059,7 @@ suite('IrisChatSessionService Test Suite', () => {
             };
             contextStore.setActiveContext(context);
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([]);
+            mockApiService.listChatSessionsForCourse.resolves([]);
             mockIrisWebSocketSessionClient.createNewSession.resolves(99);
 
             await chatSessionService.resetAndReloadSessions();
@@ -1037,7 +1081,7 @@ suite('IrisChatSessionService Test Suite', () => {
             };
             contextStore.setActiveContext(context);
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([]);
+            mockApiService.listChatSessionsForCourse.resolves([]);
             mockIrisWebSocketSessionClient.createNewSession.resolves(99);
 
             const count = await chatSessionService.resetAndReloadSessions();
@@ -1060,7 +1104,7 @@ suite('IrisChatSessionService Test Suite', () => {
             };
             contextStore.setActiveContext(context);
 
-            mockApiService.getCourseChatSessionsWithMessages.resolves([]);
+            mockApiService.listChatSessionsForCourse.resolves([]);
             mockIrisWebSocketSessionClient.createNewSession.resolves(99);
 
             await chatSessionService.resetAndReloadSessions();
@@ -1083,7 +1127,7 @@ suite('IrisChatSessionService Test Suite', () => {
             };
             contextStore.setActiveContext(context);
 
-            mockApiService.getCourseChatSessionsWithMessages.rejects(new Error('Server down'));
+            mockApiService.listChatSessionsForCourse.rejects(new Error('Server down'));
 
             await assert.rejects(
                 () => chatSessionService.resetAndReloadSessions(),

--- a/extension/test/unit/services/iris/context/contextChatMode.test.ts
+++ b/extension/test/unit/services/iris/context/contextChatMode.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert';
+import { contextToIrisMode } from '../../../../../src/extension/services/iris/context/contextChatMode';
+
+suite('contextToIrisMode', () => {
+    test('maps course → COURSE_CHAT', () => {
+        assert.strictEqual(contextToIrisMode('course'), 'COURSE_CHAT');
+    });
+
+    test('maps exercise → PROGRAMMING_EXERCISE_CHAT', () => {
+        assert.strictEqual(contextToIrisMode('exercise'), 'PROGRAMMING_EXERCISE_CHAT');
+    });
+});

--- a/extension/test/unit/services/iris/context/courseIdResolver.test.ts
+++ b/extension/test/unit/services/iris/context/courseIdResolver.test.ts
@@ -1,0 +1,73 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { resolveCourseIdFromContext } from '../../../../../src/extension/services/iris/context/courseIdResolver';
+import type { ActiveContext } from '../../../../../src/shared/types/context';
+
+function makeContextStore(overrides: any = {}): any {
+    return {
+        getExerciseById: sinon.stub().returns(undefined),
+        registerExercise: sinon.stub(),
+        ...overrides,
+    };
+}
+
+function makeApi(overrides: any = {}): any {
+    return {
+        getExerciseDetails: sinon.stub().rejects(new Error('not stubbed')),
+        ...overrides,
+    };
+}
+
+const courseContext: ActiveContext = {
+    type: 'course', id: 42, title: 'C', source: 'user-selected', locked: false, selectedAt: 0,
+};
+const exerciseContext: ActiveContext = {
+    type: 'exercise', id: 123, title: 'E', source: 'user-selected', locked: false, selectedAt: 0,
+};
+
+suite('resolveCourseIdFromContext', () => {
+    test('course context returns its own id', async () => {
+        const id = await resolveCourseIdFromContext(courseContext, makeContextStore(), makeApi());
+        assert.strictEqual(id, 42);
+    });
+
+    test('exercise context with courseId returns it directly', async () => {
+        const ctx = { ...exerciseContext, courseId: 7 };
+        const id = await resolveCourseIdFromContext(ctx, makeContextStore(), makeApi());
+        assert.strictEqual(id, 7);
+    });
+
+    test('falls back to contextStore when context has no courseId', async () => {
+        const store = makeContextStore({
+            getExerciseById: sinon.stub().withArgs(123).returns({ id: 123, title: 'E', courseId: 9 }),
+        });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, makeApi());
+        assert.strictEqual(id, 9);
+    });
+
+    test('falls back to getExerciseDetails and registers exercise on success', async () => {
+        const store = makeContextStore();
+        const api = makeApi({
+            getExerciseDetails: sinon.stub().withArgs(123).resolves({ exercise: { course: { id: 11 } } }),
+        });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, 11);
+        assert.ok((store.registerExercise as sinon.SinonStub).calledOnceWith(
+            sinon.match({ id: 123, courseId: 11 }),
+        ));
+    });
+
+    test('returns undefined when nothing resolves', async () => {
+        const store = makeContextStore();
+        const api = makeApi({ getExerciseDetails: sinon.stub().resolves({}) });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, undefined);
+    });
+
+    test('returns undefined when getExerciseDetails throws', async () => {
+        const store = makeContextStore();
+        const api = makeApi({ getExerciseDetails: sinon.stub().rejects(new Error('boom')) });
+        const id = await resolveCourseIdFromContext(exerciseContext, store, api);
+        assert.strictEqual(id, undefined);
+    });
+});

--- a/extension/test/unit/services/iris/context/sessionSyncUtils.test.ts
+++ b/extension/test/unit/services/iris/context/sessionSyncUtils.test.ts
@@ -1,0 +1,115 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { fetchSessionsWithMessages } from '../../../../../src/extension/services/iris/context/sessionSyncUtils';
+import type { ActiveContext } from '../../../../../src/shared/types/context';
+
+function makeApi(stubs: Partial<Record<string, sinon.SinonStub>> = {}): any {
+    return {
+        listChatSessionsForCourse: sinon.stub().resolves([]),
+        getChatMessages: sinon.stub().resolves([]),
+        getExerciseDetails: sinon.stub().rejects(new Error('not stubbed')),
+        ...stubs,
+    };
+}
+
+function makeStore(stubs: Partial<Record<string, sinon.SinonStub>> = {}): any {
+    return {
+        getExerciseById: sinon.stub().returns(undefined),
+        registerExercise: sinon.stub(),
+        ...stubs,
+    };
+}
+
+const exerciseCtx: ActiveContext = {
+    type: 'exercise', id: 123, courseId: 42, title: 'E', source: 'user-selected', locked: false, selectedAt: 0,
+};
+const courseCtx: ActiveContext = {
+    type: 'course', id: 42, title: 'C', source: 'user-selected', locked: false, selectedAt: 0,
+};
+
+suite('fetchSessionsWithMessages', () => {
+    test('filters summaries by mode + entityId before fetching messages', async () => {
+        const summaries = [
+            { id: 1, entityId: 42, mode: 'COURSE_CHAT',                creationDate: 't1' },
+            { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+            { id: 3, entityId: 999, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't3' },
+            { id: 4, entityId: 123, mode: 'LECTURE_CHAT',              creationDate: 't4' },
+        ];
+        const getChatMessages = sinon.stub().resolves([{ id: 100, sender: 'USER' }]);
+        const api = makeApi({
+            listChatSessionsForCourse: sinon.stub().withArgs(42).resolves(summaries),
+            getChatMessages,
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), exerciseCtx);
+
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].id, 2);
+        assert.ok(getChatMessages.calledOnceWith(2));
+        assert.ok(getChatMessages.neverCalledWith(1));
+        assert.ok(getChatMessages.neverCalledWith(3));
+        assert.ok(getChatMessages.neverCalledWith(4));
+    });
+
+    test('course context uses its own id as courseId and filters by COURSE_CHAT', async () => {
+        const summaries = [
+            { id: 10, entityId: 42, mode: 'COURSE_CHAT',                creationDate: 't1' },
+            { id: 11, entityId: 7,  mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+        ];
+        const listStub = sinon.stub().resolves(summaries);
+        const api = makeApi({ listChatSessionsForCourse: listStub });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), courseCtx);
+
+        assert.ok(listStub.calledOnceWith(42));
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].id, 10);
+    });
+
+    test('resolves courseId from contextStore when context.courseId is missing', async () => {
+        const ctx: ActiveContext = { ...exerciseCtx, courseId: undefined };
+        const listStub = sinon.stub().resolves([]);
+        const store = makeStore({
+            getExerciseById: sinon.stub().withArgs(123).returns({ id: 123, title: 'E', courseId: 77 }),
+        });
+        const api = makeApi({ listChatSessionsForCourse: listStub });
+
+        await fetchSessionsWithMessages(api, store, ctx);
+
+        assert.ok(listStub.calledOnceWith(77));
+    });
+
+    test('returns [] when courseId is fully unresolvable', async () => {
+        const ctx: ActiveContext = { ...exerciseCtx, courseId: undefined };
+        const listStub = sinon.stub().resolves([]);
+        const api = makeApi({
+            listChatSessionsForCourse: listStub,
+            getExerciseDetails: sinon.stub().resolves({}),
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), ctx);
+
+        assert.deepStrictEqual(result, []);
+        assert.ok(listStub.notCalled);
+    });
+
+    test('per-session fetch failure yields a session with empty messages', async () => {
+        const summaries = [
+            { id: 1, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't1' },
+            { id: 2, entityId: 123, mode: 'PROGRAMMING_EXERCISE_CHAT', creationDate: 't2' },
+        ];
+        const getChatMessages = sinon.stub();
+        getChatMessages.withArgs(1).rejects(new Error('boom'));
+        getChatMessages.withArgs(2).resolves([{ id: 999, sender: 'USER' }]);
+        const api = makeApi({
+            listChatSessionsForCourse: sinon.stub().resolves(summaries),
+            getChatMessages,
+        });
+
+        const result = await fetchSessionsWithMessages(api, makeStore(), exerciseCtx);
+
+        assert.strictEqual(result.length, 2);
+        assert.deepStrictEqual(result.find(s => s.id === 1)?.messages, []);
+        assert.strictEqual(result.find(s => s.id === 2)?.messages?.length, 1);
+    });
+});

--- a/extension/test/unit/services/websocket.test.ts
+++ b/extension/test/unit/services/websocket.test.ts
@@ -536,8 +536,10 @@ suite('IrisWebSocketSessionClient Safety Features', () => {
 
         // Mock API service
         apiService = sinon.createStubInstance(ArtemisApiService);
-        apiService.getCurrentExerciseChat.resolves({ id: 123 });
-        apiService.getCurrentCourseChat.resolves({ id: 456 });
+        apiService.getCurrentChat
+            .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 123 } as any);
+        apiService.getCurrentChat
+            .withArgs('COURSE_CHAT', sinon.match.any).resolves({ id: 456 } as any);
 
         // Connect WebSocket first
         const p = wsService.connect();
@@ -660,9 +662,12 @@ suite('IrisWebSocketSessionClient Subscription Management', () => {
         wsService = new TestableArtemisWebsocketService(authManager);
 
         apiService = sinon.createStubInstance(ArtemisApiService);
-        apiService.getCurrentExerciseChat.resolves({ id: 123 });
-        apiService.getCurrentCourseChat.resolves({ id: 456 });
-        apiService.createExerciseChatSession.resolves({ id: 789 });
+        apiService.getCurrentChat
+            .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 123 } as any);
+        apiService.getCurrentChat
+            .withArgs('COURSE_CHAT', sinon.match.any).resolves({ id: 456 } as any);
+        apiService.createChatSession
+            .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 789 } as any);
     });
 
     teardown(async () => {
@@ -831,7 +836,8 @@ suite('WebSocket Integration Tests', () => {
         wsService = new TestableArtemisWebsocketService(authManager);
 
         apiService = sinon.createStubInstance(ArtemisApiService);
-        apiService.getCurrentExerciseChat.resolves({ id: 123 });
+        apiService.getCurrentChat
+            .withArgs('PROGRAMMING_EXERCISE_CHAT', sinon.match.any).resolves({ id: 123 } as any);
     });
 
     teardown(async () => {


### PR DESCRIPTION
## Summary

- Replaces 7 per-context Iris session methods with 3 unified primitives (`getCurrentChat`, `createChatSession`, `listChatSessionsForCourse`) targeting Artemis develop after [PR #12504](https://github.com/ls1intum/Artemis/pull/12504).
- Extracts `resolveCourseIdFromContext` and `contextToIrisMode` as shared helpers so both `IrisChatSessionService` and `sessionSyncUtils` share resolution semantics.
- Filters the new course-scoped overview by mode + entityId before fanning out to per-session message fetches, so unrelated sessions are never fetched.

Spec: `docs/superpowers/specs/2026-05-13-iris-api-unified-sessions-design.md` (codex-approved, 2 rounds).
Plan: `docs/superpowers/plans/2026-05-13-iris-api-unified-sessions.md` (codex-approved).

## Test plan

- [x] `npm run lint && npm run check-types && npm run compile-tests && npm run test:unit && npm run knip` clean
- [ ] Manual smoke against a Helios test server: open chat in course context, open in exercise context, send messages, see WebSocket replies, reopen and verify history.
- [ ] Note: e2e (`uncommittedChanges.e2e.test.ts`) requires a live Artemis develop server; verify before merge.