### PR TITLE
refactor(webview): replace inline SVG icons with Lucide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 ## [Unreleased]
 
 - **Iris Chat Feedback Icons**: Fixed the broken thumbs-down icon on assistant messages (previously rendered as a filled blob when selected).
+- **Webview Icon Consistency**: Replaced ~25 hand-rolled inline SVG icons across the chat, exam, and shared components with their Lucide equivalents for visual consistency and to prevent future malformed-path bugs.
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.
 - **WebSocket Status Bar**: No longer shows a misleading red "WS Disconnected" indicator while logged out (unless `artemis.showWebSocketStatusBar` is explicitly enabled).
 - **Iris Context Dropdown**: Conversations sort newest-first, the dropdown panel now spans exactly down to the chat input (no input controls peek through), scroll shadows appear when lists overflow, and exercise rows align consistently whether or not a course tag is shown.

--- a/extension/src/webview/components/BackLink/BackLink.tsx
+++ b/extension/src/webview/components/BackLink/BackLink.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import clsx from 'clsx';
+import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left';
 import styles from './BackLink.module.css';
 
 interface BackLinkProps {
@@ -22,9 +23,7 @@ export function BackLink({
         className={styles.backLink}
         onClick={onClick}
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
+        <ChevronLeft size={16} />
         {children}
       </button>
       {actions && <div className={styles.actions}>{actions}</div>}

--- a/extension/src/webview/components/ServiceHealth/ServiceHealth.tsx
+++ b/extension/src/webview/components/ServiceHealth/ServiceHealth.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import clsx from 'clsx';
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
 import { Badge } from '../Badge';
 import styles from './ServiceHealth.module.css';
 
@@ -48,16 +50,10 @@ function ServiceItem({ service, isExpanded, onToggle }: ServiceItemProps) {
         <span className={styles.healthValue}>
           <span className={clsx(styles.healthIndicator, styles[service.status])} />
           <span>{service.message}</span>
-          <svg
+          <ChevronRight
             className={clsx(styles.healthChevron, isExpanded && styles.expanded)}
-            width="12"
-            height="12"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M6 4L10 8L6 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
+            size={12}
+          />
         </span>
       </div>
 
@@ -158,14 +154,7 @@ export function ServiceHealth({
           onClick={onRefresh}
           disabled={isRefreshing}
         >
-          <svg
-            className={styles.refreshIcon}
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M21 12C21 16.9706 16.9706 21 12 21C9.69494 21 7.59227 20.1334 6 18.7083L3 16M3 12C3 7.02944 7.02944 3 12 3C14.3051 3 16.4077 3.86656 18 5.29168L21 8M3 21V16M3 16H8M21 3V8M21 8H16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
+          <RefreshCw className={styles.refreshIcon} />
           <span>{isRefreshing ? 'Checking...' : 'Check Status'}</span>
         </button>
       )}

--- a/extension/src/webview/components/TextInput/TextInput.tsx
+++ b/extension/src/webview/components/TextInput/TextInput.tsx
@@ -1,5 +1,7 @@
 import { useState, KeyboardEvent, FocusEvent } from 'react';
 import clsx from 'clsx';
+import Eye from 'lucide-react/dist/esm/icons/eye';
+import EyeOff from 'lucide-react/dist/esm/icons/eye-off';
 import styles from './TextInput.module.css';
 
 interface TextInputProps {
@@ -130,16 +132,7 @@ export function TextInput({
             aria-label="Toggle password visibility"
             tabIndex={-1}
           >
-            {showPassword ? (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M2 2L22 22M9.88 9.88C9.33 10.43 9 11.18 9 12C9 13.66 10.34 15 12 15C12.82 15 13.57 14.67 14.12 14.12M19.73 16.27C17.94 17.5 15.97 18 12 18C8 18 5 16 2 12C3.29 10.21 4.78 8.81 6.47 7.73M9.9 4.24C10.6 4.07 11.3 4 12 4C16 4 19 6 22 10C21.27 11.11 20.42 12.11 19.49 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-            ) : (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M2 12C2 12 5 5 12 5C19 5 22 12 22 12C22 12 19 19 12 19C5 19 2 12 2 12Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-              </svg>
-            )}
+            {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
           </button>
         </div>
       );
@@ -176,16 +169,7 @@ export function TextInput({
         aria-label="Toggle password visibility"
         tabIndex={-1}
       >
-        {showPassword ? (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M2 2L22 22M9.88 9.88C9.33 10.43 9 11.18 9 12C9 13.66 10.34 15 12 15C12.82 15 13.57 14.67 14.12 14.12M19.73 16.27C17.94 17.5 15.97 18 12 18C8 18 5 16 2 12C3.29 10.21 4.78 8.81 6.47 7.73M9.9 4.24C10.6 4.07 11.3 4 12 4C16 4 19 6 22 10C21.27 11.11 20.42 12.11 19.49 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        ) : (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M2 12C2 12 5 5 12 5C19 5 22 12 22 12C22 12 19 19 12 19C5 19 2 12 2 12Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        )}
+        {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
       </button>
     </div>
   ) : (

--- a/extension/src/webview/views/ExamConduction/ExamConductionView.tsx
+++ b/extension/src/webview/views/ExamConduction/ExamConductionView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import { useExamConductionStore } from '../../stores/useExamConductionStore';
 import type { ExamConductionViewProps } from './types';
 import { ExamTimer } from '../../components/ExamTimer/ExamTimer';
@@ -116,13 +117,7 @@ export function ExamConductionView({ vscodeApi }: ExamConductionViewProps) {
             <BackLink onClick={handleBackToCourse} actions={
                 <>
                     <IconButton
-                        icon={
-                            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M18 13V19C18 19.5304 17.7893 20.0391 17.4142 20.4142C17.0391 20.7893 16.5304 21 16 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V8C3 7.46957 3.21071 6.96086 3.58579 6.58579C3.96086 6.21071 4.46957 6 5 6H11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                                <path d="M15 3H21V9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                                <path d="M10 14L21 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                            </svg>
-                        }
+                        icon={<ExternalLink size={16} />}
                         ariaLabel="Open in Browser"
                         onClick={handleOpenInBrowser}
                     />

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState, useRef, useMemo } from 'react';
+import Menu from 'lucide-react/dist/esm/icons/menu';
+import Info from 'lucide-react/dist/esm/icons/info';
 import { ExtensionMsg, postCommand } from '../../../shared/messageContracts';
 import type { VsCodeApi } from '../../../shared/messageContracts';
 import type { IrisStageDTO } from './types';
@@ -324,14 +326,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                         onClick={() => setSideMenuOpen(!sideMenuOpen)}
                         aria-label="Menu"
                     >
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                            <path
-                                d="M3 12h18M3 6h18M3 18h18"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                            />
-                        </svg>
+                        <Menu size={18} />
                     </button>
 
                     {sideMenuOpen && (
@@ -403,10 +398,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             {/* Disabled banner (Iris not available or .noai detected) */}
             {disabledBannerText && (
                 <div className={styles.disabledBanner}>
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
-                        <path d="M12 8v4M12 16h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                    </svg>
+                    <Info size={16} />
                     <span>{disabledBannerText}</span>
                 </div>
             )}

--- a/extension/src/webview/views/IrisChat/components/ChatInput.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useState, KeyboardEvent } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import clsx from 'clsx';
+import Send from 'lucide-react/dist/esm/icons/send';
 import styles from './ChatInput.module.css';
 
 interface ChatInputProps {
@@ -65,15 +66,7 @@ export function ChatInput({
                 disabled={!canSend}
                 aria-label="Send message"
             >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                    <path
-                        d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    />
-                </svg>
+                <Send size={20} />
             </button>
         </div>
     );

--- a/extension/src/webview/views/IrisChat/components/CodeBlock.tsx
+++ b/extension/src/webview/views/IrisChat/components/CodeBlock.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react';
 import { createHighlighterCore } from 'shiki/core';
 // @ts-expect-error - shiki ESM imports resolved by esbuild at bundle time (TS1479: Node16 module resolution vs ESM)
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import Check from 'lucide-react/dist/esm/icons/check';
+import Copy from 'lucide-react/dist/esm/icons/copy';
 import styles from './CodeBlock.module.css';
 
 interface CodeBlockProps {
@@ -110,35 +112,7 @@ export function CodeBlock({ language, children, code }: CodeBlockProps) {
                     onClick={handleCopy}
                     aria-label="Copy code"
                 >
-                    {copyText === 'Copied!' ? (
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                            <path
-                                d="M20 6L9 17l-5-5"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
-                        </svg>
-                    ) : (
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                            <rect
-                                x="9" y="9" width="13" height="13"
-                                rx="2" ry="2"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
-                            <path
-                                d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
-                        </svg>
-                    )}
+                    {copyText === 'Copied!' ? <Check size={14} /> : <Copy size={14} />}
                     <span className={styles.copyText}>{copyText}</span>
                 </button>
             </div>

--- a/extension/src/webview/views/IrisChat/components/ContextSelector.tsx
+++ b/extension/src/webview/views/IrisChat/components/ContextSelector.tsx
@@ -4,6 +4,13 @@ import { useClickOutside } from '../../../hooks/useClickOutside';
 import { formatRelativeTime } from '../../../utils/formatRelativeTime';
 import FolderGit2 from 'lucide-react/dist/esm/icons/folder-git-2';
 import Plus from 'lucide-react/dist/esm/icons/plus';
+import File from 'lucide-react/dist/esm/icons/file';
+import BookOpen from 'lucide-react/dist/esm/icons/book-open';
+import Circle from 'lucide-react/dist/esm/icons/circle';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
+import Search from 'lucide-react/dist/esm/icons/search';
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square';
+import Check from 'lucide-react/dist/esm/icons/check';
 import type { ChatContext, ChatSession, ContextItem } from '../types';
 import type { ChatContextType } from '../../../../shared/types/context';
 import styles from './ContextSelector.module.css';
@@ -111,19 +118,11 @@ export function ContextSelector({
                     ) : (
                     <div className={styles.contextIcon}>
                         {context?.type === 'exercise' ? (
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6z" />
-                                <path d="M14 2v6h6" />
-                            </svg>
+                            <File size={18} />
                         ) : context?.type === 'course' ? (
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M22 10v6M2 10l10-5 10 5-10 5z" />
-                                <path d="M6 12v5c3 3 9 3 12 0v-5" />
-                            </svg>
+                            <BookOpen size={18} />
                         ) : (
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                                <circle cx="12" cy="12" r="10" />
-                            </svg>
+                            <Circle size={18} />
                         )}
                     </div>
                     )}
@@ -136,39 +135,19 @@ export function ContextSelector({
                         </span>
                     </div>
                 </div>
-                <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
+                <ChevronDown
+                    size={16}
                     className={clsx(styles.chevron, {
                         [styles.chevronExpanded]: isOpen,
                     })}
-                >
-                    <polyline
-                        points="6 9 12 15 18 9"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    />
-                </svg>
+                />
             </button>
 
             {isOpen && (
                 <div className={styles.dropdown}>
                     <div className={styles.searchContainer}>
                         <div className={styles.searchInputWrapper}>
-                            <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                className={styles.searchIcon}
-                            >
-                                <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2" />
-                                <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                            </svg>
+                            <Search size={14} className={styles.searchIcon} />
                             <input
                                 type="text"
                                 className={styles.searchInput}
@@ -230,10 +209,7 @@ export function ContextSelector({
                                             }}
                                         >
                                             <span className={styles.actionButtonContent}>
-                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                                    <path d="M22 10v6M2 10l10-5 10 5-10 5z" />
-                                                    <path d="M6 12v5c3 3 9 3 12 0v-5" />
-                                                </svg>
+                                                <BookOpen size={14} />
                                                 {isInWorkspaceCourseContext
                                                     ? `Workspace Course (Active): ${workspaceCourse.title}`
                                                     : `Chat about Workspace Course: ${workspaceCourse.title}`}
@@ -257,21 +233,7 @@ export function ContextSelector({
                                             })}
                                             onClick={() => handleSelectSession(session.id)}
                                         >
-                                            <svg
-                                                width="14"
-                                                height="14"
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                className={styles.sessionIcon}
-                                            >
-                                                <path
-                                                    d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-                                                    stroke="currentColor"
-                                                    strokeWidth="2"
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                />
-                                            </svg>
+                                            <MessageSquare size={14} className={styles.sessionIcon} />
                                             <div className={styles.sessionContent}>
                                                 <span className={styles.sessionPreview}>
                                                     {session.title || session.preview}
@@ -281,21 +243,7 @@ export function ContextSelector({
                                                 </span>
                                             </div>
                                             {session.id === activeSessionId && (
-                                                <svg
-                                                    width="16"
-                                                    height="16"
-                                                    viewBox="0 0 24 24"
-                                                    fill="none"
-                                                    className={styles.checkIcon}
-                                                >
-                                                    <polyline
-                                                        points="20 6 9 17 4 12"
-                                                        stroke="currentColor"
-                                                        strokeWidth="2"
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                    />
-                                                </svg>
+                                                <Check size={16} className={styles.checkIcon} />
                                             )}
                                         </button>
                                     ))}

--- a/extension/src/webview/views/IrisChat/components/ReferencedFiles.tsx
+++ b/extension/src/webview/views/IrisChat/components/ReferencedFiles.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import clsx from 'clsx';
+import FileText from 'lucide-react/dist/esm/icons/file-text';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
+import XCircle from 'lucide-react/dist/esm/icons/x-circle';
 import type { ReferencedFilesData } from '../types';
 import styles from './ReferencedFiles.module.css';
 
@@ -26,49 +29,17 @@ export function ReferencedFiles({ files, onOpenFile }: ReferencedFilesProps) {
                 aria-expanded={isExpanded}
             >
                 <div className={styles.headerContent}>
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        className={styles.fileIcon}
-                    >
-                        <path
-                            d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                        <polyline
-                            points="13 2 13 9 20 9"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                    </svg>
+                    <FileText size={16} className={styles.fileIcon} />
                     <span className={styles.headerText}>
                         {includedCount}/{files.totalCount} files referenced
                     </span>
                 </div>
-                <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
+                <ChevronDown
+                    size={16}
                     className={clsx(styles.chevron, {
                         [styles.chevronExpanded]: isExpanded,
                     })}
-                >
-                    <polyline
-                        points="6 9 12 15 18 9"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    />
-                </svg>
+                />
             </button>
 
             {isExpanded && (
@@ -80,24 +51,7 @@ export function ReferencedFiles({ files, onOpenFile }: ReferencedFilesProps) {
                             className={styles.fileItem}
                             onClick={() => onOpenFile(path)}
                         >
-                            <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                className={styles.fileItemIcon}
-                            >
-                                <path
-                                    d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                />
-                                <polyline
-                                    points="13 2 13 9 20 9"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                />
-                            </svg>
+                            <FileText size={14} className={styles.fileItemIcon} />
                             <span className={styles.fileName}>{getFileName(path)}</span>
                             <span className={styles.fileStatus}>Will be sent</span>
                         </button>
@@ -115,39 +69,7 @@ export function ReferencedFiles({ files, onOpenFile }: ReferencedFilesProps) {
                             className={clsx(styles.fileItem, styles.fileItemExcluded)}
                             onClick={() => onOpenFile(file.path)}
                         >
-                            <svg
-                                width="14"
-                                height="14"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                className={styles.fileItemIcon}
-                            >
-                                <circle
-                                    cx="12"
-                                    cy="12"
-                                    r="10"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                />
-                                <line
-                                    x1="15"
-                                    y1="9"
-                                    x2="9"
-                                    y2="15"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                />
-                                <line
-                                    x1="9"
-                                    y1="9"
-                                    x2="15"
-                                    y2="15"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                />
-                            </svg>
+                            <XCircle size={14} className={styles.fileItemIcon} />
                             <span className={styles.fileName}>{getFileName(file.path)}</span>
                             <span className={styles.fileReason}>
                                 {file.reason || 'Excluded'}


### PR DESCRIPTION
## Summary

- Replaces ~25 hand-rolled inline `<svg>` icons across the React webview with their `lucide-react` equivalents, matching the existing `iconMap.ts` tree-shaking pattern.
- Removes a recurring class of bugs: the recent thumbs-down filled-blob fix in #150 was a malformed inline path. Several other inline SVGs in the codebase had the same risk.
- Net diff: **+50 / -253**.

## Files touched

| File | Replacements |
|------|--------------|
| `BackLink.tsx` | `ChevronLeft` |
| `ServiceHealth.tsx` | `ChevronRight`, `RefreshCw` |
| `TextInput.tsx` | `Eye`, `EyeOff` (×2) |
| `IrisChatView.tsx` | `Menu`, `Info` |
| `IrisChat/ChatInput.tsx` | `Send` |
| `IrisChat/CodeBlock.tsx` | `Check`, `Copy` |
| `IrisChat/ContextSelector.tsx` | `File`, `BookOpen`, `Circle`, `ChevronDown`, `Search`, `MessageSquare`, `Check` |
| `IrisChat/ReferencedFiles.tsx` | `FileText`, `ChevronDown`, `XCircle` |
| `ExamConduction/ExamConductionView.tsx` | `ExternalLink` |

## Visual notes

- Course context icon swapped from a graduation-cap path to `BookOpen` to match the existing `iconMap.ts` mapping (`course → BookOpen`).
- Fallback context icon swapped from a filled circle to outlined `Circle` (used only when no course/exercise type is set; cosmetic).
- All other icons preserve the same visual concept (file, message bubble, chevron, etc.).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all touched files
- [x] `npx vitest run` – 138 tests pass across 9 affected suites
- [x] Codex review – approved with non-blocking visual notes
- [ ] Smoke-test the extension UI locally before merge (chat input send, password toggle, expand/collapse panels, exam header buttons)