### PR TITLE
refactor(viewer): simplify annotation timestamps to server-receive time

### DIFF
--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -588,13 +588,16 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
         }
 
         // POST /api/recordings/:sessionId/annotations — append a single
-        // anchored annotation (live struggle-tagging endpoint).
+        // annotation. The timestamp is the server receive time unless the
+        // client sends an explicit `timestamp` field (used by the redo path
+        // to restore an annotation at its original moment).
+        //
+        // Legacy fields `referenceEventTimestamp` and `reactionDelayMs` are
+        // accepted in the body for backwards compatibility but ignored.
         const VALID_LABELS = new Set([
             'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
             'idle', 'trial-error', 'reading', 'off-task', 'using-ai',
         ]);
-        const ESTIMATED_FLUSH_LAG_MS = 2_500;
-        const FUTURE_TIMESTAMP_TOLERANCE_MS = 1_000;
 
         const annotPostMatch = urlPath.match(/^\/api\/recordings\/([^/]+)\/annotations$/);
         if (annotPostMatch && method === 'POST') {
@@ -604,7 +607,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
             const annotPath = path.join(sessionDir, 'annotations.json');
 
             void (async () => {
-                let parsed: { label?: unknown; text?: unknown; referenceEventTimestamp?: unknown; reactionDelayMs?: unknown };
+                let parsed: { label?: unknown; text?: unknown; timestamp?: unknown };
                 try {
                     parsed = await readJsonBody(req, 64_000) as typeof parsed;
                 } catch (err) {
@@ -617,17 +620,13 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
                     sendJson(res, 400, { error: 'Invalid label' });
                     return;
                 }
-                const text = typeof parsed.text === 'string' ? parsed.text : '';
-                const reactionDelay = (typeof parsed.reactionDelayMs === 'number' && Number.isFinite(parsed.reactionDelayMs) && parsed.reactionDelayMs >= 0)
-                    ? Math.min(parsed.reactionDelayMs, 5_000)
-                    : 300;
-                const now = Date.now();
-                let timestamp: number;
-                if (typeof parsed.referenceEventTimestamp === 'number' && Number.isFinite(parsed.referenceEventTimestamp)) {
-                    timestamp = Math.min(parsed.referenceEventTimestamp + reactionDelay, now + FUTURE_TIMESTAMP_TOLERANCE_MS);
-                } else {
-                    timestamp = now - ESTIMATED_FLUSH_LAG_MS;
+                if (parsed.timestamp !== undefined && (typeof parsed.timestamp !== 'number' || !Number.isFinite(parsed.timestamp) || parsed.timestamp < 0)) {
+                    sendJson(res, 400, { error: 'Invalid timestamp' });
+                    return;
                 }
+                const text = typeof parsed.text === 'string' ? parsed.text : '';
+                const now = Date.now();
+                const timestamp = typeof parsed.timestamp === 'number' ? parsed.timestamp : now;
                 const annotation = {
                     id: `${now}-${Math.random().toString(36).slice(2, 8)}`,
                     timestamp,

--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -620,6 +620,9 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
                     sendJson(res, 400, { error: 'Invalid label' });
                     return;
                 }
+                // No upper bound on `timestamp`: explicit timestamps are only used by
+                // the redo path, which restores a value the server itself issued earlier.
+                // Future-dated timestamps would be a client bug, not a security concern.
                 if (parsed.timestamp !== undefined && (typeof parsed.timestamp !== 'number' || !Number.isFinite(parsed.timestamp) || parsed.timestamp < 0)) {
                     sendJson(res, 400, { error: 'Invalid timestamp' });
                     return;

--- a/recording-viewer/src/App.css
+++ b/recording-viewer/src/App.css
@@ -1804,8 +1804,6 @@
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 .live-status { display: flex; align-items: center; gap: 0.75rem; }
 .live-counter, .live-age { color: #94a3b8; font-variant-numeric: tabular-nums; }
-.live-reaction label { display: flex; gap: 0.5rem; align-items: center; }
-.live-reaction input[type="range"] { width: 120px; }
 .live-legend { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .live-legend span { font-family: monospace; }
 .live-toast {

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -44,7 +44,6 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     const videoPlayerRef = useRef<VideoPlayerHandle>(null);
 
     // Live state
-    const [reactionDelayMs, setReactionDelayMs] = useState(300);
     const [lastLabelToast, setLastLabelToast] = useState<AnnotationToast | null>(null);
     const [stickyLive, setStickyLive] = useState(false);
 
@@ -533,8 +532,6 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                             connected={live.connected}
                             eventsReceived={live.events.length}
                             latestEventTimestamp={live.latestEventTimestamp}
-                            reactionDelayMs={reactionDelayMs}
-                            onReactionDelayChange={setReactionDelayMs}
                             lastLabelToast={lastLabelToast}
                         />
                     )}

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -237,8 +237,8 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     useLiveHotkeys(
         isLiveSession,
         useCallback((label) => {
-            mutator.addLabel(label, live.latestEventTimestamp, reactionDelayMs);
-        }, [mutator, live.latestEventTimestamp, reactionDelayMs]),
+            mutator.addLabel(label, live.latestEventTimestamp);
+        }, [mutator, live.latestEventTimestamp]),
         mutator.undoLast,
         mutator.redoLast,
     );

--- a/recording-viewer/src/components/LiveControlBar.tsx
+++ b/recording-viewer/src/components/LiveControlBar.tsx
@@ -6,8 +6,6 @@ interface Props {
     connected: boolean;
     eventsReceived: number;
     latestEventTimestamp: number | null;
-    reactionDelayMs: number;
-    onReactionDelayChange: (ms: number) => void;
     lastLabelToast: AnnotationToast | null;
 }
 
@@ -25,8 +23,7 @@ function renderToast(toast: AnnotationToast): string {
 }
 
 export function LiveControlBar({
-    connected, eventsReceived, latestEventTimestamp,
-    reactionDelayMs, onReactionDelayChange, lastLabelToast,
+    connected, eventsReceived, latestEventTimestamp, lastLabelToast,
 }: Props) {
     // Re-render every second so the "last event N s ago" updates live
     const [now, setNow] = useState(() => Date.now());
@@ -47,18 +44,6 @@ export function LiveControlBar({
                 {ageMs !== null && (
                     <span className="live-age">last event {(ageMs / 1000).toFixed(1)}s ago</span>
                 )}
-            </div>
-            <div className="live-reaction">
-                <label>
-                    Reaction delay
-                    <input
-                        type="range"
-                        min={0} max={1000} step={50}
-                        value={reactionDelayMs}
-                        onChange={(e) => onReactionDelayChange(Number(e.target.value))}
-                    />
-                    <span>{reactionDelayMs}ms</span>
-                </label>
             </div>
             <div className="live-legend">
                 <strong>Struggle:</strong>

--- a/recording-viewer/src/hooks/annotationController.ts
+++ b/recording-viewer/src/hooks/annotationController.ts
@@ -10,7 +10,7 @@ export interface AnnotationToast {
 export interface AnnotationMutator {
     /** Enqueue an add. Optimistic insertion happens inside the queue body so the
      *  redo-stack invalidation is atomic with the new entry. */
-    addLabel: (label: AnnotationLabel, referenceTs: number | null, reactionDelayMs: number) => void;
+    addLabel: (label: AnnotationLabel, referenceTs: number | null) => void;
     /** Enqueue an undo of whatever is the last real annotation at the moment
      *  the queue reaches this operation (not at call time). */
     undoLast: () => void;
@@ -79,7 +79,7 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
         });
     }
 
-    const addLabel: AnnotationMutator['addLabel'] = (label, referenceTs, reactionDelayMs) => {
+    const addLabel: AnnotationMutator['addLabel'] = (label, referenceTs) => {
         enqueue(async (capturedGen, sessionId) => {
             // Intent invalidates redo, ATOMIC with the new entry insertion.
             redoStack = [];
@@ -102,8 +102,6 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
                     body: JSON.stringify({
                         label,
                         text: '',
-                        referenceEventTimestamp: referenceTs ?? undefined,
-                        reactionDelayMs,
                     }),
                 });
                 if (capturedGen !== gen) return;
@@ -179,8 +177,7 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
                     body: JSON.stringify({
                         label: popped.label,
                         text: popped.text,
-                        referenceEventTimestamp: popped.timestamp,
-                        reactionDelayMs: 0,
+                        timestamp: popped.timestamp,
                     }),
                 });
                 if (capturedGen !== gen) return;

--- a/recording-viewer/src/hooks/annotationController.ts
+++ b/recording-viewer/src/hooks/annotationController.ts
@@ -85,6 +85,10 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
             redoStack = [];
 
             const tempId = makeTempId();
+            // referenceTs is used for the LOCAL optimistic display only: it positions
+            // the temp annotation on the timeline at roughly the right moment while
+            // the POST is in-flight. The server always timestamps live annotations
+            // at its own receive time, so we do NOT send referenceTs to it.
             const optimistic: Annotation = {
                 id: tempId,
                 timestamp: referenceTs ?? Date.now(),

--- a/recording-viewer/test/annotationController.test.ts
+++ b/recording-viewer/test/annotationController.test.ts
@@ -83,7 +83,7 @@ afterEach(() => { h.ctrl.dispose(); });
 
 describe('addLabel', () => {
     it('optimistically inserts temp annotation then replaces with server response', async () => {
-        h.ctrl.addLabel('confident', 1_000, 300);
+        h.ctrl.addLabel('confident', 1_000);
         // Optimistic insert happens inside the queue body; drain one microtask cycle.
         await Promise.resolve();
         await Promise.resolve();
@@ -103,7 +103,7 @@ describe('addLabel', () => {
     });
 
     it('removes the temp annotation on POST failure and reports error', async () => {
-        h.ctrl.addLabel('blocked', null, 0);
+        h.ctrl.addLabel('blocked', null);
         await Promise.resolve(); await Promise.resolve();
         expect(h.annotations).toHaveLength(1);
         h.pending[0].resolve(new Response('nope', { status: 500 }));
@@ -115,7 +115,7 @@ describe('addLabel', () => {
 
     it('uses Date.now() when referenceTs is null', async () => {
         const before = Date.now();
-        h.ctrl.addLabel('idle', null, 0);
+        h.ctrl.addLabel('idle', null);
         await Promise.resolve(); await Promise.resolve();
         expect(h.annotations).toHaveLength(1);
         expect(h.annotations[0].timestamp).toBeGreaterThanOrEqual(before);
@@ -125,7 +125,7 @@ describe('addLabel', () => {
 
 describe('temp-id race (codex r2 critical)', () => {
     it('undoLast queued during in-flight addLabel uses the REAL id', async () => {
-        h.ctrl.addLabel('confident', 1_000, 0);
+        h.ctrl.addLabel('confident', 1_000);
         await Promise.resolve(); await Promise.resolve();
         expect(h.annotations).toHaveLength(1);
         const tempIdAtCall = h.annotations[0].id;
@@ -229,7 +229,7 @@ describe('redoLast', () => {
         expect(h.annotations[1].id).toMatch(/^temp-/);
         expect(h.pending[0].init?.method).toBe('POST');
         const body = JSON.parse((h.pending[0].init?.body as string));
-        expect(body.referenceEventTimestamp).toBe(annot('a2').timestamp);
+        expect(body.timestamp).toBe(annot('a2').timestamp);
         const real = annot('real-redone', { timestamp: 1_000 });
         h.pending[0].resolve(jsonResponse({ annotation: real }));
         await h.ctrl.drain();
@@ -259,7 +259,7 @@ describe('redo invalidation on intent', () => {
         expect(h.ctrl.hasRedo()).toBe(true);
 
         // New add: this should clear redo BEFORE POST.
-        h.ctrl.addLabel('blocked', 5_000, 0);
+        h.ctrl.addLabel('blocked', 5_000);
         await Promise.resolve(); await Promise.resolve();
         expect(h.ctrl.hasRedo()).toBe(false); // cleared at queue body entry
         h.pending[1].resolve(jsonResponse({ annotation: annot('new-1') }));
@@ -282,8 +282,8 @@ describe('reset and generation counter', () => {
 
     it('reset mid-flight (queued not started): later queued add does no UI work', async () => {
         // Send two adds back-to-back. The first one is currently running its body.
-        h.ctrl.addLabel('confident', 100, 0);
-        h.ctrl.addLabel('blocked', 200, 0);
+        h.ctrl.addLabel('confident', 100);
+        h.ctrl.addLabel('blocked', 200);
         // Reset before the first one even gets to its optimistic insert? Not
         // quite: enqueue schedules the body via Promise.then, which fires in
         // the next microtask. Reset NOW bumps gen — both queued bodies will
@@ -300,7 +300,7 @@ describe('reset and generation counter', () => {
     });
 
     it('reset mid-flight (started, optimistic already applied): post-await UI updates are skipped', async () => {
-        h.ctrl.addLabel('confident', 100, 0);
+        h.ctrl.addLabel('confident', 100);
         // Let the queue body start and apply its optimistic insert.
         await Promise.resolve(); await Promise.resolve();
         expect(h.annotations).toHaveLength(1);
@@ -324,8 +324,8 @@ describe('reset and generation counter', () => {
 
 describe('serialization', () => {
     it('add → add → undo → undo resolves in order; final state empty, redo holds both', async () => {
-        h.ctrl.addLabel('confident', 100, 0);
-        h.ctrl.addLabel('blocked', 200, 0);
+        h.ctrl.addLabel('confident', 100);
+        h.ctrl.addLabel('blocked', 200);
         h.ctrl.undoLast();
         h.ctrl.undoLast();
 
@@ -368,13 +368,13 @@ describe('real-load ordering (codex r3 high)', () => {
 describe('no-session and dispose', () => {
     it('addLabel is a no-op when sessionId is null', async () => {
         h.setSessionId(null);
-        h.ctrl.addLabel('confident', 0, 0);
+        h.ctrl.addLabel('confident', 0);
         await h.ctrl.drain();
         expect(h.pending).toHaveLength(0);
     });
 
     it('dispose() causes subsequent queued bodies to bail', async () => {
-        h.ctrl.addLabel('confident', 100, 0);
+        h.ctrl.addLabel('confident', 100);
         await Promise.resolve(); await Promise.resolve();
         expect(h.annotations).toHaveLength(1);
         h.ctrl.dispose();

--- a/recording-viewer/test/server/recordingsApi.annotations.test.ts
+++ b/recording-viewer/test/server/recordingsApi.annotations.test.ts
@@ -16,31 +16,50 @@ afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 const cfg = (): AppConfig => ({ recordingsDir: tmpDir, liveToken: undefined, allowWrite: true });
 
 describe('POST /api/recordings/:id/annotations', () => {
-    it('appends single annotation with referenceEventTimestamp + reactionDelay', async () => {
-        const api = createRecordingsApi(cfg());
-        const handle = makeRes();
-        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
-            JSON.stringify({ label: 'high-struggle', text: '', referenceEventTimestamp: 1_000, reactionDelayMs: 300 })),
-            handle);
-        expect(handle.captured.status).toBe(200);
-        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
-        expect(stored).toHaveLength(1);
-        expect(stored[0].timestamp).toBe(1_300);
-        expect(stored[0].label).toBe('high-struggle');
-        expect(typeof stored[0].id).toBe('string');
-    });
-
-    it('falls back to serverNow - flushLag when reference missing', async () => {
+    it('stores annotation with timestamp = serverNow when no explicit timestamp is sent', async () => {
         const api = createRecordingsApi(cfg());
         const before = Date.now();
         const handle = makeRes();
         await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
-            JSON.stringify({ label: 'medium-struggle', text: 'note' })),
+            JSON.stringify({ label: 'high-struggle', text: '' })),
             handle);
         expect(handle.captured.status).toBe(200);
         const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
-        expect(stored[0].timestamp).toBeGreaterThanOrEqual(before - 2_500 - 100);
-        expect(stored[0].timestamp).toBeLessThanOrEqual(Date.now() - 2_500 + 100);
+        expect(stored).toHaveLength(1);
+        expect(stored[0].timestamp).toBeGreaterThanOrEqual(before);
+        expect(stored[0].timestamp).toBeLessThanOrEqual(Date.now());
+        expect(stored[0].timestamp).toBe(stored[0].createdAt);
+        expect(stored[0].label).toBe('high-struggle');
+        expect(typeof stored[0].id).toBe('string');
+    });
+
+    it('respects an explicit timestamp field when provided (redo path)', async () => {
+        const api = createRecordingsApi(cfg());
+        const explicit = 1_700_000_000_000;
+        const before = Date.now();
+        const handle = makeRes();
+        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
+            JSON.stringify({ label: 'confident', text: 'restored', timestamp: explicit })),
+            handle);
+        expect(handle.captured.status).toBe(200);
+        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
+        expect(stored[0].timestamp).toBe(explicit);
+        // createdAt is set from server-receive time regardless of explicit timestamp
+        expect(stored[0].createdAt).toBeGreaterThanOrEqual(before);
+        expect(stored[0].createdAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('ignores legacy referenceEventTimestamp and reactionDelayMs fields', async () => {
+        const api = createRecordingsApi(cfg());
+        const before = Date.now();
+        const handle = makeRes();
+        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
+            JSON.stringify({ label: 'medium-struggle', text: '', referenceEventTimestamp: 1_000, reactionDelayMs: 9_999 })),
+            handle);
+        expect(handle.captured.status).toBe(200);
+        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
+        expect(stored[0].timestamp).toBeGreaterThanOrEqual(before);
+        expect(stored[0].timestamp).toBeLessThanOrEqual(Date.now());
     });
 
     it('preserves existing annotations across calls', async () => {
@@ -49,7 +68,7 @@ describe('POST /api/recordings/:id/annotations', () => {
         const api = createRecordingsApi(cfg());
         const handle = makeRes();
         await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
-            JSON.stringify({ label: 'blocked', text: '', referenceEventTimestamp: 1_000 })),
+            JSON.stringify({ label: 'blocked', text: '' })),
             handle);
         expect(handle.captured.status).toBe(200);
         const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
@@ -66,16 +85,22 @@ describe('POST /api/recordings/:id/annotations', () => {
         expect(handle.captured.status).toBe(400);
     });
 
-    it('clamps future referenceEventTimestamp to (now + 1000)', async () => {
+    it('rejects non-finite explicit timestamp', async () => {
         const api = createRecordingsApi(cfg());
-        const future = Date.now() + 60_000_000;
         const handle = makeRes();
         await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
-            JSON.stringify({ label: 'confident', text: '', referenceEventTimestamp: future })),
+            JSON.stringify({ label: 'confident', text: '', timestamp: 'not-a-number' })),
             handle);
-        expect(handle.captured.status).toBe(200);
-        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
-        expect(stored[0].timestamp).toBeLessThanOrEqual(Date.now() + 1500);
+        expect(handle.captured.status).toBe(400);
+    });
+
+    it('rejects negative explicit timestamp', async () => {
+        const api = createRecordingsApi(cfg());
+        const handle = makeRes();
+        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
+            JSON.stringify({ label: 'confident', text: '', timestamp: -1 })),
+            handle);
+        expect(handle.captured.status).toBe(400);
     });
 
     it('refuses to overwrite when annotations.json is corrupt JSON', async () => {
@@ -83,7 +108,7 @@ describe('POST /api/recordings/:id/annotations', () => {
         const api = createRecordingsApi(cfg());
         const handle = makeRes();
         await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
-            JSON.stringify({ label: 'confident', text: '', referenceEventTimestamp: 1 })),
+            JSON.stringify({ label: 'confident', text: '' })),
             handle);
         expect(handle.captured.status).toBe(409);
     });


### PR DESCRIPTION
## Summary

Removes the heuristic anchor logic from the annotation POST endpoint on the recording viewer's HTTP middleware. Live annotations are now timestamped at server receive time. An optional explicit timestamp field on the POST body supports the redo path. Legacy body fields are silently accepted for backwards compatibility but no longer drive the stored timestamp. The reaction-delay slider in the live control bar is removed because it has no functional effect anymore.

## Why

The previous code used two magic constants (`ESTIMATED_FLUSH_LAG_MS = 2500`, `FUTURE_TIMESTAMP_TOLERANCE_MS = 1000`) and a branching anchor computation to guess when the underlying student behavior occurred. This produced badly wrong timestamps during sparse-event periods. If a student was reading or thinking silently and the observer pressed a hotkey, the annotation could land several seconds (or more) in the past, exactly the case where ground-truth labels matter most for evaluating struggle detection.

Methodological reframing: each annotation is now a **timestamped observer judgement with uncertain onset**. We know when the observer acted; the underlying student state existed in some unknown window ending at that moment. Alignment with recorded events is an analysis-time concern, documented per study, no longer baked into collection.

## Changes (5 commits)

1. `cf0fe517` Server stamps live annotations at `Date.now()` unless an explicit `timestamp` is provided. Magic numbers removed. Body validation rejects non-finite and negative timestamps. 8 tests cover the new contract (added 4, replaced 3, kept 1).

2. `72084b70` Client `addLabel` signature drops `reactionDelayMs`. Live-hotkey POST body carries no timestamp. Redo POST body uses `timestamp: popped.timestamp` instead of the old `referenceEventTimestamp + reactionDelayMs=0` hack. 12 test call sites updated, 1 assertion renamed.

3. `3e4ebb9f` Reaction-delay slider removed from `LiveControlBar` (Props, destructure, JSX). Parent state and prop pass-through in `App.tsx` removed.

4. `73470ded` Dead `.live-reaction` CSS rules dropped from `App.css`.

5. `bc99961b` Documentation polish: comment that `referenceTs` parameter is for local optimistic display only (never sent to server); comment explaining deliberate absence of upper bound on the explicit `timestamp` field.

## Compatibility

- No schema change on disk. Existing `annotations.json` files continue to work.
- Stale clients still sending `referenceEventTimestamp` and `reactionDelayMs` are accepted; the legacy fields are silently ignored. Server uses receive time.

## Test Plan

- [x] `npm test` in `recording-viewer/` (170/170 passing, +2 net from baseline)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds (`tsc -b` + Vite)
- [ ] Manual smoke: start `npm run dev:live:token`, connect to an active recording session, confirm the reaction-delay slider is absent from the live control bar
- [ ] Manual smoke: press hotkey `3` during typing, inspect `annotations.json`, confirm `timestamp` is approximately `Date.now()` and equals `createdAt`
- [ ] Manual smoke: undo and redo an annotation, confirm the redone entry restores the original `timestamp` (with `createdAt` being the new redo moment)
- [ ] Manual smoke: keep the student session idle for 30+ seconds, then press a hotkey, confirm the annotation lands at the keypress moment (this was the original bug: it used to land 2.5+ seconds in the past, more if the last event was older)