### PR TITLE
fix(telemetry): correct cadence dismiss filter, intervention state, and EQ snapshot intake

### DIFF
--- a/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
+++ b/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
@@ -79,23 +79,21 @@ export class CompileEquivalentEmitter implements vscode.Disposable, SessionReset
     }
 
     /**
-     * Handle a build result from Artemis WebSocket.
-     * Returns the CompileEquivalentEvent if emitted (for direct use by TelemetryManager).
+     * Handle a build result from Artemis WebSocket. Fires onDidEmitCompileEquivalent
+     * when the snapshot is novel; subscribers are the sole consumers.
      */
-    public handleBuildResult(result: ResultDTO): CompileEquivalentEvent | null {
+    public handleBuildResult(result: ResultDTO): void {
         const snapshot = this.createErrorSnapshotFromBuildResult(result);
         if (!this._shouldAddSnapshot(snapshot)) {
-            return null;
+            return;
         }
 
         this._lastSnapshot = snapshot;
-        const event: CompileEquivalentEvent = {
+        this._onDidEmitCompileEquivalent.fire({
             timestamp: snapshot.timestamp,
             source: 'build',
             snapshot,
-        };
-        this._onDidEmitCompileEquivalent.fire(event);
-        return event;
+        });
     }
 
     /**

--- a/extension/src/extension/services/telemetry/interventionService.ts
+++ b/extension/src/extension/services/telemetry/interventionService.ts
@@ -348,10 +348,14 @@ export class InterventionService implements vscode.Disposable, SessionResettable
 
     /**
      * Emit a dismiss event with an explicit reason.
+     *
+     * Does NOT mutate `_state.lastDismissed` — callers that represent an
+     * explicit user dismissal ('Not now' / 'Later') set that flag themselves
+     * before calling. Implicit lifecycle dismissals ('replaced', 'hidden',
+     * 'session-end') must not flip the flag, because `InterventionFilter`
+     * uses `lastDismissed` to block subsequent subtle/notification deliveries.
      */
     private _emitDismiss(decision: InterventionDecision, reason: InterventionDismissReason): void {
-        this._state.lastDismissed = true;
-        this._state.lastAccepted = false;
         this._onDidDismissIntervention.fire({ ...decision, dismissReason: reason });
     }
 

--- a/extension/src/extension/services/telemetry/telemetryManager.ts
+++ b/extension/src/extension/services/telemetry/telemetryManager.ts
@@ -200,15 +200,11 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
             return;
         }
 
-        // Step 1: EQ snapshot FIRST (synchronous)
-        const event = this._compileEmitter.handleBuildResult(result);
-        if (event) {
-            const accepted = this._eqEngine.addSnapshot(event.snapshot);
-            if (accepted) {
-                const { eq, confidence } = this._eqEngine.getCurrentEQ();
-                this._onDidCalculateEQ.fire({ eq, confidence, source: 'build' });
-            }
-        }
+        // Step 1: EQ snapshot FIRST (synchronous).
+        // handleBuildResult fires onDidEmitCompileEquivalent — the listener
+        // registered in _setupEventHandlers adds the snapshot to the EQ engine.
+        // Single-path-snapshot: both save and build flow through the listener.
+        this._compileEmitter.handleBuildResult(result);
 
         // Step 2: Existing build tracker processing
         this._buildTracker.onNewResult(result);
@@ -320,15 +316,13 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         });
         this._disposables.push(selectionListener);
 
-        // CompileEquivalentEmitter → EQEngine
+        // CompileEquivalentEmitter → EQEngine.
+        // Single source of truth for snapshot intake: handles both save and build events.
         this._compileEmitter.onDidEmitCompileEquivalent(event => {
-            // Only add from save events; build events are handled in onNewResult
-            if (event.source === 'save') {
-                const accepted = this._eqEngine.addSnapshot(event.snapshot);
-                if (accepted) {
-                    const { eq, confidence } = this._eqEngine.getCurrentEQ();
-                    this._onDidCalculateEQ.fire({ eq, confidence, source: 'save' });
-                }
+            const accepted = this._eqEngine.addSnapshot(event.snapshot);
+            if (accepted) {
+                const { eq, confidence } = this._eqEngine.getCurrentEQ();
+                this._onDidCalculateEQ.fire({ eq, confidence, source: event.source });
             }
         });
 
@@ -353,10 +347,21 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
             }
         });
 
-        // Intervention dismissed → increment adaptive cadence for the trigger that caused it
+        // Intervention dismissed → increment adaptive cadence for the trigger that caused it.
+        // Only count explicit user dismissals: 'replaced', 'hidden', 'session-end' are
+        // implicit lifecycle dismissals and must NOT skew the cadence statistics.
         this._interventionService.onDidDismissIntervention(decision => {
-            const triggerType = decision.triggerType ?? 'idle';
-            this._adaptiveCadence.incrementIgnoreCount(triggerType);
+            if (decision.dismissReason !== 'user-action') {
+                return;
+            }
+            if (decision.triggerType === undefined) {
+                logger.warn(
+                    'Dismiss event has no triggerType — skipping cadence increment',
+                    LogCategory.TELEMETRY,
+                );
+                return;
+            }
+            this._adaptiveCadence.incrementIgnoreCount(decision.triggerType);
         });
 
         // Intervention accepted → reset adaptive cadence

--- a/extension/test/unit/services/telemetry/telemetryManagerCadenceFilter.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerCadenceFilter.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for three thesis-relevant correctness fixes:
+ *
+ *   #1 / #2 — Adaptive-Cadence dismiss filter (TelemetryManager).
+ *     `onDidDismissIntervention` fires for four distinct reasons:
+ *       'user-action', 'hidden', 'replaced', 'session-end'.
+ *     Only 'user-action' represents an explicit user dismissal and is the
+ *     signal Adaptive-Cadence is supposed to react to. Implicit lifecycle
+ *     dismissals (subtle-hint replaced by a newer one, build success hiding
+ *     the hint, session ending) must NOT increment the ignore counter.
+ *     Additionally, a dismiss event without `triggerType` must skip the
+ *     increment instead of falling back to 'idle'.
+ *
+ *   #1b — Lifecycle dismissals must not mutate InterventionState.lastDismissed
+ *     (InterventionService). `InterventionFilter` blocks subtle/notification
+ *     deliveries when `lastDismissed=true`. Previously, an implicit 'replaced'
+ *     or 'hidden' dismiss flipped that flag, suppressing the next real
+ *     intervention even though the user never dismissed anything.
+ *
+ *   #5 — Single-path EQ snapshot intake (TelemetryManager).
+ *     Build results historically went through two paths: an inline
+ *     `addSnapshot` in `onNewResult` AND the `onDidEmitCompileEquivalent`
+ *     listener (which filtered out build events to prevent double-counting).
+ *     The fragile filter is gone; build events now flow through the listener
+ *     just like save events. The `onDidCalculateEQ` event must carry
+ *     `source: 'build'` for build-derived snapshots, not the previously
+ *     hardcoded `'save'`.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { TelemetryManager } from '../../../../src/extension/services/telemetry/telemetryManager';
+import { InterventionService } from '../../../../src/extension/services/telemetry/interventionService';
+import type { AdaptiveCadence } from '../../../../src/extension/services/telemetry/intervention/adaptiveCadence';
+import type {
+    InterventionDecision,
+    InterventionDismissReason,
+    TriggerType,
+} from '../../../../src/extension/services/telemetry/types';
+import type { ResultDTO } from '../../../../src/extension/domain';
+
+type DismissPayload = InterventionDecision & { dismissReason: InterventionDismissReason };
+
+interface TelemetryManagerInternals {
+    _adaptiveCadence: AdaptiveCadence;
+    _interventionService: {
+        _onDidDismissIntervention: vscode.EventEmitter<DismissPayload>;
+    };
+}
+
+function asInternals(tm: TelemetryManager): TelemetryManagerInternals {
+    return tm as unknown as TelemetryManagerInternals;
+}
+
+function makeDecision(overrides: Partial<InterventionDecision> = {}): InterventionDecision {
+    return {
+        rawWanted: true,
+        shouldIntervene: true,
+        level: 'notification',
+        triggerType: 'execution-error',
+        eq: 0.5,
+        confidence: 'sufficient',
+        ...overrides,
+    };
+}
+
+function fireDismiss(
+    tm: TelemetryManager,
+    reason: InterventionDismissReason,
+    overrides: Partial<InterventionDecision> = {},
+): void {
+    const emitter = asInternals(tm)._interventionService._onDidDismissIntervention;
+    emitter.fire({ ...makeDecision(overrides), dismissReason: reason });
+}
+
+function totalIgnoreCount(tm: TelemetryManager): number {
+    const counts = asInternals(tm)._adaptiveCadence.getState().ignoreCounts;
+    return Object.values(counts).reduce((sum, n) => sum + n, 0);
+}
+
+suite('TelemetryManager — Adaptive-Cadence dismiss filter (#1, #2)', () => {
+    let sandbox: sinon.SinonSandbox;
+    let tm: TelemetryManager;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        const statusBarItem = {
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            dispose: sandbox.stub(),
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+        };
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        tm = new TelemetryManager();
+    });
+
+    teardown(() => {
+        tm.dispose();
+        sandbox.restore();
+    });
+
+    test('user-action dismiss increments the ignore counter for the trigger', () => {
+        const before = totalIgnoreCount(tm);
+        fireDismiss(tm, 'user-action', { triggerType: 'multiline-paste' });
+        const after = asInternals(tm)._adaptiveCadence.getState().ignoreCounts;
+        assert.strictEqual(after['multiline-paste'], 1, 'multiline-paste counter should advance');
+        assert.strictEqual(totalIgnoreCount(tm) - before, 1, 'exactly one increment expected');
+    });
+
+    test("'replaced' dismiss does NOT increment the ignore counter", () => {
+        const before = totalIgnoreCount(tm);
+        fireDismiss(tm, 'replaced', { triggerType: 'execution-error' });
+        assert.strictEqual(totalIgnoreCount(tm), before, "'replaced' must not advance cadence");
+    });
+
+    test("'hidden' dismiss does NOT increment the ignore counter", () => {
+        const before = totalIgnoreCount(tm);
+        fireDismiss(tm, 'hidden', { triggerType: 'idle' });
+        assert.strictEqual(totalIgnoreCount(tm), before, "'hidden' must not advance cadence");
+    });
+
+    test("'session-end' dismiss does NOT increment the ignore counter", () => {
+        const before = totalIgnoreCount(tm);
+        fireDismiss(tm, 'session-end', { triggerType: 'selection-maintained' });
+        assert.strictEqual(totalIgnoreCount(tm), before, "'session-end' must not advance cadence");
+    });
+
+    test('user-action dismiss without triggerType is skipped (no idle fallback)', () => {
+        const idleBefore = asInternals(tm)._adaptiveCadence.getState().ignoreCounts['idle'];
+        const totalBefore = totalIgnoreCount(tm);
+        fireDismiss(tm, 'user-action', { triggerType: undefined });
+        const idleAfter = asInternals(tm)._adaptiveCadence.getState().ignoreCounts['idle'];
+        assert.strictEqual(idleAfter, idleBefore, 'idle counter must not advance on undefined triggerType');
+        assert.strictEqual(totalIgnoreCount(tm), totalBefore, 'no counter should advance');
+    });
+
+    test('mixed sequence: only the user-action increments', () => {
+        const baseline = totalIgnoreCount(tm);
+        fireDismiss(tm, 'replaced', { triggerType: 'idle' });
+        fireDismiss(tm, 'hidden', { triggerType: 'idle' });
+        fireDismiss(tm, 'session-end', { triggerType: 'idle' });
+        fireDismiss(tm, 'user-action', { triggerType: 'idle' });
+        assert.strictEqual(totalIgnoreCount(tm) - baseline, 1, 'only user-action should increment');
+    });
+});
+
+suite('InterventionService — lifecycle dismissals do not flip lastDismissed (#1b)', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        const statusBarItem = {
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            dispose: sandbox.stub(),
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+        };
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test("'replaced' dismiss does NOT set lastDismissed", async () => {
+        const svc = new InterventionService();
+        try {
+            svc.showSubtleHintEQ(makeDecision({ level: 'subtle', triggerType: 'idle' }));
+            svc.showSubtleHintEQ(makeDecision({ level: 'subtle', triggerType: 'multiline-paste' }));
+            assert.strictEqual(svc.getState().lastDismissed, false, 'replaced subtle hint must not flip lastDismissed');
+        } finally {
+            svc.dispose();
+        }
+    });
+
+    test("'hidden' dismiss does NOT set lastDismissed", async () => {
+        const svc = new InterventionService();
+        try {
+            svc.showSubtleHintEQ(makeDecision({ level: 'subtle', triggerType: 'execution-error' }));
+            svc.hideHint();
+            assert.strictEqual(svc.getState().lastDismissed, false, 'hideHint must not flip lastDismissed');
+        } finally {
+            svc.dispose();
+        }
+    });
+
+    test('user-action dismiss (notification "Not now") SETS lastDismissed', async () => {
+        // Caller-side mutation in showNotificationEQ still flips the flag.
+        const showInfoStub = sandbox.stub(vscode.window, 'showInformationMessage').resolves('Not now' as unknown as vscode.MessageItem);
+        const svc = new InterventionService();
+        try {
+            await svc.showNotificationEQ(makeDecision({ level: 'notification', triggerType: 'idle' }));
+            assert.strictEqual(svc.getState().lastDismissed, true, 'user-action dismiss must flip lastDismissed');
+            assert.strictEqual(showInfoStub.callCount, 1);
+        } finally {
+            svc.dispose();
+        }
+    });
+});
+
+suite('TelemetryManager — single-path EQ snapshot intake (#5)', () => {
+    let sandbox: sinon.SinonSandbox;
+    let tm: TelemetryManager;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        const statusBarItem = {
+            show: sandbox.stub(),
+            hide: sandbox.stub(),
+            dispose: sandbox.stub(),
+            text: '',
+            tooltip: undefined,
+            backgroundColor: undefined,
+            command: undefined,
+        };
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        tm = new TelemetryManager();
+    });
+
+    teardown(() => {
+        tm.dispose();
+        sandbox.restore();
+    });
+
+    test('build result emits onDidCalculateEQ with source "build" (no longer mislabelled as "save")', () => {
+        tm.startExerciseSession(42);
+        type EqEvent = { source: 'save' | 'build' | 'trigger'; triggerType?: TriggerType };
+        const events: EqEvent[] = [];
+        const sub = tm.onDidCalculateEQ(e => events.push(e));
+        try {
+            const result: ResultDTO = {
+                id: 1,
+                participation: { id: 5001 },
+                submission: { buildFailed: true },
+                successful: false,
+            };
+            tm.onNewResult(result);
+            const buildEvents = events.filter(e => e.source === 'build');
+            const saveEvents = events.filter(e => e.source === 'save');
+            assert.strictEqual(buildEvents.length, 1, 'expected exactly one build-source EQ event');
+            assert.strictEqual(saveEvents.length, 0, 'no save-source EQ event must be emitted for a build result');
+        } finally {
+            sub.dispose();
+        }
+    });
+
+    test('build result is added to EQ engine exactly once (no double-counting)', () => {
+        tm.startExerciseSession(43);
+        type EQEngineLike = {
+            addSnapshot: (snapshot: unknown) => boolean;
+        };
+        const internals = tm as unknown as { _eqEngine: EQEngineLike };
+        const addSnapshotSpy = sandbox.spy(internals._eqEngine, 'addSnapshot');
+
+        const result: ResultDTO = {
+            id: 2,
+            participation: { id: 5001 },
+            submission: { buildFailed: true },
+            successful: false,
+        };
+        tm.onNewResult(result);
+
+        assert.strictEqual(
+            addSnapshotSpy.callCount,
+            1,
+            'addSnapshot must be called exactly once per build result',
+        );
+    });
+
+    test('build snapshot intake flows exclusively through onDidEmitCompileEquivalent (single-path architecture)', () => {
+        // Architectural regression guard: if anyone reintroduces a direct
+        // `addSnapshot` call in `onNewResult`, silencing the emitter would no
+        // longer disable the intake — and this test would fail.
+        tm.startExerciseSession(44);
+        type EmitterLike = {
+            _onDidEmitCompileEquivalent: { fire: (e: unknown) => void };
+        };
+        type EQEngineLike = { addSnapshot: (s: unknown) => boolean };
+        const internals = tm as unknown as {
+            _compileEmitter: EmitterLike;
+            _eqEngine: EQEngineLike;
+        };
+        const addSnapshotSpy = sandbox.spy(internals._eqEngine, 'addSnapshot');
+        // Replace `fire` with a no-op so the listener never runs.
+        sandbox.replace(internals._compileEmitter._onDidEmitCompileEquivalent, 'fire', () => undefined);
+
+        tm.onNewResult({
+            id: 3,
+            participation: { id: 5001 },
+            submission: { buildFailed: true },
+            successful: false,
+        });
+
+        assert.strictEqual(
+            addSnapshotSpy.callCount,
+            0,
+            'with the emitter silenced, no snapshot path should exist — proves the listener is the only path',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Four thesis-evaluation-relevant correctness fixes in the struggle-detection pipeline. All four would have biased recorded metrics or distorted UI delivery behaviour during a study run.

| # | Bug | Effect |
|---|-----|--------|
| **#1** | Adaptive cadence incremented on every dismiss reason | `replaced` / `hidden` / `session-end` skewed per-trigger ignore counters → wrong threshold escalation |
| **#2** | Dismiss without `triggerType` fell back to `'idle'` | Polluted the idle bucket with synthetic events |
| **#1b** | Implicit dismissals flipped `InterventionState.lastDismissed` | `InterventionFilter` suppressed the next subtle/notification even though the user never dismissed anything |
| **#5** | Build snapshots took an inline path next to the emitter listener | Two paths protected by a fragile `source === 'save'` filter; any refactor of the listener guard would have double-counted |

## Changes

**`telemetryManager.ts`**
- Dismiss listener filters on `dismissReason === 'user-action'` and skips when `triggerType === undefined` (with `logger.warn`).
- Removed inline `_eqEngine.addSnapshot` in `onNewResult`; build path now flows through the same listener as save.
- Listener uses `event.source` to label `onDidCalculateEQ` correctly (previously hardcoded to `'save'`).

**`interventionService.ts`**
- `_emitDismiss` is now pure event emission. The two user-action call sites (`showNotificationEQ`, `showProactiveHelpEQ`) keep setting `lastDismissed = true` explicitly.

**`compileEquivalentEmitter.ts`**
- `handleBuildResult` returns `void`. No caller consumes the event directly anymore.

**Tests** — new file `telemetryManagerCadenceFilter.test.ts`:
- 6 tests for the cadence dismiss filter (#1 / #2).
- 3 tests for the `lastDismissed` mutation guard (#1b).
- 3 tests for the single-path snapshot architecture (#5), including a regression test that silences the emitter and asserts the listener is the only intake path.

## Verification

- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit`: **794 passing, 0 failing, 3 skipped**
- `npm run test:struggle`: **135 passing**

Plan was reviewed by codex (gpt-5.5) in two rounds; PR was reviewed by codex once and one residual issue (#1b) was fixed inline before merge.

## Test plan

- [x] Cadence-Filter unit tests (user-action / replaced / hidden / session-end / undefined triggerType / mixed sequence)
- [x] Lifecycle-dismiss state guard tests (replaced / hidden don't flip lastDismissed; user-action still does)
- [x] Single-path snapshot architecture tests (source label, single addSnapshot call, emitter-silenced regression guard)
- [x] Full unit and struggle suites green
- [ ] Manual smoke (after merge): reload extension, trigger a subtle hint, ensure a replacement doesn't cause the next notification to be suppressed