### PR TITLE
feat(api): runtime schema validation at the artemisApi boundary

### DIFF
--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -4,6 +4,7 @@ import {
     ApiError, MalformedResponseError, PROFILE_IRIS,
     parseArtemisUser, parseArtemisParticipation,
     parseIrisHealthStatus, parseProfileInfo, parseProgrammingSubmission, parseBuildLogEntry,
+    expectArray, expectObject, parseApiObject,
 } from '../types';
 import type {
     ArtemisUser, ArtemisParticipation, AuthenticationResult,
@@ -114,19 +115,23 @@ export class ArtemisApiService {
     // Get archived courses (inactive courses from previous semesters)
     async getArchivedCourses(): Promise<CourseDashboardCourse[]> {
         const response = await this.makeRequest('/api/core/courses/for-archive');
-        return response.json() as Promise<CourseDashboardCourse[]>;
+        return expectArray<CourseDashboardCourse>(
+            'archived courses',
+            await response.json(),
+            (item, i) => expectObject(`archived courses[${i}]`, item) as CourseDashboardCourse,
+        );
     }
 
     // Get courses with comprehensive dashboard data (exercises, participations, scores)
     async getCoursesForDashboard(): Promise<CourseDashboardResponse> {
         const response = await this.makeRequest('/api/core/courses/for-dashboard');
-        return response.json() as Promise<CourseDashboardResponse>;
+        return parseApiObject<CourseDashboardResponse>('CourseDashboardResponse', await response.json());
     }
 
     // Get a single course with exercises and participations for dashboard
     async getCourseForDashboard(courseId: number): Promise<CourseDashboardEntry> {
         const response = await this.makeRequest(`/api/core/courses/${courseId}/for-dashboard`);
-        return response.json() as Promise<CourseDashboardEntry>;
+        return parseApiObject<CourseDashboardEntry>('CourseDashboardEntry', await response.json());
     }
 
     // Get exercise details for a specific exercise.
@@ -136,7 +141,7 @@ export class ArtemisApiService {
         const response = await this.makeRequest(
             `/api/exercise/exercises/${exerciseId}/details`
         );
-        return response.json() as Promise<ExerciseDetailsResponse>;
+        return parseApiObject<ExerciseDetailsResponse>('ExerciseDetailsResponse', await response.json());
     }
 
     // Get latest pending submission for a participation.
@@ -188,8 +193,9 @@ export class ArtemisApiService {
         if (!text || text.trim() === '' || text.trim() === 'null') {
             return null;
         }
+        let parsed: unknown;
         try {
-            return JSON.parse(text) as ResultSummary;
+            parsed = JSON.parse(text);
         } catch (parseError) {
             const detail = parseError instanceof Error ? parseError.message : String(parseError);
             throw new MalformedResponseError(
@@ -198,6 +204,10 @@ export class ArtemisApiService {
                 detail,
             );
         }
+        return parseApiObject<ResultSummary>(
+            `latest-result for participation ${participationId}`,
+            parsed,
+        );
     }
 
     // Get build logs for a participation (optionally for a specific result)
@@ -207,8 +217,7 @@ export class ArtemisApiService {
             endpoint += `?resultId=${resultId}`;
         }
         const response = await this.makeRequest(endpoint);
-        const data: unknown = await response.json();
-        return (data as unknown[]).map(e => parseBuildLogEntry(e));
+        return expectArray('build logs', await response.json(), parseBuildLogEntry);
     }
 
     // Get VCS access token for a specific participation (per-exercise token)
@@ -409,13 +418,17 @@ export class ArtemisApiService {
     // Get Iris settings for a course
     async getIrisCourseChatSettings(courseId: number): Promise<IrisSettingsResponse> {
         const response = await this.makeRequest(`/api/iris/courses/${courseId}/iris-settings`);
-        return response.json() as Promise<IrisSettingsResponse>;
+        return parseApiObject<IrisSettingsResponse>('IrisSettingsResponse', await response.json());
     }
 
     // Get messages for a chat session
     async getChatMessages(sessionId: number): Promise<IrisChatMessage[]> {
         const response = await this.makeRequest(`/api/iris/sessions/${sessionId}/messages`);
-        return response.json() as Promise<IrisChatMessage[]>;
+        return expectArray<IrisChatMessage>(
+            'IrisChatMessage list',
+            await response.json(),
+            (item, i) => expectObject(`IrisChatMessage[${i}]`, item) as IrisChatMessage,
+        );
     }
 
     // Send a message to Iris
@@ -450,7 +463,7 @@ export class ArtemisApiService {
                     body: JSON.stringify(messagePayload)
                 }
             );
-            return response.json() as Promise<IrisChatMessage>;
+            return parseApiObject<IrisChatMessage>('IrisChatMessage', await response.json());
         } catch (error: unknown) {
             // If sending with uncommittedFiles fails, retry without them
             // This handles the case where the server doesn't support the feature yet
@@ -472,7 +485,7 @@ export class ArtemisApiService {
                         body: JSON.stringify(fallbackPayload)
                     }
                 );
-                return fallbackResponse.json() as Promise<IrisChatMessage>;
+                return parseApiObject<IrisChatMessage>('IrisChatMessage', await fallbackResponse.json());
             }
             throw error;
         }
@@ -496,7 +509,9 @@ export class ArtemisApiService {
             `/api/iris/chat/sessions/current?${params.toString()}`,
             { method: 'POST' },
         );
-        return response.json() as Promise<IrisChatSession>;
+        return parseApiObject<IrisChatSession>('IrisChatSession', await response.json(), [
+            { key: 'id', type: 'number' },
+        ]);
     }
 
     async createChatSession(mode: IrisChatMode, entityId: number): Promise<IrisChatSession> {
@@ -505,12 +520,23 @@ export class ArtemisApiService {
             `/api/iris/chat/sessions?${params.toString()}`,
             { method: 'POST' },
         );
-        return response.json() as Promise<IrisChatSession>;
+        return parseApiObject<IrisChatSession>('IrisChatSession', await response.json(), [
+            { key: 'id', type: 'number' },
+        ]);
     }
 
     async listChatSessionsForCourse(courseId: number): Promise<IrisChatSessionSummary[]> {
         const response = await this.makeRequest(`/api/iris/chat/${courseId}/sessions/overview`);
-        return response.json() as Promise<IrisChatSessionSummary[]>;
+        return expectArray<IrisChatSessionSummary>(
+            'IrisChatSessionSummary list',
+            await response.json(),
+            (item, i) => parseApiObject<IrisChatSessionSummary>(`IrisChatSessionSummary[${i}]`, item, [
+                { key: 'id', type: 'number' },
+                { key: 'entityId', type: 'number' },
+                { key: 'creationDate', type: 'string' },
+                { key: 'mode', type: 'string' },
+            ]),
+        );
     }
 
     // Get exam sidebar data for a specific course (student-accessible).
@@ -518,19 +544,23 @@ export class ArtemisApiService {
     // Note: does NOT include endDate — use course.exams from getCourseForDashboard for full data.
     async getExamSidebarData(courseId: number): Promise<ExamSummary[]> {
         const response = await this.makeRequest(`/api/exam/courses/${courseId}/real-exams-sidebar-data`);
-        return response.json() as Promise<ExamSummary[]>;
+        return expectArray<ExamSummary>(
+            'ExamSummary list',
+            await response.json(),
+            (item, i) => expectObject(`ExamSummary[${i}]`, item) as ExamSummary,
+        );
     }
 
     // Get the student's own exam for a specific exam (to check status)
     async getOwnStudentExam(courseId: number, examId: number): Promise<StudentExam> {
         const response = await this.makeRequest(`/api/exam/courses/${courseId}/exams/${examId}/own-student-exam`);
-        return response.json() as Promise<StudentExam>;
+        return parseApiObject<StudentExam>('StudentExam', await response.json());
     }
 
     // Start the exam and get conduction details
     async startStudentExam(courseId: number, examId: number, studentExamId: number): Promise<StudentExam> {
         const response = await this.makeRequest(`/api/exam/courses/${courseId}/exams/${examId}/student-exams/${studentExamId}/conduction`);
-        return response.json() as Promise<StudentExam>;
+        return parseApiObject<StudentExam>('StudentExam', await response.json());
     }
 
     // ── Problem Statement Rendering ──

--- a/extension/src/extension/domain/index.ts
+++ b/extension/src/extension/domain/index.ts
@@ -1,4 +1,5 @@
 export { ApiError, MalformedResponseError } from './errors';
+export { expectObject, expectArray, parseApiObject } from './responseValidation';
 export type {
     ArtemisUser,
     ArtemisParticipation,

--- a/extension/src/extension/domain/responseValidation.ts
+++ b/extension/src/extension/domain/responseValidation.ts
@@ -1,0 +1,62 @@
+// Lightweight runtime validators for the permissive `[key: string]: unknown`
+// API response interfaces. Catches the easy "server returned null / array /
+// primitive where we expected an object" class of failures before the data
+// flows into UI components. The validators throw `MalformedResponseError`
+// so callers can use a single `instanceof` check to distinguish schema
+// failures from transport/auth failures (see `exerciseDataLoader.ts`).
+
+import { MalformedResponseError } from './errors';
+
+function failed(label: string, detail: string): MalformedResponseError {
+    return new MalformedResponseError(`Malformed ${label} response: ${detail}`, 200, detail);
+}
+
+/** Assert that `data` is a plain (non-array) object. */
+export function expectObject(label: string, data: unknown): Record<string, unknown> {
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+        throw failed(label, `expected object, got ${describe(data)}`);
+    }
+    return data as Record<string, unknown>;
+}
+
+/** Assert that `data` is an array. Optionally validates each element. */
+export function expectArray<T = unknown>(
+    label: string,
+    data: unknown,
+    elementValidator?: (item: unknown, index: number) => T,
+): T[] {
+    if (!Array.isArray(data)) {
+        throw failed(label, `expected array, got ${describe(data)}`);
+    }
+    if (!elementValidator) {
+        return data as T[];
+    }
+    return data.map((item, index) => elementValidator(item, index));
+}
+
+/**
+ * Parse an API JSON body that maps to a permissive interface (most of the
+ * `[key: string]: unknown` types in `shared/types/apiResponses.ts`). Only
+ * the listed `required` keys are checked for presence and primitive type;
+ * everything else is trusted as the interface declares it.
+ */
+export function parseApiObject<T>(
+    label: string,
+    data: unknown,
+    required: ReadonlyArray<{ key: string; type: 'string' | 'number' }> = [],
+): T {
+    const obj = expectObject(label, data);
+    for (const { key, type } of required) {
+        const value = obj[key];
+        if (typeof value !== type) {
+            throw failed(label, `missing or non-${type} field "${key}"`);
+        }
+    }
+    return obj as T;
+}
+
+function describe(value: unknown): string {
+    if (value === null) { return 'null'; }
+    if (Array.isArray(value)) { return 'array'; }
+    return typeof value;
+}

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -576,6 +576,22 @@ suite('Artemis API Service Test Suite', () => {
         );
     });
 
+    test('getLatestResultWithFeedbacks: non-object body (array/primitive) throws MalformedResponseError', async () => {
+        const participationId = 19;
+        for (const bogus of ['[]', '42', '"ok"']) {
+            global.fetch = async () => ({
+                ok: true,
+                status: 200,
+                text: async () => bogus,
+            } as any);
+            await assert.rejects(
+                () => apiService.getLatestResultWithFeedbacks(participationId),
+                (err: unknown) => err instanceof MalformedResponseError,
+                `body ${bogus} must reject`,
+            );
+        }
+    });
+
     test('should mark message helpful', async () => {
         const sessionId = 1;
         const messageId = 1;
@@ -739,6 +755,54 @@ suite('Artemis API Service Test Suite', () => {
         };
         const summaries = await apiService.listChatSessionsForCourse(courseId);
         assert.deepStrictEqual(summaries, mockSummaries);
+    });
+
+    test('getCoursesForDashboard: rejects when body is an array (not an object)', async () => {
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => [{ courses: [] }],
+        } as any);
+        await assert.rejects(
+            () => apiService.getCoursesForDashboard(),
+            (err: unknown) => err instanceof MalformedResponseError && /expected object, got array/.test(err.message),
+        );
+    });
+
+    test('getArchivedCourses: rejects when body is not an array', async () => {
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({ items: [] }),
+        } as any);
+        await assert.rejects(
+            () => apiService.getArchivedCourses(),
+            (err: unknown) => err instanceof MalformedResponseError && /expected array, got object/.test(err.message),
+        );
+    });
+
+    test('getCurrentChat: rejects when session id is missing or non-numeric', async () => {
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({ mode: 'COURSE_CHAT' }),
+        } as any);
+        await assert.rejects(
+            () => apiService.getCurrentChat('COURSE_CHAT', 1),
+            (err: unknown) => err instanceof MalformedResponseError && /missing or non-number field "id"/.test(err.message),
+        );
+    });
+
+    test('listChatSessionsForCourse: rejects element with missing required field', async () => {
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            json: async () => [{ id: 1, entityId: 2, creationDate: '2026-01-01', mode: 'COURSE_CHAT' }, { id: 3 }],
+        } as any);
+        await assert.rejects(
+            () => apiService.listChatSessionsForCourse(1),
+            (err: unknown) => err instanceof MalformedResponseError && /IrisChatSessionSummary\[1\]/.test(err.message),
+        );
     });
 
     test('should throw when authentication succeeds without cookie', async () => {

--- a/extension/test/unit/domain/responseValidation.test.ts
+++ b/extension/test/unit/domain/responseValidation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the API-response validators in
+ * `extension/src/extension/domain/responseValidation.ts`.
+ *
+ * The validators are deliberately small. They guard the boundary between
+ * `fetch(...).json()` (typed as `unknown`) and the permissive interfaces in
+ * `shared/types/apiResponses.ts` so callers can rely on `instanceof
+ * MalformedResponseError` to distinguish schema failures from transport
+ * failures.
+ */
+
+import * as assert from 'assert';
+import {
+    expectObject,
+    expectArray,
+    parseApiObject,
+    MalformedResponseError,
+} from '../../../src/extension/domain';
+
+suite('expectObject', () => {
+    test('returns the value when it is a plain object', () => {
+        const obj = { foo: 'bar' };
+        const result = expectObject('thing', obj);
+        assert.strictEqual(result, obj);
+    });
+
+    test('rejects null', () => {
+        assert.throws(
+            () => expectObject('thing', null),
+            (err: unknown) => err instanceof MalformedResponseError && /got null/.test(err.message),
+        );
+    });
+
+    test('rejects arrays', () => {
+        assert.throws(
+            () => expectObject('thing', [1, 2, 3]),
+            (err: unknown) => err instanceof MalformedResponseError && /got array/.test(err.message),
+        );
+    });
+
+    test('rejects primitives', () => {
+        for (const v of [42, 'hello', true, undefined]) {
+            assert.throws(
+                () => expectObject('thing', v),
+                (err: unknown) => err instanceof MalformedResponseError,
+                `value ${String(v)} must reject`,
+            );
+        }
+    });
+});
+
+suite('expectArray', () => {
+    test('returns the value when it is an array', () => {
+        const arr = [1, 2, 3];
+        assert.strictEqual(expectArray('list', arr), arr);
+    });
+
+    test('rejects objects', () => {
+        assert.throws(
+            () => expectArray('list', { 0: 'x' }),
+            (err: unknown) => err instanceof MalformedResponseError && /got object/.test(err.message),
+        );
+    });
+
+    test('rejects null', () => {
+        assert.throws(
+            () => expectArray('list', null),
+            (err: unknown) => err instanceof MalformedResponseError,
+        );
+    });
+
+    test('elementValidator runs and propagates throws from it', () => {
+        assert.throws(
+            () => expectArray('list', [1, 2, 'bad'], (item, i) => {
+                if (typeof item !== 'number') {
+                    throw new Error(`item[${i}] not a number`);
+                }
+                return item;
+            }),
+            /item\[2\] not a number/,
+        );
+    });
+
+    test('elementValidator mapping result is returned', () => {
+        const out = expectArray('list', [1, 2, 3], (n) => (n as number) * 10);
+        assert.deepStrictEqual(out, [10, 20, 30]);
+    });
+});
+
+suite('parseApiObject', () => {
+    test('passes when all required fields are present with the right type', () => {
+        const data = { id: 42, title: 'Foo' };
+        const result = parseApiObject<{ id: number; title: string }>('Thing', data, [
+            { key: 'id', type: 'number' },
+            { key: 'title', type: 'string' },
+        ]);
+        assert.strictEqual(result.id, 42);
+        assert.strictEqual(result.title, 'Foo');
+    });
+
+    test('rejects when a required field is missing', () => {
+        assert.throws(
+            () => parseApiObject('Thing', { title: 'Foo' }, [{ key: 'id', type: 'number' }]),
+            (err: unknown) => err instanceof MalformedResponseError && /missing or non-number field "id"/.test(err.message),
+        );
+    });
+
+    test('rejects when a required field is the wrong type', () => {
+        assert.throws(
+            () => parseApiObject('Thing', { id: '42' }, [{ key: 'id', type: 'number' }]),
+            (err: unknown) => err instanceof MalformedResponseError && /missing or non-number field "id"/.test(err.message),
+        );
+    });
+
+    test('passes with no required fields (object-shape check only)', () => {
+        const result = parseApiObject<{ foo?: string }>('Thing', { foo: 'bar' });
+        assert.strictEqual(result.foo, 'bar');
+    });
+
+    test('rejects non-object input', () => {
+        assert.throws(
+            () => parseApiObject('Thing', null),
+            (err: unknown) => err instanceof MalformedResponseError,
+        );
+        assert.throws(
+            () => parseApiObject('Thing', [1, 2]),
+            (err: unknown) => err instanceof MalformedResponseError,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Replaces ten silent `as Promise<T>` / `as unknown[]` casts in `extension/src/extension/api/artemisApi.ts` with parser calls so an unexpected response shape from Artemis surfaces as `MalformedResponseError` (subclass of `ApiError`) rather than garbage-typed-as-`T` flowing into the UI. Builds on the per-endpoint policy from PR-2 (`exerciseDataLoader` rethrows `instanceof MalformedResponseError`).

## New helper module

`extension/src/extension/domain/responseValidation.ts`:

| Helper | Purpose |
|--------|---------|
| `expectObject(label, data)` | Non-array object check |
| `expectArray<T>(label, data, elementValidator?)` | Array check + optional per-element mapper |
| `parseApiObject<T>(label, data, required?)` | `expectObject` + required primitive-typed fields |

All three throw `MalformedResponseError`. Callers keep using `instanceof MalformedResponseError` to distinguish schema failures from transport failures.

## Endpoints wired up

| Method | Validation |
|--------|------------|
| `getArchivedCourses` | `expectArray` + per-element `expectObject` |
| `getCoursesForDashboard`, `getCourseForDashboard`, `getExerciseDetails`, `getIrisCourseChatSettings` | `parseApiObject` (shape only) |
| `getChatMessages` | `expectArray` + per-element `expectObject` |
| `sendChatMessage` (primary + fallback path) | `parseApiObject` |
| `getCurrentChat`, `createChatSession` | `parseApiObject` with required `{id: number}` |
| `listChatSessionsForCourse` | `expectArray` + per-element `parseApiObject` with required `{id, entityId, creationDate, mode}` |
| `getExamSidebarData` | `expectArray` + per-element `expectObject` |
| `getOwnStudentExam`, `startStudentExam` | `parseApiObject` |
| `getBuildLogs` | simplified to `expectArray(parseBuildLogEntry)` |
| `getLatestResultWithFeedbacks` | Parses JSON to `unknown` first, then `parseApiObject<ResultSummary>` (was silently casting any non-empty JSON to `ResultSummary`, e.g. `[]`, `42`, `"ok"`) |

Two remaining `as unknown` casts in `renderProblemStatement` live inside the pre-existing `isRenderedProblemStatementDTO` typed-guard path and stay as is.

## Verification

- `npm run check-types` ✅
- `npm run lint` ✅
- `npm run test:unit`: **837 passing, 0 failing, 3 skipped**

Codex review (two rounds): one blocker (`getLatestResultWithFeedbacks` retained an `as ResultSummary` cast inside the JSON parse) and one non-blocking note (`getArchivedCourses` only validated the top-level array) — both addressed before commit. Final approval explicit.

## Test plan

- [x] 12 helper-coverage tests (`responseValidation.test.ts`): null / array / primitive / object / required field types / element validator propagation
- [x] 5 integration tests (`artemisApi.test.ts`) on representative endpoints: `getCoursesForDashboard`, `getArchivedCourses`, `getCurrentChat`, `listChatSessionsForCourse`, `getLatestResultWithFeedbacks` (incl. array/primitive body)
- [ ] Manual smoke (post-merge): hit each affected endpoint against a live Artemis to confirm no false positives on valid responses