### PR TITLE
fix(webview): clear stuck thinking indicator on Iris send rejection (#178)

### DIFF
--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -382,8 +382,8 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         try {
             switch (message.command) {
                 case WebviewCmd.SendMessage: {
-                    const { text } = getPayload<WebCmd<'sendMessage'>>(message);
-                    void this._handleChatMessage({ text }).catch(err => {
+                    const { text, localId, localSessionId } = getPayload<WebCmd<'sendMessage'>>(message);
+                    void this._handleChatMessage({ text, localId, localSessionId }).catch(err => {
                         logger.error('Error handling chat message', LogCategory.IRIS_CHAT, err);
                         vscode.window.showErrorMessage('Failed to send message. Please try again.');
                     });
@@ -484,6 +484,81 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     }
 
     // ── Private: Helpers ───────────────────────────────────────────────
+
+    /**
+     * Dispatch a synchronous send rejection back to the webview.
+     *
+     * Keeps the existing collateral side-effects (NoAi banner, disabled
+     * banner) so visible chat state stays consistent, AND posts a
+     * targeted SendRejected so the webview can mark the optimistic user
+     * message as failed and clear its thinking indicator. Without that
+     * second post the thinking dots would loop forever (see #178).
+     *
+     * If the webview did not include `localId`/`localSessionId` in the
+     * sendMessage command (older-build edge case), we cannot correlate
+     * the rejection to a message and instead post an assistant-style
+     * AddMessage as a self-healing fallback — the current webview's
+     * AddMessage handler already calls resetTransientChatUi.
+     */
+    private _handleRejectedSend(
+        result: { sent: false; reason: 'no-ai' | 'no-context' | 'iris-disabled'; contextLabel?: string },
+        localId: string | undefined,
+        localSessionId: string | undefined,
+    ): void {
+        const errorMessage = this._friendlyRejectionMessage(result);
+
+        // Existing collateral side-effects per reason.
+        switch (result.reason) {
+            case 'no-ai':
+                this._postNoAiStatus(true);
+                break;
+            case 'no-context':
+                // No persistent UI state to update; the inline failed
+                // message communicates this fully.
+                break;
+            case 'iris-disabled':
+                this._postMessageSafe({
+                    type: ExtensionMsg.ShowDisabledState,
+                    message: `Iris chat is not enabled for this ${result.contextLabel ?? 'context'}. Please contact your instructor.`
+                });
+                break;
+        }
+
+        if (localId && localSessionId) {
+            this._postMessageSafe({
+                type: ExtensionMsg.SendRejected,
+                localId,
+                localSessionId,
+                reason: result.reason,
+                errorMessage,
+            });
+            return;
+        }
+
+        // Fallback for builds that don't carry the new correlation IDs.
+        // Posting an assistant AddMessage causes the existing webview
+        // handler to call resetTransientChatUi, which clears the stuck
+        // indicator at the cost of a slightly noisier UX.
+        this._postMessageSafe({
+            type: ExtensionMsg.AddMessage,
+            message: {
+                role: 'assistant',
+                content: errorMessage,
+                timestamp: Date.now(),
+            }
+        });
+    }
+
+    private _friendlyRejectionMessage(result: { reason: 'no-ai' | 'no-context' | 'iris-disabled'; contextLabel?: string }): string {
+        switch (result.reason) {
+            case 'no-ai':
+                return 'Not sent because AI assistance is disabled for this workspace.';
+            case 'no-context':
+                return 'Please select a course or exercise context first.';
+            case 'iris-disabled':
+                return `Iris chat is disabled for this ${result.contextLabel ?? 'context'}.`;
+        }
+    }
 
     /**
      * Post .noai status to the webview
@@ -603,10 +678,12 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         );
     }
 
-    private async _handleChatMessage(message: { text?: string }): Promise<void> {
+    private async _handleChatMessage(message: { text?: string; localId?: string; localSessionId?: string }): Promise<void> {
         if (typeof message.text !== 'string') { return; }
 
         const content = message.text;
+        const localId = typeof message.localId === 'string' ? message.localId : undefined;
+        const localSessionId = typeof message.localSessionId === 'string' ? message.localSessionId : undefined;
 
         // Emit pending before the API call so the recording captures send attempts
         // even when the call never returns (e.g. network hang).
@@ -629,20 +706,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                     status: 'failed',
                     errorMessage: `send-rejected: ${result.reason ?? 'unknown'}`,
                 });
-                switch (result.reason) {
-                    case 'no-ai':
-                        this._postNoAiStatus(true);
-                        break;
-                    case 'no-context':
-                        vscode.window.showErrorMessage('Please select a course or exercise context first');
-                        break;
-                    case 'iris-disabled':
-                        this._postMessageSafe({
-                            type: ExtensionMsg.ShowDisabledState,
-                            message: `Iris chat is not enabled for this ${result.contextLabel}. Please contact your instructor.`
-                        });
-                        break;
-                }
+                this._handleRejectedSend(result, localId, localSessionId);
             }
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -64,6 +64,7 @@ export const ExtensionMsg = {
     HideDisabledState: 'hideDisabledState',
     UpdateNoAiStatus: 'updateNoAiStatus',
     UpdateIrisStages: 'updateIrisStages',
+    SendRejected: 'sendRejected',
 
     // Exercise/Repo responses
     UpdateRepoStatus: 'updateRepoStatus',
@@ -225,6 +226,19 @@ interface ExtensionMsgPayloads {
     };
     updateIrisStages: {
         stages: IrisStageDTO[];
+    };
+    /**
+     * Posted by the extension host when a user-initiated `sendMessage`
+     * command was rejected synchronously (e.g. no chat context, .noai
+     * detected, Iris disabled for this exercise). The webview uses
+     * `localId` + `localSessionId` to find the optimistic user message and
+     * mark it failed so the thinking indicator does not get stuck.
+     */
+    sendRejected: {
+        localId: string;
+        localSessionId: string;
+        reason: 'no-ai' | 'no-context' | 'iris-disabled';
+        errorMessage: string;
     };
 
     // Exercise/Repo responses

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -169,7 +169,7 @@ interface WebviewCmdPayloads {
     performHealthChecks: { serverUrl: string };
 
     // Iris Chat
-    sendMessage: { text: string };
+    sendMessage: { text: string; localId: string; localSessionId: string };
     selectChatContext: { context: ChatContextType; itemId: number; itemName: string; itemShortName?: string };
     switchSession: { sessionId: string };
     createNewSession: undefined;

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -71,6 +71,19 @@ interface ChatState {
     /** Record that hydration failed for the given session. */
     setMessageLoadError: (localSessionId: string) => void;
     addMessage: (message: ChatMessage) => void;
+    /**
+     * Mark a still-pending user message as failed. Returns `true` only if
+     * a matching message was found AND it was a pending user send
+     * (role === 'user' && status === 'sending'). Returning false lets the
+     * caller skip the transient-UI reset when a rejection is stale
+     * (e.g. arrived after the user already switched session or retried).
+     */
+    markMessageFailed: (
+        localId: string,
+        errorMessage: string,
+        errorReason: NonNullable<ChatMessage['errorReason']>,
+    ) => boolean;
+    removeMessage: (localId: string) => void;
     clearMessages: () => void;
 
     // Streaming actions
@@ -159,6 +172,28 @@ export const useChatStore = create<ChatState>()(
                 set((state) => ({
                     messages: [...state.messages, message],
                 }), false, 'addMessage');
+            },
+
+            markMessageFailed: (localId, errorMessage, errorReason) => {
+                const current = useChatStore.getState().messages;
+                const target = current.find((m) => m.localId === localId);
+                if (!target || target.role !== 'user' || target.status !== 'sending') {
+                    return false;
+                }
+                set((state) => ({
+                    messages: state.messages.map((m) =>
+                        m.localId === localId
+                            ? { ...m, status: 'error' as const, errorMessage, errorReason }
+                            : m,
+                    ),
+                }), false, 'markMessageFailed');
+                return true;
+            },
+
+            removeMessage: (localId) => {
+                set((state) => ({
+                    messages: state.messages.filter((m) => m.localId !== localId),
+                }), false, 'removeMessage');
             },
 
             clearMessages: () => {

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -28,6 +28,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         applyLoadedMessages, setMessageLoadError,
         clearMessages, setReferencedFiles, setWebSocketStatus,
         setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi,
+        markMessageFailed,
     } = store;
     const [sideMenuOpen, setSideMenuOpen] = useState(false);
     const [contextSwitching, setContextSwitching] = useState(false);
@@ -181,11 +182,40 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 setIrisStages(msg.stages);
                 break;
             }
+
+            case ExtensionMsg.SendRejected: {
+                // Ignore stale rejections that arrive after the user already
+                // switched session — the corresponding optimistic message
+                // would not exist in the active session anyway, and clearing
+                // transient UI for an unrelated session is wrong.
+                const currentSessionId = useChatStore.getState().activeSessionId;
+                if (currentSessionId !== msg.localSessionId) {
+                    break;
+                }
+                const matched = markMessageFailed(msg.localId, msg.errorMessage, msg.reason);
+                // Only clear the indicator if we actually found and updated
+                // the message. A non-match means the rejection is stale
+                // (e.g. retry already removed the failed entry, or messages
+                // were re-hydrated from server) and we must not touch the
+                // current request's transient UI.
+                if (matched) {
+                    resetTransientChatUi();
+                }
+                break;
+            }
         }
-    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi]);
+    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi, markMessageFailed]);
 
     const handleSendMessage = (text: string) => {
         const localId = crypto.randomUUID();
+        const localSessionId = store.activeSessionId;
+        if (localSessionId === null) {
+            // No active session — the extension host could not correlate
+            // a SendRejected back to a message anyway. The ChatInput is
+            // already disabled in this state, so this is just a defensive
+            // guard against a programmer error.
+            return;
+        }
 
         // Clear any stale stages/streaming from previous request
         resetTransientChatUi();
@@ -199,14 +229,30 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             status: 'sending',
         });
 
-        // Start streaming state (thinking indicator will show until either
-        // the assistant AddMessage arrives — resetTransientChatUi clears it —
-        // or a STATUS frame populates irisStages and the stage indicator
-        // takes over).
+        // Start streaming state. The thinking indicator stays on until one
+        // of three terminal signals clears it via resetTransientChatUi:
+        //   - assistant AddMessage arrives (happy path)
+        //   - SendRejected with matching localId (synchronous rejection)
+        //   - websocket disconnect (terminal connection state)
         store.startStreaming();
 
-        // Send to extension
-        postCommand(vscodeApi, 'sendMessage', { text });
+        // Send to extension. localSessionId lets the host echo it back on
+        // rejection so the webview can ignore stale responses after a
+        // session switch.
+        postCommand(vscodeApi, 'sendMessage', { text, localId, localSessionId });
+    };
+
+    const handleRetry = (localId: string) => {
+        const failed = useChatStore.getState().messages.find((m) => m.localId === localId);
+        if (!failed || failed.role !== 'user' || failed.status !== 'error') {
+            return;
+        }
+        // Remove the failed entry first so handleSendMessage's optimistic
+        // add doesn't briefly produce two copies. Zustand+React batch the
+        // two state updates in the same event tick, so there is no visible
+        // flicker.
+        store.removeMessage(localId);
+        handleSendMessage(failed.content);
     };
 
     const handleFeedback = (messageId: number, feedback: 'positive' | 'negative') => {
@@ -253,6 +299,26 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
     // Check if chat is disabled
     const isChatDisabled = store.disabledMessage !== null || store.isNoAiDetected;
+
+    // Decide whether the Retry button on a failed user message should be
+    // active right now. Retry is meaningful only when the underlying cause
+    // has plausibly cleared since the original send. Computed inline per
+    // render because the message list is short and `messages.map` already
+    // walks it; rebuilding a Map would be wasted work.
+    const isRetryDisabled = (msg: { errorReason?: 'no-ai' | 'no-context' | 'iris-disabled' }) => {
+        switch (msg.errorReason) {
+            case 'iris-disabled':
+                // Persistent until the user navigates away from the
+                // disabled exercise; the banner already states this.
+                return true;
+            case 'no-ai':
+                return store.isNoAiDetected;
+            case 'no-context':
+                return store.context === null;
+            default:
+                return false;
+        }
+    };
 
     // Determine disabled reason text
     let disabledBannerText: string | null = null;
@@ -463,6 +529,8 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                         onSendPrompt={handleSendMessage}
                         hasContext={store.context !== null}
                         isChatDisabled={isChatDisabled}
+                        onRetry={handleRetry}
+                        isRetryDisabled={isRetryDisabled}
                     />
                 )}
             </div>
@@ -481,10 +549,19 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     snapshot arrives. */}
                 <ChatInput
                     onSend={handleSendMessage}
-                    disabled={isChatDisabled || store.context === null || messagesLoading}
+                    disabled={
+                        isChatDisabled
+                        || store.context === null
+                        || messagesLoading
+                        || store.streaming.isStreaming
+                    }
                     disabledPlaceholder={
                         disabledPlaceholder
-                        ?? (messagesLoading ? 'Loading conversation…' : undefined)
+                        ?? (messagesLoading
+                            ? 'Loading conversation…'
+                            : store.streaming.isStreaming
+                                ? 'Iris is responding…'
+                                : undefined)
                     }
                 />
 

--- a/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
@@ -16,6 +16,15 @@ interface ChatMessageListProps {
     onSendPrompt: (text: string) => void;
     hasContext: boolean;
     isChatDisabled?: boolean;
+    /** Invoked when a failed user message's Retry button is clicked. */
+    onRetry?: (localId: string) => void;
+    /**
+     * Predicate that decides whether the Retry button should be active for
+     * a given failed message. Kept as a function (rather than a Map) so
+     * the parent can derive it from live store state without rebuilding
+     * the map on every render.
+     */
+    isRetryDisabled?: (message: ChatMessage) => boolean;
 }
 
 export function ChatMessageList({
@@ -26,6 +35,8 @@ export function ChatMessageList({
     onSendPrompt,
     hasContext,
     isChatDisabled,
+    onRetry,
+    isRetryDisabled,
 }: ChatMessageListProps) {
     const { scrollRef, contentRef, scrollOnSend } = useAutoScroll();
 
@@ -56,6 +67,10 @@ export function ChatMessageList({
                                 key={message.localId}
                                 message={message}
                                 onFeedback={onFeedback}
+                                onRetry={onRetry}
+                                retryDisabled={
+                                    isRetryDisabled ? isRetryDisabled(message) : false
+                                }
                             />
                         ))}
 

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
@@ -35,30 +35,65 @@
     color: var(--vscode-foreground);
 }
 
+/* Failed user messages keep the userBubble styling but get a subtle
+   error outline so the original text remains readable. The detailed
+   error info renders in .errorFooter below the bubble. */
 .bubble.error {
-    background: var(--vscode-inputValidation-errorBackground);
     border: 1px solid var(--vscode-inputValidation-errorBorder);
+    opacity: 0.85;
 }
 
 .content {
     composes: richContent from '../../../styles/richContent.module.css';
 }
 
-.errorContent {
+/* Wrapper so the error footer can sit directly under the bubble while
+   still respecting the message wrapper's row-reverse for user messages. */
+.bubbleColumn {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 4px;
+    max-width: 70%;
 }
 
-.errorMessage {
-    margin: 0;
+.messageWrapper.user .bubbleColumn {
+    align-items: flex-end;
+}
+
+.messageWrapper.assistant .bubbleColumn {
+    align-items: flex-start;
+}
+
+/* The bubble inside the column should no longer constrain its own width
+   since the column already handles max-width. */
+.bubbleColumn .bubble {
+    max-width: 100%;
+}
+
+.errorFooter {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
     color: var(--vscode-inputValidation-errorForeground);
-    font-size: 14px;
+    padding: 0 4px;
+}
+
+.errorBadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 600;
+    color: var(--vscode-inputValidation-errorForeground);
+}
+
+.errorText {
+    color: var(--vscode-descriptionForeground);
 }
 
 .retryButton {
-    align-self: flex-start;
-    padding: 4px 12px;
+    padding: 2px 10px;
     background: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
     border: none;
@@ -67,8 +102,13 @@
     cursor: pointer;
 }
 
-.retryButton:hover {
+.retryButton:hover:not(:disabled) {
     background: var(--vscode-button-hoverBackground);
+}
+
+.retryButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .feedbackContainer {

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import ThumbsDown from 'lucide-react/dist/esm/icons/thumbs-down';
 import ThumbsUp from 'lucide-react/dist/esm/icons/thumbs-up';
 import { memo, useMemo, useState } from 'react';
@@ -14,11 +15,21 @@ import styles from './MessageBubble.module.css';
 interface MessageBubbleProps {
     message: ChatMessage;
     onFeedback: (messageId: number, feedback: 'positive' | 'negative') => void;
+    /** Invoked when the Retry button on a failed user message is clicked. */
+    onRetry?: (localId: string) => void;
+    /**
+     * Disables the Retry button. Set when the underlying rejection cause
+     * still holds (e.g. `.noai` still detected, no context still selected,
+     * Iris still disabled for the exercise).
+     */
+    retryDisabled?: boolean;
 }
 
 function MessageBubbleComponent({
     message,
     onFeedback,
+    onRetry,
+    retryDisabled,
 }: MessageBubbleProps) {
     const [hovering, setHovering] = useState(false);
     const isAssistant = message.role === 'assistant';
@@ -35,6 +46,7 @@ function MessageBubbleComponent({
     };
 
     const hasFeedback = message.helpful !== undefined && message.helpful !== null;
+    const isFailed = message.status === 'error';
 
     return (
         <div
@@ -45,28 +57,17 @@ function MessageBubbleComponent({
             onMouseEnter={() => setHovering(true)}
             onMouseLeave={() => setHovering(false)}
         >
-            <div
-                className={clsx(styles.bubble, {
-                    [styles.userBubble]: isUser,
-                    [styles.assistantBubble]: isAssistant,
-                    [styles.error]: message.status === 'error',
-                })}
-            >
-                {message.status === 'error' ? (
-                    <div className={styles.errorContent}>
-                        <p className={styles.errorMessage}>
-                            {message.errorMessage || 'Failed to send message'}
-                        </p>
-                        <button
-                            className={styles.retryButton}
-                            onClick={() => {
-                                // Retry logic would be handled by parent
-                            }}
-                        >
-                            Retry
-                        </button>
-                    </div>
-                ) : (
+            <div className={styles.bubbleColumn}>
+                <div
+                    className={clsx(styles.bubble, {
+                        [styles.userBubble]: isUser,
+                        [styles.assistantBubble]: isAssistant,
+                        [styles.error]: isFailed,
+                    })}
+                >
+                    {/* Always render the original message content. The error
+                        footer below augments it instead of replacing it, so the
+                        user can see what they tried to send. */}
                     <div className={styles.content}>
                         <Streamdown
                             mode="static"
@@ -75,38 +76,61 @@ function MessageBubbleComponent({
                             {message.content}
                         </Streamdown>
                     </div>
-                )}
 
-                {isAssistant && (
-                    <div
-                        className={clsx(styles.feedbackContainer, {
-                            [styles.visible]: hovering || hasFeedback,
-                        })}
-                    >
-                        <button
-                            className={clsx(styles.feedbackButton, {
-                                [styles.selected]: message.helpful === true,
+                    {isAssistant && !isFailed && (
+                        <div
+                            className={clsx(styles.feedbackContainer, {
+                                [styles.visible]: hovering || hasFeedback,
                             })}
-                            onClick={() => handleFeedback('positive')}
-                            aria-label="Helpful"
                         >
-                            <ThumbsUp
-                                size={16}
-                                fill={message.helpful === true ? 'currentColor' : 'none'}
-                            />
-                        </button>
-                        <button
-                            className={clsx(styles.feedbackButton, {
-                                [styles.selected]: message.helpful === false,
-                            })}
-                            onClick={() => handleFeedback('negative')}
-                            aria-label="Not helpful"
-                        >
-                            <ThumbsDown
-                                size={16}
-                                fill={message.helpful === false ? 'currentColor' : 'none'}
-                            />
-                        </button>
+                            <button
+                                className={clsx(styles.feedbackButton, {
+                                    [styles.selected]: message.helpful === true,
+                                })}
+                                onClick={() => handleFeedback('positive')}
+                                aria-label="Helpful"
+                            >
+                                <ThumbsUp
+                                    size={16}
+                                    fill={message.helpful === true ? 'currentColor' : 'none'}
+                                />
+                            </button>
+                            <button
+                                className={clsx(styles.feedbackButton, {
+                                    [styles.selected]: message.helpful === false,
+                                })}
+                                onClick={() => handleFeedback('negative')}
+                                aria-label="Not helpful"
+                            >
+                                <ThumbsDown
+                                    size={16}
+                                    fill={message.helpful === false ? 'currentColor' : 'none'}
+                                />
+                            </button>
+                        </div>
+                    )}
+                </div>
+
+                {isFailed && (
+                    <div className={styles.errorFooter} role="alert">
+                        <span className={styles.errorBadge}>
+                            <AlertTriangle size={12} aria-hidden="true" />
+                            <span>Not sent</span>
+                        </span>
+                        <span className={styles.errorText}>
+                            {message.errorMessage || 'Failed to send message'}
+                        </span>
+                        {onRetry && (
+                            <button
+                                type="button"
+                                className={styles.retryButton}
+                                onClick={() => onRetry(message.localId)}
+                                disabled={retryDisabled}
+                                aria-label="Retry sending this message"
+                            >
+                                Retry
+                            </button>
+                        )}
                     </div>
                 )}
             </div>
@@ -118,13 +142,22 @@ function MessageBubbleComponent({
     );
 }
 
-// Custom comparator for React.memo
+// Custom comparator for React.memo. We include `errorReason` because it
+// drives `retryDisabled` derivations one layer up; if it changes, the
+// parent's recomputed `retryDisabled` will already differ and trigger a
+// re-render via that prop — but keeping it here makes the equality check
+// honest about which fields actually matter to this component.
 const areEqual = (prev: MessageBubbleProps, next: MessageBubbleProps) => {
     return (
         prev.message.localId === next.message.localId &&
         prev.message.content === next.message.content &&
         prev.message.helpful === next.message.helpful &&
-        prev.message.status === next.message.status
+        prev.message.status === next.message.status &&
+        prev.message.errorMessage === next.message.errorMessage &&
+        prev.message.errorReason === next.message.errorReason &&
+        prev.retryDisabled === next.retryDisabled &&
+        prev.onRetry === next.onRetry &&
+        prev.onFeedback === next.onFeedback
     );
 };
 

--- a/extension/src/webview/views/IrisChat/types.ts
+++ b/extension/src/webview/views/IrisChat/types.ts
@@ -11,6 +11,13 @@ export interface ChatMessage {
     helpful?: boolean | null;  // Feedback state: true=positive, false=negative, null=none
     status?: 'sending' | 'sent' | 'error';  // For optimistic display
     errorMessage?: string;     // Error text for failed messages
+    /**
+     * Reason the send was rejected by the extension host. Set together
+     * with `status: 'error'`. Used by the UI to decide whether Retry is
+     * meaningful right now (e.g. `iris-disabled` is persistent; `no-ai`
+     * stays non-retryable as long as `.noai` is still detected).
+     */
+    errorReason?: 'no-ai' | 'no-context' | 'iris-disabled';
 }
 
 // Chat session summary (from extension)

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -479,6 +479,173 @@ describe('Iris Chat Flow', () => {
 		});
 	});
 
+	describe('Send rejection lifecycle (#178)', () => {
+		it('SendRejected marks the optimistic message failed, clears thinking, preserves original text', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'How do I solve task 2?{Enter}');
+
+			// Capture the localId the webview generated so the simulated
+			// host can echo it back.
+			const sendCall = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCall).toBeDefined();
+			const payload = (sendCall![0] as { payload: { localId: string; localSessionId: string } }).payload;
+
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
+
+			// Host posts SendRejected.
+			dispatchExtensionMessage({
+				type: 'sendRejected',
+				localId: payload.localId,
+				localSessionId: payload.localSessionId,
+				reason: 'no-context',
+				errorMessage: 'Please select a course or exercise context first.',
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+			});
+
+			// Original user text still visible.
+			expect(screen.getByText('How do I solve task 2?')).toBeInTheDocument();
+			// Error footer rendered.
+			expect(screen.getByText('Not sent')).toBeInTheDocument();
+			expect(
+				screen.getByText('Please select a course or exercise context first.')
+			).toBeInTheDocument();
+			// Message marked error in store.
+			const updated = useChatStore.getState().messages.find((m) => m.localId === payload.localId);
+			expect(updated?.status).toBe('error');
+			expect(updated?.errorReason).toBe('no-context');
+		});
+
+		it('stale SendRejected after session switch is ignored (no transient UI changes)', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'Old session question{Enter}');
+
+			const sendCall = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			const oldLocalSessionId = (sendCall![0] as { payload: { localSessionId: string } }).payload.localSessionId;
+			const oldLocalId = (sendCall![0] as { payload: { localId: string } }).payload.localId;
+
+			// User switches session before the rejection arrives.
+			act(() => {
+				useChatStore.setState({ activeSessionId: 'different-session' });
+			});
+
+			// Stale rejection arrives — must be ignored. Without the
+			// localSessionId guard, this would clear the next session's
+			// transient UI by accident.
+			act(() => {
+				useChatStore.getState().startStreaming(); // simulate new session has a pending send
+			});
+
+			dispatchExtensionMessage({
+				type: 'sendRejected',
+				localId: oldLocalId,
+				localSessionId: oldLocalSessionId,
+				reason: 'no-context',
+				errorMessage: 'Please select a course or exercise context first.',
+			});
+
+			// New session's streaming flag is untouched.
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+		});
+
+		it('Retry on a failed message removes it and resends with a fresh localId', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// Seed a failed user message directly.
+			act(() => {
+				useChatStore.setState({
+					messages: [{
+						localId: 'failed-1',
+						role: 'user',
+						content: 'Retry me',
+						timestamp: Date.now(),
+						status: 'error',
+						errorMessage: 'Please select a course or exercise context first.',
+						errorReason: 'no-context',
+					}],
+				});
+			});
+
+			const retry = screen.getByRole('button', { name: 'Retry sending this message' });
+			await user.click(retry);
+
+			// Failed entry removed.
+			expect(useChatStore.getState().messages.find((m) => m.localId === 'failed-1')).toBeUndefined();
+			// New optimistic message present with same content but different localId.
+			const fresh = useChatStore.getState().messages.find((m) => m.content === 'Retry me');
+			expect(fresh).toBeDefined();
+			expect(fresh!.localId).not.toBe('failed-1');
+			expect(fresh!.status).toBe('sending');
+
+			// sendMessage posted with the fresh localId.
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(1);
+			const lastPayload = (sendCalls[0][0] as { payload: { localId: string; text: string } }).payload;
+			expect(lastPayload.text).toBe('Retry me');
+			expect(lastPayload.localId).toBe(fresh!.localId);
+		});
+
+		it('ChatInput is disabled while a send is in flight', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'First send{Enter}');
+
+			// Streaming flips on synchronously inside handleSendMessage.
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			});
+			expect(textarea).toBeDisabled();
+		});
+
+		it('Retry button is disabled when the rejection reason still holds (no-context)', async () => {
+			// Context cleared but the failed message still references no-context.
+			useChatStore.setState({
+				context: null,
+				...HYDRATED,
+				messages: [{
+					localId: 'stuck-1',
+					role: 'user',
+					content: 'Still no context',
+					timestamp: Date.now(),
+					status: 'error',
+					errorMessage: 'Please select a course or exercise context first.',
+					errorReason: 'no-context',
+				}],
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const retry = screen.getByRole('button', { name: 'Retry sending this message' });
+			expect(retry).toBeDisabled();
+		});
+	});
+
 	describe('WebSocket connectivity', () => {
 		it('shows WebSocket disconnected banner when retries are exhausted', () => {
 			useChatStore.setState({ webSocketStatus: 'disconnected' });

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -623,6 +623,101 @@ describe('Iris Chat Flow', () => {
 			expect(textarea).toBeDisabled();
 		});
 
+		it('attempting a second send while one is in flight does not fire a second sendMessage', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'First{Enter}');
+
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			});
+
+			// Typing into the disabled textarea is a no-op; an Enter press
+			// while disabled cannot reach handleSendMessage either. Verify
+			// that the only sendMessage command posted is the first one.
+			await user.click(textarea);
+			await user.keyboard('Second{Enter}');
+
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(1);
+			const payload = (sendCalls[0][0] as { payload: { text: string } }).payload;
+			expect(payload.text).toBe('First');
+		});
+
+		it('retry of a retried message also produces a fresh localId and clears thinking on re-rejection', async () => {
+			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// First send.
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'Persistent question{Enter}');
+
+			const sendCall1 = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			const payload1 = (sendCall1![0] as { payload: { localId: string; localSessionId: string } }).payload;
+
+			// First rejection.
+			dispatchExtensionMessage({
+				type: 'sendRejected',
+				localId: payload1.localId,
+				localSessionId: payload1.localSessionId,
+				reason: 'no-context',
+				errorMessage: 'Please select a course or exercise context first.',
+			});
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+			});
+
+			// First retry: Retry button is currently disabled (context held —
+			// see other test) so simulate a context where retry is enabled.
+			// Use a reason that allows retry without state change: temporarily
+			// override errorReason to a value the current canRetry permits.
+			act(() => {
+				useChatStore.setState({
+					messages: useChatStore.getState().messages.map((m) =>
+						m.localId === payload1.localId
+							? { ...m, errorReason: undefined } // unrecognized reason → retry enabled
+							: m,
+					),
+				});
+			});
+
+			await user.click(screen.getByRole('button', { name: 'Retry sending this message' }));
+
+			// A second sendMessage call should have fired with a different localId.
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(2);
+			const payload2 = (sendCalls[1][0] as { payload: { localId: string; localSessionId: string } }).payload;
+			expect(payload2.localId).not.toBe(payload1.localId);
+
+			// Second rejection on the retried message.
+			dispatchExtensionMessage({
+				type: 'sendRejected',
+				localId: payload2.localId,
+				localSessionId: payload2.localSessionId,
+				reason: 'no-context',
+				errorMessage: 'Please select a course or exercise context first.',
+			});
+
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+			});
+			// The retried message is itself now marked failed.
+			const retried = useChatStore.getState().messages.find((m) => m.localId === payload2.localId);
+			expect(retried?.status).toBe('error');
+		});
+
 		it('Retry button is disabled when the rejection reason still holds (no-context)', async () => {
 			// Context cleared but the failed message still references no-context.
 			useChatStore.setState({

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -233,14 +233,20 @@ describe('Message contracts: WebviewToExtensionMessage types', () => {
         expect(msg.payload.courseData.course.id).toBe(1);
     });
 
-    it('SendMessageCommand has text payload', () => {
+    it('SendMessageCommand has text + correlation IDs payload', () => {
         const msg = {
             type: 'command' as const,
             command: 'sendMessage' as const,
-            payload: { text: 'What is a for loop?' },
+            payload: {
+                text: 'What is a for loop?',
+                localId: 'msg-local-1',
+                localSessionId: 'session-local-1',
+            },
         } satisfies WebCmd<'sendMessage'>;
 
         expect(msg.payload.text).toBe('What is a for loop?');
+        expect(msg.payload.localId).toBe('msg-local-1');
+        expect(msg.payload.localSessionId).toBe('session-local-1');
     });
 
     it('SelectChatContextCommand has context, itemId, and itemName payload', () => {

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -414,6 +414,123 @@ describe('useChatStore', () => {
 		expect(result.current.irisStages).toEqual([]);
 	});
 
+	describe('markMessageFailed', () => {
+		it('marks a pending user message as failed and returns true', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({
+					localId: 'pending-1',
+					role: 'user',
+					status: 'sending',
+				}));
+			});
+
+			let returnValue: boolean | undefined;
+			act(() => {
+				returnValue = result.current.markMessageFailed('pending-1', 'No context', 'no-context');
+			});
+
+			expect(returnValue).toBe(true);
+			expect(result.current.messages[0].status).toBe('error');
+			expect(result.current.messages[0].errorMessage).toBe('No context');
+			expect(result.current.messages[0].errorReason).toBe('no-context');
+		});
+
+		it('returns false and does not mutate when localId does not match', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({
+					localId: 'real-1',
+					role: 'user',
+					status: 'sending',
+				}));
+			});
+
+			let returnValue: boolean | undefined;
+			act(() => {
+				returnValue = result.current.markMessageFailed('stale-99', 'No context', 'no-context');
+			});
+
+			expect(returnValue).toBe(false);
+			expect(result.current.messages[0].status).toBe('sending');
+			expect(result.current.messages[0].errorMessage).toBeUndefined();
+		});
+
+		it('returns false and does not mutate when target is not a user role', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({
+					localId: 'asst-1',
+					role: 'assistant',
+					status: 'sending',
+				}));
+			});
+
+			let returnValue: boolean | undefined;
+			act(() => {
+				returnValue = result.current.markMessageFailed('asst-1', 'No context', 'no-context');
+			});
+
+			expect(returnValue).toBe(false);
+			expect(result.current.messages[0].status).toBe('sending');
+		});
+
+		it('returns false and does not mutate when target is already sent', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({
+					localId: 'sent-1',
+					role: 'user',
+					status: 'sent',
+				}));
+			});
+
+			let returnValue: boolean | undefined;
+			act(() => {
+				returnValue = result.current.markMessageFailed('sent-1', 'Stale rejection', 'no-context');
+			});
+
+			expect(returnValue).toBe(false);
+			expect(result.current.messages[0].status).toBe('sent');
+		});
+	});
+
+	describe('removeMessage', () => {
+		it('removes the matching message by localId', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({ localId: 'a' }));
+				result.current.addMessage(makeMessage({ localId: 'b' }));
+			});
+
+			act(() => {
+				result.current.removeMessage('a');
+			});
+
+			expect(result.current.messages).toHaveLength(1);
+			expect(result.current.messages[0].localId).toBe('b');
+		});
+
+		it('is a no-op when no matching localId exists', () => {
+			const { result } = renderHook(() => useChatStore());
+
+			act(() => {
+				result.current.addMessage(makeMessage({ localId: 'a' }));
+			});
+
+			act(() => {
+				result.current.removeMessage('does-not-exist');
+			});
+
+			expect(result.current.messages).toHaveLength(1);
+		});
+	});
+
 	it('clearMessages also clears irisStages', () => {
 		const { result } = renderHook(() => useChatStore());
 

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -137,7 +137,14 @@ describe('IrisChatView', () => {
 				expect.objectContaining({
 					type: 'command',
 					command: 'sendMessage',
-					payload: expect.objectContaining({ text: 'Hello Iris' }),
+					payload: expect.objectContaining({
+						text: 'Hello Iris',
+						// #178: payload carries the optimistic message's localId
+						// and the active local session UUID so the host can echo
+						// them back on rejection without races.
+						localId: expect.any(String),
+						localSessionId: 'local-test',
+					}),
 				})
 			);
 		});

--- a/extension/test/react/views/IrisChat/components/MessageBubble.test.tsx
+++ b/extension/test/react/views/IrisChat/components/MessageBubble.test.tsx
@@ -54,21 +54,86 @@ describe('MessageBubble', () => {
 		expect(container.querySelector('img')).not.toBeInTheDocument();
 	});
 
-	it('renders error state with error message', () => {
+	it('renders failed user message with original content and inline error footer', () => {
 		const message = makeMessage({
-			role: 'assistant',
+			role: 'user',
+			content: 'How do I solve task 2?',
 			status: 'error',
-			errorMessage: 'Network error occurred',
+			errorMessage: 'Please select a course or exercise context first.',
+			errorReason: 'no-context',
 		});
-		render(<MessageBubble message={message} onFeedback={vi.fn()} />);
-		expect(screen.getByText('Network error occurred')).toBeInTheDocument();
-		expect(screen.getByText('Retry')).toBeInTheDocument();
+		render(<MessageBubble message={message} onFeedback={vi.fn()} onRetry={vi.fn()} />);
+		// Original message content stays visible (this is the bugfix from #178:
+		// previously the bubble replaced its content with the error block).
+		expect(screen.getByText('How do I solve task 2?')).toBeInTheDocument();
+		expect(screen.getByText('Not sent')).toBeInTheDocument();
+		expect(screen.getByText('Please select a course or exercise context first.')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Retry sending this message' })).toBeInTheDocument();
 	});
 
 	it('renders default error message when no errorMessage provided', () => {
-		const message = makeMessage({ role: 'assistant', status: 'error' });
-		render(<MessageBubble message={message} onFeedback={vi.fn()} />);
+		const message = makeMessage({ role: 'user', content: 'Hi', status: 'error' });
+		render(<MessageBubble message={message} onFeedback={vi.fn()} onRetry={vi.fn()} />);
 		expect(screen.getByText('Failed to send message')).toBeInTheDocument();
+	});
+
+	it('does not render Retry button when onRetry prop is omitted', () => {
+		const message = makeMessage({ role: 'user', content: 'Hi', status: 'error', errorMessage: 'Boom' });
+		render(<MessageBubble message={message} onFeedback={vi.fn()} />);
+		expect(screen.queryByRole('button', { name: 'Retry sending this message' })).not.toBeInTheDocument();
+	});
+
+	it('invokes onRetry with message localId when Retry is clicked', async () => {
+		const onRetry = vi.fn();
+		const message = makeMessage({
+			localId: 'failed-msg-1',
+			role: 'user',
+			content: 'Retry me',
+			status: 'error',
+			errorMessage: 'Boom',
+		});
+		render(<MessageBubble message={message} onFeedback={vi.fn()} onRetry={onRetry} />);
+		await userEvent.click(screen.getByRole('button', { name: 'Retry sending this message' }));
+		expect(onRetry).toHaveBeenCalledWith('failed-msg-1');
+	});
+
+	it('disables Retry button when retryDisabled is true and does not call onRetry on click', async () => {
+		const onRetry = vi.fn();
+		const message = makeMessage({
+			role: 'user',
+			content: 'Stuck',
+			status: 'error',
+			errorMessage: 'No context',
+			errorReason: 'no-context',
+		});
+		render(
+			<MessageBubble
+				message={message}
+				onFeedback={vi.fn()}
+				onRetry={onRetry}
+				retryDisabled={true}
+			/>
+		);
+		const retry = screen.getByRole('button', { name: 'Retry sending this message' });
+		expect(retry).toBeDisabled();
+		await userEvent.click(retry);
+		expect(onRetry).not.toHaveBeenCalled();
+	});
+
+	it('does not render feedback buttons for failed messages', () => {
+		const message = makeMessage({
+			role: 'assistant',
+			content: 'Something',
+			status: 'error',
+			errorMessage: 'Boom',
+		});
+		const { container } = render(
+			<MessageBubble message={message} onFeedback={vi.fn()} onRetry={vi.fn()} />
+		);
+		const wrapper = container.firstChild as HTMLElement;
+		// Even on hover, feedback should not appear for an error-state message.
+		void userEvent.hover(wrapper);
+		expect(screen.queryByRole('button', { name: 'Helpful' })).not.toBeInTheDocument();
 	});
 
 	it('shows feedback buttons for assistant messages on hover', async () => {


### PR DESCRIPTION
## Summary

Fixes #178. When the extension host rejected a send synchronously (`no-context`, `no-ai`, `iris-disabled`), the webview was never told. The thinking indicator stayed on forever, the optimistic user message was orphaned, and for `no-context` the only feedback was a VS Code toast.

This PR introduces an explicit `SendRejected` extension message scoped by `localId` + `localSessionId` so stale rejections cannot clobber a fresh request after the user switched session.

## Behavior

**Before**

```
┌──────────────────────────────────┐
│ You: How do I solve task 2?     │  ← stuck
│ ● ● ●  (Iris is thinking…)      │  ← forever
└──────────────────────────────────┘
```

**After**

```
┌──────────────────────────────────┐
│ You: How do I solve task 2?     │  ← original text preserved
│ ⚠ Not sent · Please select a    │
│   course or exercise context.   │
│                        [Retry]   │  ← disabled while reason still holds
└──────────────────────────────────┘
```

## What changed

- **Wire protocol:** `sendMessage` carries `localId` + `localSessionId`; new `SendRejected` extension message.
- **Store:** `markMessageFailed` (only matches `role==='user' && status==='sending'`, returns `boolean`) + `removeMessage`. ChatMessage gains optional `errorReason`.
- **UI:** Failed user messages keep their original content visible and gain a "Not sent" footer with reason + Retry button. Retry is per-reason gated:
  - `iris-disabled` → permanently unretryable (banner already explains)
  - `no-ai` → disabled while `.noai` still detected
  - `no-context` → disabled while no context selected
- **ChatInput** is disabled while a send is in flight (prevents racing sends from each other's transient UI).
- **Host** falls back to an assistant-style `AddMessage` if it receives a `sendMessage` without correlation IDs (defensive — same-version VSIX in practice, but the bug it would re-introduce is exactly the one this PR fixes).

## Out of scope

- Catch-block in `_handleChatMessage` (line 647) — different failure mode (post-acceptance transport/backend exception). Will track separately if needed.
- `status`/`errorMessage` cleanup from #179 — now obsolete because we use those fields for this feature. Will close #179 after merge.

## Manual test checklist

Build the VSIX, install in a clean VS Code, and run through these scenarios. None should leave a stuck "Iris is thinking…" indicator.

### Happy path (no regression)
- [ ] Open an Iris-enabled exercise, send a normal message. Thinking dots appear, assistant reply arrives, dots clear, message visible. ChatInput re-enables.
- [ ] Send a second message while no rejection is in play. Stages indicator shows pipeline progress if Iris sends STATUS frames. Final reply clears everything.

### Rejection: `no-context`
- [ ] Without selecting a course/exercise, focus the chat panel (Iris available banner shown). Note: ChatInput should already be disabled. Force the path by selecting + then deselecting context.
- [ ] If you can reach a state where you can submit text without context (e.g. race the context clear), the optimistic message stays visible, "Not sent" footer shows "Please select a course or exercise context first.", Retry is **disabled**.
- [ ] No VS Code toast appears (this used to be the only feedback). 
- [ ] Pick a context. Retry becomes **enabled**. Click Retry → original text is removed, new optimistic copy added, sent successfully.

### Rejection: `iris-disabled`
- [ ] Open an exercise whose course has Iris disabled. Banner "Iris chat is not enabled for this exercise…" appears.
- [ ] If you can submit (race condition), the optimistic message stays visible, "Not sent · Iris chat is disabled for this exercise." footer shows, Retry is **disabled and stays disabled** (no way to recover without changing exercise).

### Rejection: `no-ai`
- [ ] Drop a `.noai` file in the workspace root. `.noai` banner appears.
- [ ] If you can submit (race condition), the optimistic message stays visible, "Not sent · Not sent because AI assistance is disabled for this workspace." footer shows, Retry is **disabled**.
- [ ] Delete the `.noai` file. Banner disappears, Retry becomes **enabled**. Click Retry → message is re-sent successfully.

### Session-switch / staleness
- [ ] Send a message that would be rejected. **Before** the rejection arrives (you may need to throttle network or insert a debug delay), switch to a different chat session.
- [ ] When the stale rejection arrives, it must **not** affect the current session: no new error footer appears in the old conversation when you switch back, the new session's thinking indicator (if running) keeps animating.

### Racing sends
- [ ] Send a message. While the thinking indicator is on, attempt to type/send a second message. The textarea is **disabled** ("Iris is responding…" placeholder) and the send button does not fire.
- [ ] Once the assistant reply arrives, the input re-enables.

### WebSocket disconnect during pending send
- [ ] Send a message that triggers a real backend call, then disconnect (close laptop lid / disable Wi-Fi briefly). The disconnect banner appears and the thinking indicator clears (via existing `updateWebSocketStatus !== 'connected'` reset path).

### Retry of a retry
- [ ] Fail a message (e.g. via `.noai`), delete the `.noai`, click Retry, but make it fail again before the reply (e.g. re-add `.noai` then send another rejection path). The new failed entry should also be retry-able once its cause clears.

### Accessibility
- [ ] The "Not sent" footer has `role="alert"` and is announced by VoiceOver.
- [ ] Retry button has accessible name "Retry sending this message".

## Files changed

14 files, +747 / -100. Key entry points:
- `extension/src/extension/provider/chatWebviewProvider.ts` — `_handleRejectedSend`
- `extension/src/webview/views/IrisChat/IrisChatView.tsx` — `SendRejected` handler, `handleRetry`, `isRetryDisabled`
- `extension/src/webview/stores/useChatStore.ts` — `markMessageFailed`, `removeMessage`
- `extension/src/webview/views/IrisChat/components/MessageBubble.tsx` — error footer rewrite

Closes #178
