### PR TITLE
refactor(extension): name two-step-discriminator arms in RecordedEvent (#190)

### DIFF
--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -331,58 +331,71 @@ export interface TextDocumentCloseEvent {
     uri: string;
 }
 
+/**
+ * Two-step-discriminator view events: `type` identifies the view, `action`
+ * picks the opened/closed arm. Each arm is named so it can be imported and
+ * reused in consumer signatures. Schema on the wire is unchanged.
+ */
+export interface TestResultsOverviewViewOpenedEvent {
+    type: 'testResultsOverviewView';
+    action: 'opened';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    totalTests: number;
+    passedTests: number;
+    failedTests: number;
+}
+
+export interface TestResultsOverviewViewClosedEvent {
+    type: 'testResultsOverviewView';
+    action: 'closed';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    durationMs: number;
+    closeReason: 'button' | 'escape';
+}
+
 export type TestResultsOverviewViewEvent =
-    | {
-        type: 'testResultsOverviewView';
-        action: 'opened';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        totalTests: number;
-        passedTests: number;
-        failedTests: number;
-    }
-    | {
-        type: 'testResultsOverviewView';
-        action: 'closed';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        durationMs: number;
-        closeReason: 'button' | 'escape';
-    };
+    | TestResultsOverviewViewOpenedEvent
+    | TestResultsOverviewViewClosedEvent;
+
+export interface TaskFeedbackViewOpenedEvent {
+    type: 'taskFeedbackView';
+    action: 'opened';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    taskName: string;
+    testIds: number[];
+    totalTests: number;
+    passedTests: number;
+    failedTests: number;
+}
+
+export interface TaskFeedbackViewClosedEvent {
+    type: 'taskFeedbackView';
+    action: 'closed';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    taskName: string;
+    durationMs: number;
+    closeReason: 'button' | 'escape';
+}
 
 export type TaskFeedbackViewEvent =
-    | {
-        type: 'taskFeedbackView';
-        action: 'opened';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        taskName: string;
-        testIds: number[];
-        totalTests: number;
-        passedTests: number;
-        failedTests: number;
-    }
-    | {
-        type: 'taskFeedbackView';
-        action: 'closed';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        taskName: string;
-        durationMs: number;
-        closeReason: 'button' | 'escape';
-    };
+    | TaskFeedbackViewOpenedEvent
+    | TaskFeedbackViewClosedEvent;
 
 // ── Discriminated union ───────────────────────────────────────────────
 

--- a/recording-viewer/src/generated/recordingTypes.ts
+++ b/recording-viewer/src/generated/recordingTypes.ts
@@ -326,58 +326,71 @@ export interface TextDocumentCloseEvent {
     uri: string;
 }
 
+/**
+ * Two-step-discriminator view events: `type` identifies the view, `action`
+ * picks the opened/closed arm. Each arm is named so it can be imported and
+ * reused in consumer signatures. Schema on the wire is unchanged.
+ */
+export interface TestResultsOverviewViewOpenedEvent {
+    type: 'testResultsOverviewView';
+    action: 'opened';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    totalTests: number;
+    passedTests: number;
+    failedTests: number;
+}
+
+export interface TestResultsOverviewViewClosedEvent {
+    type: 'testResultsOverviewView';
+    action: 'closed';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    durationMs: number;
+    closeReason: 'button' | 'escape';
+}
+
 export type TestResultsOverviewViewEvent =
-    | {
-        type: 'testResultsOverviewView';
-        action: 'opened';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        totalTests: number;
-        passedTests: number;
-        failedTests: number;
-    }
-    | {
-        type: 'testResultsOverviewView';
-        action: 'closed';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        durationMs: number;
-        closeReason: 'button' | 'escape';
-    };
+    | TestResultsOverviewViewOpenedEvent
+    | TestResultsOverviewViewClosedEvent;
+
+export interface TaskFeedbackViewOpenedEvent {
+    type: 'taskFeedbackView';
+    action: 'opened';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    taskName: string;
+    testIds: number[];
+    totalTests: number;
+    passedTests: number;
+    failedTests: number;
+}
+
+export interface TaskFeedbackViewClosedEvent {
+    type: 'taskFeedbackView';
+    action: 'closed';
+    timestamp: number;
+    viewId: string;
+    exerciseId: number;
+    participationId?: number;
+    resultId?: number;
+    taskName: string;
+    durationMs: number;
+    closeReason: 'button' | 'escape';
+}
 
 export type TaskFeedbackViewEvent =
-    | {
-        type: 'taskFeedbackView';
-        action: 'opened';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        taskName: string;
-        testIds: number[];
-        totalTests: number;
-        passedTests: number;
-        failedTests: number;
-    }
-    | {
-        type: 'taskFeedbackView';
-        action: 'closed';
-        timestamp: number;
-        viewId: string;
-        exerciseId: number;
-        participationId?: number;
-        resultId?: number;
-        taskName: string;
-        durationMs: number;
-        closeReason: 'button' | 'escape';
-    };
+    | TaskFeedbackViewOpenedEvent
+    | TaskFeedbackViewClosedEvent;
 
 // ── Discriminated union ───────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #190.

## Change

Extract the inline two-arm unions for `TestResultsOverviewViewEvent` and `TaskFeedbackViewEvent` (`types.ts:334-385`) into four named, exported interfaces (Option A from the issue, schema-stable):

- `TestResultsOverviewViewOpenedEvent { type: 'testResultsOverviewView'; action: 'opened'; ... }`
- `TestResultsOverviewViewClosedEvent { type: 'testResultsOverviewView'; action: 'closed'; ... }`
- `TaskFeedbackViewOpenedEvent { type: 'taskFeedbackView'; action: 'opened'; ... }`
- `TaskFeedbackViewClosedEvent { type: 'taskFeedbackView'; action: 'closed'; ... }`

`TestResultsOverviewViewEvent` and `TaskFeedbackViewEvent` stay as two-arm type aliases unioning the named interfaces — `RecordedEvent` and all existing call sites keep working unchanged.

Re-synced `recording-viewer/src/generated/recordingTypes.ts` via `npm run sync-types`. The viewer holds an auto-generated mirror of the canonical extension types; without the sync the viewer would have been stale.

## Schema impact

None. On-disk JSONL representation, `type` and `action` literals, and per-arm field shapes are identical to before.

## Consumer impact

- `sessionRecorder.ts:318,336,357,376` — object literals still satisfy the new arm types (the per-arm field shape is unchanged). No edits needed.
- `sessionRecorderViewEvents.test.ts:110-169` — existing `e.type === 'taskFeedbackView' && e.action === 'closed'` guards still narrow correctly. No edits needed.

## Verification

**Extension:**
- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:react`: 720/720 pass
- `npm run test:unit`: 835 tests, 0 failures, 3 skipped

**Recording viewer:**
- `npm run build`: clean
- `npm run lint`: clean
- `npm run test`: 168/168 pass

## Review

Reviewed via codex multi-turn. First round caught the missed `sync-types.mjs` run — the viewer-side generated copy would have been stale. Fix applied; second round explicitly approved.
