### PR TITLE
fix(websocket): settle pending deferred on connect() catch path

### DIFF
--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -235,10 +235,12 @@ export class ArtemisWebsocketService {
             logger.error(`Failed to connect to WebSocket: ${errorMessage}`, LogCategory.WEBSOCKET);
             this._clearSubscriptions();
             this._transitionTo('disconnected');
-            // Clear safety timeout; don't settle the deferred (throw handles the caller).
-            // No concurrent awaiters can exist since the deferred was just created above.
-            if (this._safetyTimeout) { clearTimeout(this._safetyTimeout); this._safetyTimeout = undefined; }
-            this._connectDeferred = undefined;
+            // Reject the deferred so any concurrent `connect()` callers that
+            // received this same deferred (via the `connecting` branch at the
+            // top while we were awaiting `_client.deactivate()`) unblock with
+            // the same error instead of hanging forever.
+            const settleError = error instanceof Error ? error : new Error(String(error));
+            this._settleDeferred(settleError);
             throw error;
         }
 
@@ -273,10 +275,17 @@ export class ArtemisWebsocketService {
         }
         const deferred = this._connectDeferred;
         this._connectDeferred = undefined;
+        if (!deferred) { return; }
         if (outcome === 'resolve') {
-            deferred?.resolve();
+            deferred.resolve();
         } else {
-            deferred?.reject(outcome);
+            // Attach a fallback catch BEFORE rejecting so the rejection is
+            // considered handled even when no external caller is awaiting
+            // this deferred (e.g. the catch path of `connect()` throws
+            // directly and no parallel `connect()` ever attached an awaiter).
+            // External awaiters still observe the rejection via their own await.
+            deferred.promise.catch(() => { /* defensive no-op */ });
+            deferred.reject(outcome);
         }
     }
 

--- a/extension/test/unit/services/websocket.test.ts
+++ b/extension/test/unit/services/websocket.test.ts
@@ -1147,6 +1147,82 @@ suite('WebSocket Race Condition Fixes', () => {
     });
 
     // ========================================================================
+    // Concurrent connect() awaiters are not orphaned when the catch path fires
+    // ========================================================================
+    //
+    // While the first connect() awaits `_client.deactivate()`, a parallel
+    // `connect()` call observes the 'connecting' state at the top of the
+    // method and returns the existing `_connectDeferred.promise`. If the
+    // catch path then throws (deactivate failed, auth headers empty, etc.)
+    // without settling the deferred, every concurrent awaiter hangs forever.
+    // The fix routes the catch through `_settleDeferred(error)`.
+    test('concurrent connect() awaiters reject when catch path fires', async () => {
+        // Hold deactivate open so a second connect() can attach as an awaiter
+        // before the first call's catch block runs.
+        const p1 = wsService.connect();
+        await flushMicrotasks();
+        wsService.mockClient!.simulateConnect();
+        await p1;
+
+        let releaseDeactivate!: () => void;
+        const deactivateGate = new Promise<void>(resolve => { releaseDeactivate = resolve; });
+        wsService.mockClient!.deactivate = async () => {
+            await deactivateGate;
+            throw new Error('deactivate failed');
+        };
+
+        // First reconnect: enters connecting, blocks inside `await deactivate()`.
+        const reconnect1 = wsService.connect();
+        await flushMicrotasks();
+        assert.strictEqual(wsService.isConnectingState, true, 'first reconnect should be in connecting state');
+
+        // Second reconnect arrives during the await: returns the same deferred.
+        const reconnect2 = wsService.connect();
+
+        // Let the catch path fire.
+        releaseDeactivate();
+
+        // Both awaiters must reject with the same root cause — neither hangs.
+        await assert.rejects(reconnect1, /deactivate failed/);
+        await assert.rejects(reconnect2, /deactivate failed/);
+        assert.strictEqual(wsService.isConnectingState, false, 'state machine must exit connecting');
+    });
+
+    // ========================================================================
+    // Catch path with NO concurrent awaiter must not orphan the deferred
+    // ========================================================================
+    //
+    // Companion to the concurrent-awaiter test: when only a single caller
+    // hits the catch path, the deferred is never observed by anyone else.
+    // It still has to settle cleanly without producing an unhandled
+    // promise rejection.
+    test('catch path with single caller does not emit unhandled rejection', async () => {
+        const rejections: unknown[] = [];
+        const onUnhandled = (reason: unknown): void => { rejections.push(reason); };
+        process.on('unhandledRejection', onUnhandled);
+        try {
+            const p1 = wsService.connect();
+            await flushMicrotasks();
+            wsService.mockClient!.simulateConnect();
+            await p1;
+
+            wsService.mockClient!.deactivate = async () => {
+                throw new Error('deactivate failed');
+            };
+
+            await assert.rejects(wsService.connect(), /deactivate failed/);
+
+            // Drain microtasks so any pending unhandled rejection would fire.
+            await flushMicrotasks();
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.deepStrictEqual(rejections, [], 'no unhandled rejection allowed');
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+        }
+    });
+
+    // ========================================================================
     // Bug 5: _isDisconnecting resets if deactivate() throws
     // ========================================================================
     test('_isDisconnecting resets if deactivate() throws', async () => {


### PR DESCRIPTION
## Summary

Tiny correctness fix in `ArtemisWebsocketService.connect()`. Concurrent `connect()` calls that attached to the same `_connectDeferred` while the first call was awaiting `_client.deactivate()` could hang forever if the first call hit the catch path. The catch now routes through `_settleDeferred(error)`.

## Why this matters

`connect()` has an `await this._client.deactivate()` deep inside its try block. During that await, a parallel `connect()` call sees `state === 'connecting'` at the top and returns the existing `_connectDeferred.promise` as its own. The old catch:

```ts
this._connectDeferred = undefined;
throw error;
```

Cleared the field but never rejected the promise that the second caller was already awaiting. That caller hung for the lifetime of the process.

## Fix

- Catch now calls `this._settleDeferred(settleError)` so every awaiter (single or concurrent) rejects with the same error.
- `_settleDeferred` attaches a defensive `.catch(() => {})` to the deferred's promise BEFORE calling `reject`. This makes the rejection considered handled in the single-caller catch path (where no external awaiter exists). External awaiters still observe the rejection via their own `await`.

## Tests

- **concurrent-awaiter regression** (`websocket.test.ts`): a gate-promise holds `deactivate()` open so a second `connect()` attaches to the same deferred. The gate is released, the catch fires, both awaiters must reject with the underlying error.
- **single-caller catch path** (`websocket.test.ts`): `process.on('unhandledRejection', ...)` hook plus microtask + setImmediate drain. Asserts the listener is never invoked.

## Verification

- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit`: **817 passing, 0 failing, 3 skipped**

Reviewed by codex in two rounds; one blocker (orphaned internal deferred in single-caller case) addressed before commit.

## Test plan

- [x] New WS unit tests green
- [ ] Manual smoke (post-merge): Server-down reconnect loop in dev mode — no hanging awaiters visible in DevTools