### PR TITLE
fix(test:ui): unblock UI tests by suppressing VS Code Copilot welcome modal (#176)

### DIFF
--- a/extension/.env.example
+++ b/extension/.env.example
@@ -1,9 +1,17 @@
-# Credentials for credential-gated UI tests (`npm run test:ui`).
+# Configuration for credential-gated UI tests (`npm run test:ui`).
 #
 # Copy this file to `.env` (which is gitignored) and fill in real values to
 # enable the suites that need an authenticated Artemis session. Without
 # these, those suites skip cleanly; the ungated suites still run.
 #
 # Loaded by `test/e2e/ui/run-tests.sh` via `set -a; source .env; set +a`.
+
+# Credentials (required to actually run credential-gated suites)
 ARTEMIS_USER=
 ARTEMIS_PASS=
+
+# Optional: override the Artemis server URL. Default when unset is the value
+# of the `artemis.serverUrl` VS Code setting (which defaults to
+# https://artemis.tum.de). Set this to point UI tests at a TUM test server:
+#   ARTEMIS_URL=https://artemis-test4.artemis.cit.tum.de
+# Known servers: artemis-test1..6, artemis-test9.artemis.cit.tum.de.

--- a/extension/.env.example
+++ b/extension/.env.example
@@ -1,0 +1,9 @@
+# Credentials for credential-gated UI tests (`npm run test:ui`).
+#
+# Copy this file to `.env` (which is gitignored) and fill in real values to
+# enable the suites that need an authenticated Artemis session. Without
+# these, those suites skip cleanly; the ungated suites still run.
+#
+# Loaded by `test/e2e/ui/run-tests.sh` via `set -a; source .env; set +a`.
+ARTEMIS_USER=
+ARTEMIS_PASS=

--- a/extension/test/e2e/ui/code-settings.json
+++ b/extension/test/e2e/ui/code-settings.json
@@ -1,0 +1,14 @@
+{
+    "workbench.welcomePage.experimentalOnboarding": false,
+    "chat.disableAIFeatures": true,
+    "chat.commandCenter.enabled": false,
+    "workbench.startupEditor": "none",
+    "workbench.welcomePage.walkthroughs.openOnInstall": false,
+    "workbench.tips.enabled": false,
+    "update.showReleaseNotes": false,
+    "extensions.autoCheckUpdates": false,
+    "extensions.autoUpdate": false,
+    "telemetry.telemetryLevel": "off",
+    "security.workspace.trust.enabled": false,
+    "git.openRepositoryInParentFolders": "never"
+}

--- a/extension/test/e2e/ui/course-detail.ui.test.ts
+++ b/extension/test/e2e/ui/course-detail.ui.test.ts
@@ -33,6 +33,10 @@ describe('CourseDetail View UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/course-detail.ui.test.ts
+++ b/extension/test/e2e/ui/course-detail.ui.test.ts
@@ -1,11 +1,12 @@
 // Covers E2EV-04: CourseDetail view smoke test
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
     performLogin,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -33,14 +34,8 @@ describe('CourseDetail View UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/course-list.ui.test.ts
+++ b/extension/test/e2e/ui/course-list.ui.test.ts
@@ -1,11 +1,12 @@
 // Covers E2EV-03: CourseList view smoke test
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
     performLogin,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -33,14 +34,8 @@ describe('CourseList View UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/course-list.ui.test.ts
+++ b/extension/test/e2e/ui/course-list.ui.test.ts
@@ -33,6 +33,10 @@ describe('CourseList View UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/dashboard.ui.test.ts
+++ b/extension/test/e2e/ui/dashboard.ui.test.ts
@@ -33,6 +33,10 @@ describe('Dashboard View UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/dashboard.ui.test.ts
+++ b/extension/test/e2e/ui/dashboard.ui.test.ts
@@ -1,11 +1,12 @@
 // Covers E2EV-02: Dashboard view smoke test
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
     performLogin,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -33,14 +34,8 @@ describe('Dashboard View UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/exercise-detail.ui.test.ts
+++ b/extension/test/e2e/ui/exercise-detail.ui.test.ts
@@ -1,11 +1,12 @@
 // Covers E2EV-05: ExerciseDetail view smoke test
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
     performLogin,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -33,14 +34,8 @@ describe('ExerciseDetail View UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/exercise-detail.ui.test.ts
+++ b/extension/test/e2e/ui/exercise-detail.ui.test.ts
@@ -33,6 +33,10 @@ describe('ExerciseDetail View UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/exercise-submission.ui.test.ts
+++ b/extension/test/e2e/ui/exercise-submission.ui.test.ts
@@ -1,11 +1,12 @@
 // Covers E2EX-02: Exercise submission interaction test
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
     performLogin,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -41,14 +42,8 @@ describe('Exercise Submission Flow UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/exercise-submission.ui.test.ts
+++ b/extension/test/e2e/ui/exercise-submission.ui.test.ts
@@ -41,6 +41,10 @@ describe('Exercise Submission Flow UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/helpers.ts
+++ b/extension/test/e2e/ui/helpers.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ActivityBar, By, SideBarView, until, VSBrowser, WebDriver, WebviewView } from 'vscode-extension-tester';
+import { ActivityBar, By, SideBarView, until, VSBrowser, WebDriver, WebviewView, Workbench } from 'vscode-extension-tester';
 
 // Resolve to the source tree screenshots dir (not the out/ compiled dir)
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
@@ -143,4 +143,19 @@ export async function runAxeInCurrentFrame(
 		  .catch(function(e) { done({ violations: [], error: e.message }); });
 	`);
 	return results as { violations: Array<{ id: string; impact: string; description: string; nodes: unknown[] }> };
+}
+
+/**
+ * Best-effort cleanup for `after()` hooks of credential-gated UI suites.
+ * No-op when `driver` is undefined — covers the case where `before()`
+ * skipped the suite (missing credentials) and never assigned `driver`,
+ * which would otherwise crash the after-hook with
+ * `Cannot read properties of undefined (reading 'sleep')` and mask the
+ * intended skip as a real failure. See #176.
+ */
+export async function safeLogoutAndCleanup(driver: WebDriver | undefined): Promise<void> {
+	if (!driver) { return; }
+	const workbench = new Workbench();
+	await workbench.executeCommand('Logout from Artemis');
+	await driver.sleep(2000);
 }

--- a/extension/test/e2e/ui/login-flow.ui.test.ts
+++ b/extension/test/e2e/ui/login-flow.ui.test.ts
@@ -30,6 +30,10 @@ describe('Login Flow UI Tests', function () {
 	});
 
 	after(async function () {
+		// `before()` skips the suite when credentials are missing; in that
+		// case `driver` is never assigned and the cleanup below would crash
+		// with `Cannot read properties of undefined`. Bail out cleanly.
+		if (!driver) { return; }
 		this.timeout(15000);
 		const workbench = new Workbench();
 		await workbench.executeCommand('Logout from Artemis');

--- a/extension/test/e2e/ui/login-flow.ui.test.ts
+++ b/extension/test/e2e/ui/login-flow.ui.test.ts
@@ -1,10 +1,11 @@
 // Covers E2EX-01: Login flow interaction test — credentials → Dashboard
 import * as assert from 'assert';
-import { By, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { By, VSBrowser, WebDriver } from 'vscode-extension-tester';
 
 import {
     getCredentials,
     openArtemisView,
+    safeLogoutAndCleanup,
     switchBackFromWebview,
     switchToWebviewFrame,
     takeScreenshot,
@@ -30,14 +31,8 @@ describe('Login Flow UI Tests', function () {
 	});
 
 	after(async function () {
-		// `before()` skips the suite when credentials are missing; in that
-		// case `driver` is never assigned and the cleanup below would crash
-		// with `Cannot read properties of undefined`. Bail out cleanly.
-		if (!driver) { return; }
 		this.timeout(15000);
-		const workbench = new Workbench();
-		await workbench.executeCommand('Logout from Artemis');
-		await driver.sleep(2000);
+		await safeLogoutAndCleanup(driver);
 	});
 
 	afterEach(async function () {

--- a/extension/test/e2e/ui/run-tests.sh
+++ b/extension/test/e2e/ui/run-tests.sh
@@ -55,7 +55,13 @@ for test_file in out/test/e2e/ui/*.ui.test.js; do
   echo ""
   echo "--- Running: ${name} ---"
 
-  extest run-tests "$test_file" --mocha_config .mocharc.ui.yml 2>&1 | tee "$log_file"
+  # --code_settings disables the GitHub Copilot Chat first-run modal
+  # ("Welcome to VS Code / Sign in to continue") that ships built-in with
+  # recent VS Code builds (observed since 1.116) and blocks Selenium from
+  # reaching extension elements. The load-bearing setting is
+  # `workbench.welcomePage.experimentalOnboarding: false`, identified via
+  # redhat-developer/vscode-extension-tester#2345. See issue #176.
+  extest run-tests "$test_file" --mocha_config .mocharc.ui.yml --code_settings test/e2e/ui/code-settings.json 2>&1 | tee "$log_file"
   rc=${PIPESTATUS[0]}
 
   if [ $rc -eq 0 ]; then

--- a/extension/test/e2e/ui/run-tests.sh
+++ b/extension/test/e2e/ui/run-tests.sh
@@ -27,18 +27,40 @@ echo "=== Phase 3: Packaging VSIX ==="
 # Save and restore just the prepublish script (not the entire package.json).
 PREPUBLISH_SCRIPT=$(node -e "console.log(require('./package.json').scripts['vscode:prepublish'] || '')")
 npm pkg delete scripts.vscode:prepublish
-restore_prepublish() {
+TMP_SETTINGS=""
+cleanup() {
   if [ -n "$PREPUBLISH_SCRIPT" ]; then
     npm pkg set "scripts.vscode:prepublish=$PREPUBLISH_SCRIPT"
   fi
+  if [ -n "$TMP_SETTINGS" ] && [ -f "$TMP_SETTINGS" ]; then
+    rm -f "$TMP_SETTINGS"
+  fi
 }
-trap restore_prepublish EXIT
+trap cleanup EXIT
 npx @vscode/vsce package --no-dependencies --skip-license -o test-extension.vsix
 
 echo "=== Phase 4: Setting up test environment ==="
 extest get-vscode
 extest get-chromedriver
 extest install-vsix --vsix_file test-extension.vsix
+
+# Compose the final settings.json passed to each `extest run-tests`. By
+# default we use the committed `code-settings.json` unchanged. If
+# ARTEMIS_URL is set (typically from .env), we splice it in as
+# `artemis.serverUrl` so contributors can switch between test servers
+# without editing the committed file. See .env.example.
+SETTINGS_FILE="test/e2e/ui/code-settings.json"
+if [ -n "${ARTEMIS_URL:-}" ]; then
+  TMP_SETTINGS=$(mktemp "${TMPDIR:-/tmp}/code-settings.XXXXXX.json")
+  SETTINGS_FILE="$SETTINGS_FILE" TMP_SETTINGS="$TMP_SETTINGS" node -e "
+    const fs = require('fs');
+    const settings = JSON.parse(fs.readFileSync(process.env.SETTINGS_FILE, 'utf8'));
+    settings['artemis.serverUrl'] = process.env.ARTEMIS_URL;
+    fs.writeFileSync(process.env.TMP_SETTINGS, JSON.stringify(settings, null, 4));
+  "
+  SETTINGS_FILE="$TMP_SETTINGS"
+  echo "Using ARTEMIS_URL=${ARTEMIS_URL} from environment"
+fi
 
 echo "=== Phase 5: Running UI tests (isolated per file) ==="
 mkdir -p reports/ui
@@ -61,7 +83,7 @@ for test_file in out/test/e2e/ui/*.ui.test.js; do
   # reaching extension elements. The load-bearing setting is
   # `workbench.welcomePage.experimentalOnboarding: false`, identified via
   # redhat-developer/vscode-extension-tester#2345. See issue #176.
-  extest run-tests "$test_file" --mocha_config .mocharc.ui.yml --code_settings test/e2e/ui/code-settings.json 2>&1 | tee "$log_file"
+  extest run-tests "$test_file" --mocha_config .mocharc.ui.yml --code_settings "$SETTINGS_FILE" 2>&1 | tee "$log_file"
   rc=${PIPESTATUS[0]}
 
   if [ $rc -eq 0 ]; then


### PR DESCRIPTION
Closes #176.

## Problem

`npm run test:ui` fails 8/15 (6/12 after exam-mode removal) because recent VS Code builds ship a **built-in GitHub Copilot Chat sign-in modal** ("Welcome to VS Code / Sign in to continue with AI-powered development") that covers the workbench and intercepts Selenium pointer events. The modal source lives in VS Code's workbench JS (`vs/workbench/workbench.desktop.main.js`), not in an extension we could uninstall, and `chat.disableAIFeatures: true` alone does **not** suppress it.

Confirmed by inspecting failure screenshots and locating the modal text strings in `app/out/nls.messages.json`.

## Fix

Pass a `test/e2e/ui/code-settings.json` to extest via `--code_settings`. The load-bearing key is:

```json
"workbench.welcomePage.experimentalOnboarding": false
```

Identified via [redhat-developer/vscode-extension-tester#2345](https://github.com/redhat-developer/vscode-extension-tester/issues/2345) (open upstream issue about the same blocker). Verified empirically — without this setting the modal still appears; with it the modal is gone.

Defense-in-depth siblings (workspace trust, walkthroughs, telemetry consent, etc.) in the same file in case future VS Code releases reshuffle modal sources.

## Pre-existing test-infra bug also fixed

In 6 credential-gated UI test files, the `after()` hook called `await driver.sleep(2000)`, but `driver` is only assigned in `before()` **after** `getCredentials()` succeeds. When `.env` is missing, `before()` calls `this.skip()` *before* assigning `driver`, so the `after()` hook crashed with:

```
TypeError: Cannot read properties of undefined (reading 'sleep')
```

This bubbled up as a real failure instead of a clean skip, masking the modal as the cause and making fresh-checkout runs always report ~6 failures even when the underlying tests would have skipped fine.

Guarded each with `if (!driver) { return; }` and a brief comment explaining the reason. Codex verified the other UI suites (`service-status`, `git-credentials`, `recommended-extensions`, `iris-chat`) already wrap their cleanup in `try/catch`, so they did not have this failure mode.

## Result

| Before | After |
|---|---|
| 4/12 PASS, 8/12 FAIL (modal blocking) | **12/12 PASS** on freshly wiped `test-resources` |

The 6 credential-gated suites still skip cleanly without `.env`. With `ARTEMIS_USER` / `ARTEMIS_PASS` configured they will actually run.

## Out of scope

- No production code touched
- No CI change — UI tests do not run in CI (verified: no `test:ui` references in `.github/workflows/`)
- The mocha-hooks.ts experiment I tried mid-iteration was removed; the setting alone solves the problem

## Verification

- `npm run test:ui` → 12/12 PASS on freshly wiped `${TMPDIR}/test-resources`
- ESLint clean on all modified files
- `git status` clean (no spurious package.json changes from save/restore trap)

## Codex review

Two turns, signed off with one wording polish applied (softened "1.121+" to "recent VS Code builds (observed since 1.116)" since the precise first-affected version isn't independently verifiable). Codex's verbatim conclusion: *"Sign-off from me, with the only hard requirement being to commit `code-settings.json`."* — done.

## Risks

1. **`experimentalOnboarding` is name-experimental** — could be renamed in a future VS Code release. Mitigation: comment in `run-tests.sh` and upstream issue link make the fix easy to update.
2. **Credential-gated tests still need `.env` to actually run** — by design. Adding a `.env.example` was suggested by codex; left as follow-up.