### PR TITLE
feat(extension): light-touch validation at Iris WebSocket boundary (#183 part B)

### DIFF
--- a/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
+++ b/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
@@ -5,8 +5,9 @@ import { ExtensionMsg } from '@shared/messageContracts';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
-import type { IrisChatMessage, IrisStageDTO } from '@extension/types';
+import type { IrisChatMessage } from '@extension/types';
 
+import { isVisibleIrisStage } from '../parseIrisWs';
 import { IrisWebSocketSessionClient } from '../transport/irisWebSocketSessionClient';
 import { extractIrisMessageContent } from './messageUtils';
 
@@ -91,10 +92,7 @@ export class IrisWebSocketMessageHandler {
         } else if (data.type === 'STATUS') {
             const rawStages = data['stages'];
             if (Array.isArray(rawStages)) {
-                const visibleStages = (rawStages as unknown[]).filter(
-                    (stage): stage is IrisStageDTO =>
-                        typeof stage === 'object' && stage !== null && (stage as IrisStageDTO).internal !== true
-                );
+                const visibleStages = (rawStages as unknown[]).filter(isVisibleIrisStage);
                 logger.info(`Iris status update: ${visibleStages.length} visible stage(s)`, LogCategory.WEBSOCKET);
                 this._postMessage({
                     type: ExtensionMsg.UpdateIrisStages,

--- a/extension/src/extension/services/iris/parseIrisWs.ts
+++ b/extension/src/extension/services/iris/parseIrisWs.ts
@@ -1,0 +1,50 @@
+/**
+ * Light-touch runtime guards for Iris WebSocket payloads (#183 part B).
+ *
+ * Deliberately less strict than the replay-surface parsers in
+ * `recording/parseRecordedData.ts`: live WS frames go straight into the
+ * UI (chat panel, status indicator), so a wrong-shaped frame just causes
+ * a missing render — there's no downstream replay aggregation to corrupt.
+ * The guards therefore check the minimum needed to safely call the
+ * payload an `IrisWebSocketMessage` / `IrisStageDTO`:
+ *   - object shape (not null, not array, not primitive)
+ *   - the one field the consumer actually reads to gate behaviour
+ *     (`internal` for stages)
+ *
+ * Everything else stays as a permissive `[key: string]: unknown` lookup
+ * at the call site — matching how live WS data is consumed elsewhere.
+ */
+
+import type { IrisChatMessage, IrisStageDTO } from '@extension/types';
+
+/**
+ * Minimal structural shape of an incoming Iris WebSocket frame. Exported
+ * so listeners can rely on it without a separate cast after the guard.
+ */
+export type IrisWebSocketMessage = Record<string, unknown> & {
+    type?: string;
+    message?: IrisChatMessage;
+};
+
+/**
+ * True if `data` looks like an object IrisWebSocketMessage payload — i.e.
+ * non-null, non-array, non-primitive. Per-key shape (`type`, `message`,
+ * etc.) is still permissive and validated downstream by the handler.
+ */
+export function isIrisWebSocketMessage(data: unknown): data is IrisWebSocketMessage {
+    return data !== null && typeof data === 'object' && !Array.isArray(data);
+}
+
+/**
+ * True if `stage` is a plain object whose `internal` flag is not `true`.
+ * This is exactly the predicate the STATUS handler uses to decide whether
+ * to surface a stage in the UI — extracting it removes the inline `as
+ * IrisStageDTO` cast from `irisWebSocketMessageHandler.ts` while keeping
+ * the gating semantics identical.
+ */
+export function isVisibleIrisStage(stage: unknown): stage is IrisStageDTO {
+    if (stage === null || typeof stage !== 'object' || Array.isArray(stage)) {
+        return false;
+    }
+    return (stage as { internal?: unknown }).internal !== true;
+}

--- a/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
+++ b/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
@@ -3,16 +3,10 @@ import * as vscode from 'vscode';
 import { ArtemisApiService } from '@extension/api';
 import { logger, LogLevel } from '@extension/services/loggingService';
 import { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
-import { ActiveContext, type IrisChatMessage } from '@extension/types';
+import { ActiveContext } from '@extension/types';
 
 import { contextToIrisMode } from '../context/contextChatMode';
-
-/** WebSocket message structure for Iris chat */
-interface IrisWebSocketMessage {
-    type?: string;
-    message?: IrisChatMessage;
-    [key: string]: unknown;
-}
+import { type IrisWebSocketMessage, isIrisWebSocketMessage } from '../parseIrisWs';
 
 /**
  * Minimum interval between resubscription attempts (milliseconds).
@@ -169,7 +163,15 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
     }
 
     private _handleWebSocketMessage(data: unknown): void {
-        this._onDidReceiveMessage.fire(data as IrisWebSocketMessage);
+        // Light-touch guard: reject primitives / null / arrays before the
+        // listeners assume the IrisWebSocketMessage object shape. Per-message
+        // narrowing (e.g. type === 'MESSAGE' && has-message) happens
+        // downstream in IrisWebSocketMessageHandler.
+        if (!isIrisWebSocketMessage(data)) {
+            logger.session(`Discarded non-object WebSocket payload: ${typeof data}`);
+            return;
+        }
+        this._onDidReceiveMessage.fire(data);
     }
 
     /**

--- a/extension/test/unit/services/iris/parseIrisWs.test.ts
+++ b/extension/test/unit/services/iris/parseIrisWs.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the light-touch Iris WS guards (#183 part B).
+ *
+ * Light-touch means: reject obvious shape failures (null, arrays, primitives)
+ * but trust the type interface for per-field details. The downstream handler
+ * (`IrisWebSocketMessageHandler.handleIrisWebSocketMessage`) performs the
+ * per-message narrowing.
+ */
+
+import * as assert from 'assert';
+
+import { isIrisWebSocketMessage, isVisibleIrisStage } from '@extension/services/iris/parseIrisWs';
+
+suite('isIrisWebSocketMessage', () => {
+    test('accepts a plain object', () => {
+        assert.strictEqual(isIrisWebSocketMessage({ type: 'MESSAGE' }), true);
+    });
+
+    test('accepts an empty object', () => {
+        assert.strictEqual(isIrisWebSocketMessage({}), true);
+    });
+
+    test('rejects null', () => {
+        assert.strictEqual(isIrisWebSocketMessage(null), false);
+    });
+
+    test('rejects undefined', () => {
+        assert.strictEqual(isIrisWebSocketMessage(undefined), false);
+    });
+
+    test('rejects arrays', () => {
+        assert.strictEqual(isIrisWebSocketMessage([{ type: 'MESSAGE' }]), false);
+    });
+
+    test('rejects primitives', () => {
+        assert.strictEqual(isIrisWebSocketMessage('STATUS'), false);
+        assert.strictEqual(isIrisWebSocketMessage(42), false);
+        assert.strictEqual(isIrisWebSocketMessage(true), false);
+    });
+});
+
+suite('isVisibleIrisStage', () => {
+    test('accepts an object without an internal flag (default-visible)', () => {
+        assert.strictEqual(isVisibleIrisStage({ name: 'Compile', state: 'DONE' }), true);
+    });
+
+    test('accepts an object with internal: false', () => {
+        assert.strictEqual(isVisibleIrisStage({ name: 'Compile', internal: false }), true);
+    });
+
+    test('rejects an object with internal: true', () => {
+        assert.strictEqual(isVisibleIrisStage({ name: 'Bookkeeping', internal: true }), false);
+    });
+
+    test('accepts an object with truthy-but-not-true internal value', () => {
+        // Production code checks `internal !== true`. Anything other than
+        // literal `true` (including 1, 'yes', objects) means "visible".
+        // Documenting this here so the guard's lenient semantic is intentional.
+        assert.strictEqual(isVisibleIrisStage({ internal: 1 }), true);
+        assert.strictEqual(isVisibleIrisStage({ internal: 'yes' }), true);
+    });
+
+    test('rejects null', () => {
+        assert.strictEqual(isVisibleIrisStage(null), false);
+    });
+
+    test('rejects arrays', () => {
+        assert.strictEqual(isVisibleIrisStage([]), false);
+    });
+
+    test('rejects primitives', () => {
+        assert.strictEqual(isVisibleIrisStage('Compile'), false);
+        assert.strictEqual(isVisibleIrisStage(0), false);
+    });
+});


### PR DESCRIPTION
Refs #183. Part B of 3 — Iris WebSocket surface.

## Approach

After PR A (#192) shipped per-variant strict validation for the replay surface (1500 LOC), the user pushed back that the rigor was overkill for a dev-only path. Part B applies the lighter approach for live WebSocket payloads: reject obvious shape failures (null / array / primitive), trust the per-message narrowing the downstream handler already does.

Net diff: **+139 / -14** across 4 files.

## Change

### New file: `extension/src/extension/services/iris/parseIrisWs.ts` (~35 LOC)

```ts
export type IrisWebSocketMessage = Record<string, unknown> & {
    type?: string;
    message?: IrisChatMessage;
};

export function isIrisWebSocketMessage(data: unknown): data is IrisWebSocketMessage {
    return data !== null && typeof data === 'object' && !Array.isArray(data);
}

export function isVisibleIrisStage(stage: unknown): stage is IrisStageDTO {
    if (stage === null || typeof stage !== 'object' || Array.isArray(stage)) {
        return false;
    }
    return (stage as { internal?: unknown }).internal !== true;
}
```

### Wired up

- **`irisWebSocketSessionClient.ts:172`** — previously fired `data as IrisWebSocketMessage` blindly. Now rejects non-object payloads with a debug log; the type predicate eliminates the post-check cast on `.fire()`. The local `IrisWebSocketMessage` interface duplicate is removed in favour of the exported one.
- **`irisWebSocketMessageHandler.ts:94-97`** — the inline filter on STATUS stages now uses `isVisibleIrisStage` directly, dropping the inline `as IrisStageDTO` cast.

### Tests

13 new cases covering happy paths, rejection (null, array, primitive), and the permissive-`internal` semantic (`internal: 1` / `'yes'` still treated as visible, matching pre-fix behaviour).

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:unit`: 917 tests, 0 failures, 3 skipped (was 904; +13 new tests in this PR)

## Codex review

Caught one **pre-existing fragility** outside this PR's scope: `extractIrisMessageContent(undefined)` returns `undefined` (via `JSON.stringify(undefined)`), then `content.length` crashes the message handler. Filed as #193 for separate fix.

Two improvements applied from codex feedback:
- Made `isIrisWebSocketMessage` a proper type predicate so the post-check cast on `.fire()` could be dropped.
- Exported `IrisWebSocketMessage` from the new file so the duplicate local interface in `irisWebSocketSessionClient.ts` could be deleted.

Second round: explicit approval.

## Manual test checklist

- [ ] Send a regular Iris chat message — assistant reply still appears (no regression on the happy path).
- [ ] Iris STATUS stages still filter `internal: true` ones out of the UI.
- [ ] If logs are visible, malformed primitive WS payloads now show a "Discarded non-object WebSocket payload" entry.
