### PR TITLE
feat(extension): light-touch validation at globalState parse boundary (#183 part C)

### DIFF
--- a/extension/src/extension/services/iris/context/contextPersistence.ts
+++ b/extension/src/extension/services/iris/context/contextPersistence.ts
@@ -10,6 +10,39 @@ const STORE_VERSION = 2;
 
 type LegacyItem = Record<string, unknown> & { id?: unknown; lastViewed?: unknown };
 
+/**
+ * Light-touch runtime guard for a v2 `StoredState` read out of `globalState`
+ * (#183 part C). Validates the top-level shape — version, expected field
+ * presence, basic types — but trusts per-element contents of the
+ * `exercises` / `courses` / `sessions` collections. The migrate path is
+ * the only place per-item validation matters; runtime corruption of an
+ * already-v2 store is exceedingly unlikely (own-process writes only) so
+ * the cost/benefit of strict per-item validation here is not worth it.
+ *
+ * Returns `null` on shape failure so `load()` can fall back to
+ * `defaultState()` rather than crash on a malformed persisted value.
+ */
+export function parseStoredState(data: unknown): StoredState | null {
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) { return null; }
+    const d = data as Record<string, unknown>;
+    if (typeof d.version !== 'number' || !Number.isFinite(d.version)) { return null; }
+    if (d.activeContext !== null && (typeof d.activeContext !== 'object' || Array.isArray(d.activeContext))) {
+        return null;
+    }
+    if (d.activeSessionId !== null && typeof d.activeSessionId !== 'string') { return null; }
+    if (!Array.isArray(d.exercises)) { return null; }
+    if (!Array.isArray(d.courses)) { return null; }
+    if (d.sessions === null || typeof d.sessions !== 'object' || Array.isArray(d.sessions)) { return null; }
+    return {
+        version: d.version,
+        activeContext: d.activeContext as StoredState['activeContext'],
+        activeSessionId: d.activeSessionId as string | null,
+        exercises: d.exercises as TrackedExercise[],
+        courses: d.courses as TrackedCourse[],
+        sessions: d.sessions as StoredState['sessions'],
+    };
+}
+
 export class ContextPersistence {
     constructor(private readonly _context: vscode.ExtensionContext) {}
 
@@ -22,7 +55,14 @@ export class ContextPersistence {
                 (err: unknown) => logger.error('Failed to persist v2 migration', undefined, err));
             return migrated;
         }
-        const valid = raw as unknown as StoredState;
+        const valid = parseStoredState(raw);
+        if (!valid) {
+            // Persisted store had the correct version but was structurally
+            // malformed (manual edit, corruption). Fall back to a clean
+            // default rather than crash on `undefined.exercises` downstream.
+            logger.error('Malformed iris.contextStore — falling back to default state');
+            return this.defaultState();
+        }
         return { ...valid, sessions: {}, activeSessionId: null };
     }
 

--- a/extension/test/unit/services/iris/context/parseStoredState.test.ts
+++ b/extension/test/unit/services/iris/context/parseStoredState.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for parseStoredState (#183 part C — light-touch validation
+ * at the globalState parse boundary).
+ *
+ * The store is written and read by the same process so corruption is
+ * unlikely; the guard's job is to handle the manual-edit / version-skew
+ * case gracefully rather than crashing on `undefined.exercises`.
+ */
+
+import * as assert from 'assert';
+import type * as vscode from 'vscode';
+
+import { ContextPersistence, parseStoredState } from '@extension/services/iris/context/contextPersistence';
+import type { StoredState } from '@extension/services/iris/context/contextStateTypes';
+
+const minimal: StoredState = {
+    version: 2,
+    activeContext: null,
+    activeSessionId: null,
+    exercises: [],
+    courses: [],
+    sessions: {},
+};
+
+suite('parseStoredState — happy paths', () => {
+    test('minimal valid v2 store roundtrips', () => {
+        assert.deepStrictEqual(parseStoredState(minimal), minimal);
+    });
+
+    test('populated store with activeContext + tracked items', () => {
+        const populated: StoredState = {
+            version: 2,
+            activeContext: {
+                type: 'exercise', id: 7, title: 'Ex 7',
+                source: 'workspace-detected', locked: false, selectedAt: 1700000000000,
+            },
+            activeSessionId: 'sess-1',
+            exercises: [{ id: 7, title: 'Ex 7' }],
+            courses: [{ id: 1, title: 'C1' }],
+            sessions: { 'exercise:7': [] },
+        };
+        assert.deepStrictEqual(parseStoredState(populated), populated);
+    });
+});
+
+suite('parseStoredState — top-level shape rejection', () => {
+    test('rejects null', () => {
+        assert.strictEqual(parseStoredState(null), null);
+    });
+
+    test('rejects undefined', () => {
+        assert.strictEqual(parseStoredState(undefined), null);
+    });
+
+    test('rejects primitives', () => {
+        assert.strictEqual(parseStoredState('v2'), null);
+        assert.strictEqual(parseStoredState(2), null);
+    });
+
+    test('rejects arrays', () => {
+        assert.strictEqual(parseStoredState([]), null);
+    });
+});
+
+suite('parseStoredState — per-field rejection', () => {
+    test('rejects missing version', () => {
+        const bad = { ...minimal, version: undefined };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects non-numeric version', () => {
+        const bad = { ...minimal, version: '2' };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects non-finite version', () => {
+        const bad = { ...minimal, version: NaN };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects activeContext that is an array (not object | null)', () => {
+        const bad = { ...minimal, activeContext: [] };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects activeContext that is a string (not object | null)', () => {
+        const bad = { ...minimal, activeContext: 'exercise:7' };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('accepts activeContext: null', () => {
+        const parsed = parseStoredState({ ...minimal, activeContext: null });
+        assert.ok(parsed);
+        assert.strictEqual(parsed.activeContext, null);
+    });
+
+    test('rejects activeSessionId that is a number', () => {
+        const bad = { ...minimal, activeSessionId: 42 };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('accepts activeSessionId: null', () => {
+        const parsed = parseStoredState({ ...minimal, activeSessionId: null });
+        assert.ok(parsed);
+        assert.strictEqual(parsed.activeSessionId, null);
+    });
+
+    test('rejects exercises that is not an array', () => {
+        const bad = { ...minimal, exercises: {} };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects courses that is not an array', () => {
+        const bad = { ...minimal, courses: 'all of them' };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects sessions that is not an object', () => {
+        const bad = { ...minimal, sessions: [] };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+
+    test('rejects sessions that is null', () => {
+        const bad = { ...minimal, sessions: null };
+        assert.strictEqual(parseStoredState(bad), null);
+    });
+});
+
+// ── Integration-shaped: load() falls back to defaultState on bad shape ──
+
+/**
+ * Minimal ExtensionContext fake exposing only the `globalState.get/update`
+ * surface that ContextPersistence reaches into. Returns whatever value the
+ * test seeds in, so we can simulate corrupted persistence.
+ */
+function makeContextWithStoredValue(value: unknown): vscode.ExtensionContext {
+    const fake = {
+        globalState: {
+            get: () => value,
+            update: () => Promise.resolve(),
+        },
+    };
+    return fake as unknown as vscode.ExtensionContext;
+}
+
+suite('ContextPersistence.load — fallback behaviour', () => {
+    test('falls back to defaultState when persisted value is structurally malformed', () => {
+        // version === 2 hits the parseStoredState path; an array is rejected
+        // as the top-level shape, so load() must return defaultState() rather
+        // than crash on undefined.exercises downstream.
+        const cp = new ContextPersistence(makeContextWithStoredValue({
+            version: 2, exercises: 'not-an-array',
+        }));
+        const result = cp.load();
+        assert.deepStrictEqual(result, {
+            version: 2,
+            activeContext: null,
+            activeSessionId: null,
+            exercises: [],
+            courses: [],
+            sessions: {},
+        });
+    });
+
+    test('returns the loaded state when persisted value is a valid v2 store', () => {
+        // Seed non-null sessions / activeSessionId so the assertion that load()
+        // clears them can actually distinguish "cleared" from "already empty".
+        const cp = new ContextPersistence(makeContextWithStoredValue({
+            version: 2,
+            activeContext: null,
+            activeSessionId: 'sess-1',
+            exercises: [{ id: 7, title: 'Ex 7' }],
+            courses: [{ id: 1, title: 'C1' }],
+            sessions: { 'exercise:7': [{ id: 'sess-1' }] },
+        }));
+        const result = cp.load();
+        assert.deepStrictEqual(result.exercises, [{ id: 7, title: 'Ex 7' }]);
+        assert.deepStrictEqual(result.courses, [{ id: 1, title: 'C1' }]);
+        // load() clears sessions / activeSessionId on every call regardless
+        // of the persisted value. With non-null seeds above, this assertion
+        // proves the clearing behaviour (not just that it stayed empty).
+        assert.deepStrictEqual(result.sessions, {});
+        assert.strictEqual(result.activeSessionId, null);
+    });
+});
+
+suite('parseStoredState — trust on inner items (light-touch contract)', () => {
+    // Deliberate: the guard does NOT validate per-element TrackedExercise /
+    // TrackedCourse / StoredSession shape. The store is written and read by
+    // the same process, so the only realistic failure is top-level
+    // structural corruption. Documenting the contract here.
+
+    test('accepts exercises with arbitrary item shape (trust)', () => {
+        const bad = {
+            ...minimal,
+            exercises: [{ id: 'not-a-number', title: undefined } as unknown],
+        };
+        const parsed = parseStoredState(bad);
+        assert.ok(parsed, 'light-touch guard accepts malformed inner items');
+    });
+
+    test('accepts sessions with arbitrary value shape (trust)', () => {
+        const bad = { ...minimal, sessions: { foo: 'not an array' as unknown } };
+        const parsed = parseStoredState(bad);
+        assert.ok(parsed, 'light-touch guard accepts malformed inner items');
+    });
+});


### PR DESCRIPTION
Closes #183.

Final part (C) of the runtime-validation series — light-touch validation at the `iris.contextStore` globalState parse boundary. Closes the issue.

## Approach

Same light-touch contract as part B (PR #194): validate top-level shape only, trust per-element contents of inner collections. The store is written and read by the same process, so realistic failures are limited to manual-edit / version-skew / corruption at the structural level — not per-item drift.

Net diff: **+248 / -1** across 2 files.

## Change

### `contextPersistence.ts`

Added an exported `parseStoredState(data: unknown): StoredState | null`:

- top-level is non-null, object, non-array
- `version` is a finite number
- `activeContext` is null or object (not array)
- `activeSessionId` is null or string
- `exercises` and `courses` are arrays — per-element content NOT validated
- `sessions` is an object — per-key value NOT validated

`load()` now uses the validator. On `null` return, logs the malformed-store error and falls back to `defaultState()` instead of crashing downstream on `undefined.exercises`.

The migrate path is untouched — it already has the `_unionAndStrip` field-level filtering, and tightening it would expand the scope to "v1 schema validation".

### Tests: 22 new cases

- **2 happy paths**: minimal valid store + populated with activeContext / tracked items.
- **4 top-level rejection cases**: null, undefined, primitives, arrays.
- **14 per-field rejection cases**: version, activeContext, activeSessionId, exercises, courses, sessions — accept-null variants for the nullable ones.
- **2 integration tests** via a minimal `ExtensionContext` fake:
  - Corrupted-store fallback: persisted v2 with `exercises: 'not-an-array'` → `load()` returns `defaultState()`
  - Valid-store load + clear: seeded non-null `sessions` and `activeSessionId` so the always-clear-on-load assertion actually distinguishes "cleared" from "already empty"
- **2 trust-contract documentation** cases for inner items.

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run test:unit`: 939 tests, 0 failures, 3 skipped (was 917; +22 in this PR)

## Codex review

Two suggestions applied:
- `as Record<string, never[]>` → `as StoredState['sessions']` for clarity (the field type already declares the right shape).
- Strengthen the valid-load integration test to seed non-null sessions / activeSessionId so the "clearing" assertion proves the behaviour.

Second round: explicit approval.

## #183 series recap

- **PR #192 (part A — replay surface)**: per-variant strict, 1500 LOC. Caught one real bug (parseSerializedDiagnostic silent-coerce). In hindsight, light-touch would have been the right call — see PR #192 discussion for the postmortem.
- **PR #194 (part B — Iris WebSocket surface)**: light-touch, ~140 LOC. Caught a pre-existing bug in `extractIrisMessageContent` (filed as #193 for separate fix).
- **PR #195 (part C, this PR — globalState boundary)**: light-touch, ~250 LOC. Closes #183.

## Manual test checklist

- [ ] Existing Iris context store loads correctly (no regression on the happy path).
- [ ] Corrupted iris.contextStore in globalState falls back to defaults; the error is logged.
- [ ] Sessions / activeSessionId always cleared on load (as before this PR).
