### PR TITLE
refactor(extension): remove ObservationRegistry whitebox shim from SessionRecorder (#184)

### DIFF
--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -106,15 +106,6 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
     private readonly _snapshots: SnapshotManager;
     private readonly _observation: ObservationRegistry;
 
-    // Test-access shims (getters only). Forward to ObservationRegistry —
-    // existing sessionRecorder.test.ts whiteboxes these per-URI maps.
-    private get _pendingSelectionPayloads(): Map<string, RecordedEvent> {
-        return (this._observation as unknown as { _pendingSelectionPayloads: Map<string, RecordedEvent> })._pendingSelectionPayloads;
-    }
-    private get _pendingVisibleRangePayloads(): Map<string, RecordedEvent> {
-        return (this._observation as unknown as { _pendingVisibleRangePayloads: Map<string, RecordedEvent> })._pendingVisibleRangePayloads;
-    }
-
     private readonly _writer: RecordingStorageWriter;
     private readonly _startup: StartupCapture;
 

--- a/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
@@ -26,6 +26,23 @@ import type {
     RecordedEvent,
 } from '@extension/services/telemetry/recording/types';
 
+/**
+ * Whitebox accessor for the per-URI debounce maps that live on the
+ * ObservationRegistry the SessionRecorder composes. Tests need to seed
+ * these maps to exercise discard/flush paths without waiting for real
+ * debounce timers to fire. Centralized so the unsafe cast lives in one
+ * place — and so the test's coupling to internal field names is honest.
+ */
+function pendingDebounceMaps(recorder: SessionRecorder): {
+    _pendingSelectionPayloads: Map<string, RecordedEvent>;
+    _pendingVisibleRangePayloads: Map<string, RecordedEvent>;
+} {
+    return (recorder as unknown as { _observation: {
+        _pendingSelectionPayloads: Map<string, RecordedEvent>;
+        _pendingVisibleRangePayloads: Map<string, RecordedEvent>;
+    } })._observation;
+}
+
 // ── Fake FS with full pause-control ───────────────────────────────────────
 
 /**
@@ -598,8 +615,8 @@ suite('SessionRecorder (Block AB+E)', () => {
         await recorder.startSession(5);
 
         // Directly prime _pendingSelectionPayloads (per-URI Map, Block J) via
-        // `as any` to simulate a debounce timer that is pending but has not
-        // yet fired when consent is revoked.
+        // the pendingDebounceMaps() whitebox helper to simulate a debounce
+        // timer that is pending but has not yet fired when consent is revoked.
         const fakeUri = 'file:///fake/Pending.java';
         const pendingPayload: RecordedEvent = {
             type: 'selectionChange',
@@ -608,7 +625,7 @@ suite('SessionRecorder (Block AB+E)', () => {
             selections: [{ startLine: 1, startCharacter: 0, endLine: 1, endCharacter: 5 }],
             kind: undefined,
         };
-        (recorder as any)._pendingSelectionPayloads.set(fakeUri, pendingPayload);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(fakeUri, pendingPayload);
 
         // Revoke consent — _doDisable must DISCARD, not flush, the pending payload.
         recorder.disable();
@@ -629,9 +646,9 @@ suite('SessionRecorder (Block AB+E)', () => {
         assert.ok(endIdx > consentIdx, 'sessionEnd must come after consentChange');
 
         // The recorder must have cleared all pending payloads.
-        assert.strictEqual((recorder as any)._pendingSelectionPayloads.size, 0,
+        assert.strictEqual(pendingDebounceMaps(recorder)._pendingSelectionPayloads.size, 0,
             '_pendingSelectionPayloads must be empty after disable()');
-        assert.strictEqual((recorder as any)._pendingVisibleRangePayloads.size, 0,
+        assert.strictEqual(pendingDebounceMaps(recorder)._pendingVisibleRangePayloads.size, 0,
             '_pendingVisibleRangePayloads must be empty after disable()');
     });
 
@@ -675,8 +692,8 @@ suite('SessionRecorder (Block AB+E)', () => {
         };
 
         // Simulate two different URIs triggering in quick succession.
-        (recorder as any)._pendingSelectionPayloads.set(uriA, payloadA);
-        (recorder as any)._pendingSelectionPayloads.set(uriB, payloadB);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uriA, payloadA);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uriB, payloadB);
 
         // Flush on session end must emit both.
         await recorder.endSession();
@@ -703,14 +720,13 @@ suite('SessionRecorder (Block AB+E)', () => {
         };
 
         // Prime the pending map as if the event listener serialized at trigger time.
-        (recorder as any)._pendingSelectionPayloads.set(uri, triggerTimePayload);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uri, triggerTimePayload);
 
         // Simulate a post-trigger state change: the map now holds a DIFFERENT payload
         // for the same URI — but we captured triggerTimePayload already, so the
         // timer closure (which holds a reference to triggerTimePayload) will compare
-        // correctly. To test the flush path here, we call _flushPendingDebouncesForEnd
-        // directly (the timer has not been set in this white-box test, so endSession
-        // is the flush path).
+        // correctly. The debounce timer has not been set in this white-box test,
+        // so endSession() is the flush path we exercise here.
         await recorder.endSession();
 
         const events = collectWrittenEvents(fs);
@@ -737,7 +753,7 @@ suite('SessionRecorder (Block AB+E)', () => {
         };
 
         // Prime a pending payload that has not yet fired its timer.
-        (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uri, payload);
 
         await recorder.endSession();
 
@@ -762,7 +778,7 @@ suite('SessionRecorder (Block AB+E)', () => {
             kind: undefined,
         };
 
-        (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+        pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uri, payload);
 
         // Consent revoked — pending payload must be discarded (Option A).
         recorder.disable();
@@ -789,12 +805,12 @@ suite('SessionRecorder (Block AB+E)', () => {
                 selections: [{ startLine: i, startCharacter: 0, endLine: i, endCharacter: 1 }],
                 kind: undefined,
             };
-            (recorder as any)._pendingSelectionPayloads.set(uri, payload);
+            pendingDebounceMaps(recorder)._pendingSelectionPayloads.set(uri, payload);
         }
 
         // After rapid triggers the map must still have exactly one entry for this URI.
         assert.strictEqual(
-            (recorder as any)._pendingSelectionPayloads.size,
+            pendingDebounceMaps(recorder)._pendingSelectionPayloads.size,
             1,
             'per-URI map must hold at most one pending payload per URI (no accumulation)',
         );
@@ -828,8 +844,8 @@ suite('SessionRecorder (Block AB+E)', () => {
         };
 
         // Simulate two different URIs triggering visible-range changes in quick succession.
-        (recorder as any)._pendingVisibleRangePayloads.set(uriA, payloadA);
-        (recorder as any)._pendingVisibleRangePayloads.set(uriB, payloadB);
+        pendingDebounceMaps(recorder)._pendingVisibleRangePayloads.set(uriA, payloadA);
+        pendingDebounceMaps(recorder)._pendingVisibleRangePayloads.set(uriB, payloadB);
 
         // Flush on session end must emit both.
         await recorder.endSession();
@@ -854,7 +870,7 @@ suite('SessionRecorder (Block AB+E)', () => {
             visibleRanges: [{ startLine: 10, startCharacter: 0, endLine: 30, endCharacter: 0 }],
         };
 
-        (recorder as any)._pendingVisibleRangePayloads.set(uri, payload);
+        pendingDebounceMaps(recorder)._pendingVisibleRangePayloads.set(uri, payload);
 
         // Consent revoked — pending payload must be discarded (Option A).
         recorder.disable();


### PR DESCRIPTION
Closes #184.

## Problem

`SessionRecorder` had two private getter shims that double-cast through `ObservationRegistry`'s private fields purely to satisfy `sessionRecorder.test.ts` which whiteboxes the per-URI debounce maps:

```ts
// src/extension/services/telemetry/recording/sessionRecorder.ts (before)

// Test-access shims (getters only). Forward to ObservationRegistry —
// existing sessionRecorder.test.ts whiteboxes these per-URI maps.
private get _pendingSelectionPayloads(): Map<string, RecordedEvent> {
    return (this._observation as unknown as { _pendingSelectionPayloads: Map<string, RecordedEvent> })._pendingSelectionPayloads;
}
private get _pendingVisibleRangePayloads(): Map<string, RecordedEvent> {
    return (this._observation as unknown as { _pendingVisibleRangePayloads: Map<string, RecordedEvent> })._pendingVisibleRangePayloads;
}
```

Production code violating encapsulation only to keep tests happy is a code smell — the test was dictating the production shape.

## Fix

Move the whitebox from production to the test:

- **Production (`sessionRecorder.ts`)**: Remove both forwarding getters and their double-cast (–9 lines).
- **Tests (`sessionRecorder.test.ts`)**: Introduce a single `pendingDebounceMaps(recorder)` whitebox helper that centralizes the unsafe access through `_observation`. All 13 test sites (consent-downgrade discard, Block J per-URI flush/discard, visible-range alternation) go through the helper instead of hitting `(recorder as any)._pendingSelectionPayloads` directly. The helper uses `as unknown as` rather than `as any` to be explicit about the whitebox.

Also fix two stale comments while nearby:
- The trigger-time payload test referenced `_flushPendingDebouncesForEnd` though the code calls `endSession()` — reworded for clarity.
- The consent-downgrade test mentioned "via `as any`" which no longer matches the helper-routed access.

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:unit` (mocha xunit): 835 tests, 0 failures, 3 skipped
- `npm run test:react`: 720/720 pass

The underlying `Map` instances accessed by the helper are identical to what the production shim used to forward — no semantic change to the tests.

## Review

Reviewed via codex multi-turn. First round gave non-blocking suggestions for a test helper + comment cleanup; both applied. Second round explicitly approved.

## Manual test checklist

- [ ] Session recording still discards pending debounce payloads on consent downgrade.
- [ ] Block J — per-URI debounce maps still flush both URIs on endSession.
- [ ] Visible-range debounce still discards on disable().
