### PR TITLE
refactor: unify Course/Dashboard data shapes (#182)

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -110,13 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const courses = data.courses;
 		if (courses && Array.isArray(courses)) {
 			for (const entry of courses) {
-				const courseExercises = entry.course?.exercises || entry.exercises || [];
-				if (courseExercises.length > 0) {
-					exerciseRegistry.registerFromCourseData({
-						course: entry.course || entry,
-						exercises: courseExercises,
-					});
-				}
+				exerciseRegistry.registerFromCourseData(entry);
 			}
 		}
 	}));

--- a/extension/src/extension/controller/commands/navigationCommands.ts
+++ b/extension/src/extension/controller/commands/navigationCommands.ts
@@ -5,11 +5,9 @@ import { ExtensionMsg, getPayload, WebviewCmd } from '@shared/messageContracts';
 import { toCourseDetailData } from '@shared/messageContracts';
 
 import { logger } from '@extension/services/loggingService';
-import type { CourseDashboardCourse, CourseDashboardEntry } from '@extension/types';
 
 import { fetchAndEnrichExerciseDetails, fetchArchivedCourseDetail } from '../exerciseDataLoader';
 import type { CommandContext, CommandMap } from './types';
-
 
 export class NavigationCommandModule {
     constructor(private readonly context: CommandContext) { }
@@ -45,72 +43,78 @@ export class NavigationCommandModule {
 
     private handleViewCourseDetails = async (message: WebviewToExtensionMessage): Promise<void> => {
         try {
-            const { courseData } = getPayload<WebCmd<'viewCourseDetails'>>(message);
-            await this.processCourseDetails(courseData);
+            const { courseId } = getPayload<WebCmd<'viewCourseDetails'>>(message);
+            const cached = this.context.appStateManager.coursesData
+                ?.courses
+                ?.find(e => e.course?.id === courseId);
+
+            let courseDTO = cached?.course;
+            if (!courseDTO) {
+                const fetched = await this.context.artemisApi.getCourseForDashboard(courseId);
+                courseDTO = fetched.course;
+            }
+
+            const detail = toCourseDetailData(courseDTO);
+            if (!detail) {
+                logger.viewError(`Course ${courseId} resolved without a valid id; cannot show`);
+                vscode.window.showErrorMessage('Course data is incomplete');
+                return;
+            }
+
+            await this.processCourseDetails(detail);
         } catch (error: unknown) {
             logger.viewError('View course details error:', error);
             vscode.window.showErrorMessage('Error viewing course details');
         }
     };
 
-    private async processCourseDetails(courseData: CourseDashboardEntry | CourseDashboardCourse): Promise<void> {
-        try {
-            const course: CourseDashboardCourse | undefined = 'course' in courseData
-                ? (courseData.course as CourseDashboardCourse | undefined)
-                : courseData;
+    private async processCourseDetails(detail: CourseDetailData): Promise<void> {
+        const course = detail.course;
+        const courseId = course.id;
 
-            const courseDetailData = toCourseDetailData(course);
-            if (!courseDetailData) {
-                logger.viewError('View course details: course is missing an id; cannot show');
-                vscode.window.showErrorMessage('Course data is incomplete');
-                return;
-            }
+        this.context.appStateManager.showCourseDetail(detail);
+        this.context.courseAccessStorage?.onCourseAccessed(courseId);
 
-            this.context.appStateManager.showCourseDetail(courseDetailData);
+        const registry = this.context.exerciseRegistry;
+        registry.registerFromCourseData({
+            course: {
+                id: courseId,
+                title: course.title,
+                exercises: course.exercises,
+            },
+        });
 
-            if (course?.id !== undefined) {
-                this.context.courseAccessStorage?.onCourseAccessed(course.id);
-            }
-
-            const registry = this.context.exerciseRegistry;
-            // Pass the entry format for registration (expects CourseDashboardEntry)
-            const entryFormat: CourseDashboardEntry = 'course' in courseData ? courseData : { course: courseData };
-            registry.registerFromCourseData(entryFormat);
-
-            const chatProvider = this.context.providerRegistry.getChatWebviewProvider();
-            if (course) {
-                const courseTitle = course.title || 'Untitled Course';
-                const courseId = course.id || 0;
-                const shortName = course.shortName;
-
-                if (chatProvider && typeof chatProvider.updateDetectedCourse === 'function') {
-                    chatProvider.updateDetectedCourse(courseTitle, courseId, shortName);
-                    logger.view('📚 [Course Detection] Notified chat about course:', courseTitle);
-                }
-
-                if (course.exercises && Array.isArray(course.exercises) && chatProvider && typeof chatProvider.updateDetectedExercise === 'function') {
-                    course.exercises.forEach((exercise) => {
-                        // Type guard: exercise is from CourseDashboardCourse which uses optional fields
-                        if (exercise && typeof exercise === 'object' && 'studentParticipations' in exercise &&
-                            Array.isArray(exercise.studentParticipations) && exercise.studentParticipations.length > 0) {
-                            const exerciseTitle = exercise.title ?? 'Untitled Exercise';
-                            const exerciseId = exercise.id ?? 0;
-                            const releaseDate = exercise.releaseDate ?? exercise.startDate;
-                            const dueDate = exercise.dueDate;
-                            const shortName = exercise.shortName;
-
-                            chatProvider.updateDetectedExercise(exerciseTitle, exerciseId, releaseDate, dueDate, shortName, courseId);
-                            logger.view(`📚 [Course Exercises] Updated exercise from course: ${exerciseTitle} (ID: ${exerciseId})`);
-                        }
-                    });
-                }
-            }
-
-            this.context.actionHandler.render();
-        } catch (error: unknown) {
-            logger.viewError('View course details error:', error);
-            vscode.window.showErrorMessage('Error viewing course details');
+        const chatProvider = this.context.providerRegistry.getChatWebviewProvider();
+        const courseTitle = course.title;
+        const shortName = course.shortName;
+        if (chatProvider && typeof chatProvider.updateDetectedCourse === 'function') {
+            chatProvider.updateDetectedCourse(courseTitle, courseId, shortName);
+            logger.view('📚 [Course Detection] Notified chat about course:', courseTitle);
         }
+
+        if (course.exercises && chatProvider && typeof chatProvider.updateDetectedExercise === 'function') {
+            for (const exercise of course.exercises) {
+                if (
+                    exercise &&
+                    Array.isArray(exercise.studentParticipations) &&
+                    exercise.studentParticipations.length > 0 &&
+                    typeof exercise.id === 'number' &&
+                    typeof exercise.title === 'string'
+                ) {
+                    chatProvider.updateDetectedExercise(
+                        exercise.title,
+                        exercise.id,
+                        exercise.releaseDate ?? exercise.startDate,
+                        exercise.dueDate,
+                        exercise.shortName,
+                        courseId,
+                    );
+                    logger.view(`📚 [Course Exercises] Updated exercise from course: ${exercise.title} (ID: ${exercise.id})`);
+                }
+            }
+        }
+
+        this.context.actionHandler.render();
     }
 
     private handleBackToDashboard = async (_message: WebviewToExtensionMessage): Promise<void> => {

--- a/extension/src/extension/controller/commands/navigationCommands.ts
+++ b/extension/src/extension/controller/commands/navigationCommands.ts
@@ -59,10 +59,12 @@ export class NavigationCommandModule {
                 ? (courseData.course as CourseDashboardCourse | undefined)
                 : courseData;
 
-            // Convert to CourseDetailData format expected by state manager
-            const courseDetailData = toCourseDetailData(
-                ('course' in courseData ? courseData.course! : courseData) as CourseDashboardCourse
-            );
+            const courseDetailData = toCourseDetailData(course);
+            if (!courseDetailData) {
+                logger.viewError('View course details: course is missing an id; cannot show');
+                vscode.window.showErrorMessage('Course data is incomplete');
+                return;
+            }
 
             this.context.appStateManager.showCourseDetail(courseDetailData);
 
@@ -216,7 +218,13 @@ export class NavigationCommandModule {
             if (courseId) {
                 // Fetch fresh course data from the single-course dashboard endpoint.
                 const dashboardDTO = await this.context.artemisApi.getCourseForDashboard(courseId);
-                const courseData = toCourseDetailData(dashboardDTO.course as CourseDashboardCourse);
+                const courseData = toCourseDetailData(dashboardDTO.course);
+                if (!courseData) {
+                    logger.viewError(`Reload course detail: course ${courseId} resolved without a valid id`);
+                    vscode.window.showErrorMessage('Course data is incomplete');
+                    this.context.actionHandler.sendInitData();
+                    return;
+                }
 
                 this.context.appStateManager.showCourseDetail(courseData);
                 // Send updated data to React without re-rendering
@@ -276,8 +284,11 @@ export class NavigationCommandModule {
                 if (courseId) {
                     const courseEntry = coursesData.courses.find(c => c.course?.id === courseId);
                     if (courseEntry?.course) {
-                        parentCourseDetailData = toCourseDetailData(courseEntry.course);
-                        logger.view(`[Navigation] Found parent course for exercise ${exerciseId} via courseId: ${courseEntry.course.title}`);
+                        const mapped = toCourseDetailData(courseEntry.course);
+                        if (mapped) {
+                            parentCourseDetailData = mapped;
+                            logger.view(`[Navigation] Found parent course for exercise ${exerciseId} via courseId: ${courseEntry.course.title}`);
+                        }
                     }
                 }
 
@@ -288,9 +299,12 @@ export class NavigationCommandModule {
                         const foundExercise = exercises.find((ex) => ex?.id === exerciseId);
 
                         if (foundExercise && courseEntry.course) {
-                            parentCourseDetailData = toCourseDetailData(courseEntry.course);
-                            logger.view(`[Navigation] Found parent course for exercise ${exerciseId}: ${courseEntry.course.title}`);
-                            break;
+                            const mapped = toCourseDetailData(courseEntry.course);
+                            if (mapped) {
+                                parentCourseDetailData = mapped;
+                                logger.view(`[Navigation] Found parent course for exercise ${exerciseId}: ${courseEntry.course.title}`);
+                                break;
+                            }
                         }
                     }
                 }

--- a/extension/src/extension/controller/exerciseDataLoader.ts
+++ b/extension/src/extension/controller/exerciseDataLoader.ts
@@ -4,7 +4,7 @@ import type { PendingSubmissionStatus } from '@shared/types/apiResponses';
 
 import type { ArtemisApiService } from '../api';
 import { LogCategory, logger } from '../services/loggingService';
-import type { CourseDashboardCourse, CourseDashboardResponse, ExerciseDetailsResponse } from '../types';
+import type { ExerciseDetailsResponse } from '../types';
 import { ApiError, MalformedResponseError } from '../types';
 import { pickHighestId } from '../utils/participationHelpers';
 
@@ -133,8 +133,9 @@ export async function fetchArchivedCourseDetail(
     courseId: number,
 ): Promise<CourseDetailData> {
     const dashboardDTO = await api.getCourseForDashboard(courseId);
-    return toCourseDetailData(
-        dashboardDTO.course as CourseDashboardCourse,
-        { isArchived: true }
-    );
+    const mapped = toCourseDetailData(dashboardDTO.course, { isArchived: true });
+    if (!mapped) {
+        throw new Error(`Archived course ${courseId} is missing an id`);
+    }
+    return mapped;
 }

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -627,18 +627,14 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         const courses = coursesData?.courses || [];
         const archivedCourses = this._appStateManager.archivedCoursesData || undefined;
 
-        const mappedCourses = courses.map((entry) => ({
-            course: {
-                id: entry.course?.id || 0,
-                title: entry.course?.title || 'Untitled Course',
-                description: entry.course?.description,
-                semester: entry.course?.semester,
-                color: entry.course?.color,
-                exercises: entry.course?.exercises,
-                numberOfStudents: entry.course?.numberOfStudents,
-                instructorGroupName: entry.course?.instructorGroupName,
+        const mappedCourses: CourseDetailData[] = courses.flatMap((entry) => {
+            const detail = toCourseDetailData(entry.course);
+            if (!detail) {
+                logger.warn(`Course list fullscreen: dropping course without numeric id (title=${entry.course?.title ?? '<unknown>'})`, LogCategory.VIEW);
+                return [];
             }
-        }));
+            return [detail];
+        });
 
         this._fullscreenPanelManager.openCourseListFullscreen(mappedCourses, archivedCourses);
     }

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -448,13 +448,16 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             case 'workspace-exercise': {
                 this._appStateManager.seedAuthenticatedSession(userInfo);
                 const entry = result.allCourses.find(e => e.course?.id === result.courseId);
-                if (entry?.course) {
-                    this._appStateManager.showCourseDetail(toCourseDetailData(entry.course));
+                const detail = toCourseDetailData(entry?.course);
+                if (detail) {
+                    this._appStateManager.showCourseDetail(detail);
                     this._postMessageSafe({ type: ExtensionMsg.UpdateLoading, message: 'Loading exercise...' });
                     await this.openExerciseDetails(result.exerciseId);
                     if (this._appStateManager.currentState === 'exercise-detail') {
                         return;
                     }
+                } else {
+                    logger.viewError(`workspace-exercise start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
                 }
                 break;
             }
@@ -462,11 +465,13 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             case 'workspace-course': {
                 this._appStateManager.seedAuthenticatedSession(userInfo);
                 const entry = result.allCourses.find(e => e.course?.id === result.courseId);
-                if (entry?.course) {
+                const detail = toCourseDetailData(entry?.course);
+                if (detail) {
                     this._courseAccessStorage.onCourseAccessed(result.courseId);
-                    this.showCourseDetail(toCourseDetailData(entry.course));
+                    this.showCourseDetail(detail);
                     return;
                 }
+                logger.viewError(`workspace-course start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
                 break;
             }
 

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -22,7 +22,13 @@ import { LogCategory, logger } from '../services/loggingService';
 import { type StruggleContext, TelemetryManager } from '../services/telemetry';
 import { getReactWebviewHtml } from '../services/ui';
 import { ArtemisWebsocketService } from '../services/websocket';
-import { detectAndRegisterWorkspaceExercise, FileMonitorService, NoAiDetectionService } from '../services/workspace';
+import {
+    detectAndRegisterWorkspaceExercise,
+    FileMonitorService,
+    getEntryExercises,
+    NoAiDetectionService,
+    toExerciseSource,
+} from '../services/workspace';
 import { ActiveContext, ChatContextType } from '../types';
 import type { IChatWebviewProvider } from '../types/IChatWebviewProvider';
 import { BaseWebviewProvider } from './baseWebviewProvider';
@@ -595,25 +601,23 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                     source: 'system-default',
                 });
 
-                const exercises = course.exercises || entry.exercises || [];
-                for (const exercise of exercises) {
-                    const ex = exercise as {
-                        id?: number; title?: string; shortName?: string;
-                        releaseDate?: string; startDate?: string; dueDate?: string;
-                        studentParticipations?: Array<{ repositoryUri?: string }>;
-                    };
-                    if (ex.id && ex.title && ex.studentParticipations?.length) {
-                        // Do not set isWorkspace here; workspaceDetectionService owns that flag.
-                        this._chatContextManager.registerExerciseAndAutoSelect({
-                            id: ex.id,
-                            title: ex.title,
-                            shortName: ex.shortName,
-                            courseId: course.id,
-                            releaseDate: ex.releaseDate ?? ex.startDate,
-                            dueDate: ex.dueDate,
-                            source: 'system-default',
-                        });
+                for (const exercise of getEntryExercises(entry)) {
+                    const source = toExerciseSource(exercise, course.id);
+                    if (!source || !source.studentParticipations?.length) {
+                        continue;
                     }
+                    // Do not set isWorkspace here; workspaceDetectionService owns that flag.
+                    // Note: dates are read from the raw exercise because ExerciseSource
+                    // intentionally omits them (kept narrow for workspace-detection use).
+                    this._chatContextManager.registerExerciseAndAutoSelect({
+                        id: source.id,
+                        title: source.title,
+                        shortName: source.shortName,
+                        courseId: course.id,
+                        releaseDate: exercise.releaseDate ?? exercise.startDate,
+                        dueDate: exercise.dueDate,
+                        source: 'system-default',
+                    });
                 }
             }
         } catch (error) {

--- a/extension/src/extension/services/exerciseRegistry.ts
+++ b/extension/src/extension/services/exerciseRegistry.ts
@@ -1,10 +1,26 @@
 import type { ExerciseRef } from '@shared/types';
 
+import type { CourseDashboardEntry } from '../types';
 import { logger } from './loggingService';
+import { getEntryExercises, toExerciseSource } from './workspace';
 
 export interface ExerciseRegistryEntry extends ExerciseRef {
     repositoryUri: string;
     participationId?: number;
+}
+
+type LegacyCourseEntry = CourseDashboardEntry & { id?: number };
+
+function isLikelyCourseEntry(value: unknown): value is LegacyCourseEntry {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+    const candidate = value as { course?: unknown; id?: unknown; exercises?: unknown };
+    return (
+        (typeof candidate.course === 'object' && candidate.course !== null) ||
+        typeof candidate.id === 'number' ||
+        Array.isArray(candidate.exercises)
+    );
 }
 
 export class ExerciseRegistry {
@@ -65,42 +81,58 @@ export class ExerciseRegistry {
     }
 
     public registerFromCourseData(courseData: unknown): void {
-        const data = courseData as { course?: { id?: number; exercises?: unknown[] }; exercises?: unknown[]; id?: number };
-        const exercises = data?.course?.exercises || data?.exercises || [];
-        const courseId = data?.course?.id ?? data?.id;
+        // Local predicate: accept anything that structurally looks like a
+        // CourseDashboardEntry (has a `course` property OR top-level `id`).
+        // Anything else is dropped silently because all known call sites
+        // pass either a server response or one of the entry shapes we
+        // construct internally.
+        if (!isLikelyCourseEntry(courseData)) {
+            return;
+        }
+        const entry = courseData;
+        // Existing semantics preserved: prefer nested `course.id`, fall back
+        // to a top-level `id` on the legacy `{ id, exercises }` shape some
+        // callers still pass. Both branches use a real `typeof` narrowing,
+        // not a cast.
+        const courseId = typeof entry.course?.id === 'number'
+            ? entry.course.id
+            : (typeof entry.id === 'number' ? entry.id : undefined);
 
-        // Clear existing exercises for this course before registering fresh data
-        // This ensures deleted exercises are properly removed from the registry
-        if (courseId !== undefined && courseId !== null) {
+        if (typeof courseId === 'number') {
             this.clearCourse(courseId);
         }
 
+        const exercises = getEntryExercises(entry);
         let registeredCount = 0;
         const registered: string[] = [];
         const skipped: string[] = [];
 
         for (const exercise of exercises) {
-            const ex = exercise as {
-                id?: number;
-                title?: string;
-                shortName?: string;
-                studentParticipations?: Array<{ id?: number; repositoryUri?: string }>
-            };
-            const participations = ex.studentParticipations || [];
-
-            if (participations.length > 0 && participations[0].repositoryUri && ex.id && ex.title) {
+            const source = toExerciseSource(exercise, courseId);
+            if (!source) {
+                continue;
+            }
+            const firstParticipation = source.studentParticipations?.[0];
+            // The original code preserved the participation id when present,
+            // for upstream wiring; toExerciseSource intentionally drops it,
+            // so we still read it from the raw exercise.
+            const rawFirstParticipation = exercise.studentParticipations?.[0];
+            const participationId = typeof rawFirstParticipation?.id === 'number'
+                ? rawFirstParticipation.id
+                : undefined;
+            if (firstParticipation?.repositoryUri && source.title) {
                 this.registerExercise(
-                    ex.id,
-                    ex.title,
-                    participations[0].repositoryUri,
-                    ex.shortName,
+                    source.id,
+                    source.title,
+                    firstParticipation.repositoryUri,
+                    source.shortName,
                     courseId,
-                    typeof participations[0].id === 'number' ? participations[0].id : undefined,
+                    participationId,
                 );
                 registeredCount++;
-                registered.push(`${ex.id}: ${ex.title}`);
+                registered.push(`${source.id}: ${source.title}`);
             } else {
-                skipped.push(`${ex.id ?? 'unknown'}: ${ex.title ?? 'unknown'} (no repo URI)`);
+                skipped.push(`${source.id}: ${source.title} (no repo URI)`);
             }
         }
 

--- a/extension/src/extension/services/ui/fullscreenPanelManager.ts
+++ b/extension/src/extension/services/ui/fullscreenPanelManager.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import type { CourseDetailData as CourseDetailPayload, ExtensionToWebviewMessage } from '@shared/messageContracts';
 import { ExtensionMsg, WebviewMsgType } from '@shared/messageContracts';
-import type { ArchivedCourse, CourseData } from '@shared/messageContracts/domainTypes';
+import type { ArchivedCourse, CourseDetailData } from '@shared/messageContracts/domainTypes';
 import { isWebviewMessage } from '@shared/messageContracts/typeGuards';
 
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
@@ -57,7 +57,7 @@ export class FullscreenPanelManager {
         });
     }
 
-    public openCourseListFullscreen(courses: CourseData[], archivedCourses?: ArchivedCourse[]): void {
+    public openCourseListFullscreen(courses: CourseDetailData[], archivedCourses?: ArchivedCourse[]): void {
         this._openFullscreenPanel({
             viewType: 'artemis.courseListFullscreen',
             title: 'All Courses',

--- a/extension/src/extension/services/ui/fullscreenPanelManager.ts
+++ b/extension/src/extension/services/ui/fullscreenPanelManager.ts
@@ -1,16 +1,15 @@
 import * as vscode from 'vscode';
 
-import type { CourseDetailData as CourseDetailPayload, ExtensionToWebviewMessage } from '@shared/messageContracts';
+import type { CourseDetailData, ExtensionToWebviewMessage } from '@shared/messageContracts';
 import { ExtensionMsg, WebviewMsgType } from '@shared/messageContracts';
-import type { ArchivedCourse, CourseDetailData } from '@shared/messageContracts/domainTypes';
+import type { ArchivedCourse } from '@shared/messageContracts/domainTypes';
 import { isWebviewMessage } from '@shared/messageContracts/typeGuards';
 
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
 import type { ExerciseDetailsResponse } from '@extension/types';
 
 import { LogCategory, logger } from '../loggingService';
-import type { ExerciseSource } from '../workspace/workspaceDetectionService';
-import { detectWorkspaceExercise, detectWorkspaceForRepoUris } from '../workspace/workspaceDetectionService';
+import { collectExerciseSources, detectWorkspaceExercise, detectWorkspaceForRepoUris } from '../workspace/workspaceDetectionService';
 import { getReactWebviewHtml } from './webviewHtml';
 
 export class FullscreenPanelManager {
@@ -72,7 +71,7 @@ export class FullscreenPanelManager {
         });
     }
 
-    public openCourseFullscreen(courseData: CourseDetailPayload): void {
+    public openCourseFullscreen(courseData: CourseDetailData): void {
         const courseTitle = courseData?.course?.title || 'Course';
         this._openFullscreenPanel({
             viewType: 'artemis.courseFullscreen',
@@ -81,9 +80,12 @@ export class FullscreenPanelManager {
             onReady: (postSafe) => {
                 const config = vscode.workspace.getConfiguration('artemis');
                 const developerMode = config.get<boolean>('developerMode', false);
-                const exercises = (courseData.course?.exercises ?? []) as ExerciseSource[];
+                const sources = collectExerciseSources([{
+                    course: courseData.course,
+                    exercises: courseData.course.exercises,
+                }]);
 
-                detectWorkspaceExercise(exercises).then((detectedExercise) => {
+                detectWorkspaceExercise(sources).then((detectedExercise) => {
                     postSafe({
                         type: ExtensionMsg.CourseDetailInit,
                         courseData: courseData,

--- a/extension/src/extension/services/ui/viewInitDataService.ts
+++ b/extension/src/extension/services/ui/viewInitDataService.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-import type { CourseDetailData as CourseDetailPayload, ExtensionToWebviewMessage } from '@shared/messageContracts';
-import { ExtensionMsg } from '@shared/messageContracts';
+import type { CourseDetailData, ExtensionToWebviewMessage, RecentCourseNode } from '@shared/messageContracts';
+import { ExtensionMsg, toCourseDetailData } from '@shared/messageContracts';
 
 import { AppStateManager } from '@extension/controller/appStateManager';
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
@@ -13,9 +13,9 @@ import { LogCategory, logger } from '../loggingService';
 import type { TelemetryManager } from '../telemetry/telemetryManager';
 import { GitService } from '../workspace/gitService';
 import {
+    collectExerciseSources,
     detectWorkspaceExercise,
     detectWorkspaceForRepoUris,
-    type ExerciseSource,
 } from '../workspace/workspaceDetectionService';
 import { selectRecentCourses } from './recentCourseSelector';
 
@@ -58,9 +58,9 @@ export class ViewInitDataService {
         const accessedIds = this._courseAccessStorage?.getLastAccessedCourses() ?? [];
         const selectedCourses = selectRecentCourses(courses, accessedIds, COURSE_ACCESS_DISPLAY_LIMIT);
 
-        const recentCourseNodes = selectedCourses.map((courseItem: CourseDashboardEntry) => {
-            const course = courseItem.course || courseItem;
-            const exercises = course.exercises || [];
+        const recentCourseNodes: RecentCourseNode[] = selectedCourses.flatMap((courseItem: CourseDashboardEntry) => {
+            const course = courseItem.course ?? courseItem;
+            const exercises = course.exercises ?? [];
 
             const recentExercises = [...exercises]
                 .sort((a: ExerciseDetail, b: ExerciseDetail) => {
@@ -72,31 +72,25 @@ export class ViewInitDataService {
                     return (b.id ?? 0) - (a.id ?? 0);
                 });
 
-            return {
-                courseData: {
-                    course: {
-                        id: (course.id ?? 0) as number,
-                        title: (course.title ?? 'Untitled Course') as string,
-                        exercises: course.exercises,
-                        startDate: course.startDate as string | undefined,
-                    }
-                },
-                exercises: recentExercises,
-            };
+            const detail = toCourseDetailData(course);
+            if (!detail) {
+                logger.warn(`Dashboard init: dropping course without numeric id (title=${course?.title ?? '<unknown>'})`, LogCategory.VIEW);
+                return [];
+            }
+            return [{ courseData: detail, exercises: recentExercises }];
         });
 
-        // Collect all exercises across courses to detect the workspace exercise
-        const allExercises = courses.flatMap((courseItem: CourseDashboardEntry) => {
-            const course = courseItem.course || courseItem;
-            return course.exercises || [];
-        });
+        // Collect typed ExerciseSource list across all courses for workspace detection.
+        // Replaces the previous `as ExerciseSource[]` cast at the detectWorkspaceExercise
+        // call site below.
+        const allExerciseSources = collectExerciseSources(courses);
 
         // null = "no match" (shown to user), undefined = "still loading" (keeps skeleton).
         // We only publish null once the archived-course check has finished,
         // so the UI doesn't flash "no exercise" before a late-arriving archived match.
         const noMatch = this._appStateManager.archiveCheckComplete ? null : undefined;
 
-        if (allExercises.length === 0) {
+        if (allExerciseSources.length === 0) {
             this._postMessage({
                 type: ExtensionMsg.DashboardInit,
                 courses: recentCourseNodes,
@@ -106,7 +100,7 @@ export class ViewInitDataService {
         }
 
         const gen = this._initGeneration;
-        detectWorkspaceExercise(allExercises as ExerciseSource[]).then((detectedExercise) => {
+        detectWorkspaceExercise(allExerciseSources).then((detectedExercise) => {
             if (gen !== this._initGeneration) { return; }
             this._postMessage({
                 type: ExtensionMsg.DashboardInit,
@@ -132,18 +126,14 @@ export class ViewInitDataService {
         const courses = coursesData?.courses || [];
         const archivedCourses = appState.archivedCoursesData || undefined;
 
-        const mappedCourses = courses.map((entry: CourseDashboardEntry) => ({
-            course: {
-                id: entry.course?.id || 0,
-                title: entry.course?.title || 'Untitled Course',
-                description: entry.course?.description,
-                semester: entry.course?.semester,
-                color: entry.course?.color,
-                exercises: entry.course?.exercises,
-                numberOfStudents: entry.course?.numberOfStudents,
-                instructorGroupName: entry.course?.instructorGroupName,
+        const mappedCourses: CourseDetailData[] = courses.flatMap((entry: CourseDashboardEntry) => {
+            const detail = toCourseDetailData(entry.course);
+            if (!detail) {
+                logger.warn(`Course list init: dropping course without numeric id (title=${entry.course?.title ?? '<unknown>'})`, LogCategory.VIEW);
+                return [];
             }
-        }));
+            return [detail];
+        });
 
         this._postMessage({
             type: ExtensionMsg.CourseListInit,
@@ -159,14 +149,17 @@ export class ViewInitDataService {
             return;
         }
 
-        const exercises = courseData.course?.exercises || [];
+        const sources = collectExerciseSources([{
+            course: courseData.course,
+            exercises: courseData.course.exercises,
+        }]);
 
         const gen = this._initGeneration;
-        detectWorkspaceExercise(exercises as ExerciseSource[]).then((detectedExercise: { id?: number } | null) => {
+        detectWorkspaceExercise(sources).then((detectedExercise) => {
             if (gen !== this._initGeneration) { return; }
             this._postMessage({
                 type: ExtensionMsg.CourseDetailInit,
-                courseData: courseData as CourseDetailPayload,
+                courseData,
                 workspaceExerciseId: detectedExercise?.id ?? null,
                 hideDeveloperTools: !this._isDeveloperMode(),
             });
@@ -175,7 +168,7 @@ export class ViewInitDataService {
             logger.error('Failed to detect workspace exercise for course detail', LogCategory.VIEW, error);
             this._postMessage({
                 type: ExtensionMsg.CourseDetailInit,
-                courseData: courseData as CourseDetailPayload,
+                courseData,
                 workspaceExerciseId: null,
                 hideDeveloperTools: !this._isDeveloperMode(),
             });

--- a/extension/src/extension/services/workspace/index.ts
+++ b/extension/src/extension/services/workspace/index.ts
@@ -7,8 +7,10 @@ export {
     type DetectedExercise,
     findExerciseByRepositoryUrl,
     findWorkspaceCourseInArchive,
+    getEntryExercises,
     getWorkspaceRepositoryUrl,
     getWorkspaceStatus,
     normalizeRepositoryUrl,
+    toExerciseSource,
 } from './workspaceDetectionService';
 export * from './workspaceFileChecker';

--- a/extension/src/extension/services/workspace/workspaceDetectionService.ts
+++ b/extension/src/extension/services/workspace/workspaceDetectionService.ts
@@ -3,7 +3,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 
 import type { ArtemisApiService } from '@extension/api';
-import type { CourseDashboardEntry } from '@extension/types';
+import type { CourseDashboardEntry, ExerciseDetail } from '@extension/types';
 
 import type { CourseDataCache } from '../courseDataCache';
 import { ExerciseRegistry, type ExerciseRegistryEntry } from '../exerciseRegistry';
@@ -31,26 +31,64 @@ export interface ExerciseSource {
 }
 
 /**
+ * Return the exercises for a CourseDashboardEntry, preferring the nested
+ * `course.exercises` array and falling back to the flat `entry.exercises`.
+ *
+ * The length check is deliberate: in JavaScript `[] || fallback` evaluates
+ * to `[]` (empty arrays are truthy), so a previous mix of `??` and `||`
+ * across the codebase was effectively identical. The new behavior treats
+ * a nested empty array as "look at flat next", which is what consumers
+ * appear to assume in practice.
+ */
+export function getEntryExercises(entry: CourseDashboardEntry): ExerciseDetail[] {
+    const nested = entry.course?.exercises;
+    return nested?.length ? nested : (entry.exercises ?? []);
+}
+
+/**
+ * Map a raw `ExerciseDetail` (server response) to the narrow `ExerciseSource`
+ * shape used by workspace detection. Returns null when the exercise is missing
+ * a numeric id or a string title — those are the only fields the workspace
+ * matching logic cannot tolerate.
+ *
+ * `courseId` is taken from the argument, not from any nested `course.id`,
+ * because the surrounding traversal knows which course the exercise belongs to.
+ */
+export function toExerciseSource(
+    exercise: ExerciseDetail,
+    courseId?: number,
+): ExerciseSource | null {
+    if (typeof exercise.id !== 'number' || typeof exercise.title !== 'string') {
+        return null;
+    }
+    const rawParticipations = exercise.studentParticipations;
+    const studentParticipations = Array.isArray(rawParticipations)
+        ? rawParticipations.map(p => ({
+            repositoryUri: p.repositoryUri,
+            testRun: p.testRun,
+        }))
+        : undefined;
+    return {
+        id: exercise.id,
+        title: exercise.title,
+        shortName: exercise.shortName,
+        courseId,
+        repositoryUri: exercise.repositoryUri,
+        studentParticipations,
+    };
+}
+
+/**
  * Extracts ExerciseSource objects from course dashboard entries.
  * Handles both nested (entry.course.exercises) and flat (entry.exercises) shapes.
  */
 export function collectExerciseSources(entries: CourseDashboardEntry[]): ExerciseSource[] {
-    const sources: ExerciseSource[] = [];
-    for (const entry of entries) {
-        for (const raw of (entry.course?.exercises ?? entry.exercises ?? [])) {
-            const ex = raw as { id?: number; title?: string; shortName?: string;
-                repositoryUri?: string;
-                studentParticipations?: Array<{ repositoryUri?: string; testRun?: boolean }> };
-            if (ex.id && ex.title) {
-                sources.push({
-                    id: ex.id, title: ex.title, shortName: ex.shortName,
-                    courseId: entry.course?.id, repositoryUri: ex.repositoryUri,
-                    studentParticipations: ex.studentParticipations,
-                });
-            }
-        }
-    }
-    return sources;
+    return entries.flatMap(entry => {
+        const exercises = getEntryExercises(entry);
+        return exercises
+            .map(ex => toExerciseSource(ex, entry.course?.id))
+            .filter((s): s is ExerciseSource => s !== null);
+    });
 }
 
 /**
@@ -307,12 +345,11 @@ export async function findWorkspaceCourseInArchive(
     }
 
     // Check if the exercise is already in active courses
-    const allActiveExercises: ExerciseSource[] = activeCourseEntries.flatMap(entry => {
-        const exercises = entry.course?.exercises || entry.exercises || [];
-        return exercises
-            .filter((ex): ex is typeof ex & { id: number; title: string } => ex.id !== undefined && ex.title !== undefined)
-            .map(ex => ({ ...ex, courseId: entry.course?.id }));
-    });
+    const allActiveExercises: ExerciseSource[] = activeCourseEntries.flatMap(entry =>
+        getEntryExercises(entry)
+            .map(ex => toExerciseSource(ex, entry.course?.id))
+            .filter((s): s is ExerciseSource => s !== null)
+    );
 
     if (findExerciseByRepositoryUrl(repositoryUrl, allActiveExercises)) {
         return null; // Already matched in active courses
@@ -328,9 +365,9 @@ export async function findWorkspaceCourseInArchive(
         }
         try {
             const entry = await artemisApi.getCourseForDashboard(course.id);
-            const exercises: ExerciseSource[] = (entry.course?.exercises || entry.exercises || [])
-                .filter((ex): ex is typeof ex & { id: number; title: string } => ex.id !== undefined && ex.title !== undefined)
-                .map(ex => ({ ...ex, courseId: entry.course?.id }));
+            const exercises: ExerciseSource[] = getEntryExercises(entry)
+                .map(ex => toExerciseSource(ex, entry.course?.id))
+                .filter((s): s is ExerciseSource => s !== null);
 
             if (findExerciseByRepositoryUrl(repositoryUrl, exercises)) {
                 logger.irisChat(`Found workspace match in archived course: ${entry.course?.title}`);
@@ -382,13 +419,7 @@ export async function detectAndRegisterWorkspaceExercise(
 
                 if (courses && Array.isArray(courses) && courses.length > 0) {
                     for (const courseData of courses) {
-                        const courseExercises = courseData?.course?.exercises || courseData?.exercises || [];
-                        if (courseExercises.length > 0) {
-                            registry.registerFromCourseData({
-                                course: courseData.course || courseData,
-                                exercises: courseExercises
-                            });
-                        }
+                        registry.registerFromCourseData(courseData);
                     }
                 }
                 exercises = registry.getAllExercises();
@@ -406,13 +437,7 @@ export async function detectAndRegisterWorkspaceExercise(
             try {
                 const archivedEntry = await findWorkspaceCourseInArchive(artemisApiService, []);
                 if (archivedEntry) {
-                    const courseExercises = archivedEntry.course?.exercises || archivedEntry.exercises || [];
-                    if (courseExercises.length > 0) {
-                        registry.registerFromCourseData({
-                            course: archivedEntry.course || {},
-                            exercises: courseExercises
-                        });
-                    }
+                    registry.registerFromCourseData(archivedEntry);
                     exercises = registry.getAllExercises();
                     detected = await detectWorkspaceExercise(exercises);
                 }

--- a/extension/src/shared/messageContracts/domainMappers.ts
+++ b/extension/src/shared/messageContracts/domainMappers.ts
@@ -2,22 +2,44 @@ import type { CourseDashboardCourse } from '../types/apiResponses';
 import type { CourseDetailData } from './domainTypes';
 
 /**
- * Maps a raw CourseDashboardCourse to CourseDetailData.
- * Spreads the raw course to preserve all server-provided fields,
- * then overlays the required fields with safe defaults.
+ * Maps a raw `CourseDashboardCourse` (server response, all fields optional,
+ * carries unknown extra keys) to the validated `CourseDetailData` shape used
+ * by the webview state.
+ *
+ * Returns `null` when the input is missing the only field the webview cannot
+ * tolerate (a numeric `id`). Callers are expected to log and either bail out
+ * or drop the row. The mapper itself stays pure: no logging, no throwing,
+ * no `[key: string]: unknown` leakage into the domain DTO. Fields are listed
+ * explicitly so unknown server keys (e.g. `exams`) are dropped at the
+ * boundary instead of being smuggled into webview state.
+ *
+ * Runtime check is `typeof course.id !== 'number'` rather than `=== undefined`
+ * so a malformed server payload sending `null` or a string id also drops to
+ * null instead of being smuggled past static optionality.
  */
 export function toCourseDetailData(
-    course: CourseDashboardCourse,
+    course: CourseDashboardCourse | undefined,
     opts?: { isArchived?: boolean }
-): CourseDetailData {
-    // Drop any server-provided exam data — exam mode is not supported.
-    const { exams: _exams, ...rest } = course;
+): CourseDetailData | null {
+    if (!course || typeof course.id !== 'number') {
+        return null;
+    }
     return {
         course: {
-            ...rest,
-            id: course.id!,
+            id: course.id,
             title: course.title || 'Untitled Course',
+            description: course.description,
+            semester: course.semester,
+            color: course.color,
+            // TASK-2-SCAFFOLD: cast survives until Task 2 widens
+            // CourseDetailData.course.exercises to ExerciseDetail[].
+            // Deleted in the Task 2 commit.
+            exercises: course.exercises as unknown as CourseDetailData['course']['exercises'],
+            numberOfStudents: course.numberOfStudents,
+            instructorGroupName: course.instructorGroupName,
+            shortName: course.shortName,
+            startDate: course.startDate,
             isArchived: opts?.isArchived,
-        } as CourseDetailData['course'],
+        },
     };
 }

--- a/extension/src/shared/messageContracts/domainMappers.ts
+++ b/extension/src/shared/messageContracts/domainMappers.ts
@@ -31,10 +31,7 @@ export function toCourseDetailData(
             description: course.description,
             semester: course.semester,
             color: course.color,
-            // TASK-2-SCAFFOLD: cast survives until Task 2 widens
-            // CourseDetailData.course.exercises to ExerciseDetail[].
-            // Deleted in the Task 2 commit.
-            exercises: course.exercises as unknown as CourseDetailData['course']['exercises'],
+            exercises: course.exercises,
             numberOfStudents: course.numberOfStudents,
             instructorGroupName: course.instructorGroupName,
             shortName: course.shortName,

--- a/extension/src/shared/messageContracts/domainTypes.ts
+++ b/extension/src/shared/messageContracts/domainTypes.ts
@@ -50,5 +50,6 @@ export interface CourseDetailData {
         instructorGroupName?: string;
         isArchived?: boolean;
         shortName?: string;
+        startDate?: string;
     };
 }

--- a/extension/src/shared/messageContracts/domainTypes.ts
+++ b/extension/src/shared/messageContracts/domainTypes.ts
@@ -2,33 +2,11 @@
  * Domain types shared between extension and webview messages.
  */
 
-export interface CourseData {
-    course: {
-        id?: number;
-        title: string;
-        description?: string;
-        semester?: string;
-        color?: string;
-        exercises?: Exercise[];
-        numberOfStudents?: number;
-        instructorGroupName?: string;
-        startDate?: string;
-    };
-}
+import type { ExerciseDetail } from '../types/apiResponses';
 
 export interface RecentCourseNode {
-    courseData: CourseData;
-    exercises: Exercise[];
-}
-
-export interface Exercise {
-    id?: number;
-    title?: string;
-    type?: string;
-    releaseDate?: string;
-    startDate?: string;
-    dueDate?: string;
-    maxPoints?: number;
+    courseData: CourseDetailData;
+    exercises: ExerciseDetail[];
 }
 
 export interface ArchivedCourse {
@@ -45,7 +23,7 @@ export interface CourseDetailData {
         description?: string;
         semester?: string;
         color?: string;
-        exercises?: Exercise[];
+        exercises?: ExerciseDetail[];
         numberOfStudents?: number;
         instructorGroupName?: string;
         isArchived?: boolean;

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -9,7 +9,7 @@ import type {
     SubmissionSummary,
 } from '../types/apiResponses';
 import type { ChatContextType } from '../types/context';
-import type { ArchivedCourse, CourseData, CourseDetailData, RecentCourseNode } from './domainTypes';
+import type { ArchivedCourse, CourseDetailData, RecentCourseNode } from './domainTypes';
 
 /**
  * Display-facing projection of the websocket connection state. Both the chat
@@ -98,7 +98,7 @@ interface ExtensionMsgPayloads {
         } | null;
     };
     courseListInit: {
-        courses: CourseData[];
+        courses: CourseDetailData[];
         archivedCourses?: ArchivedCourse[];
     };
     courseDetailInit: {

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -2,7 +2,6 @@
  * Webview -> Extension command contracts.
  */
 
-import type { CourseDashboardCourse } from '../types/apiResponses';
 import type { ChatContextType } from '../types/context';
 
 /** Non-command webview message types (ready, requestInit, error) */
@@ -113,7 +112,7 @@ interface WebviewCmdPayloads {
     // Navigation
     backToDashboard: undefined;
     showAllCourses: undefined;
-    viewCourseDetails: { courseData: CourseDashboardCourse };
+    viewCourseDetails: { courseId: number };
     openExercise: { exerciseId: number; courseId?: number | null };
     openExerciseDetails: { exerciseId: number };
     backToCourseDetails: undefined;

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -81,6 +81,7 @@ export interface ExerciseDetail {
     dueDate?: string;
     maxPoints?: number;
     bonusPoints?: number;
+    repositoryUri?: string;
     problemStatement?: string;
     mode?: string;
     includedInScore?: boolean;

--- a/extension/src/webview/stores/useCourseDetailStore.ts
+++ b/extension/src/webview/stores/useCourseDetailStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-import { type CourseDetailData, type Exercise, postCommand, type VsCodeApi } from '@shared/messageContracts';
+import { type CourseDetailData, postCommand, type VsCodeApi } from '@shared/messageContracts';
+import type { ExerciseDetail } from '@shared/types';
 
 interface CourseDetailState {
     courseData: CourseDetailData | null;
@@ -21,13 +22,13 @@ interface CourseDetailState {
     loadCourseDetail: (vscodeApi: VsCodeApi, courseId?: number) => void;
 
     // Derived
-    filteredExercises: () => Exercise[];
+    filteredExercises: () => ExerciseDetail[];
 }
 
 /**
  * Filter exercises by search term (case-insensitive, matches title or type).
  */
-function filterExercises(exercises: Exercise[], searchTerm: string): Exercise[] {
+function filterExercises(exercises: ExerciseDetail[], searchTerm: string): ExerciseDetail[] {
     const lowerSearchTerm = searchTerm.toLowerCase().trim();
     if (!lowerSearchTerm) {
         return exercises;
@@ -43,7 +44,7 @@ function filterExercises(exercises: Exercise[], searchTerm: string): Exercise[] 
 /**
  * Sort exercises based on selected sort option.
  */
-function sortExercises(exercises: Exercise[], sortBy: string): Exercise[] {
+function sortExercises(exercises: ExerciseDetail[], sortBy: string): ExerciseDetail[] {
     const sorted = [...exercises];
 
     switch (sortBy) {

--- a/extension/src/webview/stores/useCourseListStore.ts
+++ b/extension/src/webview/stores/useCourseListStore.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-import { type ArchivedCourse, type CourseData, postCommand, type VsCodeApi } from '@shared/messageContracts';
+import { type ArchivedCourse, type CourseDetailData, postCommand, type VsCodeApi } from '@shared/messageContracts';
 
 interface CourseListState {
-    courses: CourseData[];
+    courses: CourseDetailData[];
     archivedCourses: ArchivedCourse[];
     archivedLoaded: boolean;
     isLoading: boolean;
@@ -14,7 +14,7 @@ interface CourseListState {
     sortBy: string;
 
     // Actions
-    setCourses: (courses: CourseData[], archived?: ArchivedCourse[]) => void;
+    setCourses: (courses: CourseDetailData[], archived?: ArchivedCourse[]) => void;
     setArchivedCourses: (archived: ArchivedCourse[]) => void;
     setLoading: (loading: boolean) => void;
     setSearchTerm: (term: string) => void;
@@ -26,7 +26,7 @@ interface CourseListState {
     loadArchivedCourses: (vscodeApi: VsCodeApi) => void;
 
     // Derived
-    filteredCourses: () => { active: CourseData[]; archived: ArchivedCourse[] };
+    filteredCourses: () => { active: CourseDetailData[]; archived: ArchivedCourse[] };
 }
 
 /**

--- a/extension/src/webview/views/CourseDetail/CourseDetailView.tsx
+++ b/extension/src/webview/views/CourseDetail/CourseDetailView.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
-import type { Exercise } from '@shared/messageContracts';
 import { ExtensionMsg, postCommand, requestInit } from '@shared/messageContracts';
+import type { ExerciseDetail } from '@shared/types';
 
 import type { DropdownOption } from '@webview/components';
 import {
@@ -254,7 +254,7 @@ export function CourseDetailView({ vscodeApi }: CourseDetailViewProps) {
 
                 {exercises.length > 0 && (
                     <div className={styles.exercisesList}>
-                        {exercises.map((exercise: Exercise) => {
+                        {exercises.map((exercise: ExerciseDetail) => {
                             const isWorkspaceExercise = exercise.id === workspaceExerciseId;
                             const points = exercise.maxPoints || 0;
 

--- a/extension/src/webview/views/CourseList/CourseListView.tsx
+++ b/extension/src/webview/views/CourseList/CourseListView.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
 import { ExtensionMsg, postCommand } from '@shared/messageContracts';
-import type { CourseDashboardCourse } from '@shared/types/apiResponses';
 
 import type { DropdownOption } from '@webview/components';
 import {
@@ -135,7 +134,7 @@ export function CourseListView({ vscodeApi }: CourseListViewProps) {
     };
 
     const handleViewCourseDetails = (courseData: CourseDetailData) => {
-        postCommand(vscodeApi, 'viewCourseDetails', { courseData: courseData.course as CourseDashboardCourse });
+        postCommand(vscodeApi, 'viewCourseDetails', { courseId: courseData.course.id });
     };
 
     const handleViewArchivedCourse = (courseId: number) => {

--- a/extension/src/webview/views/CourseList/CourseListView.tsx
+++ b/extension/src/webview/views/CourseList/CourseListView.tsx
@@ -20,7 +20,7 @@ import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
 import { useCourseListStore } from '@webview/stores/useCourseListStore';
 
 import styles from './CourseListView.module.css';
-import type { ArchivedCourse, CourseData, CourseListPersistedState, CourseListViewProps } from './types';
+import type { ArchivedCourse, CourseDetailData, CourseListPersistedState, CourseListViewProps } from './types';
 
 export function CourseListView({ vscodeApi }: CourseListViewProps) {
     const {
@@ -134,7 +134,7 @@ export function CourseListView({ vscodeApi }: CourseListViewProps) {
         postCommand(vscodeApi, 'toggleCourseListFullscreen');
     };
 
-    const handleViewCourseDetails = (courseData: CourseData) => {
+    const handleViewCourseDetails = (courseData: CourseDetailData) => {
         postCommand(vscodeApi, 'viewCourseDetails', { courseData: courseData.course as CourseDashboardCourse });
     };
 

--- a/extension/src/webview/views/CourseList/types.ts
+++ b/extension/src/webview/views/CourseList/types.ts
@@ -1,4 +1,4 @@
-import type { ArchivedCourse, CourseData, VsCodeApi } from '@shared/messageContracts';
+import type { ArchivedCourse, CourseDetailData, VsCodeApi } from '@shared/messageContracts';
 
 export interface CourseListViewProps {
     vscodeApi: VsCodeApi;
@@ -12,4 +12,4 @@ export interface CourseListPersistedState {
 }
 
 // Re-export types from messageContracts
-export type { ArchivedCourse, CourseData };
+export type { ArchivedCourse, CourseDetailData };

--- a/extension/src/webview/views/Dashboard/DashboardView.tsx
+++ b/extension/src/webview/views/Dashboard/DashboardView.tsx
@@ -21,7 +21,7 @@ import { useDashboardStore } from '@webview/stores/useDashboardStore';
 import { getIcon } from '@webview/utils/iconMap';
 
 import styles from './DashboardView.module.css';
-import type { DashboardViewProps, Exercise, RecentCourseNode } from './types';
+import type { DashboardViewProps, RecentCourseNode } from './types';
 
 export function DashboardView({ vscodeApi }: DashboardViewProps) {
     const {

--- a/extension/src/webview/views/Dashboard/DashboardView.tsx
+++ b/extension/src/webview/views/Dashboard/DashboardView.tsx
@@ -13,7 +13,6 @@ import SquareArrowOutUpRight from 'lucide-react/dist/esm/icons/square-arrow-out-
 import { useState } from 'react';
 
 import { ExtensionMsg, postCommand } from '@shared/messageContracts';
-import type { CourseDashboardCourse } from '@shared/types/apiResponses';
 
 import { Button, Container, IconButton, ListItem, Skeleton, SkeletonList } from '@webview/components';
 import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
@@ -61,7 +60,7 @@ export function DashboardView({ vscodeApi }: DashboardViewProps) {
 
     const handleViewCourseDetails = (courseData: RecentCourseNode) => {
         postCommand(vscodeApi, 'viewCourseDetails', {
-            courseData: courseData.courseData.course as CourseDashboardCourse,
+            courseId: courseData.courseData.course.id,
         });
     };
 

--- a/extension/src/webview/views/Dashboard/types.ts
+++ b/extension/src/webview/views/Dashboard/types.ts
@@ -1,6 +1,6 @@
 import type { VsCodeApi } from '@shared/messageContracts';
 
-export type { Exercise, RecentCourseNode } from '@shared/messageContracts';
+export type { RecentCourseNode } from '@shared/messageContracts';
 
 export interface DashboardViewProps {
     vscodeApi: VsCodeApi;

--- a/extension/test/react/fixtures/courseListPayload.ts
+++ b/extension/test/react/fixtures/courseListPayload.ts
@@ -1,11 +1,11 @@
-import type { ArchivedCourse, CourseData, ExtMsg } from '@shared/messageContracts';
+import type { ArchivedCourse, CourseDetailData, ExtMsg } from '@shared/messageContracts';
 
 export function createCourseListPayload(
     overrides?: Partial<Omit<ExtMsg<'courseListInit'>, 'type'>>,
 ): ExtMsg<'courseListInit'> {
     return {
         type: 'courseListInit',
-        courses: [] as CourseData[],
+        courses: [] as CourseDetailData[],
         archivedCourses: [] as ArchivedCourse[],
         ...overrides,
     };

--- a/extension/test/react/flows/courseNavigation.flow.test.tsx
+++ b/extension/test/react/flows/courseNavigation.flow.test.tsx
@@ -75,9 +75,7 @@ describe('Course Navigation Flow', () => {
 				expect.objectContaining({
 					type: 'command',
 					command: 'viewCourseDetails',
-					payload: expect.objectContaining({
-						courseData: expect.objectContaining({ id: 10 }),
-					}),
+					payload: { courseId: 10 },
 				})
 			);
 		});

--- a/extension/test/react/flows/courseNavigation.flow.test.tsx
+++ b/extension/test/react/flows/courseNavigation.flow.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
-import type { CourseData } from '@shared/messageContracts';
+import type { CourseDetailData } from '@shared/messageContracts';
 
 import { useCourseDetailStore } from '@webview/stores/useCourseDetailStore';
 import { useCourseListStore } from '@webview/stores/useCourseListStore';
@@ -19,7 +19,7 @@ import { createMockVsCodeApi, dispatchExtensionMessage } from '../__helpers__/vs
  * with mocked store data. Exercises full postMessage round-trip verification.
  */
 
-function makeCourseData(overrides: Partial<CourseData['course']> = {}): CourseData {
+function makeCourseDetailData(overrides: Partial<CourseDetailData['course']> = {}): CourseDetailData {
 	return {
 		course: {
 			id: 1,
@@ -41,8 +41,8 @@ describe('Course Navigation Flow', () => {
 			dispatchExtensionMessage({
 				type: 'courseListInit',
 				courses: [
-					makeCourseData({ id: 1, title: 'Algorithms', semester: 'WS24/25' }),
-					makeCourseData({ id: 2, title: 'Data Structures', semester: 'SS25' }),
+					makeCourseDetailData({ id: 1, title: 'Algorithms', semester: 'WS24/25' }),
+					makeCourseDetailData({ id: 2, title: 'Data Structures', semester: 'SS25' }),
 				],
 			});
 
@@ -60,7 +60,7 @@ describe('Course Navigation Flow', () => {
 			// Load courses via message
 			dispatchExtensionMessage({
 				type: 'courseListInit',
-				courses: [makeCourseData({ id: 10, title: 'Software Engineering', semester: 'SS25' })],
+				courses: [makeCourseDetailData({ id: 10, title: 'Software Engineering', semester: 'SS25' })],
 			});
 
 			await waitFor(() => {

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -218,19 +218,15 @@ describe('Message contracts: WebviewToExtensionMessage types', () => {
         expect(msg.command).toBe('reloadCourses');
     });
 
-    it('ViewCourseDetailsCommand has courseData payload', () => {
+    it('ViewCourseDetailsCommand has courseId payload', () => {
         const msg = {
             type: 'command' as const,
             command: 'viewCourseDetails' as const,
-            payload: {
-                courseData: {
-                    course: { id: 1, title: 'Test', shortName: 'T' },
-                },
-            },
+            payload: { courseId: 1 },
         } satisfies WebCmd<'viewCourseDetails'>;
 
         expect(msg.command).toBe('viewCourseDetails');
-        expect(msg.payload.courseData.course.id).toBe(1);
+        expect(msg.payload.courseId).toBe(1);
     });
 
     it('SendMessageCommand has text + correlation IDs payload', () => {

--- a/extension/test/react/stores/useCourseDetailStore.test.ts
+++ b/extension/test/react/stores/useCourseDetailStore.test.ts
@@ -1,7 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import type { CourseDetailData, Exercise } from '@shared/messageContracts';
+import type { CourseDetailData } from '@shared/messageContracts';
+import type { ExerciseDetail } from '@shared/types';
 
 import { useCourseDetailStore } from '@webview/stores/useCourseDetailStore';
 
@@ -17,7 +18,7 @@ const makeCourseDetailData = (overrides: Partial<CourseDetailData['course']> = {
 	},
 });
 
-const makeExercise = (overrides: Partial<Exercise> = {}): Exercise => ({
+const makeExercise = (overrides: Partial<ExerciseDetail> = {}): ExerciseDetail => ({
 	id: 1,
 	title: 'Test Exercise',
 	type: 'programming',

--- a/extension/test/react/stores/useCourseListStore.test.ts
+++ b/extension/test/react/stores/useCourseListStore.test.ts
@@ -1,13 +1,13 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import type { ArchivedCourse, CourseData } from '@shared/messageContracts';
+import type { ArchivedCourse, CourseDetailData } from '@shared/messageContracts';
 
 import { useCourseListStore } from '@webview/stores/useCourseListStore';
 
 import { createMockVsCodeApi } from '../__helpers__/vscodeApi';
 
-const makeCourseData = (overrides: Partial<CourseData['course']> = {}): CourseData => ({
+const makeCourseDetailData = (overrides: Partial<CourseDetailData['course']> = {}): CourseDetailData => ({
 	course: {
 		id: 1,
 		title: 'Test Course',
@@ -69,7 +69,7 @@ describe('useCourseListStore', () => {
 
 	it('setCourses populates courses and stops loading', () => {
 		const { result } = renderHook(() => useCourseListStore());
-		const courses = [makeCourseData({ title: 'Course A' })];
+		const courses = [makeCourseDetailData({ title: 'Course A' })];
 
 		act(() => {
 			result.current.setLoading(true);
@@ -85,7 +85,7 @@ describe('useCourseListStore', () => {
 
 	it('setCourses with archived parameter populates archived courses', () => {
 		const { result } = renderHook(() => useCourseListStore());
-		const courses = [makeCourseData()];
+		const courses = [makeCourseDetailData()];
 		const archived = [makeArchivedCourse()];
 
 		act(() => {
@@ -101,7 +101,7 @@ describe('useCourseListStore', () => {
 		const { result } = renderHook(() => useCourseListStore());
 
 		act(() => {
-			result.current.setCourses([makeCourseData()]);
+			result.current.setCourses([makeCourseDetailData()]);
 		});
 
 		expect(result.current.archivedLoaded).toBe(false);
@@ -190,8 +190,8 @@ describe('useCourseListStore', () => {
 
 		act(() => {
 			result.current.setCourses([
-				makeCourseData({ title: 'Algorithms and Data Structures', id: 1 }),
-				makeCourseData({ title: 'Software Engineering', id: 2 }),
+				makeCourseDetailData({ title: 'Algorithms and Data Structures', id: 1 }),
+				makeCourseDetailData({ title: 'Software Engineering', id: 2 }),
 			]);
 			result.current.setSearchTerm('algorithm');
 		});
@@ -206,8 +206,8 @@ describe('useCourseListStore', () => {
 
 		act(() => {
 			result.current.setCourses([
-				makeCourseData({ id: 1 }),
-				makeCourseData({ id: 2, title: 'Another' }),
+				makeCourseDetailData({ id: 1 }),
+				makeCourseDetailData({ id: 2, title: 'Another' }),
 			]);
 		});
 
@@ -220,8 +220,8 @@ describe('useCourseListStore', () => {
 
 		act(() => {
 			result.current.setCourses([
-				makeCourseData({ title: 'Zebra Course', id: 1 }),
-				makeCourseData({ title: 'Alpha Course', id: 2 }),
+				makeCourseDetailData({ title: 'Zebra Course', id: 1 }),
+				makeCourseDetailData({ title: 'Alpha Course', id: 2 }),
 			]);
 			result.current.setSortBy('title-asc');
 		});
@@ -236,8 +236,8 @@ describe('useCourseListStore', () => {
 
 		act(() => {
 			result.current.setCourses([
-				makeCourseData({ title: 'Old Course', semester: 'WS23/24', id: 1 }),
-				makeCourseData({ title: 'New Course', semester: 'SS25', id: 2 }),
+				makeCourseDetailData({ title: 'Old Course', semester: 'WS23/24', id: 1 }),
+				makeCourseDetailData({ title: 'New Course', semester: 'SS25', id: 2 }),
 			]);
 			result.current.setSortBy('semester-desc');
 		});
@@ -251,8 +251,8 @@ describe('useCourseListStore', () => {
 
 		act(() => {
 			result.current.setCourses([
-				makeCourseData({ title: 'Spring Course', semester: 'ss25', id: 1 }),
-				makeCourseData({ title: 'Winter Course', semester: 'ws24/25', id: 2 }),
+				makeCourseDetailData({ title: 'Spring Course', semester: 'ss25', id: 1 }),
+				makeCourseDetailData({ title: 'Winter Course', semester: 'ws24/25', id: 2 }),
 			]);
 			result.current.setSemesterFilter('ss25');
 		});

--- a/extension/test/react/stores/useDashboardStore.test.ts
+++ b/extension/test/react/stores/useDashboardStore.test.ts
@@ -43,7 +43,7 @@ describe('useDashboardStore', () => {
 		const { result } = renderHook(() => useDashboardStore());
 
 		const makeCourse = (title: string, startDate: string): RecentCourseNode => ({
-			courseData: { course: { title, startDate } },
+			courseData: { course: { id: 1, title, startDate } },
 			exercises: [],
 		});
 
@@ -69,7 +69,7 @@ describe('useDashboardStore', () => {
 		const { result } = renderHook(() => useDashboardStore());
 
 		const makeCourse = (title: string, startDate: string): RecentCourseNode => ({
-			courseData: { course: { title, startDate } },
+			courseData: { course: { id: 1, title, startDate } },
 			exercises: [],
 		});
 
@@ -119,11 +119,11 @@ describe('useDashboardStore', () => {
 
 		const courses: RecentCourseNode[] = [
 			{
-				courseData: { course: { title: 'Course without startDate' } },
+				courseData: { course: { id: 1, title: 'Course without startDate' } },
 				exercises: [],
 			},
 			{
-				courseData: { course: { title: 'Course with startDate', startDate: '2023-05-01' } },
+				courseData: { course: { id: 2, title: 'Course with startDate', startDate: '2023-05-01' } },
 				exercises: [],
 			},
 		];
@@ -157,7 +157,7 @@ describe('useDashboardStore', () => {
 		const { result } = renderHook(() => useDashboardStore());
 
 		const makeCourse = (title: string, startDate: string): RecentCourseNode => ({
-			courseData: { course: { title, startDate } },
+			courseData: { course: { id: 1, title, startDate } },
 			exercises: [],
 		});
 
@@ -186,7 +186,7 @@ describe('useDashboardStore', () => {
 		const { result } = renderHook(() => useDashboardStore());
 
 		const makeCourse = (title: string, startDate: string): RecentCourseNode => ({
-			courseData: { course: { title, startDate } },
+			courseData: { course: { id: 1, title, startDate } },
 			exercises: [],
 		});
 

--- a/extension/test/react/views/CourseList/CourseListView.test.tsx
+++ b/extension/test/react/views/CourseList/CourseListView.test.tsx
@@ -2,14 +2,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
-import type { CourseData } from '@shared/messageContracts';
+import type { CourseDetailData } from '@shared/messageContracts';
 
 import { useCourseListStore } from '@webview/stores/useCourseListStore';
 import { CourseListView } from '@webview/views/CourseList/CourseListView';
 
 import { createMockVsCodeApi, dispatchExtensionMessage } from '../../__helpers__/vscodeApi';
 
-const makeCourseData = (overrides: Partial<CourseData['course']> = {}): CourseData => ({
+const makeCourseDetailData = (overrides: Partial<CourseDetailData['course']> = {}): CourseDetailData => ({
 	course: {
 		id: 1,
 		title: 'Test Course',
@@ -35,7 +35,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ title: 'Algorithms', id: 1 })],
+			courses: [makeCourseDetailData({ title: 'Algorithms', id: 1 })],
 		});
 
 		await waitFor(() => {
@@ -49,7 +49,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ title: 'Software Engineering', semester: 'WS24/25', id: 2 })],
+			courses: [makeCourseDetailData({ title: 'Software Engineering', semester: 'WS24/25', id: 2 })],
 		});
 
 		await waitFor(() => {
@@ -66,7 +66,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ title: 'Click Me Course', id: 42 })],
+			courses: [makeCourseDetailData({ title: 'Click Me Course', id: 42 })],
 		});
 
 		await waitFor(() => {
@@ -104,7 +104,7 @@ describe('CourseListView', () => {
 		dispatchExtensionMessage({
 			type: 'courseListInit',
 			courses: [
-				makeCourseData({
+				makeCourseDetailData({
 					title: 'Course with Exercises',
 					id: 10,
 					exercises: [
@@ -127,7 +127,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ id: 1 })],
+			courses: [makeCourseDetailData({ id: 1 })],
 		});
 
 		await waitFor(() => {
@@ -142,8 +142,8 @@ describe('CourseListView', () => {
 		dispatchExtensionMessage({
 			type: 'courseListInit',
 			courses: [
-				makeCourseData({ title: 'Algorithms', id: 1 }),
-				makeCourseData({ title: 'Biology 101', id: 2 }),
+				makeCourseDetailData({ title: 'Algorithms', id: 1 }),
+				makeCourseDetailData({ title: 'Biology 101', id: 2 }),
 			],
 		});
 
@@ -166,7 +166,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ id: 1 })],
+			courses: [makeCourseDetailData({ id: 1 })],
 		});
 
 		await waitFor(() => {
@@ -180,7 +180,7 @@ describe('CourseListView', () => {
 
 		dispatchExtensionMessage({
 			type: 'courseListInit',
-			courses: [makeCourseData({ id: 1 })],
+			courses: [makeCourseDetailData({ id: 1 })],
 		});
 
 		await waitFor(() => {

--- a/extension/test/unit/controller/navigationCommands.test.ts
+++ b/extension/test/unit/controller/navigationCommands.test.ts
@@ -1,6 +1,6 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as vscode from 'vscode';
 
 import type { WebCmd } from '@shared/messageContracts';
 

--- a/extension/test/unit/controller/navigationCommands.test.ts
+++ b/extension/test/unit/controller/navigationCommands.test.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import type { WebCmd } from '@shared/messageContracts';
+
+import { NavigationCommandModule } from '@extension/controller/commands/navigationCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+
+suite('handleViewCourseDetails resolver', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function buildContext(overrides: {
+        coursesData?: { courses: Array<{ course: { id: number; title?: string } }> };
+        getCourseForDashboard?: sinon.SinonStub;
+        showCourseDetail?: sinon.SinonStub;
+    }): CommandContext {
+        return {
+            appStateManager: {
+                coursesData: overrides.coursesData,
+                showCourseDetail: overrides.showCourseDetail ?? sandbox.stub(),
+            },
+            artemisApi: {
+                getCourseForDashboard: overrides.getCourseForDashboard
+                    ?? sandbox.stub().resolves({ course: undefined }),
+            },
+            actionHandler: { render: sandbox.stub() },
+            courseAccessStorage: { onCourseAccessed: sandbox.stub() },
+            providerRegistry: { getChatWebviewProvider: () => undefined },
+            exerciseRegistry: { registerFromCourseData: sandbox.stub() },
+        } as unknown as CommandContext;
+    }
+
+    test('uses cache when course is present', async () => {
+        const showCourseDetail = sandbox.stub();
+        const getCourseForDashboard = sandbox.stub().resolves({ course: { id: 7, title: 'fetched' } });
+        const ctx = buildContext({
+            coursesData: { courses: [{ course: { id: 7, title: 'cached' } }] },
+            getCourseForDashboard,
+            showCourseDetail,
+        });
+        const mod = new NavigationCommandModule(ctx);
+
+        await mod.getHandlers().viewCourseDetails({
+            type: 'command',
+            command: 'viewCourseDetails',
+            payload: { courseId: 7 },
+        } satisfies WebCmd<'viewCourseDetails'>);
+
+        assert.strictEqual(getCourseForDashboard.callCount, 0, 'API must not be called on cache hit');
+        assert.strictEqual(showCourseDetail.callCount, 1, 'showCourseDetail must be called on cache hit');
+    });
+
+    test('falls back to getCourseForDashboard on cache miss', async () => {
+        const showCourseDetail = sandbox.stub();
+        const getCourseForDashboard = sandbox.stub().resolves({ course: { id: 99, title: 'fetched' } });
+        const ctx = buildContext({
+            coursesData: { courses: [] },
+            getCourseForDashboard,
+            showCourseDetail,
+        });
+        const mod = new NavigationCommandModule(ctx);
+
+        await mod.getHandlers().viewCourseDetails({
+            type: 'command',
+            command: 'viewCourseDetails',
+            payload: { courseId: 99 },
+        } satisfies WebCmd<'viewCourseDetails'>);
+
+        assert.strictEqual(getCourseForDashboard.callCount, 1, 'API must be called once on cache miss');
+        sinon.assert.calledWith(getCourseForDashboard, 99);
+        assert.strictEqual(showCourseDetail.callCount, 1, 'showCourseDetail must be called after API fetch');
+    });
+
+    test('shows error and aborts when mapper returns null', async () => {
+        const showCourseDetail = sandbox.stub();
+        const getCourseForDashboard = sandbox.stub().resolves({ course: { title: 'no-id' } });
+        const ctx = buildContext({
+            coursesData: { courses: [] },
+            getCourseForDashboard,
+            showCourseDetail,
+        });
+        const mod = new NavigationCommandModule(ctx);
+
+        await mod.getHandlers().viewCourseDetails({
+            type: 'command',
+            command: 'viewCourseDetails',
+            payload: { courseId: 5 },
+        } satisfies WebCmd<'viewCourseDetails'>);
+
+        assert.strictEqual(showCourseDetail.callCount, 0, 'showCourseDetail must not be called');
+        assert.strictEqual(showErrorMessage.callCount, 1, 'error toast must be shown');
+        sinon.assert.calledWith(showErrorMessage, 'Course data is incomplete');
+    });
+
+    test('shows error toast when API throws on cache miss', async () => {
+        const showCourseDetail = sandbox.stub();
+        const apiError = new Error('boom');
+        const getCourseForDashboard = sandbox.stub().rejects(apiError);
+        const ctx = buildContext({
+            coursesData: { courses: [] },
+            getCourseForDashboard,
+            showCourseDetail,
+        });
+        const mod = new NavigationCommandModule(ctx);
+
+        await mod.getHandlers().viewCourseDetails({
+            type: 'command',
+            command: 'viewCourseDetails',
+            payload: { courseId: 12 },
+        } satisfies WebCmd<'viewCourseDetails'>);
+
+        assert.strictEqual(showCourseDetail.callCount, 0, 'showCourseDetail must not be called');
+        assert.strictEqual(showErrorMessage.callCount, 1, 'error toast must be shown');
+        sinon.assert.calledWith(showErrorMessage, 'Error viewing course details');
+    });
+});

--- a/extension/test/unit/services/viewInitDataService.test.ts
+++ b/extension/test/unit/services/viewInitDataService.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+
+import type { ExtensionToWebviewMessage } from '@shared/messageContracts';
+
+import { ViewInitDataService } from '@extension/services/ui/viewInitDataService';
+
+type Posted = ExtensionToWebviewMessage | undefined;
+
+function buildService(coursesData: { courses: Array<{ course: { id?: number; title?: string; exercises?: unknown[] } }> }) {
+    let posted: Posted = undefined;
+    const appState = {
+        coursesData,
+        archiveCheckComplete: true,
+        archivedCoursesData: undefined,
+        currentCourseData: undefined,
+        currentState: 'dashboard',
+    } as never;
+    const messageHandler = { clearRepositoryContext: () => undefined } as never;
+    const courseAccessStorage = { getLastAccessedCourses: () => [] } as never;
+    const service = new ViewInitDataService(
+        appState,
+        undefined,
+        messageHandler,
+        (msg: ExtensionToWebviewMessage) => { posted = msg; },
+        courseAccessStorage,
+    );
+    return { service, getPosted: () => posted };
+}
+
+suite('ViewInitDataService.sendDashboardInit', () => {
+    // Note: courses without a numeric id are filtered upstream by
+    // selectRecentCourses, so the drop-coverage for the mapper's null
+    // return happens in the toCourseDetailData test suite. This test
+    // documents the end-to-end behavior: no id=0 sentinel reaches the
+    // emitted payload.
+    test('emits no id=0 entries (id-less courses dropped upstream + mapper)', () => {
+        const { service, getPosted } = buildService({
+            courses: [
+                { course: { title: 'no-id' } },
+                { course: { id: 5, title: 'with-id' } },
+            ],
+        });
+        service.sendDashboardInit();
+        const posted = getPosted();
+        assert.ok(posted, 'dashboard init must post a message');
+        assert.strictEqual(posted.type, 'dashboardInit');
+        const ids = (posted as { courses: Array<{ courseData: { course: { id: number } } }> })
+            .courses.map(n => n.courseData.course.id);
+        assert.deepStrictEqual(ids, [5], 'invalid courses must be dropped, not emitted with id=0');
+    });
+
+    test('emits RecentCourseNode[] whose courseData uses CourseDetailData', () => {
+        const { service, getPosted } = buildService({
+            courses: [{ course: { id: 7, title: 'X' } }],
+        });
+        service.sendDashboardInit();
+        const posted = getPosted();
+        assert.ok(posted);
+        const first = (posted as { courses: Array<{ courseData: { course: { id: number; title: string } } }> }).courses[0];
+        assert.strictEqual(first.courseData.course.id, 7);
+        assert.strictEqual(first.courseData.course.title, 'X');
+    });
+});
+
+suite('ViewInitDataService.sendCourseListInit', () => {
+    test('drops courses without numeric id', () => {
+        const { service, getPosted } = buildService({
+            courses: [
+                { course: { title: 'no-id' } },
+                { course: { id: 1, title: 'A' } },
+                { course: { title: 'no-id-2' } },
+            ],
+        });
+        service.sendCourseListInit();
+        const posted = getPosted();
+        assert.ok(posted);
+        assert.strictEqual(posted.type, 'courseListInit');
+        const ids = (posted as { courses: Array<{ course: { id: number } }> })
+            .courses.map(c => c.course.id);
+        assert.deepStrictEqual(ids, [1], 'invalid courses must be dropped');
+    });
+});

--- a/extension/test/unit/services/workspaceDetectionService.test.ts
+++ b/extension/test/unit/services/workspaceDetectionService.test.ts
@@ -6,9 +6,12 @@ import {
     detectWorkspaceExercise,
     type ExerciseSource,
     findExerciseByRepositoryUrl,
+    getEntryExercises,
     getWorkspaceRepositoryUrl,
     normalizeRepositoryUrl,
+    toExerciseSource,
 } from '@extension/services/workspace/workspaceDetectionService';
+import type { CourseDashboardEntry, ExerciseDetail } from '@extension/types';
 
 suite('WorkspaceDetectionService', () => {
     suite('normalizeRepositoryUrl', () => {
@@ -359,4 +362,106 @@ suite('WorkspaceDetectionService', () => {
         });
     });
 
+});
+
+suite('getEntryExercises', () => {
+    test('returns nested exercises when present and non-empty', () => {
+        const entry: CourseDashboardEntry = {
+            course: { id: 1, exercises: [{ id: 10, title: 'A' }] },
+        };
+        const result = getEntryExercises(entry);
+        assert.deepStrictEqual(result.map(e => e.id), [10]);
+    });
+
+    test('falls back to flat exercises when nested is empty array', () => {
+        const entry: CourseDashboardEntry = {
+            course: { id: 1, exercises: [] },
+            exercises: [{ id: 99, title: 'flat' }],
+        };
+        const result = getEntryExercises(entry);
+        assert.deepStrictEqual(result.map(e => e.id), [99]);
+    });
+
+    test('falls back to flat exercises when nested is undefined', () => {
+        const entry: CourseDashboardEntry = {
+            course: { id: 1 },
+            exercises: [{ id: 5, title: 'flat-only' }],
+        };
+        const result = getEntryExercises(entry);
+        assert.deepStrictEqual(result.map(e => e.id), [5]);
+    });
+
+    test('returns empty array when both are missing', () => {
+        const entry: CourseDashboardEntry = { course: { id: 1 } };
+        assert.deepStrictEqual(getEntryExercises(entry), []);
+    });
+});
+
+suite('toExerciseSource', () => {
+    test('returns null when id is not a number', () => {
+        const ex: ExerciseDetail = { title: 'no-id' };
+        assert.strictEqual(toExerciseSource(ex), null);
+    });
+
+    test('returns null when title is not a string', () => {
+        const ex: ExerciseDetail = { id: 1 };
+        assert.strictEqual(toExerciseSource(ex), null);
+    });
+
+    test('preserves direct repositoryUri', () => {
+        const ex: ExerciseDetail = { id: 1, title: 'A', repositoryUri: 'git://x/y.git' };
+        const result = toExerciseSource(ex);
+        assert.ok(result);
+        assert.strictEqual(result.repositoryUri, 'git://x/y.git');
+    });
+
+    test('preserves studentParticipations with only the read fields', () => {
+        const ex: ExerciseDetail = {
+            id: 1, title: 'A',
+            studentParticipations: [
+                { id: 99, repositoryUri: 'r1', testRun: true, type: 'STUDENT' as never },
+                { id: 100, repositoryUri: 'r2', testRun: false, type: 'STUDENT' as never },
+            ],
+        };
+        const result = toExerciseSource(ex);
+        assert.ok(result);
+        assert.deepStrictEqual(
+            result.studentParticipations,
+            [
+                { repositoryUri: 'r1', testRun: true },
+                { repositoryUri: 'r2', testRun: false },
+            ],
+        );
+    });
+
+    test('uses courseId argument over any nested course.id', () => {
+        const ex: ExerciseDetail = { id: 1, title: 'A', course: { id: 999 } };
+        const result = toExerciseSource(ex, 42);
+        assert.ok(result);
+        assert.strictEqual(result.courseId, 42);
+    });
+});
+
+suite('collectExerciseSources', () => {
+    test('handles entries with nested-only, flat-only, and both', () => {
+        // import collectExerciseSources locally to avoid the global suite reorg
+        const { collectExerciseSources } = require('@extension/services/workspace/workspaceDetectionService');
+        const entries: CourseDashboardEntry[] = [
+            { course: { id: 1, exercises: [{ id: 11, title: 'nested' }] } },
+            { course: { id: 2 }, exercises: [{ id: 22, title: 'flat' }] },
+            { course: { id: 3, exercises: [] }, exercises: [{ id: 33, title: 'both' }] },
+        ];
+        const out = collectExerciseSources(entries);
+        assert.deepStrictEqual(out.map((s: { id: number }) => s.id), [11, 22, 33]);
+        assert.deepStrictEqual(out.map((s: { courseId?: number }) => s.courseId), [1, 2, 3]);
+    });
+
+    test('drops malformed entries silently', () => {
+        const { collectExerciseSources } = require('@extension/services/workspace/workspaceDetectionService');
+        const entries: CourseDashboardEntry[] = [
+            { course: { id: 1, exercises: [{ /* no id */ title: 'x' } as ExerciseDetail, { id: 9, title: 'ok' }] } },
+        ];
+        const out = collectExerciseSources(entries);
+        assert.deepStrictEqual(out.map((s: { id: number }) => s.id), [9]);
+    });
 });

--- a/extension/test/unit/shared/messageContracts/domainMappers.test.ts
+++ b/extension/test/unit/shared/messageContracts/domainMappers.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+
+import { toCourseDetailData } from '@shared/messageContracts/domainMappers';
+import type { CourseDashboardCourse } from '@shared/types/apiResponses';
+
+suite('toCourseDetailData', () => {
+    test('returns null when course is undefined', () => {
+        assert.strictEqual(toCourseDetailData(undefined), null);
+    });
+
+    test('returns null when course.id is undefined', () => {
+        const course: CourseDashboardCourse = { title: 'X' };
+        assert.strictEqual(toCourseDetailData(course), null);
+    });
+
+    test('returns null when course.id is null', () => {
+        const course = { id: null as unknown as number, title: 'X' } as CourseDashboardCourse;
+        assert.strictEqual(toCourseDetailData(course), null);
+    });
+
+    test('returns null when course.id is a string', () => {
+        const course = { id: '1' as unknown as number, title: 'X' } as CourseDashboardCourse;
+        assert.strictEqual(toCourseDetailData(course), null);
+    });
+
+    test('maps a valid course preserving id and explicit fields', () => {
+        const course: CourseDashboardCourse = {
+            id: 42,
+            title: 'Algorithms',
+            description: 'desc',
+            semester: 'WS25/26',
+            color: '#abcdef',
+            numberOfStudents: 120,
+            instructorGroupName: 'instructors',
+            shortName: 'alg',
+            startDate: '2026-04-15T10:00:00Z',
+        };
+        const result = toCourseDetailData(course);
+        assert.ok(result);
+        assert.strictEqual(result.course.id, 42);
+        assert.strictEqual(result.course.title, 'Algorithms');
+        assert.strictEqual(result.course.description, 'desc');
+        assert.strictEqual(result.course.semester, 'WS25/26');
+        assert.strictEqual(result.course.color, '#abcdef');
+        assert.strictEqual(result.course.numberOfStudents, 120);
+        assert.strictEqual(result.course.instructorGroupName, 'instructors');
+        assert.strictEqual(result.course.shortName, 'alg');
+        assert.strictEqual(result.course.startDate, '2026-04-15T10:00:00Z');
+        assert.strictEqual(result.course.isArchived, undefined);
+    });
+
+    test('falls back to "Untitled Course" when title is missing', () => {
+        const result = toCourseDetailData({ id: 1 });
+        assert.ok(result);
+        assert.strictEqual(result.course.title, 'Untitled Course');
+    });
+
+    test('drops unknown server keys from the result', () => {
+        // Use a key the current mapper does NOT special-case (the current
+        // implementation explicitly strips `exams`, so we'd get a false
+        // pre-impl green). `serverOnlyField` is fictional and proves the
+        // explicit-field-list construction in the new impl really drops it.
+        const raw = { id: 1, title: 'X', serverOnlyField: 'leak' } as CourseDashboardCourse;
+        const result = toCourseDetailData(raw);
+        assert.ok(result);
+        assert.strictEqual((result.course as Record<string, unknown>).serverOnlyField, undefined);
+    });
+
+    test('drops exams (exam mode is unsupported)', () => {
+        const raw = { id: 1, title: 'X', exams: [{ id: 9 }] } as CourseDashboardCourse;
+        const result = toCourseDetailData(raw);
+        assert.ok(result);
+        assert.strictEqual((result.course as Record<string, unknown>).exams, undefined);
+    });
+
+    test('propagates isArchived from opts', () => {
+        const result = toCourseDetailData({ id: 1, title: 'X' }, { isArchived: true });
+        assert.ok(result);
+        assert.strictEqual(result.course.isArchived, true);
+    });
+
+    test('result type does not allow arbitrary index-signature access', () => {
+        const raw: CourseDashboardCourse & { exams: unknown[] } = { id: 1, exams: [] };
+        const detail = toCourseDetailData(raw)!;
+
+        // @ts-expect-error CourseDetailData.course must not expose server-only keys.
+        void detail.course.exams;
+
+        assert.strictEqual((detail.course as Record<string, unknown>).exams, undefined);
+    });
+});


### PR DESCRIPTION
Closes #182.

Eliminates cross-layer \`as\` casts around Course/Exercise DTOs by hardening the boundary between loose server-response DTOs and the validated webview-domain shape, through explicit mappers that fail loudly on malformed input.

## What changed

- **\`toCourseDetailData\` hardened** (Commit 1): returns \`CourseDetailData | null\`, uses \`typeof course.id !== 'number'\` runtime narrowing, drops the \`id!\` non-null assertion and the outer \`as\` cast, lists fields explicitly so unknown server keys (e.g. \`exams\`, \`serverOnlyField\`) are dropped at the boundary. Six caller sites updated to handle null.
- **Legacy types deleted** (Commit 2): \`CourseData\` and \`Exercise\` interfaces removed. \`CourseDetailData\` is the single webview-domain shape across list/dashboard/detail. \`CourseDetailData.course.exercises\` now \`ExerciseDetail[]\` (preserves \`shortName\`, \`repositoryUri\`, \`studentParticipations\`). \`repositoryUri?: string\` added to \`ExerciseDetail\`. \`startDate?: string\` added to \`CourseDetailData.course\`.
- **\`viewCourseDetails\` contract reshape** (Commit 3): payload \`{ courseData: CourseDashboardCourse }\` → \`{ courseId: number }\`. Extension resolves via cache-first then API-fallback, maps through \`toCourseDetailData\`. \`processCourseDetails\` simplified: no more union acceptance, no more \`as\` casts.
- **Workspace-detection mappers** (Commit 4): new \`toExerciseSource\` mapper and \`getEntryExercises\` helper. Applied to \`collectExerciseSources\`, \`findWorkspaceCourseInArchive\` (two sites), \`chatWebviewProvider.ts\` per-exercise registration, and \`exerciseRegistry.registerFromCourseData\` (kept \`unknown\` signature, replaced inline casts with \`isLikelyCourseEntry\` type guard).
- **id=0 synthesis eliminated** (Commit 5): three synthesis sites (\`viewInitDataService.ts\` x2, \`artemisWebviewProvider.ts\`) replaced with \`toCourseDetailData\`-drop + \`logger.warn\`. Remaining \`as ExerciseSource[]\` and \`as CourseDetailPayload\` casts removed.

## Verification

Final \`rg\` audit:
- \`as CourseDashboardCourse\`: 0 hits (excluding the explicitly out-of-scope parse-boundary cast at \`artemisApi.ts:141\`)
- \`as ExerciseSource[]\`: 0 hits
- \`as CourseDetailPayload\`: 0 hits
- \`as CourseDetailData\`: 0 hits in production code
- \`id ?? 0\` / \`id || 0\`: only sort-comparator defaults (legitimate per spec)

\`npm run check-types\`, \`lint\`, \`test:unit\` (978 tests), \`test:react\` (720 tests): all clean.

## Test coverage

3 new test files + 1 extended:
- \`test/unit/shared/messageContracts/domainMappers.test.ts\` (NEW): 10 tests for \`toCourseDetailData\` (incl. compile-time \`@ts-expect-error\` guard against \`[key: string]: unknown\` leakage)
- \`test/unit/services/workspaceDetectionService.test.ts\` (extended): 11 new tests (\`getEntryExercises\` 4, \`toExerciseSource\` 5, \`collectExerciseSources\` 2)
- \`test/unit/controller/navigationCommands.test.ts\` (NEW): 4 tests for \`handleViewCourseDetails\` resolver (cache hit, API fallback, mapper-null abort, API-throw)
- \`test/unit/services/viewInitDataService.test.ts\` (NEW): 3 tests asserting no \`id=0\` synthesis in emitted payloads

## Behavior changes (intentional)

- **\`getEntryExercises\` falls through to flat exercises when nested is \`[]\`**. The previous mix of \`??\` and \`||\` across the codebase was effectively identical (\`[] || fallback\` returns \`[]\` because empty arrays are truthy). New helper uses an explicit \`.length\` check. Documented in JSDoc.
- **Deep-link to a course not yet in cache** now triggers one \`getCourseForDashboard(courseId)\` call from the resolver. Subsequent navigation uses the cache.
- **Mapper rejects malformed server payloads** (id not a number, or course with no id at all). Previously these would surface as \`id=0\` rows that were unclickable under the new \`{ courseId }\` contract anyway.

## Out of scope (documented in spec)

- \`artemisApi.ts:141\` parse-boundary cast (schema-validation concern)
- Full reshape of \`exerciseRegistry.registerFromCourseData\` to typed input (body's casts removed; signature kept as \`unknown\`)
- \`recentCourseSelector.ts:69\` nested-only fallback (intentional, recent-course flow doesn't fall through)
- Test-side \`as any\` casts
- Webview-message routing casts in \`webviewCommands.ts\` (structurally required by discriminated-union signature)

## Process

This refactor went through Superpowers brainstorm → spec → plan with extensive codex review:
- Spec: 2 codex review rounds before sign-off
- Plan: 5 codex review rounds before sign-off (~24 findings addressed)
- Per-task: implementer subagent + spec compliance reviewer + code quality reviewer, with re-dispatched fixes when reviewers flagged issues
- Final cross-cutting review confirmed READY TO MERGE

Spec: \`docs/superpowers/specs/2026-05-22-unify-course-shapes-design.md\`
Plan: \`docs/superpowers/plans/2026-05-22-unify-course-shapes.md\`