### PR TITLE
refactor(extension): drop redundant casts in replayEngine — rely on RecordedEvent narrowing (#185)

### DIFF
--- a/extension/src/extension/services/telemetry/replay/replayEngine.ts
+++ b/extension/src/extension/services/telemetry/replay/replayEngine.ts
@@ -8,14 +8,9 @@
 
 import { ErrorQuotientEngine } from '../metrics/errorQuotientEngine';
 import type {
-    BuildResultEvent,
-    DiagnosticsEvent,
     EqEngineStateEvent,
-    EqSnapshotEvent,
     RecordedEvent,
-    SaveEvent,
     SerializedDiagnostic,
-    SessionStartEvent,
 } from '../recording/types';
 import type { EQConfig, ErrorSnapshot } from '../types';
 import { DEFAULT_EQ_CONFIG } from '../types';
@@ -50,8 +45,7 @@ function applyLookaheadDiagnostics(
             break;
         }
         if (future.type === 'diagnostics') {
-            const diagEvent = future as DiagnosticsEvent;
-            diagnosticState.set(diagEvent.uri, diagEvent.diagnostics);
+            diagnosticState.set(future.uri, future.diagnostics);
         }
     }
 }
@@ -100,20 +94,19 @@ export function replaySession(
 
         // Extract exercise root from session start for diagnostic filtering
         if (event.type === 'sessionStart') {
-            exerciseRoot = (event as SessionStartEvent).exerciseRoot;
+            exerciseRoot = event.exerciseRoot;
             continue;
         }
 
         // Seed engine with pre-existing state from before recording started
         if (event.type === 'eqEngineState') {
-            const stateEvent = event as EqEngineStateEvent;
-            const snapshots = deserializeEngineState(stateEvent);
+            const snapshots = deserializeEngineState(event);
             engine.seedSnapshots(snapshots);
             continue;
         }
 
         // Emit replay point at trigger evaluations so the replay line matches the original
-        if (event.type === 'eqSnapshot' && (event as EqSnapshotEvent).source === 'trigger') {
+        if (event.type === 'eqSnapshot' && event.source === 'trigger') {
             const { eq, confidence } = engine.getCurrentEQ();
             const lastSnapshot = engine.getState().snapshots.at(-1);
             result.push({
@@ -127,17 +120,14 @@ export function replaySession(
         }
 
         if (event.type === 'diagnostics') {
-            const diagEvent = event as DiagnosticsEvent;
-            diagnosticState.set(diagEvent.uri, diagEvent.diagnostics);
+            diagnosticState.set(event.uri, event.diagnostics);
         }
 
         if (event.type === 'save') {
-            const saveEvent = event as SaveEvent;
-
             // Coalescing: skip if another save within 500ms (live clears+resets timer)
             let coalesced = false;
             for (let j = i + 1; j < events.length; j++) {
-                if (events[j].timestamp > saveEvent.timestamp + LOOKAHEAD_WINDOW_MS) {
+                if (events[j].timestamp > event.timestamp + LOOKAHEAD_WINDOW_MS) {
                     break;
                 }
                 if (events[j].type === 'save') {
@@ -149,7 +139,7 @@ export function replaySession(
                 continue;
             }
 
-            const snapshotTimestamp = saveEvent.timestamp + LOOKAHEAD_WINDOW_MS;
+            const snapshotTimestamp = event.timestamp + LOOKAHEAD_WINDOW_MS;
             applyLookaheadDiagnostics(events, i, snapshotTimestamp, diagnosticState);
 
             const snapshot = createSnapshotFromDiagnosticState(
@@ -159,9 +149,8 @@ export function replaySession(
         }
 
         if (event.type === 'buildResult') {
-            const buildEvent = event as BuildResultEvent;
-            const snapshot = createSnapshotFromBuildEvent(buildEvent);
-            pushIfAccepted(snapshot, 'build', buildEvent.timestamp);
+            const snapshot = createSnapshotFromBuildEvent(event);
+            pushIfAccepted(snapshot, 'build', event.timestamp);
         }
     }
 


### PR DESCRIPTION
Closes #185.

## Finding

`RecordedEvent` in `recording/types.ts:389-422` is already a properly tagged discriminated union — each of the 33 variants declares `type: '<literal>'`. TypeScript therefore narrows `event` automatically after every `event.type === '<literal>'` check.

The 7 type assertions called out in #185 (`as DiagnosticsEvent`, `as SessionStartEvent`, `as EqEngineStateEvent`, `as EqSnapshotEvent`, `as SaveEvent`, `as BuildResultEvent`, plus a duplicate `as DiagnosticsEvent` in `applyLookaheadDiagnostics`) were redundant from day one.

## Change

- Drop all 7 `as ConcreteEvent` assertions.
- Drop the 5 intermediate `const xEvent = event as ...` aliases that existed only to host the casts. Body now uses `event` directly inside each narrowed branch.
- Remove the 5 now-unused type imports (`BuildResultEvent`, `DiagnosticsEvent`, `EqSnapshotEvent`, `SaveEvent`, `SessionStartEvent`). `EqEngineStateEvent`, `RecordedEvent` and `SerializedDiagnostic` remain — they are still used as parameter / array types.

Net: `-20 / +9` across one file.

## Codex review nuance (worth recording)

Codex flagged that two events in `RecordedEvent` (`testResultsOverviewView` and `taskFeedbackView`) share their `type` value with sub-shapes and rely on a secondary `action` discriminator. This PR does not touch those — all seven removed casts are on uniquely-discriminated variants — but it is worth noting for any future audit.

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:react` (covers `replayEngine.test.ts`): 720/720 pass
- `npm run test:unit`: 835 tests, 0 failures, 3 skipped

## Review

Reviewed via codex multi-turn. First round: "No findings. The change is type-only cleanup and I don't see a behavioral regression in the current code." Second round explicitly approved: "Approved for merge as-is. I have no remaining concerns."
