### PR TITLE
feat(extension): add runtime validation at replay parse boundaries (#183 part A)

### DIFF
--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -1,0 +1,679 @@
+/**
+ * Runtime validators for data read off disk in the replay path.
+ *
+ * Two consumers:
+ *   - `parseSessionMetadata` validates a recording's `metadata.json` file.
+ *   - `parseRecordedEvent` validates a single line of `events.jsonl`.
+ *
+ * Both return `null` on any shape failure so the replay command can skip
+ * the offending session / line instead of letting downstream code dereference
+ * `undefined`. The contract used to be `JSON.parse(...) as SessionMetadata`
+ * (a blind cast) — see #183 for the audit that surfaced it.
+ *
+ * The `RecordedEvent` validator is strict per-variant: each of the 33 type
+ * literals has a dedicated validator that checks the fields declared in
+ * `recording/types.ts`. Adding a new event variant requires adding both a
+ * type interface there and a matching parser case here — a deliberate review
+ * affordance so schema drift can't silently land.
+ */
+
+import type {
+    BuildResultEvent,
+    ConfigurationChangeEvent,
+    ConfigurationSnapshotEvent,
+    ConsentChangeEvent,
+    DiagnosticsEvent,
+    EqEngineStateEvent,
+    EqSnapshotEvent,
+    FileCreateEvent,
+    FileDeleteEvent,
+    FileRenameEvent,
+    FileSnapshotErrorEvent,
+    FileSnapshotEvent,
+    FileSwitchEvent,
+    InterventionEvent,
+    IrisChatFeedbackEvent,
+    IrisChatMessageEvent,
+    IrisChatSendAttemptEvent,
+    PanelVisibilityEvent,
+    RecordedEvent,
+    SaveEvent,
+    SelectionChangeEvent,
+    SerializedDiagnostic,
+    SerializedErrorSnapshot,
+    SerializedRange,
+    SessionEndEvent,
+    SessionMetadata,
+    SessionStartEvent,
+    StartupPhaseCompleteEvent,
+    TaskFeedbackViewClosedEvent,
+    TaskFeedbackViewEvent,
+    TaskFeedbackViewOpenedEvent,
+    TerminalCommandEvent,
+    TerminalOpenCloseEvent,
+    TestResultsOverviewViewClosedEvent,
+    TestResultsOverviewViewEvent,
+    TestResultsOverviewViewOpenedEvent,
+    TextChangeEvent,
+    TextDocumentCloseEvent,
+    TextDocumentOpenEvent,
+    ViewNavigationEvent,
+    VisibleRangeChangeEvent,
+    WindowFocusEvent,
+} from './types';
+
+// ── Primitive guards ──────────────────────────────────────────────────
+
+function isObject(v: unknown): v is Record<string, unknown> {
+    return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isFiniteNumber(v: unknown): v is number {
+    return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isString(v: unknown): v is string {
+    return typeof v === 'string';
+}
+
+function isBoolean(v: unknown): v is boolean {
+    return typeof v === 'boolean';
+}
+
+function isOptString(v: unknown): boolean {
+    return v === undefined || typeof v === 'string';
+}
+
+function isOptFiniteNumber(v: unknown): boolean {
+    return v === undefined || (typeof v === 'number' && Number.isFinite(v));
+}
+
+function isOptBoolean(v: unknown): boolean {
+    return v === undefined || typeof v === 'boolean';
+}
+
+function isStringOrUndefined(v: unknown): v is string | undefined {
+    return v === undefined || typeof v === 'string';
+}
+
+function isOneOf<T extends readonly string[]>(v: unknown, options: T): v is T[number] {
+    return typeof v === 'string' && (options as readonly string[]).includes(v);
+}
+
+/**
+ * Strip keys whose value is `undefined` so the parser's output round-trips
+ * cleanly through JSON.stringify. Without this, parsed events would carry
+ * explicit `key: undefined` entries that diverge from the on-disk JSONL
+ * form (which omits them) and trip `deepStrictEqual` in tests.
+ */
+function stripUndefined<T extends object>(obj: T): T {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+        if (v !== undefined) {
+            out[k] = v;
+        }
+    }
+    return out as T;
+}
+
+// ── Sub-shape parsers ─────────────────────────────────────────────────
+
+function parseSerializedRange(data: unknown): SerializedRange | null {
+    if (!isObject(data)) { return null; }
+    if (!isFiniteNumber(data.startLine) || !isFiniteNumber(data.startCharacter)
+        || !isFiniteNumber(data.endLine) || !isFiniteNumber(data.endCharacter)) {
+        return null;
+    }
+    return {
+        startLine: data.startLine,
+        startCharacter: data.startCharacter,
+        endLine: data.endLine,
+        endCharacter: data.endCharacter,
+    };
+}
+
+function parseSerializedDiagnostic(data: unknown): SerializedDiagnostic | null {
+    if (!isObject(data)) { return null; }
+    if (!isString(data.message)) { return null; }
+    if (!isFiniteNumber(data.severity)) { return null; }
+    const range = parseSerializedRange(data.range);
+    if (!range) { return null; }
+    // `code` is `string | number | undefined`: absent is fine, but a
+    // present-but-wrong-typed value (object, boolean, etc.) is a schema
+    // failure and must reject rather than silently coerce to undefined.
+    if (data.code !== undefined && !isString(data.code) && !isFiniteNumber(data.code)) { return null; }
+    if (data.source !== undefined && !isString(data.source)) { return null; }
+    const code = data.code as string | number | undefined;
+    const source = data.source as string | undefined;
+    return stripUndefined({ code, message: data.message, severity: data.severity, range, source });
+}
+
+function parseSerializedErrorSnapshot(data: unknown): SerializedErrorSnapshot | null {
+    if (!isObject(data)) { return null; }
+    if (!isFiniteNumber(data.timestamp)) { return null; }
+    if (!isBoolean(data.hasErrors)) { return null; }
+    if (!Array.isArray(data.errorFamilies) || !data.errorFamilies.every(isString)) { return null; }
+    if (!isFiniteNumber(data.errorCount)) { return null; }
+    return {
+        timestamp: data.timestamp,
+        hasErrors: data.hasErrors,
+        errorFamilies: data.errorFamilies as string[],
+        errorCount: data.errorCount,
+    };
+}
+
+// ── Per-variant parsers ───────────────────────────────────────────────
+//
+// Each takes a pre-validated `Record<string, unknown>` (the dispatcher has
+// already confirmed `type` is a string and `timestamp` is finite) and either
+// returns the typed event or `null` if any required field is malformed.
+// The dispatcher re-asserts `timestamp` per variant by inlining the cast,
+// which keeps the per-variant signatures uniform.
+
+function parseTextChange(d: Record<string, unknown>, timestamp: number): TextChangeEvent | null {
+    if (!isString(d.uri) || !Array.isArray(d.changes)) { return null; }
+    const changes: TextChangeEvent['changes'] = [];
+    for (const raw of d.changes) {
+        if (!isObject(raw)) { return null; }
+        const range = parseSerializedRange(raw.range);
+        if (!range) { return null; }
+        if (!isFiniteNumber(raw.rangeOffset) || !isFiniteNumber(raw.rangeLength) || !isString(raw.text)) {
+            return null;
+        }
+        changes.push({ range, rangeOffset: raw.rangeOffset, rangeLength: raw.rangeLength, text: raw.text });
+    }
+    return { type: 'textChange', timestamp, uri: d.uri, changes };
+}
+
+function parseSave(d: Record<string, unknown>, timestamp: number): SaveEvent | null {
+    if (!isString(d.uri)) { return null; }
+    return { type: 'save', timestamp, uri: d.uri };
+}
+
+function parseFileSwitch(d: Record<string, unknown>, timestamp: number): FileSwitchEvent | null {
+    if (!isStringOrUndefined(d.fromUri) || !isStringOrUndefined(d.toUri)) { return null; }
+    return stripUndefined({ type: 'fileSwitch' as const, timestamp, fromUri: d.fromUri, toUri: d.toUri });
+}
+
+function parseDiagnostics(d: Record<string, unknown>, timestamp: number): DiagnosticsEvent | null {
+    if (!isString(d.uri) || !Array.isArray(d.diagnostics)) { return null; }
+    const diagnostics: SerializedDiagnostic[] = [];
+    for (const raw of d.diagnostics) {
+        const parsed = parseSerializedDiagnostic(raw);
+        if (!parsed) { return null; }
+        diagnostics.push(parsed);
+    }
+    return { type: 'diagnostics', timestamp, uri: d.uri, diagnostics };
+}
+
+function parseBuildResult(d: Record<string, unknown>, timestamp: number): BuildResultEvent | null {
+    if (!isOptBoolean(d.successful)) { return null; }
+    if (!isFiniteNumber(d.errorCount)) { return null; }
+    if (!Array.isArray(d.failedTests) || !d.failedTests.every(isString)) { return null; }
+    if (!isBoolean(d.buildFailed)) { return null; }
+    if (d.buildErrorFamilies !== undefined
+        && !(Array.isArray(d.buildErrorFamilies) && d.buildErrorFamilies.every(isString))) {
+        return null;
+    }
+    if (!isOptFiniteNumber(d.exerciseId)
+        || !isOptFiniteNumber(d.participationId)
+        || !isOptFiniteNumber(d.submissionId)) {
+        return null;
+    }
+    let failedTestDetails: BuildResultEvent['failedTestDetails'];
+    if (d.failedTestDetails !== undefined) {
+        if (!Array.isArray(d.failedTestDetails)) { return null; }
+        const list: { testName: string; detail: string }[] = [];
+        for (const raw of d.failedTestDetails) {
+            if (!isObject(raw) || !isString(raw.testName) || !isString(raw.detail)) { return null; }
+            list.push({ testName: raw.testName, detail: raw.detail });
+        }
+        failedTestDetails = list;
+    }
+    return stripUndefined({
+        type: 'buildResult' as const,
+        timestamp,
+        successful: d.successful as boolean | undefined,
+        errorCount: d.errorCount,
+        failedTests: d.failedTests as string[],
+        buildFailed: d.buildFailed,
+        buildErrorFamilies: d.buildErrorFamilies as string[] | undefined,
+        exerciseId: d.exerciseId as number | undefined,
+        participationId: d.participationId as number | undefined,
+        submissionId: d.submissionId as number | undefined,
+        failedTestDetails,
+    });
+}
+
+function parseWindowFocus(d: Record<string, unknown>, timestamp: number): WindowFocusEvent | null {
+    if (!isBoolean(d.focused)) { return null; }
+    return { type: 'windowFocus', timestamp, focused: d.focused };
+}
+
+function parseFileSnapshot(d: Record<string, unknown>, timestamp: number): FileSnapshotEvent | null {
+    if (!isString(d.uri) || !isString(d.snapshotPath)) { return null; }
+    return { type: 'fileSnapshot', timestamp, uri: d.uri, snapshotPath: d.snapshotPath };
+}
+
+function parseSessionStart(d: Record<string, unknown>, timestamp: number): SessionStartEvent | null {
+    if (!isFiniteNumber(d.exerciseId)) { return null; }
+    if (!isStringOrUndefined(d.participantId)) { return null; }
+    if (!isOptString(d.exerciseRoot)) { return null; }
+    if (!isOptFiniteNumber(d.schemaVersion)) { return null; }
+    return stripUndefined({
+        type: 'sessionStart' as const,
+        timestamp,
+        exerciseId: d.exerciseId,
+        participantId: d.participantId,
+        exerciseRoot: d.exerciseRoot as string | undefined,
+        schemaVersion: d.schemaVersion as number | undefined,
+    });
+}
+
+function parseSessionEnd(d: Record<string, unknown>, timestamp: number): SessionEndEvent | null {
+    if (!isFiniteNumber(d.exerciseId)) { return null; }
+    return { type: 'sessionEnd', timestamp, exerciseId: d.exerciseId };
+}
+
+function parseConsentChange(d: Record<string, unknown>, timestamp: number): ConsentChangeEvent | null {
+    if (!isOneOf(d.level, ['downgraded', 'upgraded'] as const)) { return null; }
+    return { type: 'consentChange', timestamp, level: d.level };
+}
+
+function parseStartupPhaseComplete(_d: Record<string, unknown>, timestamp: number): StartupPhaseCompleteEvent {
+    return { type: 'startupPhaseComplete', timestamp };
+}
+
+function parseConfigurationSnapshot(d: Record<string, unknown>, timestamp: number): ConfigurationSnapshotEvent | null {
+    if (!isBoolean(d.struggleDetectionEnabled) || !isBoolean(d.showInterventions)) { return null; }
+    return {
+        type: 'configurationSnapshot',
+        timestamp,
+        struggleDetectionEnabled: d.struggleDetectionEnabled,
+        showInterventions: d.showInterventions,
+    };
+}
+
+function parseConfigurationChange(d: Record<string, unknown>, timestamp: number): ConfigurationChangeEvent | null {
+    if (!isObject(d.changes)) { return null; }
+    if (!isOptBoolean(d.changes.struggleDetectionEnabled) || !isOptBoolean(d.changes.showInterventions)) {
+        return null;
+    }
+    return {
+        type: 'configurationChange',
+        timestamp,
+        changes: stripUndefined({
+            struggleDetectionEnabled: d.changes.struggleDetectionEnabled as boolean | undefined,
+            showInterventions: d.changes.showInterventions as boolean | undefined,
+        }),
+    };
+}
+
+function parseIrisChatMessage(d: Record<string, unknown>, timestamp: number): IrisChatMessageEvent | null {
+    if (!isOneOf(d.direction, ['sent', 'received'] as const)) { return null; }
+    if (!isString(d.content)) { return null; }
+    if (!isOptString(d.messageId) || !isOptString(d.sessionId) || !isOptFiniteNumber(d.sentAt)) { return null; }
+    return stripUndefined({
+        type: 'irisChatMessage' as const,
+        timestamp,
+        direction: d.direction,
+        content: d.content,
+        messageId: d.messageId as string | undefined,
+        sessionId: d.sessionId as string | undefined,
+        sentAt: d.sentAt as number | undefined,
+    });
+}
+
+function parseIrisChatSendAttempt(d: Record<string, unknown>, timestamp: number): IrisChatSendAttemptEvent | null {
+    if (!isString(d.content)) { return null; }
+    if (!isOneOf(d.status, ['pending', 'sent', 'failed'] as const)) { return null; }
+    if (!isOptString(d.errorMessage)) { return null; }
+    return stripUndefined({
+        type: 'irisChatSendAttempt' as const,
+        timestamp,
+        content: d.content,
+        status: d.status,
+        errorMessage: d.errorMessage as string | undefined,
+    });
+}
+
+function parseIrisChatFeedback(d: Record<string, unknown>, timestamp: number): IrisChatFeedbackEvent | null {
+    if (!isString(d.messageId) || !isBoolean(d.helpful)) { return null; }
+    return { type: 'irisChatFeedback', timestamp, messageId: d.messageId, helpful: d.helpful };
+}
+
+function parseEqSnapshot(d: Record<string, unknown>, timestamp: number): EqSnapshotEvent | null {
+    if (!isFiniteNumber(d.eq)) { return null; }
+    if (!isOneOf(d.confidence, ['sufficient', 'insufficient'] as const)) { return null; }
+    if (!isOneOf(d.source, ['save', 'build', 'trigger'] as const)) { return null; }
+    if (!isOptString(d.triggerType)) { return null; }
+    return stripUndefined({
+        type: 'eqSnapshot' as const,
+        timestamp,
+        eq: d.eq,
+        confidence: d.confidence,
+        source: d.source,
+        triggerType: d.triggerType as string | undefined,
+    });
+}
+
+function parseEqEngineState(d: Record<string, unknown>, timestamp: number): EqEngineStateEvent | null {
+    if (!Array.isArray(d.snapshots)) { return null; }
+    const snapshots: SerializedErrorSnapshot[] = [];
+    for (const raw of d.snapshots) {
+        const parsed = parseSerializedErrorSnapshot(raw);
+        if (!parsed) { return null; }
+        snapshots.push(parsed);
+    }
+    if (!isFiniteNumber(d.currentEQ) || !isFiniteNumber(d.pairCount)) { return null; }
+    if (!isOneOf(d.confidence, ['sufficient', 'insufficient'] as const)) { return null; }
+    return {
+        type: 'eqEngineState',
+        timestamp,
+        snapshots,
+        currentEQ: d.currentEQ,
+        pairCount: d.pairCount,
+        confidence: d.confidence,
+    };
+}
+
+function parseIntervention(d: Record<string, unknown>, timestamp: number): InterventionEvent | null {
+    if (!isOneOf(d.action, ['shown', 'accepted', 'dismissed', 'blocked', 'suppressed'] as const)) { return null; }
+    if (!isOneOf(d.level, ['subtle', 'notification', 'proactive'] as const)) { return null; }
+    if (!isBoolean(d.shouldIntervene)) { return null; }
+    if (!isFiniteNumber(d.eq)) { return null; }
+    if (!isOneOf(d.confidence, ['sufficient', 'insufficient'] as const)) { return null; }
+    if (d.triggerType !== undefined
+        && !isOneOf(d.triggerType, ['execution-error', 'multiline-paste', 'idle', 'selection-maintained'] as const)) {
+        return null;
+    }
+    if (d.blockedReason !== undefined
+        && !isOneOf(d.blockedReason, ['cooldown', 'warmup', 'session-limit', 'low-confidence'] as const)) {
+        return null;
+    }
+    if (d.suppressionReason !== undefined && !isOneOf(d.suppressionReason, ['user-disabled'] as const)) {
+        return null;
+    }
+    if (d.dismissReason !== undefined
+        && !isOneOf(d.dismissReason, ['user-action', 'hidden', 'replaced', 'session-end'] as const)) {
+        return null;
+    }
+    if (!isOptBoolean(d.rawWanted)) { return null; }
+    return stripUndefined({
+        type: 'intervention' as const,
+        timestamp,
+        action: d.action,
+        level: d.level,
+        shouldIntervene: d.shouldIntervene,
+        eq: d.eq,
+        confidence: d.confidence,
+        triggerType: d.triggerType as InterventionEvent['triggerType'],
+        blockedReason: d.blockedReason as InterventionEvent['blockedReason'],
+        suppressionReason: d.suppressionReason as InterventionEvent['suppressionReason'],
+        dismissReason: d.dismissReason as InterventionEvent['dismissReason'],
+        rawWanted: d.rawWanted as boolean | undefined,
+    });
+}
+
+function parseViewNavigation(d: Record<string, unknown>, timestamp: number): ViewNavigationEvent | null {
+    if (!isString(d.from) || !isString(d.to)) { return null; }
+    return { type: 'viewNavigation', timestamp, from: d.from, to: d.to };
+}
+
+function parsePanelVisibility(d: Record<string, unknown>, timestamp: number): PanelVisibilityEvent | null {
+    if (!isOneOf(d.panel, ['artemis', 'chat'] as const)) { return null; }
+    if (!isBoolean(d.visible)) { return null; }
+    return { type: 'panelVisibility', timestamp, panel: d.panel, visible: d.visible };
+}
+
+function parseSelectionChange(d: Record<string, unknown>, timestamp: number): SelectionChangeEvent | null {
+    if (!isString(d.uri) || !Array.isArray(d.selections)) { return null; }
+    const selections: SerializedRange[] = [];
+    for (const raw of d.selections) {
+        const parsed = parseSerializedRange(raw);
+        if (!parsed) { return null; }
+        selections.push(parsed);
+    }
+    if (d.kind !== undefined && !isOneOf(d.kind, ['keyboard', 'mouse', 'command'] as const)) { return null; }
+    const kind = d.kind as SelectionChangeEvent['kind'];
+    return stripUndefined({ type: 'selectionChange' as const, timestamp, uri: d.uri, selections, kind });
+}
+
+function parseVisibleRangeChange(d: Record<string, unknown>, timestamp: number): VisibleRangeChangeEvent | null {
+    if (!isString(d.uri) || !Array.isArray(d.visibleRanges)) { return null; }
+    const visibleRanges: SerializedRange[] = [];
+    for (const raw of d.visibleRanges) {
+        const parsed = parseSerializedRange(raw);
+        if (!parsed) { return null; }
+        visibleRanges.push(parsed);
+    }
+    return { type: 'visibleRangeChange', timestamp, uri: d.uri, visibleRanges };
+}
+
+function parseTerminalCommand(d: Record<string, unknown>, timestamp: number): TerminalCommandEvent | null {
+    if (!isString(d.command)) { return null; }
+    if (!isOptFiniteNumber(d.exitCode)) { return null; }
+    if (!isString(d.output)) { return null; }
+    if (!isBoolean(d.outputTruncated)) { return null; }
+    if (!isStringOrUndefined(d.cwd)) { return null; }
+    if (!isString(d.terminalName)) { return null; }
+    if (!isFiniteNumber(d.durationMs)) { return null; }
+    return stripUndefined({
+        type: 'terminalCommand' as const,
+        timestamp,
+        command: d.command,
+        exitCode: d.exitCode as number | undefined,
+        output: d.output,
+        outputTruncated: d.outputTruncated,
+        cwd: d.cwd,
+        terminalName: d.terminalName,
+        durationMs: d.durationMs,
+    });
+}
+
+function parseTerminalOpenClose(d: Record<string, unknown>, timestamp: number): TerminalOpenCloseEvent | null {
+    if (!isOneOf(d.action, ['opened', 'closed'] as const)) { return null; }
+    if (!isString(d.terminalName)) { return null; }
+    return { type: 'terminalOpenClose', timestamp, action: d.action, terminalName: d.terminalName };
+}
+
+function parseFileSnapshotError(d: Record<string, unknown>, timestamp: number): FileSnapshotErrorEvent | null {
+    if (!isString(d.uri) || !isString(d.reason)) { return null; }
+    return { type: 'fileSnapshotError', timestamp, uri: d.uri, reason: d.reason };
+}
+
+function parseFileCreate(d: Record<string, unknown>, timestamp: number): FileCreateEvent | null {
+    if (!isString(d.uri)) { return null; }
+    return { type: 'fileCreate', timestamp, uri: d.uri };
+}
+
+function parseFileDelete(d: Record<string, unknown>, timestamp: number): FileDeleteEvent | null {
+    if (!isString(d.uri)) { return null; }
+    return { type: 'fileDelete', timestamp, uri: d.uri };
+}
+
+function parseFileRename(d: Record<string, unknown>, timestamp: number): FileRenameEvent | null {
+    if (!isString(d.oldUri) || !isString(d.newUri)) { return null; }
+    return { type: 'fileRename', timestamp, oldUri: d.oldUri, newUri: d.newUri };
+}
+
+function parseTextDocumentOpen(d: Record<string, unknown>, timestamp: number): TextDocumentOpenEvent | null {
+    if (!isString(d.uri)) { return null; }
+    return { type: 'textDocumentOpen', timestamp, uri: d.uri };
+}
+
+function parseTextDocumentClose(d: Record<string, unknown>, timestamp: number): TextDocumentCloseEvent | null {
+    if (!isString(d.uri)) { return null; }
+    return { type: 'textDocumentClose', timestamp, uri: d.uri };
+}
+
+function parseTestResultsOverviewView(
+    d: Record<string, unknown>,
+    timestamp: number,
+): TestResultsOverviewViewEvent | null {
+    if (!isString(d.viewId) || !isFiniteNumber(d.exerciseId)) { return null; }
+    if (!isOptFiniteNumber(d.participationId) || !isOptFiniteNumber(d.resultId)) { return null; }
+    if (d.action === 'opened') {
+        if (!isFiniteNumber(d.totalTests) || !isFiniteNumber(d.passedTests) || !isFiniteNumber(d.failedTests)) {
+            return null;
+        }
+        return stripUndefined<TestResultsOverviewViewOpenedEvent>({
+            type: 'testResultsOverviewView',
+            action: 'opened',
+            timestamp,
+            viewId: d.viewId,
+            exerciseId: d.exerciseId,
+            participationId: d.participationId as number | undefined,
+            resultId: d.resultId as number | undefined,
+            totalTests: d.totalTests,
+            passedTests: d.passedTests,
+            failedTests: d.failedTests,
+        });
+    }
+    if (d.action === 'closed') {
+        if (!isFiniteNumber(d.durationMs)) { return null; }
+        if (!isOneOf(d.closeReason, ['button', 'escape'] as const)) { return null; }
+        return stripUndefined<TestResultsOverviewViewClosedEvent>({
+            type: 'testResultsOverviewView',
+            action: 'closed',
+            timestamp,
+            viewId: d.viewId,
+            exerciseId: d.exerciseId,
+            participationId: d.participationId as number | undefined,
+            resultId: d.resultId as number | undefined,
+            durationMs: d.durationMs,
+            closeReason: d.closeReason,
+        });
+    }
+    return null;
+}
+
+function parseTaskFeedbackView(d: Record<string, unknown>, timestamp: number): TaskFeedbackViewEvent | null {
+    if (!isString(d.viewId) || !isFiniteNumber(d.exerciseId)) { return null; }
+    if (!isOptFiniteNumber(d.participationId) || !isOptFiniteNumber(d.resultId)) { return null; }
+    if (!isString(d.taskName)) { return null; }
+    if (d.action === 'opened') {
+        if (!Array.isArray(d.testIds) || !d.testIds.every(isFiniteNumber)) { return null; }
+        if (!isFiniteNumber(d.totalTests) || !isFiniteNumber(d.passedTests) || !isFiniteNumber(d.failedTests)) {
+            return null;
+        }
+        return stripUndefined<TaskFeedbackViewOpenedEvent>({
+            type: 'taskFeedbackView',
+            action: 'opened',
+            timestamp,
+            viewId: d.viewId,
+            exerciseId: d.exerciseId,
+            participationId: d.participationId as number | undefined,
+            resultId: d.resultId as number | undefined,
+            taskName: d.taskName,
+            testIds: d.testIds as number[],
+            totalTests: d.totalTests,
+            passedTests: d.passedTests,
+            failedTests: d.failedTests,
+        });
+    }
+    if (d.action === 'closed') {
+        if (!isFiniteNumber(d.durationMs)) { return null; }
+        if (!isOneOf(d.closeReason, ['button', 'escape'] as const)) { return null; }
+        return stripUndefined<TaskFeedbackViewClosedEvent>({
+            type: 'taskFeedbackView',
+            action: 'closed',
+            timestamp,
+            viewId: d.viewId,
+            exerciseId: d.exerciseId,
+            participationId: d.participationId as number | undefined,
+            resultId: d.resultId as number | undefined,
+            taskName: d.taskName,
+            durationMs: d.durationMs,
+            closeReason: d.closeReason,
+        });
+    }
+    return null;
+}
+
+// ── Public dispatcher ─────────────────────────────────────────────────
+
+/**
+ * Parse one line of an `events.jsonl` recording. Returns `null` on any shape
+ * failure so the replay command can skip the line. Adding a new event variant
+ * to `RecordedEvent` requires a matching `case` here — the `default` branch
+ * deliberately rejects unknown types instead of silently widening.
+ */
+export function parseRecordedEvent(data: unknown): RecordedEvent | null {
+    if (!isObject(data)) { return null; }
+    if (!isFiniteNumber(data.timestamp)) { return null; }
+    if (!isString(data.type)) { return null; }
+    const ts = data.timestamp;
+    switch (data.type) {
+        case 'textChange': return parseTextChange(data, ts);
+        case 'save': return parseSave(data, ts);
+        case 'fileSwitch': return parseFileSwitch(data, ts);
+        case 'diagnostics': return parseDiagnostics(data, ts);
+        case 'buildResult': return parseBuildResult(data, ts);
+        case 'windowFocus': return parseWindowFocus(data, ts);
+        case 'fileSnapshot': return parseFileSnapshot(data, ts);
+        case 'sessionStart': return parseSessionStart(data, ts);
+        case 'sessionEnd': return parseSessionEnd(data, ts);
+        case 'consentChange': return parseConsentChange(data, ts);
+        case 'startupPhaseComplete': return parseStartupPhaseComplete(data, ts);
+        case 'configurationSnapshot': return parseConfigurationSnapshot(data, ts);
+        case 'configurationChange': return parseConfigurationChange(data, ts);
+        case 'irisChatMessage': return parseIrisChatMessage(data, ts);
+        case 'irisChatSendAttempt': return parseIrisChatSendAttempt(data, ts);
+        case 'irisChatFeedback': return parseIrisChatFeedback(data, ts);
+        case 'eqSnapshot': return parseEqSnapshot(data, ts);
+        case 'eqEngineState': return parseEqEngineState(data, ts);
+        case 'intervention': return parseIntervention(data, ts);
+        case 'viewNavigation': return parseViewNavigation(data, ts);
+        case 'panelVisibility': return parsePanelVisibility(data, ts);
+        case 'selectionChange': return parseSelectionChange(data, ts);
+        case 'visibleRangeChange': return parseVisibleRangeChange(data, ts);
+        case 'terminalCommand': return parseTerminalCommand(data, ts);
+        case 'terminalOpenClose': return parseTerminalOpenClose(data, ts);
+        case 'fileSnapshotError': return parseFileSnapshotError(data, ts);
+        case 'fileCreate': return parseFileCreate(data, ts);
+        case 'fileDelete': return parseFileDelete(data, ts);
+        case 'fileRename': return parseFileRename(data, ts);
+        case 'textDocumentOpen': return parseTextDocumentOpen(data, ts);
+        case 'textDocumentClose': return parseTextDocumentClose(data, ts);
+        case 'testResultsOverviewView': return parseTestResultsOverviewView(data, ts);
+        case 'taskFeedbackView': return parseTaskFeedbackView(data, ts);
+        default: return null;
+    }
+}
+
+/**
+ * Parse a recording's `metadata.json` file body. Returns `null` on any shape
+ * failure. The replay command's session lister keeps the entry in the
+ * QuickPick with a `metadata: null` placeholder (rendered as "unknown date"
+ * / "unknown exercise"); the parser just refuses to construct a partially-
+ * populated SessionMetadata object that downstream code would deref into.
+ */
+export function parseSessionMetadata(data: unknown): SessionMetadata | null {
+    if (!isObject(data)) { return null; }
+    if (!isString(data.sessionId)) { return null; }
+    if (!isFiniteNumber(data.exerciseId)) { return null; }
+    if (!isStringOrUndefined(data.participantId)) { return null; }
+    if (!isFiniteNumber(data.startTime)) { return null; }
+    // endTime is `number | null | undefined`.
+    if (data.endTime !== null && data.endTime !== undefined
+        && !(typeof data.endTime === 'number' && Number.isFinite(data.endTime))) {
+        return null;
+    }
+    if (!isFiniteNumber(data.eventCount)) { return null; }
+    if (!isOptFiniteNumber(data.schemaVersion)) { return null; }
+    if (!isOptString(data.recorderVersion)) { return null; }
+    return stripUndefined({
+        sessionId: data.sessionId,
+        exerciseId: data.exerciseId,
+        participantId: data.participantId,
+        startTime: data.startTime,
+        // endTime is intentionally NOT stripped when null (different meaning
+        // from "missing"): null = recording in progress, undefined = session
+        // closed without writing endTime. We preserve null explicitly.
+        endTime: data.endTime as number | null | undefined,
+        eventCount: data.eventCount,
+        schemaVersion: data.schemaVersion as number | undefined,
+        recorderVersion: data.recorderVersion as string | undefined,
+    });
+}

--- a/extension/src/extension/services/telemetry/replay/replayCommand.ts
+++ b/extension/src/extension/services/telemetry/replay/replayCommand.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { parseRecordedEvent, parseSessionMetadata } from '../recording/parseRecordedData';
 import type { RecordedEvent, SessionMetadata } from '../recording/types';
 import { replaySession } from './replayEngine';
 
@@ -30,9 +31,9 @@ export async function executeReplayCommand(globalStorageUri: vscode.Uri): Promis
         let metadata: SessionMetadata | null = null;
         if (fs.existsSync(metaPath)) {
             try {
-                metadata = JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as SessionMetadata;
+                metadata = parseSessionMetadata(JSON.parse(fs.readFileSync(metaPath, 'utf-8')));
             } catch {
-                // Skip invalid metadata
+                // Skip invalid JSON
             }
         }
         sessions.push({ id: entry.name, metadata });
@@ -81,11 +82,20 @@ export async function executeReplayCommand(globalStorageUri: vscode.Uri): Promis
         .filter(l => l.trim().length > 0);
     const events: RecordedEvent[] = [];
     for (const line of lines) {
+        let raw: unknown;
         try {
-            events.push(JSON.parse(line) as RecordedEvent);
+            raw = JSON.parse(line);
         } catch {
-            // Skip malformed JSONL lines
+            continue; // Skip malformed JSON
         }
+        const event = parseRecordedEvent(raw);
+        if (event !== null) {
+            events.push(event);
+        }
+        // Silently skip lines that JSON-parse but don't validate against the
+        // RecordedEvent shape (unknown type, missing required field, etc.).
+        // The replay UI surfaces total replayed-event count, so corrupted
+        // lines manifest as a shorter session in the picker.
     }
 
     // Run replay

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -1,0 +1,531 @@
+/**
+ * Unit tests for parseRecordedEvent + parseSessionMetadata (#183).
+ *
+ * The recording replay path reads untrusted on-disk data (metadata.json,
+ * events.jsonl). Pre-fix it was cast directly to the typed shape, masking
+ * schema drift. The validators are strict per-variant on RecordedEvent so
+ * adding a new event type requires touching both the type declaration and
+ * the parser case (deliberate review affordance).
+ *
+ * Test strategy:
+ *   - Happy-path roundtrip per variant: build an object literal that matches
+ *     the declared type, parse it, assert deep-equal back.
+ *   - Reject malformed input at the dispatcher level (non-object, wrong
+ *     `type`, missing `timestamp`).
+ *   - Reject malformed input at the per-variant level for each shape that
+ *     has a "tricky" required field (literal unions, secondary discriminator
+ *     on view events, nested arrays, etc.).
+ */
+
+import * as assert from 'assert';
+
+import { parseRecordedEvent, parseSessionMetadata } from '@extension/services/telemetry/recording/parseRecordedData';
+import type { RecordedEvent, SessionMetadata } from '@extension/services/telemetry/recording/types';
+
+const ts = 1700000000000;
+
+function clone<T>(v: T): T {
+    return JSON.parse(JSON.stringify(v)) as T;
+}
+
+suite('parseRecordedEvent — dispatcher-level rejection', () => {
+    test('null returns null', () => {
+        assert.strictEqual(parseRecordedEvent(null), null);
+    });
+    test('array returns null', () => {
+        assert.strictEqual(parseRecordedEvent([1, 2, 3]), null);
+    });
+    test('string returns null', () => {
+        assert.strictEqual(parseRecordedEvent('save'), null);
+    });
+    test('missing timestamp returns null', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'save', uri: 'file:///x' }), null);
+    });
+    test('non-finite timestamp returns null', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'save', timestamp: Infinity, uri: 'file:///x' }), null);
+        assert.strictEqual(parseRecordedEvent({ type: 'save', timestamp: NaN, uri: 'file:///x' }), null);
+    });
+    test('missing type returns null', () => {
+        assert.strictEqual(parseRecordedEvent({ timestamp: ts, uri: 'file:///x' }), null);
+    });
+    test('unknown type literal returns null', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'somethingNew', timestamp: ts }), null);
+    });
+});
+
+// ── Per-variant happy-path roundtrips ──────────────────────────────────
+
+suite('parseRecordedEvent — per-variant happy path', () => {
+    const range = { startLine: 1, startCharacter: 2, endLine: 3, endCharacter: 4 };
+
+    test('textChange', () => {
+        const e: RecordedEvent = {
+            type: 'textChange', timestamp: ts, uri: 'file:///a.ts',
+            changes: [{ range, rangeOffset: 5, rangeLength: 0, text: 'hello' }],
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('save', () => {
+        const e: RecordedEvent = { type: 'save', timestamp: ts, uri: 'file:///a.ts' };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('fileSwitch', () => {
+        const e: RecordedEvent = {
+            type: 'fileSwitch', timestamp: ts, fromUri: 'file:///a.ts', toUri: 'file:///b.ts',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('fileSwitch with undefined endpoints', () => {
+        const e: RecordedEvent = { type: 'fileSwitch', timestamp: ts, fromUri: undefined, toUri: undefined };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('diagnostics', () => {
+        const e: RecordedEvent = {
+            type: 'diagnostics', timestamp: ts, uri: 'file:///a.ts',
+            diagnostics: [{
+                code: 'E0001', message: 'oops', severity: 1, range, source: 'tsc',
+            }],
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('buildResult — minimal required fields', () => {
+        const e: RecordedEvent = {
+            type: 'buildResult', timestamp: ts, successful: true,
+            errorCount: 0, failedTests: [], buildFailed: false,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('buildResult — with optional scoping + failed details', () => {
+        const e: RecordedEvent = {
+            type: 'buildResult', timestamp: ts, successful: false,
+            errorCount: 2, failedTests: ['t1', 't2'], buildFailed: false,
+            buildErrorFamilies: ['type-mismatch'],
+            exerciseId: 7, participationId: 8, submissionId: 9,
+            failedTestDetails: [{ testName: 't1', detail: 'expected 1 got 2' }],
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('windowFocus', () => {
+        const e: RecordedEvent = { type: 'windowFocus', timestamp: ts, focused: true };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('fileSnapshot', () => {
+        const e: RecordedEvent = {
+            type: 'fileSnapshot', timestamp: ts, uri: 'file:///a.ts',
+            snapshotPath: '/x/snap.txt',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('sessionStart', () => {
+        const e: RecordedEvent = {
+            type: 'sessionStart', timestamp: ts, exerciseId: 7,
+            participantId: 'abc', exerciseRoot: '/workspace/ex', schemaVersion: 2,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('sessionEnd', () => {
+        const e: RecordedEvent = { type: 'sessionEnd', timestamp: ts, exerciseId: 7 };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('consentChange — both levels accepted', () => {
+        const down: RecordedEvent = { type: 'consentChange', timestamp: ts, level: 'downgraded' };
+        const up: RecordedEvent = { type: 'consentChange', timestamp: ts, level: 'upgraded' };
+        assert.deepStrictEqual(parseRecordedEvent(clone(down)), down);
+        assert.deepStrictEqual(parseRecordedEvent(clone(up)), up);
+    });
+
+    test('startupPhaseComplete', () => {
+        const e: RecordedEvent = { type: 'startupPhaseComplete', timestamp: ts };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('configurationSnapshot', () => {
+        const e: RecordedEvent = {
+            type: 'configurationSnapshot', timestamp: ts,
+            struggleDetectionEnabled: true, showInterventions: false,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('configurationChange — both keys optional', () => {
+        const e: RecordedEvent = {
+            type: 'configurationChange', timestamp: ts,
+            changes: { struggleDetectionEnabled: true },
+        };
+        const parsed = parseRecordedEvent(clone(e));
+        assert.ok(parsed);
+        assert.strictEqual(parsed.type, 'configurationChange');
+        if (parsed.type === 'configurationChange') {
+            assert.strictEqual(parsed.changes.struggleDetectionEnabled, true);
+            assert.strictEqual(parsed.changes.showInterventions, undefined);
+        }
+    });
+
+    test('irisChatMessage — sent', () => {
+        const e: RecordedEvent = {
+            type: 'irisChatMessage', timestamp: ts, direction: 'sent', content: 'hi',
+            messageId: 'm1', sessionId: 's1', sentAt: ts + 1,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('irisChatSendAttempt — failed with error', () => {
+        const e: RecordedEvent = {
+            type: 'irisChatSendAttempt', timestamp: ts, content: 'hi',
+            status: 'failed', errorMessage: 'rate limited',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('irisChatFeedback', () => {
+        const e: RecordedEvent = {
+            type: 'irisChatFeedback', timestamp: ts, messageId: 'm1', helpful: false,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('eqSnapshot — with triggerType', () => {
+        const e: RecordedEvent = {
+            type: 'eqSnapshot', timestamp: ts, eq: 0.42,
+            confidence: 'sufficient', source: 'trigger', triggerType: 'idle',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('eqEngineState — with empty snapshots', () => {
+        const e: RecordedEvent = {
+            type: 'eqEngineState', timestamp: ts, snapshots: [],
+            currentEQ: 0, pairCount: 0, confidence: 'insufficient',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('eqEngineState — with populated snapshots', () => {
+        const e: RecordedEvent = {
+            type: 'eqEngineState', timestamp: ts,
+            snapshots: [{ timestamp: ts - 1, hasErrors: true, errorFamilies: ['compile'], errorCount: 3 }],
+            currentEQ: 0.18, pairCount: 5, confidence: 'sufficient',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('intervention — all optional fields populated', () => {
+        const e: RecordedEvent = {
+            type: 'intervention', timestamp: ts, action: 'blocked', level: 'notification',
+            shouldIntervene: false, eq: 0.7, confidence: 'sufficient',
+            triggerType: 'idle', blockedReason: 'cooldown', rawWanted: true,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('viewNavigation', () => {
+        const e: RecordedEvent = {
+            type: 'viewNavigation', timestamp: ts, from: 'dashboard', to: 'exerciseDetail',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('panelVisibility', () => {
+        const e: RecordedEvent = {
+            type: 'panelVisibility', timestamp: ts, panel: 'artemis', visible: true,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('selectionChange — with kind', () => {
+        const e: RecordedEvent = {
+            type: 'selectionChange', timestamp: ts, uri: 'file:///a.ts',
+            selections: [range], kind: 'mouse',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('visibleRangeChange', () => {
+        const e: RecordedEvent = {
+            type: 'visibleRangeChange', timestamp: ts, uri: 'file:///a.ts',
+            visibleRanges: [range],
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('terminalCommand', () => {
+        const e: RecordedEvent = {
+            type: 'terminalCommand', timestamp: ts, command: 'npm test',
+            exitCode: 0, output: 'ok', outputTruncated: false,
+            cwd: '/proj', terminalName: 'zsh', durationMs: 1234,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('terminalOpenClose', () => {
+        const e: RecordedEvent = {
+            type: 'terminalOpenClose', timestamp: ts, action: 'opened', terminalName: 'zsh',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('fileSnapshotError', () => {
+        const e: RecordedEvent = {
+            type: 'fileSnapshotError', timestamp: ts, uri: 'file:///a.ts',
+            reason: 'snapshot-write-failed-after-3-retries',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('fileCreate / fileDelete / textDocumentOpen / textDocumentClose share the simple uri shape', () => {
+        for (const type of ['fileCreate', 'fileDelete', 'textDocumentOpen', 'textDocumentClose'] as const) {
+            const e = { type, timestamp: ts, uri: 'file:///a.ts' } as RecordedEvent;
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        }
+    });
+
+    test('fileRename', () => {
+        const e: RecordedEvent = {
+            type: 'fileRename', timestamp: ts, oldUri: 'file:///a.ts', newUri: 'file:///b.ts',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('testResultsOverviewView — opened arm', () => {
+        const e: RecordedEvent = {
+            type: 'testResultsOverviewView', action: 'opened', timestamp: ts,
+            viewId: 'v1', exerciseId: 7,
+            totalTests: 10, passedTests: 7, failedTests: 3,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('testResultsOverviewView — closed arm', () => {
+        const e: RecordedEvent = {
+            type: 'testResultsOverviewView', action: 'closed', timestamp: ts,
+            viewId: 'v1', exerciseId: 7, durationMs: 500, closeReason: 'escape',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('taskFeedbackView — opened arm', () => {
+        const e: RecordedEvent = {
+            type: 'taskFeedbackView', action: 'opened', timestamp: ts,
+            viewId: 'v1', exerciseId: 7, taskName: 'task A',
+            testIds: [1, 2, 3], totalTests: 3, passedTests: 2, failedTests: 1,
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+
+    test('taskFeedbackView — closed arm', () => {
+        const e: RecordedEvent = {
+            type: 'taskFeedbackView', action: 'closed', timestamp: ts,
+            viewId: 'v1', exerciseId: 7, taskName: 'task A', durationMs: 800,
+            closeReason: 'button',
+        };
+        assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+    });
+});
+
+// ── Per-variant rejection of tricky shapes ─────────────────────────────
+
+suite('parseRecordedEvent — per-variant rejection', () => {
+    const validRange = { startLine: 1, startCharacter: 2, endLine: 3, endCharacter: 4 };
+
+    test('textChange rejects on non-object change entry', () => {
+        const bad = {
+            type: 'textChange', timestamp: ts, uri: 'file:///a.ts',
+            changes: ['not an object'],
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('textChange rejects on malformed range inside change', () => {
+        const bad = {
+            type: 'textChange', timestamp: ts, uri: 'file:///a.ts',
+            changes: [{ range: { startLine: 'x' }, rangeOffset: 0, rangeLength: 0, text: '' }],
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('eqSnapshot rejects unknown confidence literal', () => {
+        const bad = {
+            type: 'eqSnapshot', timestamp: ts, eq: 0.5,
+            confidence: 'maybe', source: 'save',
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('intervention rejects unknown action literal', () => {
+        const bad = {
+            type: 'intervention', timestamp: ts, action: 'wiggled', level: 'subtle',
+            shouldIntervene: true, eq: 0.5, confidence: 'sufficient',
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('consentChange rejects unknown level literal', () => {
+        const bad = { type: 'consentChange', timestamp: ts, level: 'reset' };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('selectionChange rejects unknown kind literal but accepts undefined', () => {
+        const bad = {
+            type: 'selectionChange', timestamp: ts, uri: 'file:///a.ts',
+            selections: [validRange], kind: 'voice',
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('testResultsOverviewView rejects on missing action', () => {
+        const bad = {
+            type: 'testResultsOverviewView', timestamp: ts, viewId: 'v1', exerciseId: 7,
+            totalTests: 10, passedTests: 7, failedTests: 3,
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('testResultsOverviewView rejects on opened arm with missing total counts', () => {
+        const bad = {
+            type: 'testResultsOverviewView', action: 'opened', timestamp: ts,
+            viewId: 'v1', exerciseId: 7,
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('taskFeedbackView rejects on opened arm with non-numeric testIds', () => {
+        const bad = {
+            type: 'taskFeedbackView', action: 'opened', timestamp: ts,
+            viewId: 'v1', exerciseId: 7, taskName: 't',
+            testIds: ['1', '2'], totalTests: 1, passedTests: 1, failedTests: 0,
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('buildResult rejects on non-boolean buildFailed', () => {
+        const bad = {
+            type: 'buildResult', timestamp: ts, successful: false,
+            errorCount: 0, failedTests: [], buildFailed: 0,
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('diagnostics rejects on diagnostic without range', () => {
+        const bad = {
+            type: 'diagnostics', timestamp: ts, uri: 'file:///a.ts',
+            diagnostics: [{ code: 'E1', message: 'x', severity: 1 }],
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('diagnostics rejects diagnostic with present-but-wrong-typed code (regression)', () => {
+        // Pre-fix this slipped through and silently coerced `code` to undefined,
+        // losing the schema failure signal. Now an explicit non-string/non-number
+        // `code` must trip the validator.
+        const bad = {
+            type: 'diagnostics', timestamp: ts, uri: 'file:///a.ts',
+            diagnostics: [{
+                code: { weird: 'object' }, message: 'x', severity: 1,
+                range: validRange, source: 'tsc',
+            }],
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('diagnostics rejects diagnostic with present-but-wrong-typed source (regression)', () => {
+        const bad = {
+            type: 'diagnostics', timestamp: ts, uri: 'file:///a.ts',
+            diagnostics: [{
+                code: 'E1', message: 'x', severity: 1,
+                range: validRange, source: 42,
+            }],
+        };
+        assert.strictEqual(parseRecordedEvent(bad), null);
+    });
+
+    test('diagnostics accepts diagnostic with absent code and source', () => {
+        const e = {
+            type: 'diagnostics', timestamp: ts, uri: 'file:///a.ts',
+            diagnostics: [{ message: 'x', severity: 1, range: validRange }],
+        };
+        const parsed = parseRecordedEvent(clone(e));
+        assert.ok(parsed);
+        assert.strictEqual(parsed.type, 'diagnostics');
+        if (parsed.type === 'diagnostics') {
+            assert.strictEqual(parsed.diagnostics[0].code, undefined);
+            assert.strictEqual(parsed.diagnostics[0].source, undefined);
+        }
+    });
+});
+
+// ── SessionMetadata ────────────────────────────────────────────────────
+
+suite('parseSessionMetadata', () => {
+    test('happy path — all fields including optional', () => {
+        const m: SessionMetadata = {
+            sessionId: 'abc', exerciseId: 7, participantId: 'student-1',
+            startTime: ts, endTime: ts + 1000, eventCount: 42,
+            schemaVersion: 2, recorderVersion: '0.4.4',
+        };
+        assert.deepStrictEqual(parseSessionMetadata(clone(m)), clone(m));
+    });
+
+    test('happy path — endTime null is accepted (session still open)', () => {
+        const m: SessionMetadata = {
+            sessionId: 'abc', exerciseId: 7, participantId: undefined,
+            startTime: ts, endTime: null, eventCount: 0,
+        };
+        assert.deepStrictEqual(parseSessionMetadata(clone(m)), clone(m));
+    });
+
+    test('happy path — endTime undefined also accepted', () => {
+        const data = {
+            sessionId: 'abc', exerciseId: 7, participantId: undefined,
+            startTime: ts, eventCount: 0,
+        };
+        const parsed = parseSessionMetadata(clone(data));
+        assert.ok(parsed);
+        assert.strictEqual(parsed.endTime, undefined);
+    });
+
+    test('rejects non-object', () => {
+        assert.strictEqual(parseSessionMetadata(null), null);
+        assert.strictEqual(parseSessionMetadata('bad'), null);
+        assert.strictEqual(parseSessionMetadata([]), null);
+    });
+
+    test('rejects missing sessionId', () => {
+        const bad = { exerciseId: 7, participantId: 'x', startTime: ts, endTime: null, eventCount: 0 };
+        assert.strictEqual(parseSessionMetadata(bad), null);
+    });
+
+    test('rejects non-numeric exerciseId', () => {
+        const bad = {
+            sessionId: 'a', exerciseId: '7', participantId: undefined,
+            startTime: ts, endTime: null, eventCount: 0,
+        };
+        assert.strictEqual(parseSessionMetadata(bad), null);
+    });
+
+    test('rejects endTime that is neither number nor null nor undefined', () => {
+        const bad = {
+            sessionId: 'a', exerciseId: 7, participantId: undefined,
+            startTime: ts, endTime: 'still running', eventCount: 0,
+        };
+        assert.strictEqual(parseSessionMetadata(bad), null);
+    });
+
+    test('rejects non-finite startTime', () => {
+        const bad = {
+            sessionId: 'a', exerciseId: 7, participantId: undefined,
+            startTime: NaN, endTime: null, eventCount: 0,
+        };
+        assert.strictEqual(parseSessionMetadata(bad), null);
+    });
+});


### PR DESCRIPTION
Refs #183. Part A of 3 — replay-surface validators.

## Background

Issue #183 audited 5 parse boundaries where untyped on-disk / wire data was blindly cast to typed shapes. This PR addresses the two **replay-surface** boundaries:
- `replayCommand.ts:33` — `metadata.json` was cast directly to `SessionMetadata`
- `replayCommand.ts:85` — every line of `events.jsonl` was cast directly to `RecordedEvent`

The remaining 3 boundaries (Iris WebSocket, Iris stage filter, globalState `StoredState`) ship as separate PRs to keep review surface manageable.

## Approach

Per the issue's preference (and confirmed with user), **per-variant strict** validation for `RecordedEvent` rather than light-touch. Each of the 33 event variants in the discriminated union gets its own validator that checks every declared field. Adding a new event variant to `RecordedEvent` requires touching both `recording/types.ts` and `parseRecordedData.ts` — a deliberate review affordance against silent schema drift.

## New file: `extension/src/extension/services/telemetry/recording/parseRecordedData.ts`

- `parseSessionMetadata(data: unknown): SessionMetadata | null`
- `parseRecordedEvent(data: unknown): RecordedEvent | null`
- Type-guard helpers: `isObject`, `isFiniteNumber`, `isString`, `isBoolean`, `isOneOf<T>` for literal-union membership
- Sub-shape parsers: `parseSerializedRange`, `parseSerializedDiagnostic`, `parseSerializedErrorSnapshot`
- `stripUndefined` helper ensures parser output is JSON-roundtrip-clean (matches what `JSON.stringify` would produce — no `key: undefined` entries diverging from on-disk JSONL form)

## Wired up: `replayCommand.ts`

```diff
-    metadata = JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as SessionMetadata;
+    metadata = parseSessionMetadata(JSON.parse(fs.readFileSync(metaPath, 'utf-8')));

-    events.push(JSON.parse(line) as RecordedEvent);
+    const event = parseRecordedEvent(JSON.parse(line));
+    if (event !== null) {
+        events.push(event);
+    }
```

Behavior on malformed input is unchanged from before — the loop already used `try/catch` to skip malformed JSON lines; now lines that JSON-parse but fail the `RecordedEvent` shape (unknown `type`, missing required field, etc.) are also skipped. Without the validator they would have entered the replay pipeline and silently produced bad downstream snapshots.

## Tests: 69 new cases in `parseRecordedData.test.ts`

- **Dispatcher-level rejection** (7): null, array, missing timestamp, missing type, non-finite timestamp, unknown type literal
- **Per-variant happy-path roundtrip** (33): all event types, both arms of the two-step-discriminator view events
- **Per-variant rejection** (14): literal-union enforcement, secondary discriminator on view events, nested arrays, missing required fields, present-but-wrong-typed diagnostic `code` and `source`
- **`parseSessionMetadata`** (8): all-fields happy, endTime null accepted, endTime undefined accepted, rejection on non-object / missing fields / wrong types

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:unit`: 904 tests, 0 failures, 3 skipped (was 835; +69 new tests in this PR)
- `npm run test:react`: 720/720 pass

## Codex review (caught one real bug pre-merge)

`parseSerializedDiagnostic` was silently coercing present-but-wrong-typed `code` (e.g. an object) to `undefined`, hiding schema failures — the exact behavior the issue called out as the reason for adding validation. Fixed: present-but-invalid `code` or `source` now reject explicitly (absent is still allowed since the declared type is `string | number | undefined`). Three regression tests added.

Second round: explicit approval.

## Manual test checklist

- [ ] Replay a known-good recording — events still appear correctly in the EQ-snapshot output.
- [ ] Replay against a recording with a corrupted line — that line is silently skipped, others process correctly.
- [ ] Replay against a session where `metadata.json` is missing or corrupt — the picker still lists the session with "unknown date / unknown exercise" labels (current behavior preserved).
