### PR TITLE
refactor(extension): replace four trivial type assertions with type guards (#186)

### DIFF
--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -159,6 +159,10 @@ const WS_STATUS_ACTION = {
 
 type WSStatusAction = (typeof WS_STATUS_ACTION)[keyof typeof WS_STATUS_ACTION];
 
+function isWSStatusAction(value: string): value is WSStatusAction {
+    return (Object.values(WS_STATUS_ACTION) as string[]).includes(value);
+}
+
 interface WSAuthSnapshot {
     hasCookie: boolean;
     hasJwtToken: boolean;
@@ -321,8 +325,8 @@ function registerWebSocketStatusCommand(
                 { modal: false },
                 ...actions,
             );
-            if (chosen) {
-                await handleStatusAction(chosen as WSStatusAction, artemisWebsocketService, report);
+            if (chosen && isWSStatusAction(chosen)) {
+                await handleStatusAction(chosen, artemisWebsocketService, report);
             }
         } catch (error) {
             logger.error('Error checking WebSocket status', LogCategory.WEBSOCKET, error);

--- a/extension/src/extension/controller/commands/utilityCommands.ts
+++ b/extension/src/extension/controller/commands/utilityCommands.ts
@@ -7,7 +7,6 @@ import { getOptionalPayload, getPayload, WebviewCmd } from '@shared/messageContr
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
 import { executeReplayCommand } from '@extension/services/telemetry/replay';
-import type { ExerciseDetailsResponse } from '@extension/types';
 import { CONFIG, extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
 
 import type { CommandContext, CommandMap } from './types';
@@ -311,7 +310,7 @@ export class UtilityCommandModule {
 
     private handleFreshSsrPreview = async (message: WebviewToExtensionMessage): Promise<void> => {
         const { darkMode } = getPayload<WebCmd<'freshSsrPreview'>>(message);
-        const exerciseData = this.context.appStateManager.currentExerciseData as ExerciseDetailsResponse | undefined;
+        const exerciseData = this.context.appStateManager.currentExerciseData;
         if (!exerciseData?.exercise) { return; }
 
         const renderService = new ProblemStatementRenderService(this.context.artemisApi);

--- a/extension/src/webview/components/exercise/ParticipationActions.tsx
+++ b/extension/src/webview/components/exercise/ParticipationActions.tsx
@@ -9,7 +9,14 @@ import { useClickOutside } from '@webview/hooks/useClickOutside';
 import { Button } from '../Button';
 import styles from './ParticipationActions.module.css';
 
-export type ExerciseType = 'programming' | 'quiz' | 'modeling' | 'text' | 'file-upload';
+export const EXERCISE_TYPES = ['programming', 'quiz', 'modeling', 'text', 'file-upload'] as const;
+export type ExerciseType = (typeof EXERCISE_TYPES)[number];
+
+/** Narrow an arbitrary string (e.g. from API or persisted state) to a known ExerciseType. */
+export function isExerciseType(value: string | undefined): value is ExerciseType {
+    return value !== undefined && (EXERCISE_TYPES as readonly string[]).includes(value);
+}
+
 export type ParticipationStatusType = 'not-started' | 'in-progress' | 'submitted' | 'graded';
 type RepositoryStatus = 'connected' | 'disconnected' | 'checking' | 'unknown';
 type WorkspaceStatus = 'clean' | 'dirty' | 'checking' | 'disconnected' | 'wrong-repo';

--- a/extension/src/webview/utils/iconMap.ts
+++ b/extension/src/webview/utils/iconMap.ts
@@ -94,6 +94,12 @@ const ICONS = {
  */
 type IconKey = keyof typeof ICONS;
 
+function isIconKey(key: string): key is IconKey {
+  // Use hasOwnProperty so inherited names like 'constructor', 'toString'
+  // don't slip through and return a non-LucideIcon at runtime.
+  return Object.prototype.hasOwnProperty.call(ICONS, key);
+}
+
 /**
  * Get an icon component by type string
  * Normalizes input (lowercase, replace underscores) and falls back to default icon
@@ -109,5 +115,5 @@ type IconKey = keyof typeof ICONS;
  */
 export function getIcon(type: string | undefined): LucideIcon {
   const normalizedType = type?.toLowerCase().replace(/_/g, '-') || 'default';
-  return ICONS[normalizedType as IconKey] || ICONS.default;
+  return isIconKey(normalizedType) ? ICONS[normalizedType] : ICONS.default;
 }

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -16,7 +16,7 @@ import {
     SkeletonList,
 } from '@webview/components';
 import { ParticipationActions, SubmissionStatus } from '@webview/components/exercise';
-import type { ExerciseType } from '@webview/components/exercise/ParticipationActions';
+import { type ExerciseType, isExerciseType } from '@webview/components/exercise/ParticipationActions';
 import { TestResultsOverlay } from '@webview/components/exercise/TestResultsOverlay';
 import { useExerciseStatusMessages } from '@webview/hooks/useExerciseStatusMessages';
 import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
@@ -191,7 +191,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     }
 
     const exercise = exerciseData.exercise;
-    const exerciseType = (exercise.type || 'programming') as ExerciseType;
+    const exerciseType: ExerciseType = isExerciseType(exercise.type) ? exercise.type : 'programming';
     const isProgramming = exerciseType === 'programming';
 
     // Extract participation data


### PR DESCRIPTION
Closes #186.

This PR addresses the five trivial cast-site cleanups enumerated in #186 — the "leftover" tier of the wider type-safety audit (#171 follow-up).

## Changes

### 1. `extension/src/extension/controller/commands/utilityCommands.ts`
Drop redundant `as ExerciseDetailsResponse | undefined` (and the now-unused import). `AppStateManager.currentExerciseData` already returns exactly that type via a discriminated `_payload.kind === 'exercise'` check — the cast was stale leftover from before the appStateManager refactor.

### 2. `extension/src/webview/utils/iconMap.ts`
Introduce `isIconKey()` type guard. Uses `Object.prototype.hasOwnProperty.call(ICONS, key)` (not `in`) so inherited prototype names like `constructor` or `toString` cannot slip through and return a non-`LucideIcon` at runtime.

### 3. `extension/src/webview/components/exercise/ParticipationActions.tsx` + `ExerciseDetailView.tsx`
Promote `ExerciseType` to a const array + derived type + `isExerciseType()` guard. The guard is now the single source of truth; `ExerciseDetailView` consumes it to replace the prior `(exercise.type || 'programming') as ExerciseType` blind cast.

### 4. `extension/src/extension/activation/extensionCommands.ts`
Introduce `isWSStatusAction()` guard derived from `Object.values(WS_STATUS_ACTION)`. The VS Code `showInformationMessage` return type loses the `WSStatusAction[]` info from the items spread, so the prior cast was unsound. The guard is now the single narrowing point.

## Verification

- `npm run check-types` — clean
- `npm run lint` — clean
- `npm run test:react` — 720/720 pass
- `npm run test:unit` — 835 tests, 0 failures, 3 skipped

## Review

Reviewed via codex multi-turn. Codex caught one real bug (`isIconKey` using `in` rather than `hasOwnProperty`, which would have allowed `'constructor'` to slip through). Fix applied; codex explicitly approved on the second round.

## Manual test checklist

- [ ] `getIcon('constructor')` / `getIcon('toString')` now return the default icon (regression for the new `hasOwnProperty` guard).
- [ ] Exercise detail view still renders for `exercise.type === 'programming'`.
- [ ] Exercise detail view falls back gracefully if the API returns an unexpected `exercise.type` (e.g. `'lecture'`).
- [ ] WebSocket status quick-pick action handling unchanged.
