### PR TITLE
fix(extension): scope pending submissions per participation (#168)

### DIFF
--- a/extension/src/extension/controller/exerciseDataLoader.ts
+++ b/extension/src/extension/controller/exerciseDataLoader.ts
@@ -1,5 +1,6 @@
 import type { CourseDetailData } from '@shared/messageContracts';
 import { toCourseDetailData } from '@shared/messageContracts';
+import type { PendingSubmissionStatus } from '@shared/types/apiResponses';
 
 import type { ArtemisApiService } from '../api';
 import { LogCategory, logger } from '../services/loggingService';
@@ -20,8 +21,40 @@ function isAuthError(err: unknown): boolean {
 }
 
 /**
+ * Decide what to do with a settled rejection from per-participation
+ * enrichment. Returns the error if it must propagate, `null` if it was
+ * handled (logged) and the load can continue without that piece of data.
+ *
+ * Centralizing this prevents the policy from drifting across the two
+ * call sites (pending submission + latest result) where it used to live.
+ */
+function classifyEnrichmentError(err: unknown, context: string): Error | null {
+    if (isAuthError(err) || err instanceof MalformedResponseError) {
+        return err as Error;
+    }
+    const status = err instanceof ApiError ? err.status : undefined;
+    logger.warn(
+        `${context} (status=${status ?? 'network'}); continuing without it`,
+        LogCategory.VIEW,
+    );
+    return null;
+}
+
+/**
  * Fetch exercise details and enrich all participations with pending submissions
  * and result feedbacks. This is the single source of truth for exercise data loading.
+ *
+ * Per-participation enrichment runs in parallel; auth (401/403) and malformed
+ * responses are deferred until every per-participation task has settled, then
+ * the first such fatal error is rethrown. Non-fatal failures (network, 5xx)
+ * are logged and the load continues with whatever did succeed. This matters
+ * for exercises with concurrent pending builds across participations — see
+ * #168 for the data-loss bug this loop used to silently produce when the
+ * `pendingSubmission` field was a singleton.
+ *
+ * The expected participation count per exercise is ≤2 (graded + practice),
+ * so we do not impose a concurrency cap on the outer Promise.all. If the
+ * instructor / test-run case ever causes that to grow, revisit.
  */
 export async function fetchAndEnrichExerciseDetails(
     api: ArtemisApiService,
@@ -30,50 +63,65 @@ export async function fetchAndEnrichExerciseDetails(
     const exerciseDetails = await api.getExerciseDetails(exerciseId);
 
     const participations = exerciseDetails.exercise?.studentParticipations ?? [];
-    for (const participation of participations) {
-        if (!participation.id) { continue; }
+    const pendingSubmissionsByParticipationId: Record<number, PendingSubmissionStatus> = {};
+    const fatalErrors: Error[] = [];
 
-        // Check for pending submissions (builds in progress).
-        try {
-            const pendingSubmission = await api.getLatestPendingSubmission(participation.id);
-            if (pendingSubmission) {
-                exerciseDetails.pendingSubmission = pendingSubmission;
+    await Promise.all(participations.map(async (participation) => {
+        if (!participation.id) { return; }
+        const participationId = participation.id;
+
+        const [pendingResult, feedbacksResult] = await Promise.allSettled([
+            api.getLatestPendingSubmission(participationId),
+            api.getLatestResultWithFeedbacks(participationId),
+        ]);
+
+        if (pendingResult.status === 'fulfilled') {
+            if (pendingResult.value) {
+                // Normalize the raw ProgrammingSubmission to the lean DTO the
+                // store/UI expect. `state` and `buildTimingInfo` only ever
+                // arrive via the WebSocket submissionProcessing path; the
+                // REST endpoint just signals presence.
+                pendingSubmissionsByParticipationId[participationId] = { participationId };
             }
-        } catch (err) {
-            if (isAuthError(err) || err instanceof MalformedResponseError) {
-                throw err;
-            }
-            const status = err instanceof ApiError ? err.status : undefined;
-            logger.warn(
-                `Pending submission enrichment failed for participation ${participation.id} (status=${status ?? 'network'}); continuing without it`,
-                LogCategory.VIEW,
+        } else {
+            const fatal = classifyEnrichmentError(
+                pendingResult.reason,
+                `Pending submission enrichment failed for participation ${participationId}`,
             );
+            if (fatal) { fatalErrors.push(fatal); }
         }
 
-        // Enrich the latest result with feedbacks using the same endpoint as the Artemis webapp.
-        // This single call returns the latest Result with feedbacks embedded — no need to
-        // manually find the resultId or make a separate feedbacks call.
-        try {
-            const resultWithFeedbacks = await api.getLatestResultWithFeedbacks(participation.id);
+        if (feedbacksResult.status === 'fulfilled') {
+            const resultWithFeedbacks = feedbacksResult.value;
             if (resultWithFeedbacks?.feedbacks?.length) {
+                // Enrich the latest result with feedbacks using the same endpoint
+                // as the Artemis webapp. This single call returns the latest
+                // Result with feedbacks embedded — no need to manually find the
+                // resultId or make a separate feedbacks call.
                 const latestSubmission = pickHighestId(participation.submissions);
                 const latestResult = pickHighestId(latestSubmission?.results);
                 if (latestResult) {
                     latestResult.feedbacks = resultWithFeedbacks.feedbacks;
                 }
             }
-        } catch (err) {
-            if (isAuthError(err) || err instanceof MalformedResponseError) {
-                throw err;
-            }
-            const status = err instanceof ApiError ? err.status : undefined;
-            logger.warn(
-                `Latest-result enrichment failed for participation ${participation.id} (status=${status ?? 'network'}); continuing without feedbacks`,
-                LogCategory.VIEW,
+        } else {
+            const fatal = classifyEnrichmentError(
+                feedbacksResult.reason,
+                `Latest-result enrichment failed for participation ${participationId}`,
             );
+            if (fatal) { fatalErrors.push(fatal); }
         }
+    }));
+
+    if (fatalErrors.length > 0) {
+        // Throwing the first fatal error matches the previous semantics
+        // (the old serial loop would have aborted on the first auth/
+        // malformed failure). Settling everything first prevents
+        // background log spam after the rejection.
+        throw fatalErrors[0];
     }
 
+    exerciseDetails.pendingSubmissionsByParticipationId = pendingSubmissionsByParticipationId;
     return exerciseDetails;
 }
 

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -34,7 +34,41 @@ export interface CourseDashboardCourse {
 export interface ExerciseDetailsResponse {
     exercise?: ExerciseDetail;
     plagiarismCaseInfo?: unknown;
+    /**
+     * Pending build statuses keyed by `participation.id`. Populated by the
+     * extension's exerciseDataLoader after fetching the base details, and
+     * later mutated in the webview store from WebSocket update events.
+     *
+     * Multiple participations may have concurrent pending builds (e.g.
+     * graded + practice). The webview picks the entry that matches its
+     * currently-selected participation. Previously this was a single
+     * field that was silently overwritten per participation (#168).
+     */
+    pendingSubmissionsByParticipationId?: Record<number, PendingSubmissionStatus>;
     [key: string]: unknown;
+}
+
+/**
+ * Pending-build status DTO shared between the extension host and the
+ * webview store.
+ *
+ * Two producers feed this shape with deliberately asymmetric fidelity:
+ *   - The REST `latest-pending-submission` endpoint only signals
+ *     "a build is in flight for this participation" — the loader
+ *     normalizes its `ProgrammingSubmission` response to bare
+ *     `{ participationId }` (no state, no timing).
+ *   - WebSocket `submissionProcessing` events carry the full status
+ *     (queued vs. building, buildTimingInfo) and overwrite the entry.
+ *
+ * UI code is therefore tolerant of missing `state` and `buildTimingInfo`.
+ */
+export interface PendingSubmissionStatus {
+    participationId: number;
+    state?: string;
+    buildTimingInfo?: {
+        buildStartDate?: string;
+        estimatedCompletionDate?: string;
+    };
 }
 
 export interface ExerciseDetail {

--- a/extension/src/webview/stores/useExerciseDetailStore.ts
+++ b/extension/src/webview/stores/useExerciseDetailStore.ts
@@ -5,6 +5,7 @@ import { postCommand, type VsCodeApi } from '@shared/messageContracts';
 import type {
     ExerciseDetailsResponse,
     ParticipationSummary,
+    PendingSubmissionStatus,
     ResultSummary,
     SubmissionSummary,
 } from '@shared/types/apiResponses';
@@ -21,14 +22,9 @@ interface DirtyPagesStatus {
     autoSaveEnabled: boolean;
 }
 
-export interface PendingSubmissionInfo {
-    state: string;
-    participationId: number;
-    buildTimingInfo?: {
-        buildStartDate?: string;
-        estimatedCompletionDate?: string;
-    };
-}
+// Re-export so existing webview callers that already import this name keep
+// working. The canonical source of truth is now @shared/types/apiResponses.
+export type PendingSubmissionInfo = PendingSubmissionStatus;
 
 interface ExerciseDetailState {
     exerciseData: ExerciseDetailsResponse | null;
@@ -36,8 +32,13 @@ interface ExerciseDetailState {
     isLoading: boolean;
     error: string | null;
 
-    // Submission processing
-    pendingSubmission: PendingSubmissionInfo | null;
+    /**
+     * Pending build statuses keyed by `participation.id`. The view picks the
+     * entry that matches the participation it has selected (graded vs.
+     * practice). Replaces a singleton `pendingSubmission` field that was
+     * silently overwritten per participation by the loader — see #168.
+     */
+    pendingSubmissionsByParticipationId: Record<number, PendingSubmissionStatus>;
 
     // Extension→Webview response state
     repoStatus: RepoStatus | null;
@@ -51,11 +52,12 @@ interface ExerciseDetailState {
     loadExerciseDetail: (vscodeApi: VsCodeApi, exerciseId: number) => void;
     updateBuildStatus: (payload: ResultSummary) => void;
     updateSubmission: (payload: SubmissionSummary) => void;
-    updateSubmissionProcessing: (payload: PendingSubmissionInfo) => void;
+    updateSubmissionProcessing: (payload: PendingSubmissionStatus) => void;
     setRepoStatus: (status: RepoStatus) => void;
     setClonedNotice: (exerciseTitle: string, participationId: number) => void;
     setDirtyPagesStatus: (status: DirtyPagesStatus) => void;
     clearClonedNotice: () => void;
+    /** Clear all pending entries (e.g. on result arrival without per-participation context). */
     clearPendingSubmission: () => void;
 }
 
@@ -90,7 +92,7 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
             hideDeveloperTools: false,
             isLoading: true,
             error: null,
-            pendingSubmission: null,
+            pendingSubmissionsByParticipationId: {},
             repoStatus: null,
             clonedNotice: null,
             dirtyPagesStatus: null,
@@ -101,7 +103,12 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
                     hideDeveloperTools,
                     isLoading: false,
                     error: null,
-                    pendingSubmission: (data.pendingSubmission as PendingSubmissionInfo) ?? null,
+                    // Always reset to the freshly-loaded map (or `{}` if the
+                    // server didn't supply one). Keeping stale entries across
+                    // a reload would let an already-finished build keep
+                    // displaying "in progress" on the next exercise open.
+                    pendingSubmissionsByParticipationId:
+                        data.pendingSubmissionsByParticipationId ?? {},
                     repoStatus: repoStatus ?? null,
                     clonedNotice: null,
                     dirtyPagesStatus: null,
@@ -168,7 +175,21 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
                     }
                 }
 
-                set({ exerciseData: updatedData, pendingSubmission: null }, false, 'updateBuildStatus');
+                // Clear the pending entry for this participation only. Other
+                // participations' pending builds are preserved — they were
+                // unaffected by this result. If payload.participationId was
+                // not provided, fall back to the participation we resolved
+                // via the result/submission tree.
+                const clearedParticipationId = payload.participationId ?? participation.id;
+                const nextPending = { ...state.pendingSubmissionsByParticipationId };
+                if (clearedParticipationId !== undefined) {
+                    delete nextPending[clearedParticipationId];
+                }
+
+                set({
+                    exerciseData: updatedData,
+                    pendingSubmissionsByParticipationId: nextPending,
+                }, false, 'updateBuildStatus');
             },
 
             updateSubmission: (payload) => {
@@ -218,7 +239,12 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
                     return;
                 }
 
-                set({ pendingSubmission: payload }, false, 'updateSubmissionProcessing');
+                set({
+                    pendingSubmissionsByParticipationId: {
+                        ...state.pendingSubmissionsByParticipationId,
+                        [payload.participationId]: payload,
+                    },
+                }, false, 'updateSubmissionProcessing');
             },
 
             setRepoStatus: (status) => {
@@ -238,7 +264,7 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
             },
 
             clearPendingSubmission: () => {
-                set({ pendingSubmission: null }, false, 'clearPendingSubmission');
+                set({ pendingSubmissionsByParticipationId: {} }, false, 'clearPendingSubmission');
             },
         }),
         {

--- a/extension/src/webview/stores/useExerciseDetailStore.ts
+++ b/extension/src/webview/stores/useExerciseDetailStore.ts
@@ -175,12 +175,13 @@ export const useExerciseDetailStore = create<ExerciseDetailState>()(
                     }
                 }
 
-                // Clear the pending entry for this participation only. Other
-                // participations' pending builds are preserved — they were
-                // unaffected by this result. If payload.participationId was
-                // not provided, fall back to the participation we resolved
-                // via the result/submission tree.
-                const clearedParticipationId = payload.participationId ?? participation.id;
+                // Clear the pending entry for the participation we actually
+                // mutated. We use `participation.id` (the resolved owner)
+                // rather than `payload.participationId` so a malformed or
+                // mismatched payload never deletes an unrelated key.
+                // Other participations' pending builds are preserved — they
+                // were unaffected by this result.
+                const clearedParticipationId = participation.id;
                 const nextPending = { ...state.pendingSubmissionsByParticipationId };
                 if (clearedParticipationId !== undefined) {
                     delete nextPending[clearedParticipationId];

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -63,7 +63,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
         repoStatus,
         dirtyPagesStatus,
         clonedNotice,
-        pendingSubmission,
+        pendingSubmissionsByParticipationId,
         setExerciseData,
         setError,
         loadExerciseDetail,
@@ -203,6 +203,14 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     const hasParticipation = !!participation;
     const participationId = participation?.id;
     const repositoryUri = participation?.repositoryUri;
+
+    // Pick the pending build entry that belongs to the participation we
+    // actually surface in this view. The map can carry concurrent pending
+    // builds for other participations (graded + practice) without their
+    // status leaking into the selected view (#168).
+    const pendingSubmission = participationId !== undefined
+        ? pendingSubmissionsByParticipationId[participationId] ?? null
+        : null;
 
     // Extract submission and result data
     // In Artemis, "latest" = highest ID (not date-sorted)

--- a/extension/test/react/flows/exerciseSubmission.flow.test.tsx
+++ b/extension/test/react/flows/exerciseSubmission.flow.test.tsx
@@ -241,6 +241,73 @@ describe('Exercise Submission Flow', () => {
 		expect(storeState.pendingSubmissionsByParticipationId[99]).toBeTruthy();
 	});
 
+	it('renders the pending-build indicator only for the selected participation (#168)', async () => {
+		// Exercise has both a graded (testRun=false) and a practice (testRun=true)
+		// participation. Only the practice one has a pending build. With the
+		// graded repo selected as workspace, the view must NOT show the building
+		// indicator — its participation has no pending entry. This is the
+		// regression the singleton field used to permit.
+		const mockApi = createMockVsCodeApi();
+		render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+		const dataWithTwoParticipations = makeExerciseData({
+			exercise: {
+				id: 42,
+				title: 'Binary Search Tree',
+				type: 'programming',
+				maxPoints: 100,
+				bonusPoints: 0,
+				problemStatement: '<p>Implement a binary search tree.</p>',
+				course: { id: 1, title: 'Data Structures', shortName: 'DS' },
+				studentParticipations: [
+					{
+						id: 99,
+						testRun: false,
+						repositoryUri: 'https://git.example.com/bst-graded',
+						submissions: [],
+					},
+					{
+						id: 199,
+						testRun: true,
+						repositoryUri: 'https://git.example.com/bst-practice',
+						submissions: [],
+					},
+				],
+			},
+			// Pending only on the practice participation.
+			pendingSubmissionsByParticipationId: {
+				199: { participationId: 199, state: 'BUILDING' },
+			},
+		});
+
+		dispatchExtensionMessage({
+			type: 'exerciseDetailInit',
+			exerciseData: dataWithTwoParticipations,
+			repoStatus: { isConnected: true, hasChanges: false, isPracticeRepo: false },
+			hideDeveloperTools: false,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('Binary Search Tree')).toBeInTheDocument();
+		});
+
+		// The graded participation has no pending build → no "Building" message
+		// should leak from the practice participation's map entry.
+		expect(screen.queryByText(/Building your submission/)).not.toBeInTheDocument();
+
+		// Sanity: switching to practice repo should now surface the indicator.
+		dispatchExtensionMessage({
+			type: 'updateRepoStatus',
+			isConnected: true,
+			hasChanges: false,
+			isPracticeRepo: true,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText(/Building your submission/)).toBeInTheDocument();
+		});
+	});
+
 	it('completes full submission lifecycle with build progress simulation', async () => {
 		const user = userEvent.setup();
 		const mockApi = createMockVsCodeApi();

--- a/extension/test/react/flows/exerciseSubmission.flow.test.tsx
+++ b/extension/test/react/flows/exerciseSubmission.flow.test.tsx
@@ -38,7 +38,7 @@ function makeExerciseData(overrides: Record<string, unknown> = {}) {
 			studentParticipations: [],
 			...((overrides.exercise as Record<string, unknown>) ?? {}),
 		},
-		pendingSubmission: null,
+		pendingSubmissionsByParticipationId: {},
 		...overrides,
 	};
 }
@@ -221,7 +221,7 @@ describe('Exercise Submission Flow', () => {
 		// Simulate exercise with pending submission (building)
 		const dataWithPending = {
 			...makeExerciseDataWithParticipation(),
-			pendingSubmission: { submissionId: 500 },
+			pendingSubmissionsByParticipationId: { 99: { participationId: 99 } },
 		};
 
 		dispatchExtensionMessage({
@@ -235,9 +235,10 @@ describe('Exercise Submission Flow', () => {
 			expect(screen.getByText('Binary Search Tree')).toBeInTheDocument();
 		});
 
-		// The exercise is in building state — verify the store reflects this
+		// The exercise is in building state — verify the store reflects this,
+		// keyed by participation.id (#168 fix).
 		const storeState = useExerciseDetailStore.getState();
-		expect(storeState.pendingSubmission).toBeTruthy();
+		expect(storeState.pendingSubmissionsByParticipationId[99]).toBeTruthy();
 	});
 
 	it('completes full submission lifecycle with build progress simulation', async () => {
@@ -278,7 +279,7 @@ describe('Exercise Submission Flow', () => {
 			type: 'exerciseDetailInit',
 			exerciseData: {
 				...makeExerciseDataWithParticipation(),
-				pendingSubmission: { submissionId: 500 },
+				pendingSubmissionsByParticipationId: { 99: { participationId: 99 } },
 			},
 			hideDeveloperTools: false,
 		});

--- a/extension/test/react/stores/useExerciseDetailStore.test.ts
+++ b/extension/test/react/stores/useExerciseDetailStore.test.ts
@@ -209,9 +209,9 @@ describe('useExerciseDetailStore', () => {
 			result.current.updateSubmissionProcessing({ state: 'BUILDING', participationId: 555 });
 		});
 
-		// After processing, pendingSubmission should be on store state
+		// After processing, the entry should be present keyed by participation.id (#168 fix).
 		expect(result.current.exerciseData).not.toBeNull();
-		expect(result.current.pendingSubmission?.participationId).toBe(555);
+		expect(result.current.pendingSubmissionsByParticipationId[555]?.participationId).toBe(555);
 	});
 
 	it('updateSubmissionProcessing ignores events for unknown participations', () => {
@@ -229,7 +229,8 @@ describe('useExerciseDetailStore', () => {
 			result.current.updateSubmissionProcessing({ state: 'BUILDING', participationId: 999 });
 		});
 
-		expect(result.current.pendingSubmission).toBeNull();
+		// Unknown participation must not insert into the map.
+		expect(result.current.pendingSubmissionsByParticipationId).toEqual({});
 	});
 
 	it('updateBuildStatus with unknown participationId does not mutate state', () => {
@@ -254,7 +255,7 @@ describe('useExerciseDetailStore', () => {
 		expect(p?.id).toBe(10);
 		expect(p?.submissions).toHaveLength(1);
 		expect(p?.submissions?.[0]?.results).toBeUndefined();
-		expect(result.current.pendingSubmission).toBeNull();
+		expect(result.current.pendingSubmissionsByParticipationId).toEqual({});
 	});
 
 	it('updateSubmission with unknown participationId does not mutate state', () => {
@@ -278,6 +279,157 @@ describe('useExerciseDetailStore', () => {
 		const p = result.current.exerciseData?.exercise?.studentParticipations?.[0];
 		expect(p?.submissions).toHaveLength(1);
 		expect(p?.submissions?.[0]?.id).toBe(200);
+	});
+
+	// --- #168 per-participation pending submission map ---
+
+	it('setExerciseData hydrates pendingSubmissionsByParticipationId from the response', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		const data = makeExerciseData({
+			exercise: {
+				id: 1,
+				studentParticipations: [
+					{ id: 100, testRun: false },
+					{ id: 200, testRun: true },
+				],
+			},
+			pendingSubmissionsByParticipationId: {
+				100: { participationId: 100 },
+				200: { participationId: 200 },
+			},
+		});
+
+		act(() => {
+			result.current.setExerciseData(data, false);
+		});
+
+		expect(result.current.pendingSubmissionsByParticipationId[100]?.participationId).toBe(100);
+		expect(result.current.pendingSubmissionsByParticipationId[200]?.participationId).toBe(200);
+	});
+
+	it('setExerciseData resets stale pending entries when the new response carries no map', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		// Seed a stale map from a previous load.
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: { id: 1, studentParticipations: [{ id: 100 }] },
+				pendingSubmissionsByParticipationId: { 100: { participationId: 100 } },
+			}), false);
+		});
+		expect(result.current.pendingSubmissionsByParticipationId[100]).toBeTruthy();
+
+		// New exercise loaded; server did not include the map → must clear.
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: { id: 2, studentParticipations: [] },
+			}), false);
+		});
+
+		expect(result.current.pendingSubmissionsByParticipationId).toEqual({});
+	});
+
+	it('updateSubmissionProcessing preserves existing entries for other participations', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: {
+					id: 1,
+					studentParticipations: [{ id: 100 }, { id: 200 }],
+				},
+				pendingSubmissionsByParticipationId: { 100: { participationId: 100 } },
+			}), false);
+		});
+
+		act(() => {
+			result.current.updateSubmissionProcessing({
+				state: 'BUILDING',
+				participationId: 200,
+				buildTimingInfo: { buildStartDate: '2026-05-21T10:00:00Z' },
+			});
+		});
+
+		// Both entries must coexist; the pre-fix singleton would have dropped one.
+		expect(result.current.pendingSubmissionsByParticipationId[100]).toBeTruthy();
+		expect(result.current.pendingSubmissionsByParticipationId[200]?.state).toBe('BUILDING');
+		expect(result.current.pendingSubmissionsByParticipationId[200]?.buildTimingInfo?.buildStartDate)
+			.toBe('2026-05-21T10:00:00Z');
+	});
+
+	it('updateBuildStatus removes only the matching participation\'s pending entry', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: {
+					id: 1,
+					studentParticipations: [
+						makeParticipation({ id: 100, submissions: [makeSubmission({ id: 1 })] }),
+						makeParticipation({ id: 200, submissions: [makeSubmission({ id: 2 })] }),
+					],
+				},
+				pendingSubmissionsByParticipationId: {
+					100: { participationId: 100 },
+					200: { participationId: 200 },
+				},
+			}), false);
+		});
+
+		act(() => {
+			result.current.updateBuildStatus(makeResult({ id: 50, participationId: 100 }));
+		});
+
+		// Participation 100 build finished → its pending entry is cleared.
+		expect(result.current.pendingSubmissionsByParticipationId[100]).toBeUndefined();
+		// Participation 200 is untouched.
+		expect(result.current.pendingSubmissionsByParticipationId[200]).toBeTruthy();
+	});
+
+	it('updateBuildStatus without payload.participationId clears via findParticipationForResult', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		// Seed a submission with a result id we can match later, plus a
+		// pending entry on the same participation.
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: {
+					id: 1,
+					studentParticipations: [
+						makeParticipation({
+							id: 100,
+							submissions: [{ id: 1, results: [{ id: 777 }] }],
+						}),
+					],
+				},
+				pendingSubmissionsByParticipationId: {
+					100: { participationId: 100 },
+				},
+			}), false);
+		});
+
+		// Payload omits participationId — the store falls back to walking
+		// the submission/result tree to find the owning participation.
+		act(() => {
+			result.current.updateBuildStatus(makeResult({ id: 777 }));
+		});
+
+		expect(result.current.pendingSubmissionsByParticipationId[100]).toBeUndefined();
+	});
+
+	it('clearPendingSubmission clears every entry, not just one', () => {
+		const { result } = renderHook(() => useExerciseDetailStore());
+		act(() => {
+			result.current.setExerciseData(makeExerciseData({
+				exercise: { id: 1, studentParticipations: [{ id: 100 }, { id: 200 }] },
+				pendingSubmissionsByParticipationId: {
+					100: { participationId: 100 },
+					200: { participationId: 200 },
+				},
+			}), false);
+		});
+
+		act(() => {
+			result.current.clearPendingSubmission();
+		});
+
+		expect(result.current.pendingSubmissionsByParticipationId).toEqual({});
 	});
 
 	it('setExerciseData clears stale clonedNotice and dirtyPagesStatus', () => {

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -33,7 +33,7 @@ function makeExerciseData(overrides: Partial<ExerciseDetailsResponse> = {}): Exe
 			studentParticipations: [],
 			...((overrides.exercise as Partial<ExerciseDetailsResponse['exercise']>) ?? {}),
 		},
-		pendingSubmission: null,
+		pendingSubmissionsByParticipationId: {},
 		...overrides,
 	};
 }

--- a/extension/test/unit/controller/exerciseDataLoader.test.ts
+++ b/extension/test/unit/controller/exerciseDataLoader.test.ts
@@ -21,6 +21,19 @@ import { ApiError, MalformedResponseError } from '@extension/types';
 interface ApiStubOptions {
     pendingSubmissionResult?: ProgrammingSubmission | null | (() => Promise<never>);
     resultWithFeedbacks?: ResultSummary | null | (() => Promise<never>);
+    /** Override the participations the stubbed exercise carries. Defaults to a single participation id 5001. */
+    participations?: Array<{ id: number }>;
+    /**
+     * Per-participation overrides for the two enrichment calls. When set,
+     * these take precedence over the global `pendingSubmissionResult` /
+     * `resultWithFeedbacks` options for that participationId. Used to
+     * model the multi-participation cases (different builds in flight on
+     * graded vs. practice).
+     */
+    perParticipation?: Record<number, {
+        pendingSubmissionResult?: ProgrammingSubmission | null | (() => Promise<never>);
+        resultWithFeedbacks?: ResultSummary | null | (() => Promise<never>);
+    }>;
 }
 
 function makeApiStub(opts: ApiStubOptions): {
@@ -33,25 +46,41 @@ function makeApiStub(opts: ApiStubOptions): {
     const exerciseDetails: ExerciseDetailsResponse = {
         exercise: {
             id: 1,
-            studentParticipations: [{ id: 5001 }],
+            studentParticipations: opts.participations ?? [{ id: 5001 }],
         },
     } as unknown as ExerciseDetailsResponse;
 
+    const resolveValue = <T>(
+        participationId: number,
+        global: T | (() => Promise<never>) | undefined,
+        perKey: 'pendingSubmissionResult' | 'resultWithFeedbacks',
+    ): T | null | (() => Promise<never>) => {
+        const perPart = opts.perParticipation?.[participationId]?.[perKey] as T | (() => Promise<never>) | undefined;
+        const resolved = perPart !== undefined ? perPart : global;
+        return resolved === undefined ? null : (resolved as T | null | (() => Promise<never>));
+    };
+
     const api = {
         getExerciseDetails: async () => structuredClone(exerciseDetails),
-        getLatestPendingSubmission: async () => {
+        getLatestPendingSubmission: async (participationId: number) => {
             state.pendingCalls++;
-            if (typeof opts.pendingSubmissionResult === 'function') {
-                return opts.pendingSubmissionResult();
-            }
-            return opts.pendingSubmissionResult ?? null;
+            const resolved = resolveValue<ProgrammingSubmission | null>(
+                participationId,
+                opts.pendingSubmissionResult,
+                'pendingSubmissionResult',
+            );
+            if (typeof resolved === 'function') { return (resolved as () => Promise<never>)(); }
+            return resolved;
         },
-        getLatestResultWithFeedbacks: async () => {
+        getLatestResultWithFeedbacks: async (participationId: number) => {
             state.resultCalls++;
-            if (typeof opts.resultWithFeedbacks === 'function') {
-                return opts.resultWithFeedbacks();
-            }
-            return opts.resultWithFeedbacks ?? null;
+            const resolved = resolveValue<ResultSummary | null>(
+                participationId,
+                opts.resultWithFeedbacks,
+                'resultWithFeedbacks',
+            );
+            if (typeof resolved === 'function') { return (resolved as () => Promise<never>)(); }
+            return resolved;
         },
     } as unknown as ArtemisApiService;
 
@@ -155,5 +184,100 @@ suite('fetchAndEnrichExerciseDetails — enrichment-error policy', () => {
             () => fetchAndEnrichExerciseDetails(stub.api, 1),
             (err: unknown) => err instanceof MalformedResponseError,
         );
+    });
+});
+
+suite('fetchAndEnrichExerciseDetails — per-participation pending submission map (#168)', () => {
+    test('two participations with concurrent pending submissions both land in the map under distinct keys', async () => {
+        const stub = makeApiStub({
+            participations: [{ id: 100 }, { id: 200 }],
+            perParticipation: {
+                100: { pendingSubmissionResult: { id: 9001 } as unknown as ProgrammingSubmission },
+                200: { pendingSubmissionResult: { id: 9002 } as unknown as ProgrammingSubmission },
+            },
+        });
+
+        const data = await fetchAndEnrichExerciseDetails(stub.api, 1);
+        const map = data.pendingSubmissionsByParticipationId ?? {};
+        assert.ok(map[100], 'participation 100 must have a pending entry');
+        assert.ok(map[200], 'participation 200 must have a pending entry');
+        // Neither entry should be silently lost (the pre-fix bug from #168
+        // would drop everything but the last iteration).
+        assert.strictEqual(Object.keys(map).length, 2);
+    });
+
+    test('REST ProgrammingSubmission is normalized to a lean { participationId } DTO', async () => {
+        // The loader must not just stash the raw ProgrammingSubmission — the
+        // wire DTO is intentionally minimal because state + buildTimingInfo
+        // only ever arrive via the WebSocket submissionProcessing path.
+        const rawSubmission = {
+            id: 7777,
+            commitHash: 'abc123',
+            submissionDate: '2026-05-21T10:00:00Z',
+            // Deliberately no state, no participationId at the top level —
+            // matches what parseProgrammingSubmission produces.
+        } as unknown as ProgrammingSubmission;
+
+        const stub = makeApiStub({
+            participations: [{ id: 42 }],
+            pendingSubmissionResult: rawSubmission,
+        });
+
+        const data = await fetchAndEnrichExerciseDetails(stub.api, 1);
+        const entry = data.pendingSubmissionsByParticipationId?.[42];
+        assert.ok(entry, 'entry must exist for participation 42');
+        assert.strictEqual(entry.participationId, 42);
+        assert.strictEqual(entry.state, undefined, 'state must remain undefined; WS path supplies it later');
+        assert.strictEqual(entry.buildTimingInfo, undefined, 'buildTimingInfo must remain undefined here');
+        // Ensure no raw API fields leaked through the normalization.
+        assert.strictEqual((entry as unknown as Record<string, unknown>).commitHash, undefined);
+        assert.strictEqual((entry as unknown as Record<string, unknown>).id, undefined);
+    });
+
+    test('one participation 500-failing does not drop another participation\'s pending entry', async () => {
+        const stub = makeApiStub({
+            participations: [{ id: 100 }, { id: 200 }],
+            perParticipation: {
+                100: { pendingSubmissionResult: () => Promise.reject(new ApiError('server', 500)) },
+                200: { pendingSubmissionResult: { id: 9002 } as unknown as ProgrammingSubmission },
+            },
+        });
+
+        const data = await fetchAndEnrichExerciseDetails(stub.api, 1);
+        const map = data.pendingSubmissionsByParticipationId ?? {};
+        assert.strictEqual(map[100], undefined, 'failed call yields no entry but does not abort the load');
+        assert.ok(map[200], 'sibling participation\'s data is preserved');
+    });
+
+    test('auth error on one participation\'s call still rethrows after all participations settle', async () => {
+        // Even with parallel enrichment, auth errors must still abort the
+        // load — they are not enrichment-recoverable. Promise.allSettled
+        // lets every sibling call settle first so background calls do not
+        // keep logging after the rejection.
+        const stub = makeApiStub({
+            participations: [{ id: 100 }, { id: 200 }],
+            perParticipation: {
+                100: { pendingSubmissionResult: () => Promise.reject(new ApiError('auth', 401)) },
+                200: { pendingSubmissionResult: { id: 9002 } as unknown as ProgrammingSubmission },
+            },
+        });
+
+        await assert.rejects(
+            () => fetchAndEnrichExerciseDetails(stub.api, 1),
+            (err: unknown) => err instanceof ApiError && err.status === 401,
+        );
+        // Both per-participation pending calls were attempted before the
+        // throw — verifies "settle, then rethrow" rather than "fail-fast".
+        assert.strictEqual(stub.pendingCalls, 2);
+    });
+
+    test('participations with no pending submission produce no map entry', async () => {
+        const stub = makeApiStub({
+            participations: [{ id: 100 }, { id: 200 }],
+            pendingSubmissionResult: null,
+        });
+
+        const data = await fetchAndEnrichExerciseDetails(stub.api, 1);
+        assert.deepStrictEqual(data.pendingSubmissionsByParticipationId, {});
     });
 });


### PR DESCRIPTION
## Summary

Fixes #168. The exerciseDataLoader's per-participation loop assigned every participation's pending submission onto a single shared `exerciseDetails.pendingSubmission` field, so only the last participation's pending build survived. The webview then risked showing a stale or wrong "build in progress" state when the user was viewing a different participation (e.g. practice repo while the graded repo had the surviving entry).

## What changed

**Wire shape**

- New shared DTO `PendingSubmissionStatus` in `apiResponses.ts`. `ExerciseDetailsResponse` now carries `pendingSubmissionsByParticipationId: Record<number, PendingSubmissionStatus>` instead of the old singleton field.
- Webview store mirrors the map. `updateSubmissionProcessing` and `updateBuildStatus` mutate per-participationId; entries for other participations are preserved.
- `updateBuildStatus` falls back to `findParticipationForResult` when the result payload omits `participationId`, so stale pending state cannot remain for result events lacking that field.
- `ExerciseDetailView` picks the entry matching the currently-selected participation (`participation?.id !== undefined ? map[id] : null`).

**Normalization (caught by codex review)**

`api.getLatestPendingSubmission` actually returns a `ProgrammingSubmission` (no top-level `state`, no `participationId`). The loader normalizes that into a bare `{ participationId }` entry — `state` and `buildTimingInfo` only ever arrive from the WebSocket `submissionProcessing` path. The UI is already tolerant of undefined `state` and chains `buildTimingInfo?` optionally.

**Parallelization**

Per-participation enrichment now runs in parallel via `Promise.allSettled`. Auth (401/403) and `MalformedResponseError` are collected and rethrown after every per-participation task has settled, matching the previous abort-on-fatal semantics while preventing background log spam from sibling calls after rejection. Non-fatal failures (network, 5xx) are logged and the load continues with whatever did succeed. Concurrency cap intentionally omitted: typical participation count is ≤2 (graded + practice).

## Tests

- **Loader** (`test/unit/controller/exerciseDataLoader.test.ts`): two-participation co-existence, normalization shape, one-failing-doesn't-drop-the-other, auth-after-settle (verifies all pending calls completed before rethrow), empty-map for no pending builds.
- **Store** (`test/react/stores/useExerciseDetailStore.test.ts`): hydration from response, stale-reset on reload without map, preservation across `updateSubmissionProcessing`, per-participation deletion via `updateBuildStatus` (with and without `payload.participationId`), `clearPendingSubmission` clears all.
- Fixtures in `exerciseSubmission.flow.test.tsx` and `ExerciseDetailView.test.tsx` migrated.

All 719/719 react tests pass; check-types, lint, knip clean.

## Backward compatibility

Extension host and webview ship in the same VSIX, so the wire-shape change has no version-skew surface. No persistence — Zustand uses `devtools` only.

## Manual test checklist

Build the VSIX, install in a clean VS Code, run through these scenarios:

### Single participation (regression check)
- [ ] Open a programming exercise with one participation. Submit. Pending dots show on the build status. Result arrives, dots clear, result is rendered.
- [ ] Reload the exercise detail view. Pending dots stay off (no stale state from previous load).

### Multiple participations (graded + practice)
- [ ] Open an exercise that has both a graded and a practice participation, with the **graded** repo as the workspace.
- [ ] Submit on graded. Verify dots show while pending.
- [ ] Without waiting for the build to finish, switch the workspace to the **practice** repo. The dots should disappear (different participation has no pending build).
- [ ] Switch back to graded; dots should reappear if the build is still in flight.
- [ ] Verify the opposite direction: submit on practice, switch to graded, ensure graded view does not show practice's pending state.

### Concurrent pending builds
- [ ] If you can drive two concurrent pending builds (e.g. quickly submit on both participations), verify each participation view shows its own dots and the views don't interfere.

### Failed enrichment doesn't lose data
- [ ] If one participation's `/latest-pending-submission` endpoint returns 500 (can be simulated via a local Artemis proxy), the OTHER participation's pending state is still shown correctly when you switch to it.

### Auth failure still aborts
- [ ] Force a 401 on one of the participation calls. The whole exercise load should fail and the user should see the login flow (previous behavior preserved).

## Files changed

8 files, +459 / -66:

- `extension/src/extension/controller/exerciseDataLoader.ts` — map + `Promise.allSettled` + normalize + extracted `classifyEnrichmentError`
- `extension/src/shared/types/apiResponses.ts` — new `PendingSubmissionStatus` DTO + field on response
- `extension/src/webview/stores/useExerciseDetailStore.ts` — map shape, per-participation mutations
- `extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx` — lookup by participation.id
- 4 test files updated + new test cases

Closes #168
