### PR TITLE
fix(iris): make extractIrisMessageContent total to avoid WS handler crash (#193)

### DIFF
--- a/extension/src/extension/services/iris/chat/messageUtils.ts
+++ b/extension/src/extension/services/iris/chat/messageUtils.ts
@@ -1,7 +1,20 @@
 import type { IrisChatMessageContent } from '@extension/types';
 
+/**
+ * Normalise an Iris message `content` field into a plain string suitable
+ * for the chat surface and persistence. Artemis ships the field as either
+ * a string, an array of `{ textContent }` parts, or a missing/null value.
+ *
+ * Returns `''` for `null`/`undefined`. The previous implementation called
+ * `JSON.stringify` unconditionally, which returns the *value* `undefined`
+ * (not the string `'undefined'`) for an `undefined` input. Callers then
+ * read `.length` on the result and crashed. See #193.
+ */
 export function extractIrisMessageContent(content: unknown): string {
-    if (content && Array.isArray(content) && content.length > 0) {
+    if (content === null || content === undefined) {
+        return '';
+    }
+    if (Array.isArray(content) && content.length > 0) {
         return content.map((item: IrisChatMessageContent) => {
             if (item.textContent) {
                 return item.textContent;
@@ -12,5 +25,5 @@ export function extractIrisMessageContent(content: unknown): string {
     if (typeof content === 'string') {
         return content;
     }
-    return JSON.stringify(content);
+    return JSON.stringify(content) ?? '';
 }

--- a/extension/src/extension/services/iris/context/sessionSyncUtils.ts
+++ b/extension/src/extension/services/iris/context/sessionSyncUtils.ts
@@ -106,7 +106,7 @@ export function importSessionsToStore(
             const firstUserMsg = session.messages.find((m: IrisChatMessage) => m.sender === 'USER');
             if (firstUserMsg) {
                 const content = extractIrisMessageContent(firstUserMsg.content);
-                if (content && content !== 'undefined' && content !== 'null') {
+                if (content) {
                     preview = content.substring(0, 50);
                 }
             }

--- a/extension/test/unit/services/iris/chat/messageUtils.test.ts
+++ b/extension/test/unit/services/iris/chat/messageUtils.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for `extractIrisMessageContent` (#193 fix). With null/undefined
+ * inputs the function previously returned the *value* `undefined` from
+ * `JSON.stringify`, which then crashed `IrisWebSocketMessageHandler` on
+ * `content.length`.
+ */
+
+import * as assert from 'assert';
+
+import { extractIrisMessageContent } from '@extension/services/iris/chat/messageUtils';
+
+suite('extractIrisMessageContent: null / undefined (regression #193)', () => {
+    test('returns empty string for undefined', () => {
+        assert.strictEqual(extractIrisMessageContent(undefined), '');
+    });
+
+    test('returns empty string for null', () => {
+        assert.strictEqual(extractIrisMessageContent(null), '');
+    });
+
+    test('result is always a string (type-honest)', () => {
+        // The declared return type is `string`; verify it for the inputs
+        // that previously violated the contract.
+        assert.strictEqual(typeof extractIrisMessageContent(undefined), 'string');
+        assert.strictEqual(typeof extractIrisMessageContent(null), 'string');
+    });
+});
+
+suite('extractIrisMessageContent: string inputs', () => {
+    test('passes through plain strings unchanged', () => {
+        assert.strictEqual(extractIrisMessageContent('hello'), 'hello');
+    });
+
+    test('passes through empty string unchanged', () => {
+        assert.strictEqual(extractIrisMessageContent(''), '');
+    });
+});
+
+suite('extractIrisMessageContent: array of content parts', () => {
+    test('joins textContent fields with newline', () => {
+        const parts = [{ textContent: 'first' }, { textContent: 'second' }];
+        assert.strictEqual(extractIrisMessageContent(parts), 'first\nsecond');
+    });
+
+    test('single textContent part', () => {
+        assert.strictEqual(extractIrisMessageContent([{ textContent: 'only' }]), 'only');
+    });
+
+    test('part without textContent falls back to String(item)', () => {
+        // Items without textContent and without a custom toString collapse
+        // to the default `[object Object]` rendering. Not pretty, but the
+        // function must not crash and must still return a string.
+        const out = extractIrisMessageContent([{}]);
+        assert.strictEqual(typeof out, 'string');
+        assert.ok(out.length > 0);
+    });
+
+    test('empty array falls through to JSON.stringify', () => {
+        // Pre-existing behaviour: empty array does not match the
+        // length > 0 branch and serializes to `'[]'`. Documenting here
+        // so a future refactor noticing it knows the call sites have
+        // tolerated this for the entire history of the function.
+        assert.strictEqual(extractIrisMessageContent([]), '[]');
+    });
+});
+
+suite('extractIrisMessageContent: other inputs (defensive)', () => {
+    test('object input serializes via JSON.stringify', () => {
+        assert.strictEqual(extractIrisMessageContent({ a: 1 }), '{"a":1}');
+    });
+
+    test('number input serializes via JSON.stringify', () => {
+        assert.strictEqual(extractIrisMessageContent(42), '42');
+    });
+});


### PR DESCRIPTION
Closes #193.

## Problem

`extractIrisMessageContent(undefined)` used to return the *value* `undefined` (not the string `'undefined'`) because `JSON.stringify(undefined) === undefined`. The function's declared return type was `string`. Downstream, `IrisWebSocketMessageHandler.handleIrisWebSocketMessage` then read `content.length` and crashed the WS handler on payloads shaped like `{ type: 'MESSAGE', message: {} }` (i.e. the `message` object is present but the `content` field is missing).

The pre-existing defensive check `content !== 'undefined' && content !== 'null'` in `sessionSyncUtils.ts:109` is the smoking gun: a previous author had observed the bug locally and patched it at *one* call site only.

## Fix

Make the helper total:

```ts
if (content === null || content === undefined) {
    return '';
}
// ... existing string / array branches ...
return JSON.stringify(content) ?? '';
```

The catch-all `?? ''` also covers functions and symbols, both of which return `undefined` from `JSON.stringify`. (BigInt and circular objects throw rather than return undefined; out of scope for the crash fix.)

## Cleanup

The defensive checks in `sessionSyncUtils.ts` that paper-covered this exact bug are now dead. Dropped them and reduced the branch to `if (content) { ... }`.

## Tests

11 new test cases in `extension/test/unit/services/iris/chat/messageUtils.test.ts`:
- null/undefined regression (the actual #193 crash inputs)
- type-honesty check (return type is always `string`)
- string / empty string passthrough
- array-of-content-parts joining (textContent and toString fallback)
- empty array pre-existing behaviour pinned (`'[]'`)
- object / number catch-all inputs

950 unit tests pass, lint clean.

## Review

Reviewed by codex over one turn. Sign-off: *"No blocking concerns for issue #193. I'd approve the fix as-is."*

## Surfaced by

Codex review during PR #194 (Iris WebSocket runtime guards, #183B).