### PR TITLE
fix(telemetry): tighten InterventionService lifecycle, drop duplicate-command bandaid

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -264,7 +264,14 @@ export async function deactivate(): Promise<void> {
 		activeSessionRecorder = undefined;
 	}
 	if (activeTelemetryManager) {
-		activeTelemetryManager.endCurrentSession();
+		try {
+			// Explicit dispose so session-end + command/status-bar teardown
+			// run before VS Code disposes context.subscriptions. dispose() is
+			// idempotent, so the subscription teardown is a safe no-op.
+			activeTelemetryManager.dispose();
+		} catch (err) {
+			logger.error('Failed to dispose TelemetryManager during deactivate', LogCategory.TELEMETRY, err);
+		}
 		activeTelemetryManager = undefined;
 	}
 }

--- a/extension/src/extension/services/telemetry/interventionService.ts
+++ b/extension/src/extension/services/telemetry/interventionService.ts
@@ -97,22 +97,15 @@ export class InterventionService implements vscode.Disposable, SessionResettable
         // during an active subtle hint, this fires onDidAcceptIntervention and
         // opens Iris Chat.
         //
-        // Defensive try-catch: in test environments multiple InterventionService
-        // instances may be created (e.g. via TelemetryManager) without the
-        // previous instance being disposed. VS Code throws on duplicate command
-        // registration; we swallow the error so tests and any edge-case
-        // re-activation paths don't hard-crash. In production there is only
-        // ever one InterventionService instance.
-        try {
-            const subtleAcceptCmd = vscode.commands.registerCommand(
-                'iris.intervention.acceptSubtle',
-                () => this.handleAcceptSubtle(),
-            );
-            this._disposables.push(subtleAcceptCmd);
-        } catch {
-            // Command already registered — another InterventionService instance
-            // is active. Status bar clicks will route to that instance's handler.
-        }
+        // Tests must dispose previous instances before creating a new one;
+        // VS Code throws on duplicate command registration and that exception
+        // is intentionally surfaced now so test pollution can't silently route
+        // status-bar clicks to a stale handler.
+        const subtleAcceptCmd = vscode.commands.registerCommand(
+            'iris.intervention.acceptSubtle',
+            () => this.handleAcceptSubtle(),
+        );
+        this._disposables.push(subtleAcceptCmd);
     }
 
     public dispose(): void {

--- a/extension/src/extension/services/telemetry/telemetryManager.ts
+++ b/extension/src/extension/services/telemetry/telemetryManager.ts
@@ -37,6 +37,7 @@ import { shouldAcceptBuildResult } from './buildResultGuard';
  */
 export class TelemetryManager implements vscode.Disposable, WebSocketMessageHandler {
     private readonly _disposables: vscode.Disposable[] = [];
+    private _disposed = false;
 
     // Sub-services (kept from old system)
     private readonly _diagnosticService: DiagnosticPersistenceService;
@@ -165,6 +166,14 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
     }
 
     public dispose(): void {
+        // Idempotent: VS Code disposes context.subscriptions during deactivate,
+        // and extension.ts also calls this explicitly so session-end telemetry
+        // flushes before teardown. Both paths must be safe to run.
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+
         if (this._websocketService) {
             this._websocketService.unregisterMessageHandler(this);
         }

--- a/extension/test/unit/provider/artemisWebviewProvider.test.ts
+++ b/extension/test/unit/provider/artemisWebviewProvider.test.ts
@@ -117,8 +117,14 @@ suite('ArtemisWebviewProvider Test Suite', () => {
     let mockContext: MockExtensionContext;
     let mockAuthManager: MockAuthManager;
     let mockApiService: MockArtemisApiService;
+    let suiteSandbox: sinon.SinonSandbox;
 
     setup(() => {
+        // Stub command registration so concurrent TelemetryManager
+        // instances in this suite do not collide on the global registry.
+        suiteSandbox = sinon.createSandbox();
+        suiteSandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+
         mockContext = new MockExtensionContext();
         mockAuthManager = new MockAuthManager(mockContext);
         mockApiService = new MockArtemisApiService(mockAuthManager);
@@ -140,6 +146,10 @@ suite('ArtemisWebviewProvider Test Suite', () => {
             mockTelemetry,
             mockUpdateAuth,
         );
+    });
+
+    teardown(() => {
+        suiteSandbox.restore();
     });
 
     test('should be instantiated', () => {
@@ -228,6 +238,7 @@ suite('Panel hide/show state persistence', () => {
 
     setup(async () => {
         sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
 
         mockContext = new MockExtensionContext();
         mockAuthManager = new MockAuthManager(mockContext);

--- a/extension/test/unit/services/telemetry/interventionService.test.ts
+++ b/extension/test/unit/services/telemetry/interventionService.test.ts
@@ -72,6 +72,10 @@ suite('Block C — InterventionService: subtle accept/dismiss', () => {
 
     setup(() => {
         sandbox = sinon.createSandbox();
+        // The extension under test has already registered the subtle-accept
+        // command during activate(). Stub registerCommand so test-scoped
+        // InterventionService instances don't collide on the global registry.
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         service = new InterventionService();
     });
 
@@ -163,6 +167,7 @@ suite('Block C — InterventionService: blocked decisions and rate-limiting', ()
 
     setup(() => {
         sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         service = new InterventionService();
     });
 
@@ -507,6 +512,17 @@ suite('Block C — InterventionDecisionEngine: rawWanted and blockedReason', () 
 });
 
 suite('Block C — TelemetryManager dispatch routing', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
     // Test 9: shouldIntervene=false && rawWanted=false → no block event
     // We test this via InterventionDecisionEngine + InterventionService integration
     // since TelemetryManager._evaluateAndIntervene is private.
@@ -586,6 +602,7 @@ suite('InterventionService.hideHint() — full status-bar reset', () => {
             accessibilityInformation: undefined,
         } as unknown as vscode.StatusBarItem;
         sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem);
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         svc = new InterventionService();
     });
 
@@ -607,3 +624,4 @@ suite('InterventionService.hideHint() — full status-bar reset', () => {
         assert.strictEqual(statusBarItem.backgroundColor, undefined);
     });
 });
+

--- a/extension/test/unit/services/telemetry/telemetryManagerCadenceFilter.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerCadenceFilter.test.ts
@@ -95,6 +95,7 @@ suite('TelemetryManager — Adaptive-Cadence dismiss filter (#1, #2)', () => {
             command: undefined,
         };
         sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         tm = new TelemetryManager();
     });
 
@@ -163,6 +164,7 @@ suite('InterventionService — lifecycle dismissals do not flip lastDismissed (#
             command: undefined,
         };
         sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
     });
 
     teardown(() => {
@@ -221,6 +223,7 @@ suite('TelemetryManager — single-path EQ snapshot intake (#5)', () => {
             command: undefined,
         };
         sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         tm = new TelemetryManager();
     });
 
@@ -303,5 +306,30 @@ suite('TelemetryManager — single-path EQ snapshot intake (#5)', () => {
             0,
             'with the emitter silenced, no snapshot path should exist — proves the listener is the only path',
         );
+    });
+});
+
+suite('TelemetryManager.dispose() — idempotent', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns({
+            show: sandbox.stub(), hide: sandbox.stub(), dispose: sandbox.stub(),
+            text: '', tooltip: undefined, backgroundColor: undefined, command: undefined,
+        } as unknown as vscode.StatusBarItem);
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('calling dispose twice does not throw and does not re-run teardown', () => {
+        const tm = new TelemetryManager();
+        tm.dispose();
+        // No throw on the second call — VS Code disposes context.subscriptions
+        // after extension.ts:deactivate has already disposed explicitly.
+        assert.doesNotThrow(() => tm.dispose());
     });
 });

--- a/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
+++ b/extension/test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts
@@ -105,6 +105,10 @@ suite('TelemetryManager — intervention UI toggle', () => {
             command: undefined,
         };
         sandbox.stub(vscode.window, 'createStatusBarItem').returns(statusBarItem as unknown as vscode.StatusBarItem);
+        // Stub command registration so InterventionService construction in
+        // multiple tests does not collide on the global command registry.
+        // sandbox.restore() in teardown guarantees cleanup even on throw.
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         showInfoStub = sandbox.stub(vscode.window, 'showInformationMessage');
         showWarnStub = sandbox.stub(vscode.window, 'showWarningMessage');
     });

--- a/extension/test/unit/struggle-detection/telemetryManagerCrossExercise.test.ts
+++ b/extension/test/unit/struggle-detection/telemetryManagerCrossExercise.test.ts
@@ -13,6 +13,8 @@
  */
 
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { TelemetryManager } from '../../../src/extension/services/telemetry/telemetryManager';
 import { ExerciseRegistry } from '../../../src/extension/services/exerciseRegistry';
 import type { ResultDTO } from '../../../src/extension/domain';
@@ -29,8 +31,11 @@ function makeResult(participationId: number | undefined, opts: { buildFailed?: b
 suite('TelemetryManager Cross-Exercise Filter (NEW-2 fix)', () => {
     let registry: ExerciseRegistry;
     let telemetry: TelemetryManager;
+    let sandbox: sinon.SinonSandbox;
 
     setup(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
         registry = new ExerciseRegistry();
         // Exercise A: exerciseId=1, participationId=5001
         // Exercise B: exerciseId=2, participationId=5002
@@ -41,6 +46,7 @@ suite('TelemetryManager Cross-Exercise Filter (NEW-2 fix)', () => {
 
     teardown(() => {
         telemetry.dispose();
+        sandbox.restore();
     });
 
     // Note: a failing build result causes *two* EQ fires — one with source='build'


### PR DESCRIPTION
## Summary

Removes a long-standing try/catch in InterventionService that silently swallowed VS Code's "command already exists" error from `vscode.commands.registerCommand('iris.intervention.acceptSubtle', …)`. Tightens the deactivate path so the global command and status bar item are torn down explicitly, and makes the dispose contract idempotent so the implicit second teardown via `context.subscriptions` is safe.

## Why this matters

The bandaid masked a real production hazard: any code path that accidentally re-instantiated InterventionService (e.g. an extension reload, a test pollution) would silently route status-bar clicks to the previous stale instance. The catch also blocked future maintainers from seeing the underlying lifecycle bug.

## Changes

**`extension.ts:deactivate`**
- Calls `activeTelemetryManager.dispose()` instead of `endCurrentSession()`.
- Wrapped in try/catch; failures log via `logger.error` and don't break shutdown.

**`telemetry/telemetryManager.ts`**
- `dispose()` is idempotent: `if (this._disposed) return;` guard. VS Code disposes `context.subscriptions.push(telemetryManager)` after the explicit deactivate dispose; second teardown is now a no-op.

**`telemetry/interventionService.ts`**
- Removed the try/catch around `vscode.commands.registerCommand`. Duplicate registration now throws loudly. Comment updated to spell out the new contract for future readers.

**Tests**
- Every suite that constructs `InterventionService` or `TelemetryManager` now stubs `vscode.commands.registerCommand` through a sinon sandbox so it doesn't collide with the extension's own activate()'d instance. `sandbox.restore()` in teardown guarantees cleanup even if a test throws mid-flight.
- Added `TelemetryManager.dispose()` idempotency test (`assert.doesNotThrow` on the second call).
- Affected files:
  - `test/unit/provider/artemisWebviewProvider.test.ts`
  - `test/unit/services/telemetry/interventionService.test.ts`
  - `test/unit/services/telemetry/telemetryManagerCadenceFilter.test.ts`
  - `test/unit/services/telemetry/telemetryManagerInterventionToggle.test.ts`
  - `test/unit/struggle-detection/telemetryManagerCrossExercise.test.ts`

## Verification

- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit`: **818 passing, 0 failing, 3 skipped**
- `npm run test:struggle`: **135 passing**

Codex review (one round): explicitly approved with one non-blocking note on a stricter spy assertion for the idempotency test.

## Test plan

- [x] All affected unit + struggle suites green
- [ ] Manual smoke (post-merge): reload extension while subtle hint is visible — no Duplicate-Command-Error in DevTools, status bar item disappears cleanly