### PR TITLE
refactor(extension): decompose RepositoryCommandModule into 5 cohesive command modules (#205)

### DIFF
--- a/extension/src/extension/controller/commands/buildLogCommands.ts
+++ b/extension/src/extension/controller/commands/buildLogCommands.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+
+import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts';
+import { getPayload, WebviewCmd } from '@shared/messageContracts';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import { BuildLogParser } from '@extension/utils';
+
+import type { CommandContext, CommandMap } from './types';
+
+export class BuildLogCommands {
+    constructor(private readonly context: CommandContext) { }
+
+    public getHandlers(): CommandMap {
+        return {
+            [WebviewCmd.ViewBuildLog]: this.handleViewBuildLog,
+            [WebviewCmd.GoToSource]: this.handleGoToSource,
+        };
+    }
+
+    private handleViewBuildLog = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const { participationId, resultId } = getPayload<WebCmd<'viewBuildLog'>>(message);
+            const logs = await this.context.artemisApi.getBuildLogs(participationId, resultId);
+            const logText = logs.map(entry => `[${entry.time}] ${entry.log}`).join('\n');
+            const doc = await vscode.workspace.openTextDocument({ content: logText, language: 'log' });
+            await vscode.window.showTextDocument(doc);
+        } catch (error: unknown) {
+            logger.error('Failed to fetch build logs:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage('Failed to fetch build logs.');
+        }
+    };
+
+    private handleGoToSource = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const { participationId, resultId } = getPayload<WebCmd<'goToSource'>>(message);
+            const logs = await this.context.artemisApi.getBuildLogs(participationId, resultId);
+            const error = BuildLogParser.parseFirstError(logs);
+            if (error) {
+                await vscode.commands.executeCommand('artemis.goToSourceError', error.filePath, error.line, error.column, error.message);
+            } else {
+                vscode.window.showInformationMessage('No source error location found in build logs');
+            }
+        } catch (err: unknown) {
+            logger.error('Failed to navigate to source error:', LogCategory.SUBMISSION, err);
+            vscode.window.showErrorMessage('Failed to navigate to source error.');
+        }
+    };
+}

--- a/extension/src/extension/controller/commands/exerciseLifecycleCommands.ts
+++ b/extension/src/extension/controller/commands/exerciseLifecycleCommands.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts';
+import { getPayload, WebviewCmd } from '@shared/messageContracts';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import { extractErrorMessage } from '@extension/utils';
+
+import type { CommandContext, CommandMap } from './types';
+
+export class ExerciseLifecycleCommands {
+    constructor(private readonly context: CommandContext) { }
+
+    public getHandlers(): CommandMap {
+        return {
+            [WebviewCmd.StartPractice]: this.handleStartPractice,
+            [WebviewCmd.StartExercise]: this.handleStartExercise,
+        };
+    }
+
+    private handleStartPractice = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const payload = getPayload<WebCmd<'startPractice'>>(message);
+            const exerciseId = payload.exerciseId;
+            const exerciseTitle = payload.exerciseTitle ?? 'Exercise';
+            vscode.window.showInformationMessage('Starting practice mode...');
+            const participation = await this.context.artemisApi.startPracticeParticipation(exerciseId);
+
+            if (participation) {
+                vscode.window.showInformationMessage(
+                    `Successfully started practice mode for "${exerciseTitle}". You can now clone the practice repository.`
+                );
+                await this.context.actionHandler.openExerciseDetails(exerciseId);
+            }
+        } catch (error: unknown) {
+            logger.error('Failed to start practice participation:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage(
+                `Failed to start practice mode: ${extractErrorMessage(error)}`
+            );
+        }
+    };
+
+    private handleStartExercise = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const payload = getPayload<WebCmd<'startExercise'>>(message);
+            const exerciseId = payload.exerciseId;
+            vscode.window.showInformationMessage('Starting exercise...');
+            const participation = await this.context.artemisApi.startExerciseParticipation(exerciseId);
+
+            if (participation) {
+                vscode.window.showInformationMessage('Successfully started exercise participation.');
+                await this.context.actionHandler.openExerciseDetails(exerciseId);
+            }
+        } catch (error: unknown) {
+            logger.error('Failed to start exercise:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage(
+                `Failed to start exercise: ${extractErrorMessage(error)}`
+            );
+        }
+    };
+}

--- a/extension/src/extension/controller/commands/repositoryCloneCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCloneCommands.ts
@@ -1,0 +1,369 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts';
+import { ExtensionMsg, getOptionalPayload, getPayload, WebviewCmd } from '@shared/messageContracts';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import {
+    getWorkspaceRepositoryUrl as defaultGetWorkspaceRepositoryUrl,
+    GitService,
+    normalizeRepositoryUrl as defaultNormalizeRepositoryUrl,
+} from '@extension/services/workspace';
+import {
+    cloneRepositoryProgrammatic as defaultCloneRepositoryProgrammatic,
+    getTheiaEnvironment as defaultGetTheiaEnvironment,
+} from '@extension/theia';
+import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
+
+import type { CommandContext, CommandMap } from './types';
+
+/**
+ * Soft cap on the in-memory map of recently cloned repositories per
+ * participation. Bounded to keep the map from growing unboundedly during a
+ * long session; FIFO eviction is acceptable because the map is only used to
+ * surface "open cloned repo" notices.
+ */
+const MAX_CLONED_REPO_CACHE_SIZE = 10;
+
+/**
+ * Helper functions injected via the constructor so tests can substitute
+ * deterministic doubles. The defaults wire up to the production modules.
+ *
+ * (This injection seam was added because the production helpers are
+ * re-exported through `@extension/services/workspace` and `@extension/theia`
+ * barrel modules, where the TS-emitted descriptors are non-configurable
+ * getters that sinon cannot stub. Direct namespace stubbing fails with
+ * "descriptor is not configurable", so we inject the callables instead.)
+ */
+export interface RepositoryCloneCommandsDeps {
+    getWorkspaceRepositoryUrl: typeof defaultGetWorkspaceRepositoryUrl;
+    normalizeRepositoryUrl: typeof defaultNormalizeRepositoryUrl;
+    cloneRepositoryProgrammatic: typeof defaultCloneRepositoryProgrammatic;
+    getTheiaEnvironment: typeof defaultGetTheiaEnvironment;
+    statSync: typeof fs.statSync;
+    statAsync: (p: fs.PathLike) => Promise<fs.Stats>;
+}
+
+const defaultDeps: RepositoryCloneCommandsDeps = {
+    getWorkspaceRepositoryUrl: defaultGetWorkspaceRepositoryUrl,
+    normalizeRepositoryUrl: defaultNormalizeRepositoryUrl,
+    cloneRepositoryProgrammatic: defaultCloneRepositoryProgrammatic,
+    getTheiaEnvironment: defaultGetTheiaEnvironment,
+    statSync: fs.statSync,
+    statAsync: fs.promises.stat,
+};
+
+export class RepositoryCloneCommands {
+    private clonedRepositoriesByParticipationId: Map<number, { path: string; title: string }> = new Map();
+    private readonly deps: RepositoryCloneCommandsDeps;
+
+    constructor(
+        private readonly context: CommandContext,
+        private readonly gitService: GitService = new GitService(),
+        deps: Partial<RepositoryCloneCommandsDeps> = {},
+    ) {
+        this.deps = { ...defaultDeps, ...deps };
+    }
+
+    public getHandlers(): CommandMap {
+        return {
+            [WebviewCmd.CloneRepository]: this.handleCloneRepository,
+            [WebviewCmd.CopyAuthenticatedCloneUrl]: this.handleCopyAuthenticatedCloneUrl,
+            [WebviewCmd.OpenRepository]: this.handleOpenRepository,
+            [WebviewCmd.OpenClonedRepository]: this.handleOpenClonedRepository,
+        };
+    }
+
+    /**
+     * Build an authenticated clone URL by fetching a VCS token and the current user's login.
+     * Returns the URL string on success, or null if token retrieval or URL construction fails.
+     */
+    private async buildAuthenticatedUrl(participationId: number, repositoryUri: string): Promise<string | null> {
+        let vcsToken: string;
+        try {
+            vcsToken = await this.context.artemisApi.getOrCreateVcsAccessToken(participationId);
+        } catch (tokenErr) {
+            logger.error('Failed to get participation token:', LogCategory.SUBMISSION, tokenErr);
+            vscode.window.showErrorMessage('Failed to obtain VCS access token.');
+            return null;
+        }
+
+        let username = 'user';
+        try {
+            const currentUser = await this.context.artemisApi.getCurrentUser();
+            if (currentUser?.login) {
+                username = currentUser.login;
+            }
+        } catch (userErr) {
+            logger.warn('Could not fetch current user, defaulting username:', LogCategory.SUBMISSION, userErr);
+        }
+
+        try {
+            const url = new URL(repositoryUri);
+            url.username = username;
+            url.password = vcsToken;
+            return url.toString();
+        } catch {
+            vscode.window.showErrorMessage('Invalid repository URL received from server.');
+            return null;
+        }
+    }
+
+    private async _selectFolder(openLabel: string, title: string): Promise<string | undefined> {
+        // In Theia, always use the workspace root instead of showing a dialog
+        if (this.deps.getTheiaEnvironment().isTheia) {
+            return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        }
+
+        const folderUri = await vscode.window.showOpenDialog({
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel,
+            title,
+        });
+        return folderUri?.[0]?.fsPath;
+    }
+
+    /**
+     * Resolve the destination folder for a clone in one of three ways:
+     *   1. The configured default-clone-path, if it points to an existing dir.
+     *   2. The full "set default / choose / don't ask again" modal (when the
+     *      prompt is enabled and no default is configured).
+     *   3. A bare folder picker when the prompt has been silenced.
+     *
+     * Returns `undefined` when the user cancels at any branch; an information
+     * notice is shown with the cancellation reason as a side effect.
+     */
+    private async _resolveCloneDestination(exerciseTitle: string): Promise<string | undefined> {
+        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
+        const defaultClonePath = config.get<string>(VSCODE_CONFIG.DEFAULT_CLONE_PATH_KEY, '').trim();
+        const showPrompt = config.get<boolean>(VSCODE_CONFIG.SHOW_SET_DEFAULT_CLONE_PATH_PROMPT_KEY, true);
+
+        if (defaultClonePath) {
+            const reasonInvalid = await this._validateDefaultClonePath(defaultClonePath);
+            if (!reasonInvalid) {
+                return defaultClonePath;
+            }
+            vscode.window.showWarningMessage(`Default clone path "${defaultClonePath}" ${reasonInvalid}. Please select a folder.`);
+            return this._pickFolderOrCancelClone('Select Clone Destination', `Choose where to clone ${exerciseTitle}`);
+        }
+
+        if (!showPrompt) {
+            return this._pickFolderOrCancelClone('Select Clone Destination', `Choose where to clone ${exerciseTitle}`);
+        }
+
+        const choice = await vscode.window.showInformationMessage(
+            'Where should exercise repositories be cloned?\n\nYou can set a default folder now (e.g., ~/artemis-exercises) so all future exercises are automatically saved there, or choose a location each time.',
+            { modal: true },
+            'Set Default Folder',
+            'Choose Each Time',
+            "Don't Ask Again",
+        );
+
+        if (choice === 'Set Default Folder') {
+            const defaultFolderPath = await this._selectFolder('Set as Default', 'Select default folder for all exercise repositories');
+            if (!defaultFolderPath) {
+                vscode.window.showInformationMessage('Clone cancelled - no folder selected.');
+                return undefined;
+            }
+            await config.update(VSCODE_CONFIG.DEFAULT_CLONE_PATH_KEY, defaultFolderPath, vscode.ConfigurationTarget.Global);
+            vscode.window.showInformationMessage(`✓ All exercises will now be cloned to: ${defaultFolderPath}`);
+            return defaultFolderPath;
+        }
+        if (choice === "Don't Ask Again") {
+            await config.update(VSCODE_CONFIG.SHOW_SET_DEFAULT_CLONE_PATH_PROMPT_KEY, false, vscode.ConfigurationTarget.Global);
+            return this._pickFolderOrCancelClone('Select Folder', `Where should "${exerciseTitle}" be cloned?`);
+        }
+        if (choice === 'Choose Each Time') {
+            return this._pickFolderOrCancelClone('Select Folder', `Where should "${exerciseTitle}" be cloned?`);
+        }
+
+        // ESC / dismissed modal — abort.
+        vscode.window.showInformationMessage('Clone cancelled.');
+        return undefined;
+    }
+
+    /**
+     * Returns `undefined` if the configured default-clone-path is usable; a
+     * short reason string ('does not exist' / 'is not a directory') otherwise.
+     */
+    private async _validateDefaultClonePath(p: string): Promise<string | undefined> {
+        try {
+            const stats = await this.deps.statAsync(p);
+            return stats.isDirectory() ? undefined : 'is not a directory';
+        } catch {
+            return 'does not exist';
+        }
+    }
+
+    /** Folder picker + the standard "Clone cancelled" notice on dismissal. */
+    private async _pickFolderOrCancelClone(label: string, title: string): Promise<string | undefined> {
+        const folderPath = await this._selectFolder(label, title);
+        if (!folderPath) {
+            vscode.window.showInformationMessage('Clone cancelled - no folder selected.');
+            return undefined;
+        }
+        return folderPath;
+    }
+
+    /**
+     * Insert a freshly cloned repository into the per-participation cache,
+     * evicting the oldest entry by insertion order when the cap is reached.
+     * (FIFO, not LRU — sufficient for the current "open cloned repo" notice
+     * usage, which doesn't depend on recency-of-access semantics.)
+     */
+    private _rememberClonedRepo(participationId: number, repoPath: string, title: string): void {
+        if (this.clonedRepositoriesByParticipationId.size >= MAX_CLONED_REPO_CACHE_SIZE
+            && !this.clonedRepositoriesByParticipationId.has(participationId)) {
+            const firstKey = this.clonedRepositoriesByParticipationId.keys().next().value;
+            if (firstKey !== undefined) {
+                this.clonedRepositoriesByParticipationId.delete(firstKey);
+            }
+        }
+        this.clonedRepositoriesByParticipationId.set(participationId, { path: repoPath, title });
+    }
+
+    private handleCloneRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const payload = getPayload<WebCmd<'cloneRepository'>>(message);
+            const { participationId, repositoryUri, exerciseTitle } = payload;
+            if (!participationId || !repositoryUri) {
+                vscode.window.showErrorMessage('Cannot clone: missing participation or repository URL.');
+                return;
+            }
+
+            if (!(await this.gitService.isGitAvailable())) {
+                vscode.window.showErrorMessage('Git not found in PATH. Please install Git to clone repositories.');
+                return;
+            }
+
+            const selectedPath = await this._resolveCloneDestination(exerciseTitle);
+            if (!selectedPath) { return; }
+
+            const cloneUrl = await this.buildAuthenticatedUrl(participationId, repositoryUri);
+            if (!cloneUrl) { return; }
+
+            const repoName = path.basename(repositoryUri).replace(/\.git$/, '');
+            const repoPath = path.join(selectedPath, repoName);
+
+            // Run git clone as an awaitable child process (same for Theia and
+            // VS Code Desktop). A terminal-based fire-and-forget clone cannot
+            // reliably signal success or failure back to the extension, which
+            // caused the "Open Folder" prompt to appear even when the clone
+            // errored out. Using the programmatic clone, a thrown error lands
+            // in the outer catch and the prompt is only reached on success.
+            await this.deps.cloneRepositoryProgrammatic(cloneUrl, repoPath, exerciseTitle);
+
+            this._rememberClonedRepo(participationId, repoPath, exerciseTitle);
+
+            this.context.sendMessage({
+                type: ExtensionMsg.ShowClonedRepoNotice,
+                exerciseTitle: exerciseTitle,
+                participationId,
+            });
+
+            const openAction = await vscode.window.showInformationMessage(
+                `Open cloned repository "${exerciseTitle}"?`,
+                'Open Folder',
+                'Skip',
+            );
+            if (openAction === 'Open Folder') {
+                void vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(repoPath), true);
+            }
+        } catch (error: unknown) {
+            logger.error('Clone repository error:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage(`Failed to clone repository: ${extractErrorMessage(error)}`);
+        }
+    };
+
+    private handleCopyAuthenticatedCloneUrl = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const { participationId, repositoryUri } = getPayload<WebCmd<'copyAuthenticatedCloneUrl'>>(message);
+            if (!participationId || !repositoryUri) {
+                vscode.window.showErrorMessage('Cannot copy clone URL: missing participation or repository URL.');
+                return;
+            }
+
+            const authenticatedUrl = await this.buildAuthenticatedUrl(participationId, repositoryUri);
+            if (!authenticatedUrl) {
+                return;
+            }
+
+            await vscode.env.clipboard.writeText(authenticatedUrl);
+            vscode.window.showInformationMessage(
+                'Authenticated clone URL copied to clipboard. It contains a VCS access token, so do not share it.'
+            );
+        } catch (error: unknown) {
+            logger.error('Failed to copy authenticated clone URL:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage(`Failed to copy clone URL: ${extractErrorMessage(error)}`);
+        }
+    };
+
+    private handleOpenClonedRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const { participationId } = getPayload<WebCmd<'openClonedRepository'>>(message);
+            const repoInfo = this.clonedRepositoriesByParticipationId.get(participationId);
+
+            if (!repoInfo) {
+                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
+                return;
+            }
+
+            try {
+                const stats = this.deps.statSync(repoInfo.path);
+                if (!stats.isDirectory()) {
+                    this.clonedRepositoriesByParticipationId.delete(participationId);
+                    vscode.window.showWarningMessage('Cloned repository path is not a directory.');
+                    return;
+                }
+            } catch {
+                this.clonedRepositoriesByParticipationId.delete(participationId);
+                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
+                return;
+            }
+
+            const repoUri = vscode.Uri.file(repoInfo.path);
+
+            const currentFolder = vscode.workspace.workspaceFolders?.[0];
+            if (currentFolder && currentFolder.uri.fsPath === repoInfo.path) {
+                await vscode.commands.executeCommand('workbench.view.explorer');
+                return;
+            }
+
+            await vscode.commands.executeCommand('vscode.openFolder', repoUri, true);
+        } catch (error: unknown) {
+            logger.error('Open cloned repository error:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage('Failed to open cloned repository.');
+        }
+    };
+
+    private handleOpenRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
+        try {
+            const repositoryUri = getOptionalPayload<WebCmd<'openRepository'>>(message)?.repositoryUri;
+
+            if (!repositoryUri) {
+                vscode.window.showWarningMessage('No repository URL available.');
+                return;
+            }
+            // Try to open the repository folder if it's already cloned in the workspace
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            if (workspaceFolder) {
+                const wsUrl = await this.deps.getWorkspaceRepositoryUrl(workspaceFolder);
+                if (wsUrl && this.deps.normalizeRepositoryUrl(wsUrl) === this.deps.normalizeRepositoryUrl(repositoryUri)) {
+                    // Already in the correct workspace — just reveal the explorer
+                    await vscode.commands.executeCommand('workbench.view.explorer');
+                    return;
+                }
+            }
+
+            // Open the URL externally as a fallback
+            await vscode.env.openExternal(vscode.Uri.parse(repositoryUri));
+        } catch (error: unknown) {
+            logger.error('Open repository error:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage('Failed to open repository.');
+        }
+    };
+}

--- a/extension/src/extension/controller/commands/repositoryCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCommands.ts
@@ -14,7 +14,7 @@ import {
 } from '@extension/services/workspace';
 import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
 import { cloneRepositoryProgrammatic, getTheiaEnvironment } from '@extension/theia';
-import { BuildLogParser, extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
+import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
 
 import type { CommandContext, CommandMap } from './types';
 
@@ -140,8 +140,6 @@ export class RepositoryCommandModule {
             [WebviewCmd.StartExercise]: this.handleStartExercise,
             [WebviewCmd.OpenRepository]: this.handleOpenRepository,
             [WebviewCmd.OpenClonedRepository]: this.handleOpenClonedRepository,
-            [WebviewCmd.ViewBuildLog]: this.handleViewBuildLog,
-            [WebviewCmd.GoToSource]: this.handleGoToSource,
         };
     }
 
@@ -712,37 +710,6 @@ export class RepositoryCommandModule {
             vscode.window.showErrorMessage(
                 `Failed to start exercise: ${extractErrorMessage(error)}`
             );
-        }
-    };
-
-    private handleViewBuildLog = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const payload = getPayload<WebCmd<'viewBuildLog'>>(message);
-            const { participationId, resultId } = payload;
-            const logs = await this.context.artemisApi.getBuildLogs(participationId, resultId);
-            const logText = logs.map(entry => `[${entry.time}] ${entry.log}`).join('\n');
-            const doc = await vscode.workspace.openTextDocument({ content: logText, language: 'log' });
-            await vscode.window.showTextDocument(doc);
-        } catch (error: unknown) {
-            logger.error('Failed to fetch build logs:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage('Failed to fetch build logs.');
-        }
-    };
-
-    private handleGoToSource = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const payload = getPayload<WebCmd<'goToSource'>>(message);
-            const { participationId, resultId } = payload;
-            const logs = await this.context.artemisApi.getBuildLogs(participationId, resultId);
-            const error = BuildLogParser.parseFirstError(logs);
-            if (error) {
-                await vscode.commands.executeCommand('artemis.goToSourceError', error.filePath, error.line, error.column, error.message);
-            } else {
-                vscode.window.showInformationMessage('No source error location found in build logs');
-            }
-        } catch (err: unknown) {
-            logger.error('Failed to navigate to source error:', LogCategory.SUBMISSION, err);
-            vscode.window.showErrorMessage('Failed to navigate to source error.');
         }
     };
 

--- a/extension/src/extension/controller/commands/repositoryCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCommands.ts
@@ -1,32 +1,17 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
 import * as path from 'path';
 
 import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts';
-import { ExtensionMsg, getOptionalPayload, getPayload, WebviewCmd } from '@shared/messageContracts';
+import { ExtensionMsg, getPayload, WebviewCmd } from '@shared/messageContracts';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
-import {
-    getWorkspaceRepositoryUrl,
-    getWorkspaceStatus,
-    GitService,
-    normalizeRepositoryUrl,
-} from '@extension/services/workspace';
+import { getWorkspaceStatus, GitService } from '@extension/services/workspace';
 import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
-import { cloneRepositoryProgrammatic, getTheiaEnvironment } from '@extension/theia';
 import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
 
 import type { CommandContext, CommandMap } from './types';
 
 const GIT_IDENTITY_NOT_CONFIGURED = 'GIT_IDENTITY_NOT_CONFIGURED';
-
-/**
- * Soft cap on the in-memory map of recently cloned repositories per
- * participation. Bounded to keep the map from growing unboundedly during a
- * long session; FIFO eviction is acceptable because the map is only used to
- * surface "open cloned repo" notices.
- */
-const MAX_CLONED_REPO_CACHE_SIZE = 10;
 
 interface RepoContext {
     expectedRepoUrl: string;
@@ -38,7 +23,6 @@ export class RepositoryCommandModule {
     private currentWorkspacePath?: string;
     private workspaceChangeDebounce?: NodeJS.Timeout;
     private workspaceListenersRegistered = false;
-    private clonedRepositoriesByParticipationId: Map<number, { path: string; title: string }> = new Map();
     private dirtyPagesCheckDebounce?: NodeJS.Timeout;
     private readonly listenerDisposables: vscode.Disposable[] = [];
     private readonly gitService: GitService;
@@ -77,67 +61,12 @@ export class RepositoryCommandModule {
         this.workspaceListenersRegistered = false;
     }
 
-    /**
-     * Build an authenticated clone URL by fetching a VCS token and the current user's login.
-     * Returns the URL string on success, or null if token retrieval or URL construction fails.
-     */
-    private async buildAuthenticatedUrl(participationId: number, repositoryUri: string): Promise<string | null> {
-        let vcsToken: string;
-        try {
-            vcsToken = await this.context.artemisApi.getOrCreateVcsAccessToken(participationId);
-        } catch (tokenErr) {
-            logger.error('Failed to get participation token:', LogCategory.SUBMISSION, tokenErr);
-            vscode.window.showErrorMessage('Failed to obtain VCS access token.');
-            return null;
-        }
-
-        let username = 'user';
-        try {
-            const currentUser = await this.context.artemisApi.getCurrentUser();
-            if (currentUser?.login) {
-                username = currentUser.login;
-            }
-        } catch (userErr) {
-            logger.warn('Could not fetch current user, defaulting username:', LogCategory.SUBMISSION, userErr);
-        }
-
-        try {
-            const url = new URL(repositoryUri);
-            url.username = username;
-            url.password = vcsToken;
-            return url.toString();
-        } catch {
-            vscode.window.showErrorMessage('Invalid repository URL received from server.');
-            return null;
-        }
-    }
-
-    private async _selectFolder(openLabel: string, title: string): Promise<string | undefined> {
-        // In Theia, always use the workspace root instead of showing a dialog
-        if (getTheiaEnvironment().isTheia) {
-            return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-        }
-
-        const folderUri = await vscode.window.showOpenDialog({
-            canSelectFiles: false,
-            canSelectFolders: true,
-            canSelectMany: false,
-            openLabel,
-            title,
-        });
-        return folderUri?.[0]?.fsPath;
-    }
-
     public getHandlers(): CommandMap {
         return {
             [WebviewCmd.CheckRepositoryStatus]: this.handleCheckRepositoryStatus,
-            [WebviewCmd.CloneRepository]: this.handleCloneRepository,
-            [WebviewCmd.CopyAuthenticatedCloneUrl]: this.handleCopyAuthenticatedCloneUrl,
             [WebviewCmd.SubmitExercise]: this.handleSubmitExercise,
             [WebviewCmd.SaveGitIdentity]: this.handleSaveGitIdentity,
             [WebviewCmd.RequestGitIdentity]: this.handleRequestGitIdentity,
-            [WebviewCmd.OpenRepository]: this.handleOpenRepository,
-            [WebviewCmd.OpenClonedRepository]: this.handleOpenClonedRepository,
         };
     }
 
@@ -193,181 +122,6 @@ export class RepositoryCommandModule {
         } catch (error: unknown) {
             logger.error('Check repository status error:', LogCategory.SUBMISSION, error);
             vscode.window.showErrorMessage('Error checking repository status');
-        }
-    };
-
-    private handleCloneRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const payload = getPayload<WebCmd<'cloneRepository'>>(message);
-            const { participationId, repositoryUri, exerciseTitle } = payload;
-            if (!participationId || !repositoryUri) {
-                vscode.window.showErrorMessage('Cannot clone: missing participation or repository URL.');
-                return;
-            }
-
-            if (!(await this.gitService.isGitAvailable())) {
-                vscode.window.showErrorMessage('Git not found in PATH. Please install Git to clone repositories.');
-                return;
-            }
-
-            const selectedPath = await this._resolveCloneDestination(exerciseTitle);
-            if (!selectedPath) { return; }
-
-            const cloneUrl = await this.buildAuthenticatedUrl(participationId, repositoryUri);
-            if (!cloneUrl) { return; }
-
-            const repoName = path.basename(repositoryUri).replace(/\.git$/, '');
-            const repoPath = path.join(selectedPath, repoName);
-
-            // Run git clone as an awaitable child process (same for Theia and
-            // VS Code Desktop). A terminal-based fire-and-forget clone cannot
-            // reliably signal success or failure back to the extension, which
-            // caused the "Open Folder" prompt to appear even when the clone
-            // errored out. Using the programmatic clone, a thrown error lands
-            // in the outer catch and the prompt is only reached on success.
-            await cloneRepositoryProgrammatic(cloneUrl, repoPath, exerciseTitle);
-
-            this._rememberClonedRepo(participationId, repoPath, exerciseTitle);
-
-            this.context.sendMessage({
-                type: ExtensionMsg.ShowClonedRepoNotice,
-                exerciseTitle: exerciseTitle,
-                participationId,
-            });
-
-            const openAction = await vscode.window.showInformationMessage(
-                `Open cloned repository "${exerciseTitle}"?`,
-                'Open Folder',
-                'Skip',
-            );
-            if (openAction === 'Open Folder') {
-                void vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(repoPath), true);
-            }
-        } catch (error: unknown) {
-            logger.error('Clone repository error:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage(`Failed to clone repository: ${extractErrorMessage(error)}`);
-        }
-    };
-
-    /**
-     * Resolve the destination folder for a clone in one of three ways:
-     *   1. The configured default-clone-path, if it points to an existing dir.
-     *   2. The full "set default / choose / don't ask again" modal (when the
-     *      prompt is enabled and no default is configured).
-     *   3. A bare folder picker when the prompt has been silenced.
-     *
-     * Returns `undefined` when the user cancels at any branch; an information
-     * notice is shown with the cancellation reason as a side effect.
-     */
-    private async _resolveCloneDestination(exerciseTitle: string): Promise<string | undefined> {
-        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-        const defaultClonePath = config.get<string>(VSCODE_CONFIG.DEFAULT_CLONE_PATH_KEY, '').trim();
-        const showPrompt = config.get<boolean>(VSCODE_CONFIG.SHOW_SET_DEFAULT_CLONE_PATH_PROMPT_KEY, true);
-
-        if (defaultClonePath) {
-            const reasonInvalid = await this._validateDefaultClonePath(defaultClonePath);
-            if (!reasonInvalid) {
-                return defaultClonePath;
-            }
-            vscode.window.showWarningMessage(`Default clone path "${defaultClonePath}" ${reasonInvalid}. Please select a folder.`);
-            return this._pickFolderOrCancelClone('Select Clone Destination', `Choose where to clone ${exerciseTitle}`);
-        }
-
-        if (!showPrompt) {
-            return this._pickFolderOrCancelClone('Select Clone Destination', `Choose where to clone ${exerciseTitle}`);
-        }
-
-        const choice = await vscode.window.showInformationMessage(
-            'Where should exercise repositories be cloned?\n\nYou can set a default folder now (e.g., ~/artemis-exercises) so all future exercises are automatically saved there, or choose a location each time.',
-            { modal: true },
-            'Set Default Folder',
-            'Choose Each Time',
-            "Don't Ask Again",
-        );
-
-        if (choice === 'Set Default Folder') {
-            const defaultFolderPath = await this._selectFolder('Set as Default', 'Select default folder for all exercise repositories');
-            if (!defaultFolderPath) {
-                vscode.window.showInformationMessage('Clone cancelled - no folder selected.');
-                return undefined;
-            }
-            await config.update(VSCODE_CONFIG.DEFAULT_CLONE_PATH_KEY, defaultFolderPath, vscode.ConfigurationTarget.Global);
-            vscode.window.showInformationMessage(`✓ All exercises will now be cloned to: ${defaultFolderPath}`);
-            return defaultFolderPath;
-        }
-        if (choice === "Don't Ask Again") {
-            await config.update(VSCODE_CONFIG.SHOW_SET_DEFAULT_CLONE_PATH_PROMPT_KEY, false, vscode.ConfigurationTarget.Global);
-            return this._pickFolderOrCancelClone('Select Folder', `Where should "${exerciseTitle}" be cloned?`);
-        }
-        if (choice === 'Choose Each Time') {
-            return this._pickFolderOrCancelClone('Select Folder', `Where should "${exerciseTitle}" be cloned?`);
-        }
-
-        // ESC / dismissed modal — abort.
-        vscode.window.showInformationMessage('Clone cancelled.');
-        return undefined;
-    }
-
-    /**
-     * Returns `undefined` if the configured default-clone-path is usable; a
-     * short reason string ('does not exist' / 'is not a directory') otherwise.
-     */
-    private async _validateDefaultClonePath(p: string): Promise<string | undefined> {
-        try {
-            const stats = await fs.promises.stat(p);
-            return stats.isDirectory() ? undefined : 'is not a directory';
-        } catch {
-            return 'does not exist';
-        }
-    }
-
-    /** Folder picker + the standard "Clone cancelled" notice on dismissal. */
-    private async _pickFolderOrCancelClone(label: string, title: string): Promise<string | undefined> {
-        const folderPath = await this._selectFolder(label, title);
-        if (!folderPath) {
-            vscode.window.showInformationMessage('Clone cancelled - no folder selected.');
-            return undefined;
-        }
-        return folderPath;
-    }
-
-    /**
-     * Insert a freshly cloned repository into the per-participation cache,
-     * evicting the oldest entry by insertion order when the cap is reached.
-     * (FIFO, not LRU — sufficient for the current "open cloned repo" notice
-     * usage, which doesn't depend on recency-of-access semantics.)
-     */
-    private _rememberClonedRepo(participationId: number, repoPath: string, title: string): void {
-        if (this.clonedRepositoriesByParticipationId.size >= MAX_CLONED_REPO_CACHE_SIZE
-            && !this.clonedRepositoriesByParticipationId.has(participationId)) {
-            const firstKey = this.clonedRepositoriesByParticipationId.keys().next().value;
-            if (firstKey !== undefined) {
-                this.clonedRepositoriesByParticipationId.delete(firstKey);
-            }
-        }
-        this.clonedRepositoriesByParticipationId.set(participationId, { path: repoPath, title });
-    }
-
-    private handleCopyAuthenticatedCloneUrl = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const { participationId, repositoryUri } = getPayload<WebCmd<'copyAuthenticatedCloneUrl'>>(message);
-            if (!participationId || !repositoryUri) {
-                vscode.window.showErrorMessage('Cannot copy clone URL: missing participation or repository URL.');
-                return;
-            }
-
-            const authenticatedUrl = await this.buildAuthenticatedUrl(participationId, repositoryUri);
-            if (!authenticatedUrl) {
-                return;
-            }
-
-            await vscode.env.clipboard.writeText(authenticatedUrl);
-            vscode.window.showInformationMessage(
-                'Authenticated clone URL copied to clipboard. It contains a VCS access token, so do not share it.'
-            );
-        } catch (error: unknown) {
-            logger.error('Failed to copy authenticated clone URL:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage(`Failed to copy clone URL: ${extractErrorMessage(error)}`);
         }
     };
 
@@ -668,70 +422,5 @@ export class RepositoryCommandModule {
             autoSaveEnabled: autoSave !== 'off'
         });
     }
-
-    private handleOpenClonedRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const { participationId } = getPayload<WebCmd<'openClonedRepository'>>(message);
-            const repoInfo = this.clonedRepositoriesByParticipationId.get(participationId);
-
-            if (!repoInfo) {
-                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
-                return;
-            }
-
-            try {
-                const stats = fs.statSync(repoInfo.path);
-                if (!stats.isDirectory()) {
-                    this.clonedRepositoriesByParticipationId.delete(participationId);
-                    vscode.window.showWarningMessage('Cloned repository path is not a directory.');
-                    return;
-                }
-            } catch {
-                this.clonedRepositoriesByParticipationId.delete(participationId);
-                vscode.window.showWarningMessage('Cloned repository not found. It may have been moved or deleted.');
-                return;
-            }
-
-            const repoUri = vscode.Uri.file(repoInfo.path);
-
-            const currentFolder = vscode.workspace.workspaceFolders?.[0];
-            if (currentFolder && currentFolder.uri.fsPath === repoInfo.path) {
-                await vscode.commands.executeCommand('workbench.view.explorer');
-                return;
-            }
-
-            await vscode.commands.executeCommand('vscode.openFolder', repoUri, true);
-        } catch (error: unknown) {
-            logger.error('Open cloned repository error:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage('Failed to open cloned repository.');
-        }
-    };
-
-    private handleOpenRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const repositoryUri = getOptionalPayload<WebCmd<'openRepository'>>(message)?.repositoryUri;
-
-            if (!repositoryUri) {
-                vscode.window.showWarningMessage('No repository URL available.');
-                return;
-            }
-            // Try to open the repository folder if it's already cloned in the workspace
-            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-            if (workspaceFolder) {
-                const wsUrl = await getWorkspaceRepositoryUrl(workspaceFolder);
-                if (wsUrl && normalizeRepositoryUrl(wsUrl) === normalizeRepositoryUrl(repositoryUri)) {
-                    // Already in the correct workspace — just reveal the explorer
-                    await vscode.commands.executeCommand('workbench.view.explorer');
-                    return;
-                }
-            }
-
-            // Open the URL externally as a fallback
-            await vscode.env.openExternal(vscode.Uri.parse(repositoryUri));
-        } catch (error: unknown) {
-            logger.error('Open repository error:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage('Failed to open repository.');
-        }
-    };
 
 }

--- a/extension/src/extension/controller/commands/repositoryCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCommands.ts
@@ -1,11 +1,10 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts';
 import { ExtensionMsg, getPayload, WebviewCmd } from '@shared/messageContracts';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { getWorkspaceStatus, GitService } from '@extension/services/workspace';
+import { GitService } from '@extension/services/workspace';
 import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
 import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
 
@@ -13,117 +12,24 @@ import type { CommandContext, CommandMap } from './types';
 
 const GIT_IDENTITY_NOT_CONFIGURED = 'GIT_IDENTITY_NOT_CONFIGURED';
 
-interface RepoContext {
-    expectedRepoUrl: string;
-    exerciseId: number;
-}
-
+/**
+ * @deprecated TEMPORARY: submit and identity handlers will move to
+ * RepositorySubmitCommands in the next commit. Tracked under #205.
+ */
 export class RepositoryCommandModule {
-    private currentRepoContext?: RepoContext;
-    private currentWorkspacePath?: string;
-    private workspaceChangeDebounce?: NodeJS.Timeout;
-    private workspaceListenersRegistered = false;
-    private dirtyPagesCheckDebounce?: NodeJS.Timeout;
-    private readonly listenerDisposables: vscode.Disposable[] = [];
     private readonly gitService: GitService;
 
     constructor(private readonly context: CommandContext) {
         this.gitService = new GitService();
-        this.registerWorkspaceListeners();
-    }
-
-    /**
-     * Set the repository context so workspace listeners can detect changes
-     * without requiring a manual checkRepositoryStatus command.
-     */
-    public setRepositoryContext(repoUrl: string, exerciseId: number): void {
-        this.currentRepoContext = { expectedRepoUrl: repoUrl, exerciseId };
-        this.currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    }
-
-    public clearRepositoryContext(): void {
-        this.currentRepoContext = undefined;
-    }
-
-    public dispose(): void {
-        for (const d of this.listenerDisposables) {
-            d.dispose();
-        }
-        this.listenerDisposables.length = 0;
-        if (this.workspaceChangeDebounce) {
-            clearTimeout(this.workspaceChangeDebounce);
-            this.workspaceChangeDebounce = undefined;
-        }
-        if (this.dirtyPagesCheckDebounce) {
-            clearTimeout(this.dirtyPagesCheckDebounce);
-            this.dirtyPagesCheckDebounce = undefined;
-        }
-        this.workspaceListenersRegistered = false;
     }
 
     public getHandlers(): CommandMap {
         return {
-            [WebviewCmd.CheckRepositoryStatus]: this.handleCheckRepositoryStatus,
             [WebviewCmd.SubmitExercise]: this.handleSubmitExercise,
             [WebviewCmd.SaveGitIdentity]: this.handleSaveGitIdentity,
             [WebviewCmd.RequestGitIdentity]: this.handleRequestGitIdentity,
         };
     }
-
-    private handleCheckRepositoryStatus = async (_message: WebviewToExtensionMessage): Promise<void> => {
-        const exerciseData = this.context.appStateManager.currentExerciseData;
-        const exercise = exerciseData?.exercise;
-        const participations = exercise?.studentParticipations ?? [];
-        const repoUris = participations
-            .map(p => p.repositoryUri)
-            .filter((uri): uri is string => !!uri);
-
-        if (exercise?.id === undefined || repoUris.length === 0) {
-            // Fall back to cached context if available
-            if (this.currentRepoContext) {
-                await this._checkRepositoryStatusWithContext([this.currentRepoContext.expectedRepoUrl], this.currentRepoContext.exerciseId);
-            } else {
-                logger.warn('No repository context available', LogCategory.SUBMISSION);
-            }
-            return;
-        }
-
-        this.currentRepoContext = { expectedRepoUrl: repoUris[0], exerciseId: exercise.id };
-        await this._checkRepositoryStatusWithContext(repoUris, exercise.id);
-    };
-
-    private async _checkRepositoryStatusWithContext(repoUris: string[], exerciseId: number): Promise<void> {
-        try {
-            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-            this.currentWorkspacePath = workspaceFolder?.uri.fsPath;
-
-            // Try each participation URI until we find a match
-            for (const uri of repoUris) {
-                const status = await getWorkspaceStatus(uri, workspaceFolder);
-                if (status.isConnected) {
-                    this.currentRepoContext = { expectedRepoUrl: uri, exerciseId };
-                    this.context.sendMessage({
-                        type: ExtensionMsg.UpdateRepoStatus,
-                        isConnected: status.isConnected,
-                        hasChanges: status.hasChanges,
-                        isPracticeRepo: status.isPracticeRepo,
-                    });
-                    return;
-                }
-            }
-
-            // No match found
-            this.context.sendMessage({
-                type: ExtensionMsg.UpdateRepoStatus,
-                isConnected: false,
-                hasChanges: false,
-                isPracticeRepo: false,
-            });
-        } catch (error: unknown) {
-            logger.error('Check repository status error:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage('Error checking repository status');
-        }
-    };
 
     private handleSubmitExercise = async (message: WebviewToExtensionMessage): Promise<void> => {
         try {
@@ -136,7 +42,6 @@ export class RepositoryCommandModule {
                 return;
             }
 
-            this.currentWorkspacePath = workspaceFolder.uri.fsPath;
             const cwd = workspaceFolder.uri.fsPath;
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
@@ -188,12 +93,7 @@ export class RepositoryCommandModule {
             vscode.window.showInformationMessage(`Successfully submitted "${exerciseTitle}".`);
 
             // Re-check workspace status so UI reflects clean state after push
-            if (this.currentRepoContext) {
-                void this._checkRepositoryStatusWithContext(
-                    [this.currentRepoContext.expectedRepoUrl],
-                    this.currentRepoContext.exerciseId,
-                );
-            }
+            void this.context.recheckRepoStatus?.();
 
             // Ensure WebSocket is connected to receive real-time result updates
             const websocketService = this.context.getWebsocketService?.();
@@ -294,133 +194,4 @@ export class RepositoryCommandModule {
             email: email ?? ''
         });
     };
-
-    private registerWorkspaceListeners(): void {
-        if (this.workspaceListenersRegistered) {
-            return;
-        }
-
-        const handleUri = (uri?: vscode.Uri) => {
-            this.scheduleWorkspaceStatusCheck(uri);
-        };
-
-        this.listenerDisposables.push(
-            vscode.workspace.onDidSaveTextDocument(document => {
-                handleUri(document.uri);
-                this.scheduleDirtyPagesCheck();
-            }),
-            vscode.workspace.onDidCreateFiles(event => {
-                if (event.files && event.files.length > 0) {
-                    handleUri(event.files[0]);
-                } else {
-                    handleUri();
-                }
-            }),
-            vscode.workspace.onDidDeleteFiles(event => {
-                if (event.files && event.files.length > 0) {
-                    handleUri(event.files[0]);
-                } else {
-                    handleUri();
-                }
-            }),
-            vscode.workspace.onDidRenameFiles(event => {
-                if (event.files && event.files.length > 0) {
-                    handleUri(event.files[0].newUri);
-                } else {
-                    handleUri();
-                }
-            }),
-            vscode.workspace.onDidChangeTextDocument(event => {
-                if (event.document.uri.scheme === 'file') {
-                    this.scheduleDirtyPagesCheck();
-                }
-            }),
-        );
-
-        this.workspaceListenersRegistered = true;
-    }
-
-    private scheduleWorkspaceStatusCheck(uri?: vscode.Uri): void {
-        if (!this.currentRepoContext || !this.currentWorkspacePath) {
-            return;
-        }
-
-        if (uri) {
-            const relative = path.relative(this.currentWorkspacePath, uri.fsPath);
-            if (relative.startsWith('..')) {
-                return;
-            }
-        }
-
-        if (this.workspaceChangeDebounce) {
-            clearTimeout(this.workspaceChangeDebounce);
-        }
-
-        this.workspaceChangeDebounce = setTimeout(() => {
-            if (this.currentRepoContext) {
-                void this._checkRepositoryStatusWithContext(
-                    [this.currentRepoContext.expectedRepoUrl],
-                    this.currentRepoContext.exerciseId,
-                );
-            }
-        }, 500);
-    }
-
-    private scheduleDirtyPagesCheck(): void {
-        if (this.dirtyPagesCheckDebounce) {
-            clearTimeout(this.dirtyPagesCheckDebounce);
-        }
-
-        this.dirtyPagesCheckDebounce = setTimeout(() => {
-            this.checkDirtyPages();
-        }, 300);
-    }
-
-    private checkDirtyPages(): void {
-        const artemisConfig = vscode.workspace.getConfiguration('artemis');
-        const showWarning = artemisConfig.get<boolean>('showUnsavedChangesWarning', true);
-
-        if (!showWarning) {
-            this.context.sendMessage({
-                type: ExtensionMsg.UpdateDirtyPagesStatus,
-                hasDirtyPages: false,
-                dirtyFileCount: 0,
-                autoSaveEnabled: false
-            });
-            return;
-        }
-
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (!workspaceFolder) {
-            return;
-        }
-
-        const dirtyDocuments = vscode.workspace.textDocuments.filter(doc => {
-            if (doc.uri.scheme !== 'file') {
-                return false;
-            }
-
-            const docPath = doc.uri.fsPath;
-            const workspacePath = workspaceFolder.uri.fsPath;
-            const relative = path.relative(workspacePath, docPath);
-
-            if (relative.startsWith('..')) {
-                return false;
-            }
-
-            return doc.isDirty;
-        });
-
-        const hasDirtyPages = dirtyDocuments.length > 0;
-        const config = vscode.workspace.getConfiguration('files');
-        const autoSave = config.get<string>('autoSave', 'off');
-
-        this.context.sendMessage({
-            type: ExtensionMsg.UpdateDirtyPagesStatus,
-            hasDirtyPages: hasDirtyPages,
-            dirtyFileCount: dirtyDocuments.length,
-            autoSaveEnabled: autoSave !== 'off'
-        });
-    }
-
 }

--- a/extension/src/extension/controller/commands/repositoryCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryCommands.ts
@@ -136,8 +136,6 @@ export class RepositoryCommandModule {
             [WebviewCmd.SubmitExercise]: this.handleSubmitExercise,
             [WebviewCmd.SaveGitIdentity]: this.handleSaveGitIdentity,
             [WebviewCmd.RequestGitIdentity]: this.handleRequestGitIdentity,
-            [WebviewCmd.StartPractice]: this.handleStartPractice,
-            [WebviewCmd.StartExercise]: this.handleStartExercise,
             [WebviewCmd.OpenRepository]: this.handleOpenRepository,
             [WebviewCmd.OpenClonedRepository]: this.handleOpenClonedRepository,
         };
@@ -670,48 +668,6 @@ export class RepositoryCommandModule {
             autoSaveEnabled: autoSave !== 'off'
         });
     }
-
-    private handleStartPractice = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const payload = getPayload<WebCmd<'startPractice'>>(message);
-            const exerciseId = payload.exerciseId;
-            const exerciseTitle = payload.exerciseTitle ?? 'Exercise';
-            vscode.window.showInformationMessage('Starting practice mode...');
-            const participation = await this.context.artemisApi.startPracticeParticipation(exerciseId);
-
-            if (participation) {
-                vscode.window.showInformationMessage(
-                    `Successfully started practice mode for "${exerciseTitle}". You can now clone the practice repository.`
-                );
-
-                await this.context.actionHandler.openExerciseDetails(exerciseId);
-            }
-        } catch (error: unknown) {
-            logger.error('Failed to start practice participation:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage(
-                `Failed to start practice mode: ${extractErrorMessage(error)}`
-            );
-        }
-    };
-
-    private handleStartExercise = async (message: WebviewToExtensionMessage): Promise<void> => {
-        try {
-            const payload = getPayload<WebCmd<'startExercise'>>(message);
-            const exerciseId = payload.exerciseId;
-            vscode.window.showInformationMessage('Starting exercise...');
-            const participation = await this.context.artemisApi.startExerciseParticipation(exerciseId);
-
-            if (participation) {
-                vscode.window.showInformationMessage('Successfully started exercise participation.');
-                await this.context.actionHandler.openExerciseDetails(exerciseId);
-            }
-        } catch (error: unknown) {
-            logger.error('Failed to start exercise:', LogCategory.SUBMISSION, error);
-            vscode.window.showErrorMessage(
-                `Failed to start exercise: ${extractErrorMessage(error)}`
-            );
-        }
-    };
 
     private handleOpenClonedRepository = async (message: WebviewToExtensionMessage): Promise<void> => {
         try {

--- a/extension/src/extension/controller/commands/repositoryStatusCommands.ts
+++ b/extension/src/extension/controller/commands/repositoryStatusCommands.ts
@@ -1,0 +1,283 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+import type { WebviewToExtensionMessage } from '@shared/messageContracts';
+import { ExtensionMsg, WebviewCmd } from '@shared/messageContracts';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import * as workspaceServices from '@extension/services/workspace';
+
+import type { CommandContext, CommandMap } from './types';
+
+interface RepoContext {
+    expectedRepoUrl: string;
+    exerciseId: number;
+}
+
+/**
+ * Helper functions injected via the constructor so tests can substitute
+ * deterministic doubles. The defaults wire up to the production modules.
+ *
+ * (This injection seam was added because the production helpers are
+ * re-exported through `@extension/services/workspace` barrel modules, where
+ * the TS-emitted descriptors are non-configurable getters that sinon cannot
+ * stub. Direct namespace stubbing fails with "descriptor is not configurable",
+ * so we inject the callables instead.)
+ */
+export interface RepositoryStatusCommandsDeps {
+    getWorkspaceStatus: typeof workspaceServices.getWorkspaceStatus;
+}
+
+const defaultDeps: RepositoryStatusCommandsDeps = {
+    getWorkspaceStatus: workspaceServices.getWorkspaceStatus,
+};
+
+export class RepositoryStatusCommands {
+    private currentRepoContext?: RepoContext;
+    private currentWorkspacePath?: string;
+    private workspaceChangeDebounce?: NodeJS.Timeout;
+    private dirtyPagesCheckDebounce?: NodeJS.Timeout;
+    private workspaceListenersRegistered = false;
+    private readonly listenerDisposables: vscode.Disposable[] = [];
+    private readonly deps: RepositoryStatusCommandsDeps;
+
+    constructor(
+        private readonly context: CommandContext,
+        deps: Partial<RepositoryStatusCommandsDeps> = {},
+    ) {
+        this.deps = { ...defaultDeps, ...deps };
+        this.registerWorkspaceListeners();
+    }
+
+    public getHandlers(): CommandMap {
+        return {
+            [WebviewCmd.CheckRepositoryStatus]: this.handleCheckRepositoryStatus,
+        };
+    }
+
+    /**
+     * Set the repository context so workspace listeners can detect changes
+     * without requiring a manual checkRepositoryStatus command.
+     */
+    public setRepositoryContext(repoUrl: string, exerciseId: number): void {
+        this.currentRepoContext = { expectedRepoUrl: repoUrl, exerciseId };
+        this.currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    }
+
+    public clearRepositoryContext(): void {
+        this.currentRepoContext = undefined;
+    }
+
+    /**
+     * Trigger a fresh status check using the currently stored context.
+     * No-op if no context has been set.
+     */
+    public async recheckCurrentRepoStatus(): Promise<void> {
+        if (!this.currentRepoContext) {
+            return;
+        }
+        await this._checkRepositoryStatusWithContext(
+            [this.currentRepoContext.expectedRepoUrl],
+            this.currentRepoContext.exerciseId,
+        );
+    }
+
+    public dispose(): void {
+        for (const d of this.listenerDisposables) {
+            d.dispose();
+        }
+        this.listenerDisposables.length = 0;
+        if (this.workspaceChangeDebounce) {
+            clearTimeout(this.workspaceChangeDebounce);
+            this.workspaceChangeDebounce = undefined;
+        }
+        if (this.dirtyPagesCheckDebounce) {
+            clearTimeout(this.dirtyPagesCheckDebounce);
+            this.dirtyPagesCheckDebounce = undefined;
+        }
+        this.workspaceListenersRegistered = false;
+    }
+
+    private handleCheckRepositoryStatus = async (_message: WebviewToExtensionMessage): Promise<void> => {
+        const exerciseData = this.context.appStateManager.currentExerciseData;
+        const exercise = exerciseData?.exercise;
+        const participations = exercise?.studentParticipations ?? [];
+        const repoUris = participations
+            .map(p => p.repositoryUri)
+            .filter((uri): uri is string => !!uri);
+
+        if (exercise?.id === undefined || repoUris.length === 0) {
+            // Fall back to cached context if available
+            if (this.currentRepoContext) {
+                await this._checkRepositoryStatusWithContext([this.currentRepoContext.expectedRepoUrl], this.currentRepoContext.exerciseId);
+            } else {
+                logger.warn('No repository context available', LogCategory.SUBMISSION);
+            }
+            return;
+        }
+
+        this.currentRepoContext = { expectedRepoUrl: repoUris[0], exerciseId: exercise.id };
+        await this._checkRepositoryStatusWithContext(repoUris, exercise.id);
+    };
+
+    private async _checkRepositoryStatusWithContext(repoUris: string[], exerciseId: number): Promise<void> {
+        try {
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            this.currentWorkspacePath = workspaceFolder?.uri.fsPath;
+
+            // Try each participation URI until we find a match
+            for (const uri of repoUris) {
+                const status = await this.deps.getWorkspaceStatus(uri, workspaceFolder);
+                if (status.isConnected) {
+                    this.currentRepoContext = { expectedRepoUrl: uri, exerciseId };
+                    this.context.sendMessage({
+                        type: ExtensionMsg.UpdateRepoStatus,
+                        isConnected: status.isConnected,
+                        hasChanges: status.hasChanges,
+                        isPracticeRepo: status.isPracticeRepo,
+                    });
+                    return;
+                }
+            }
+
+            // No match found
+            this.context.sendMessage({
+                type: ExtensionMsg.UpdateRepoStatus,
+                isConnected: false,
+                hasChanges: false,
+                isPracticeRepo: false,
+            });
+        } catch (error: unknown) {
+            logger.error('Check repository status error:', LogCategory.SUBMISSION, error);
+            vscode.window.showErrorMessage('Error checking repository status');
+        }
+    }
+
+    private registerWorkspaceListeners(): void {
+        if (this.workspaceListenersRegistered) {
+            return;
+        }
+
+        const handleUri = (uri?: vscode.Uri) => {
+            this.scheduleWorkspaceStatusCheck(uri);
+        };
+
+        this.listenerDisposables.push(
+            vscode.workspace.onDidSaveTextDocument(document => {
+                handleUri(document.uri);
+                this.scheduleDirtyPagesCheck();
+            }),
+            vscode.workspace.onDidCreateFiles(event => {
+                if (event.files && event.files.length > 0) {
+                    handleUri(event.files[0]);
+                } else {
+                    handleUri();
+                }
+            }),
+            vscode.workspace.onDidDeleteFiles(event => {
+                if (event.files && event.files.length > 0) {
+                    handleUri(event.files[0]);
+                } else {
+                    handleUri();
+                }
+            }),
+            vscode.workspace.onDidRenameFiles(event => {
+                if (event.files && event.files.length > 0) {
+                    handleUri(event.files[0].newUri);
+                } else {
+                    handleUri();
+                }
+            }),
+            vscode.workspace.onDidChangeTextDocument(event => {
+                if (event.document.uri.scheme === 'file') {
+                    this.scheduleDirtyPagesCheck();
+                }
+            }),
+        );
+
+        this.workspaceListenersRegistered = true;
+    }
+
+    private scheduleWorkspaceStatusCheck(uri?: vscode.Uri): void {
+        if (!this.currentRepoContext || !this.currentWorkspacePath) {
+            return;
+        }
+
+        if (uri) {
+            const relative = path.relative(this.currentWorkspacePath, uri.fsPath);
+            if (relative.startsWith('..')) {
+                return;
+            }
+        }
+
+        if (this.workspaceChangeDebounce) {
+            clearTimeout(this.workspaceChangeDebounce);
+        }
+
+        this.workspaceChangeDebounce = setTimeout(() => {
+            if (this.currentRepoContext) {
+                void this._checkRepositoryStatusWithContext(
+                    [this.currentRepoContext.expectedRepoUrl],
+                    this.currentRepoContext.exerciseId,
+                );
+            }
+        }, 500);
+    }
+
+    private scheduleDirtyPagesCheck(): void {
+        if (this.dirtyPagesCheckDebounce) {
+            clearTimeout(this.dirtyPagesCheckDebounce);
+        }
+
+        this.dirtyPagesCheckDebounce = setTimeout(() => {
+            this.checkDirtyPages();
+        }, 300);
+    }
+
+    private checkDirtyPages(): void {
+        const artemisConfig = vscode.workspace.getConfiguration('artemis');
+        const showWarning = artemisConfig.get<boolean>('showUnsavedChangesWarning', true);
+
+        if (!showWarning) {
+            this.context.sendMessage({
+                type: ExtensionMsg.UpdateDirtyPagesStatus,
+                hasDirtyPages: false,
+                dirtyFileCount: 0,
+                autoSaveEnabled: false
+            });
+            return;
+        }
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return;
+        }
+
+        const dirtyDocuments = vscode.workspace.textDocuments.filter(doc => {
+            if (doc.uri.scheme !== 'file') {
+                return false;
+            }
+
+            const docPath = doc.uri.fsPath;
+            const workspacePath = workspaceFolder.uri.fsPath;
+            const relative = path.relative(workspacePath, docPath);
+
+            if (relative.startsWith('..')) {
+                return false;
+            }
+
+            return doc.isDirty;
+        });
+
+        const hasDirtyPages = dirtyDocuments.length > 0;
+        const config = vscode.workspace.getConfiguration('files');
+        const autoSave = config.get<string>('autoSave', 'off');
+
+        this.context.sendMessage({
+            type: ExtensionMsg.UpdateDirtyPagesStatus,
+            hasDirtyPages: hasDirtyPages,
+            dirtyFileCount: dirtyDocuments.length,
+            autoSaveEnabled: autoSave !== 'off'
+        });
+    }
+}

--- a/extension/src/extension/controller/commands/repositorySubmitCommands.ts
+++ b/extension/src/extension/controller/commands/repositorySubmitCommands.ts
@@ -4,8 +4,8 @@ import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts
 import { ExtensionMsg, getPayload, WebviewCmd } from '@shared/messageContracts';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { GitService } from '@extension/services/workspace';
-import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
+import * as workspaceServices from '@extension/services/workspace';
+import * as fileChecker from '@extension/services/workspace/workspaceFileChecker';
 import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
 
 import type { CommandContext, CommandMap } from './types';
@@ -13,14 +13,32 @@ import type { CommandContext, CommandMap } from './types';
 const GIT_IDENTITY_NOT_CONFIGURED = 'GIT_IDENTITY_NOT_CONFIGURED';
 
 /**
- * @deprecated TEMPORARY: submit and identity handlers will move to
- * RepositorySubmitCommands in the next commit. Tracked under #205.
+ * Helper functions injected via the constructor so tests can substitute
+ * deterministic doubles. The defaults wire up to the production modules.
+ *
+ * (This injection seam exists because the production helper is re-exported
+ * through `@extension/services/workspace/workspaceFileChecker`, where the
+ * TS-emitted descriptor is a non-configurable getter that sinon cannot stub.
+ * Direct namespace stubbing fails with "descriptor is not configurable",
+ * so we inject the callable instead.)
  */
-export class RepositoryCommandModule {
-    private readonly gitService: GitService;
+export interface RepositorySubmitCommandsDeps {
+    checkWorkspaceFiles: typeof fileChecker.checkWorkspaceFiles;
+}
 
-    constructor(private readonly context: CommandContext) {
-        this.gitService = new GitService();
+const defaultDeps: RepositorySubmitCommandsDeps = {
+    checkWorkspaceFiles: fileChecker.checkWorkspaceFiles,
+};
+
+export class RepositorySubmitCommands {
+    private readonly deps: RepositorySubmitCommandsDeps;
+
+    constructor(
+        private readonly context: CommandContext,
+        private readonly gitService: workspaceServices.GitService = new workspaceServices.GitService(),
+        deps: Partial<RepositorySubmitCommandsDeps> = {},
+    ) {
+        this.deps = { ...defaultDeps, ...deps };
     }
 
     public getHandlers(): CommandMap {
@@ -51,7 +69,7 @@ export class RepositoryCommandModule {
                 progress.report({ message: 'Preparing repository...' });
 
                 // Use unified workspace file checker (lightweight)
-                const result = await checkWorkspaceFiles(workspaceFolder, {
+                const result = await this.deps.checkWorkspaceFiles(workspaceFolder, {
                     includeContent: false,
                     applyFilters: false
                 });

--- a/extension/src/extension/controller/commands/types.ts
+++ b/extension/src/extension/controller/commands/types.ts
@@ -23,6 +23,7 @@ export interface CommandContext {
     sendMessage(message: ExtensionToWebviewMessage): void;
     updateAuthContext(isAuthenticated: boolean): Promise<void>;
     getWebsocketService?: () => ArtemisWebsocketService | undefined;
+    recheckRepoStatus?: () => Promise<void>;
     extensionContext: vscode.ExtensionContext;
     exerciseRegistry: ExerciseRegistry;
     providerRegistry: IProviderRegistry;

--- a/extension/src/extension/controller/webViewMessageHandler.ts
+++ b/extension/src/extension/controller/webViewMessageHandler.ts
@@ -21,6 +21,7 @@ import { IrisCommandModule } from './commands/irisCommands';
 import { NavigationCommandModule } from './commands/navigationCommands';
 import { RepositoryCloneCommands } from './commands/repositoryCloneCommands';
 import { RepositoryCommandModule } from './commands/repositoryCommands';
+import { RepositoryStatusCommands } from './commands/repositoryStatusCommands';
 import { TestResultsTrackingCommandModule } from './commands/testResultsTrackingCommands';
 import type { CommandContext, CommandHandler } from './commands/types';
 import { UtilityCommandModule } from './commands/utilityCommands';
@@ -35,7 +36,7 @@ export class WebViewMessageHandler {
         logger.debug('Message to send to webview:', LogCategory.VIEW, message);
     };
     private readonly commandHandlers: Map<string, CommandHandler> = new Map();
-    private readonly repositoryModule: RepositoryCommandModule;
+    private readonly repositoryStatusModule: RepositoryStatusCommands;
     private _websocketService?: ArtemisWebsocketService;
     private _senderQueue: Promise<void> = Promise.resolve();
 
@@ -67,11 +68,15 @@ export class WebViewMessageHandler {
             courseAccessStorage,
         };
 
+        this.repositoryStatusModule = new RepositoryStatusCommands(context);
+        context.recheckRepoStatus = () => this.repositoryStatusModule.recheckCurrentRepoStatus();
+
         const modules = [
             new AuthCommandModule(context),
             new NavigationCommandModule(context),
-            (this.repositoryModule = new RepositoryCommandModule(context)),
+            this.repositoryStatusModule,
             new RepositoryCloneCommands(context),
+            new RepositoryCommandModule(context),
             new IrisCommandModule(context),
             new HealthCommandModule(context),
             new UtilityCommandModule(context),
@@ -132,7 +137,7 @@ export class WebViewMessageHandler {
      * Dispose the handler and its command modules.
      */
     public dispose(): void {
-        this.repositoryModule.dispose();
+        this.repositoryStatusModule.dispose();
     }
 
     /**
@@ -154,11 +159,11 @@ export class WebViewMessageHandler {
      * can automatically detect changes without a manual check.
      */
     public setRepositoryContext(repoUrl: string, exerciseId: number): void {
-        this.repositoryModule.setRepositoryContext(repoUrl, exerciseId);
+        this.repositoryStatusModule.setRepositoryContext(repoUrl, exerciseId);
     }
 
     public clearRepositoryContext(): void {
-        this.repositoryModule.clearRepositoryContext();
+        this.repositoryStatusModule.clearRepositoryContext();
     }
 
     private async updateAuthContext(isAuthenticated: boolean): Promise<void> {

--- a/extension/src/extension/controller/webViewMessageHandler.ts
+++ b/extension/src/extension/controller/webViewMessageHandler.ts
@@ -19,6 +19,7 @@ import { ExerciseLifecycleCommands } from './commands/exerciseLifecycleCommands'
 import { HealthCommandModule } from './commands/healthCommands';
 import { IrisCommandModule } from './commands/irisCommands';
 import { NavigationCommandModule } from './commands/navigationCommands';
+import { RepositoryCloneCommands } from './commands/repositoryCloneCommands';
 import { RepositoryCommandModule } from './commands/repositoryCommands';
 import { TestResultsTrackingCommandModule } from './commands/testResultsTrackingCommands';
 import type { CommandContext, CommandHandler } from './commands/types';
@@ -70,6 +71,7 @@ export class WebViewMessageHandler {
             new AuthCommandModule(context),
             new NavigationCommandModule(context),
             (this.repositoryModule = new RepositoryCommandModule(context)),
+            new RepositoryCloneCommands(context),
             new IrisCommandModule(context),
             new HealthCommandModule(context),
             new UtilityCommandModule(context),

--- a/extension/src/extension/controller/webViewMessageHandler.ts
+++ b/extension/src/extension/controller/webViewMessageHandler.ts
@@ -15,6 +15,7 @@ import { ArtemisWebsocketService } from '@extension/services/websocket';
 import { AppStateManager } from './appStateManager';
 import { AuthCommandModule } from './commands/authCommands';
 import { BuildLogCommands } from './commands/buildLogCommands';
+import { ExerciseLifecycleCommands } from './commands/exerciseLifecycleCommands';
 import { HealthCommandModule } from './commands/healthCommands';
 import { IrisCommandModule } from './commands/irisCommands';
 import { NavigationCommandModule } from './commands/navigationCommands';
@@ -74,6 +75,7 @@ export class WebViewMessageHandler {
             new UtilityCommandModule(context),
             new TestResultsTrackingCommandModule(context),
             new BuildLogCommands(context),
+            new ExerciseLifecycleCommands(context),
         ];
 
         modules.forEach(module => {

--- a/extension/src/extension/controller/webViewMessageHandler.ts
+++ b/extension/src/extension/controller/webViewMessageHandler.ts
@@ -20,8 +20,8 @@ import { HealthCommandModule } from './commands/healthCommands';
 import { IrisCommandModule } from './commands/irisCommands';
 import { NavigationCommandModule } from './commands/navigationCommands';
 import { RepositoryCloneCommands } from './commands/repositoryCloneCommands';
-import { RepositoryCommandModule } from './commands/repositoryCommands';
 import { RepositoryStatusCommands } from './commands/repositoryStatusCommands';
+import { RepositorySubmitCommands } from './commands/repositorySubmitCommands';
 import { TestResultsTrackingCommandModule } from './commands/testResultsTrackingCommands';
 import type { CommandContext, CommandHandler } from './commands/types';
 import { UtilityCommandModule } from './commands/utilityCommands';
@@ -76,7 +76,7 @@ export class WebViewMessageHandler {
             new NavigationCommandModule(context),
             this.repositoryStatusModule,
             new RepositoryCloneCommands(context),
-            new RepositoryCommandModule(context),
+            new RepositorySubmitCommands(context),
             new IrisCommandModule(context),
             new HealthCommandModule(context),
             new UtilityCommandModule(context),

--- a/extension/src/extension/controller/webViewMessageHandler.ts
+++ b/extension/src/extension/controller/webViewMessageHandler.ts
@@ -14,6 +14,7 @@ import { ArtemisWebsocketService } from '@extension/services/websocket';
 
 import { AppStateManager } from './appStateManager';
 import { AuthCommandModule } from './commands/authCommands';
+import { BuildLogCommands } from './commands/buildLogCommands';
 import { HealthCommandModule } from './commands/healthCommands';
 import { IrisCommandModule } from './commands/irisCommands';
 import { NavigationCommandModule } from './commands/navigationCommands';
@@ -72,6 +73,7 @@ export class WebViewMessageHandler {
             new HealthCommandModule(context),
             new UtilityCommandModule(context),
             new TestResultsTrackingCommandModule(context),
+            new BuildLogCommands(context),
         ];
 
         modules.forEach(module => {

--- a/extension/test/unit/controller/buildLogCommands.test.ts
+++ b/extension/test/unit/controller/buildLogCommands.test.ts
@@ -1,0 +1,146 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { WebviewCmd } from '@shared/messageContracts/webviewCommands';
+
+import { BuildLogCommands } from '@extension/controller/commands/buildLogCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+import { BuildLogParser } from '@extension/utils';
+
+suite('BuildLogCommands', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let showInformationMessage: sinon.SinonStub;
+    let openTextDocument: sinon.SinonStub;
+    let showTextDocument: sinon.SinonStub;
+    let executeCommand: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+        openTextDocument = sandbox.stub(vscode.workspace, 'openTextDocument').resolves({ uri: vscode.Uri.parse('untitled:logs') } as never);
+        showTextDocument = sandbox.stub(vscode.window, 'showTextDocument').resolves(undefined as never);
+        executeCommand = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined as never);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function buildContext(getBuildLogs: sinon.SinonStub): CommandContext {
+        return {
+            artemisApi: { getBuildLogs },
+        } as unknown as CommandContext;
+    }
+
+    test('getHandlers returns exactly viewBuildLog and goToSource keys', () => {
+        const ctx = buildContext(sandbox.stub().resolves([]));
+        const mod = new BuildLogCommands(ctx);
+
+        const keys = Object.keys(mod.getHandlers()).sort();
+
+        assert.deepStrictEqual(keys, [WebviewCmd.GoToSource, WebviewCmd.ViewBuildLog].sort());
+    });
+
+    test('viewBuildLog fetches logs, opens a text document with joined log lines, and shows it', async () => {
+        const logs = [
+            { id: 1, time: '2024-01-01T00:00:00Z', log: 'compile error line 1' },
+            { id: 2, time: '2024-01-01T00:00:01Z', log: 'compile error line 2' },
+        ];
+        const getBuildLogs = sandbox.stub().resolves(logs);
+        const ctx = buildContext(getBuildLogs);
+        const mod = new BuildLogCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.ViewBuildLog]({
+            type: 'command',
+            command: WebviewCmd.ViewBuildLog,
+            payload: { participationId: 42, resultId: 7 },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(getBuildLogs, 42, 7);
+        sinon.assert.calledOnce(openTextDocument);
+        const openArgs = openTextDocument.firstCall.args[0];
+        assert.strictEqual(
+            openArgs.content,
+            '[2024-01-01T00:00:00Z] compile error line 1\n[2024-01-01T00:00:01Z] compile error line 2',
+        );
+        assert.strictEqual(openArgs.language, 'log');
+        sinon.assert.calledOnce(showTextDocument);
+    });
+
+    test('viewBuildLog surfaces an error toast when getBuildLogs throws', async () => {
+        const getBuildLogs = sandbox.stub().rejects(new Error('network down'));
+        const ctx = buildContext(getBuildLogs);
+        const mod = new BuildLogCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.ViewBuildLog]({
+            type: 'command',
+            command: WebviewCmd.ViewBuildLog,
+            payload: { participationId: 1, resultId: 2 },
+        } as never);
+
+        sinon.assert.notCalled(openTextDocument);
+        sinon.assert.notCalled(showTextDocument);
+        sinon.assert.calledOnceWithExactly(showErrorMessage, 'Failed to fetch build logs.');
+    });
+
+    test('goToSource executes artemis.goToSourceError with parsed error coordinates when a source error is found', async () => {
+        const logs = [{ id: 1, time: 't', log: 'irrelevant' }];
+        const parsedError = { filePath: 'src/Foo.java', line: 12, column: 3, message: 'cannot find symbol' };
+        const getBuildLogs = sandbox.stub().resolves(logs);
+        sandbox.stub(BuildLogParser, 'parseFirstError').returns(parsedError);
+        const ctx = buildContext(getBuildLogs);
+        const mod = new BuildLogCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.GoToSource]({
+            type: 'command',
+            command: WebviewCmd.GoToSource,
+            payload: { participationId: 11, resultId: 22 },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(getBuildLogs, 11, 22);
+        sinon.assert.calledOnceWithExactly(
+            executeCommand,
+            'artemis.goToSourceError',
+            'src/Foo.java',
+            12,
+            3,
+            'cannot find symbol',
+        );
+        sinon.assert.notCalled(showInformationMessage);
+    });
+
+    test('goToSource shows an information toast when no error is found in the logs', async () => {
+        const logs = [{ id: 1, time: 't', log: 'no error here' }];
+        const getBuildLogs = sandbox.stub().resolves(logs);
+        sandbox.stub(BuildLogParser, 'parseFirstError').returns(null);
+        const ctx = buildContext(getBuildLogs);
+        const mod = new BuildLogCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.GoToSource]({
+            type: 'command',
+            command: WebviewCmd.GoToSource,
+            payload: { participationId: 1, resultId: 2 },
+        } as never);
+
+        sinon.assert.notCalled(executeCommand);
+        sinon.assert.calledOnceWithExactly(showInformationMessage, 'No source error location found in build logs');
+    });
+
+    test('goToSource surfaces an error toast when an exception is thrown', async () => {
+        const getBuildLogs = sandbox.stub().rejects(new Error('boom'));
+        const ctx = buildContext(getBuildLogs);
+        const mod = new BuildLogCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.GoToSource]({
+            type: 'command',
+            command: WebviewCmd.GoToSource,
+            payload: { participationId: 1, resultId: 2 },
+        } as never);
+
+        sinon.assert.notCalled(executeCommand);
+        sinon.assert.calledOnceWithExactly(showErrorMessage, 'Failed to navigate to source error.');
+    });
+});

--- a/extension/test/unit/controller/exerciseLifecycleCommands.test.ts
+++ b/extension/test/unit/controller/exerciseLifecycleCommands.test.ts
@@ -1,0 +1,144 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { WebviewCmd } from '@shared/messageContracts/webviewCommands';
+
+import { ExerciseLifecycleCommands } from '@extension/controller/commands/exerciseLifecycleCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+
+suite('ExerciseLifecycleCommands', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let showInformationMessage: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function buildContext(overrides: {
+        startPracticeParticipation?: sinon.SinonStub;
+        startExerciseParticipation?: sinon.SinonStub;
+        openExerciseDetails?: sinon.SinonStub;
+    }): CommandContext {
+        return {
+            artemisApi: {
+                startPracticeParticipation: overrides.startPracticeParticipation ?? sandbox.stub().resolves(undefined),
+                startExerciseParticipation: overrides.startExerciseParticipation ?? sandbox.stub().resolves(undefined),
+            },
+            actionHandler: {
+                openExerciseDetails: overrides.openExerciseDetails ?? sandbox.stub().resolves(undefined),
+            },
+        } as unknown as CommandContext;
+    }
+
+    test('getHandlers returns exactly startPractice and startExercise keys', () => {
+        const ctx = buildContext({});
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        const keys = Object.keys(mod.getHandlers()).sort();
+
+        assert.deepStrictEqual(keys, [WebviewCmd.StartExercise, WebviewCmd.StartPractice].sort());
+    });
+
+    test('startPractice happy path: calls API, shows success message with title, and opens exercise details', async () => {
+        const startPracticeParticipation = sandbox.stub().resolves({ id: 99 });
+        const openExerciseDetails = sandbox.stub().resolves(undefined);
+        const ctx = buildContext({ startPracticeParticipation, openExerciseDetails });
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.StartPractice]({
+            type: 'command',
+            command: WebviewCmd.StartPractice,
+            payload: { exerciseId: 42, exerciseTitle: 'Sorting Algorithms' },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(startPracticeParticipation, 42);
+        sinon.assert.calledOnceWithExactly(openExerciseDetails, 42);
+        const messages = showInformationMessage.getCalls().map(c => c.args[0] as string);
+        assert.ok(
+            messages.some(m => m.includes('Sorting Algorithms')),
+            `Expected an information message to contain the exercise title; got: ${JSON.stringify(messages)}`,
+        );
+    });
+
+    test('startPractice does NOT open exercise details when API returns a falsy participation', async () => {
+        const startPracticeParticipation = sandbox.stub().resolves(undefined);
+        const openExerciseDetails = sandbox.stub().resolves(undefined);
+        const ctx = buildContext({ startPracticeParticipation, openExerciseDetails });
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.StartPractice]({
+            type: 'command',
+            command: WebviewCmd.StartPractice,
+            payload: { exerciseId: 7, exerciseTitle: 'Title' },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(startPracticeParticipation, 7);
+        sinon.assert.notCalled(openExerciseDetails);
+    });
+
+    test('startPractice surfaces an error toast prefixed with "Failed to start practice mode:" when the API throws', async () => {
+        const startPracticeParticipation = sandbox.stub().rejects(new Error('boom'));
+        const openExerciseDetails = sandbox.stub().resolves(undefined);
+        const ctx = buildContext({ startPracticeParticipation, openExerciseDetails });
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.StartPractice]({
+            type: 'command',
+            command: WebviewCmd.StartPractice,
+            payload: { exerciseId: 1, exerciseTitle: 'X' },
+        } as never);
+
+        sinon.assert.notCalled(openExerciseDetails);
+        sinon.assert.calledOnce(showErrorMessage);
+        const msg = showErrorMessage.firstCall.args[0] as string;
+        assert.ok(
+            msg.startsWith('Failed to start practice mode:'),
+            `Expected error message to start with "Failed to start practice mode:"; got: ${msg}`,
+        );
+    });
+
+    test('startExercise happy path: calls API and opens exercise details on success', async () => {
+        const startExerciseParticipation = sandbox.stub().resolves({ id: 123 });
+        const openExerciseDetails = sandbox.stub().resolves(undefined);
+        const ctx = buildContext({ startExerciseParticipation, openExerciseDetails });
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.StartExercise]({
+            type: 'command',
+            command: WebviewCmd.StartExercise,
+            payload: { exerciseId: 55 },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(startExerciseParticipation, 55);
+        sinon.assert.calledOnceWithExactly(openExerciseDetails, 55);
+    });
+
+    test('startExercise surfaces an error toast prefixed with "Failed to start exercise:" when the API throws', async () => {
+        const startExerciseParticipation = sandbox.stub().rejects(new Error('network down'));
+        const openExerciseDetails = sandbox.stub().resolves(undefined);
+        const ctx = buildContext({ startExerciseParticipation, openExerciseDetails });
+        const mod = new ExerciseLifecycleCommands(ctx);
+
+        await mod.getHandlers()[WebviewCmd.StartExercise]({
+            type: 'command',
+            command: WebviewCmd.StartExercise,
+            payload: { exerciseId: 2 },
+        } as never);
+
+        sinon.assert.notCalled(openExerciseDetails);
+        sinon.assert.calledOnce(showErrorMessage);
+        const msg = showErrorMessage.firstCall.args[0] as string;
+        assert.ok(
+            msg.startsWith('Failed to start exercise:'),
+            `Expected error message to start with "Failed to start exercise:"; got: ${msg}`,
+        );
+    });
+});

--- a/extension/test/unit/controller/repositoryCloneCommands.test.ts
+++ b/extension/test/unit/controller/repositoryCloneCommands.test.ts
@@ -1,0 +1,389 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg, WebviewCmd } from '@shared/messageContracts';
+
+import type { RepositoryCloneCommandsDeps } from '@extension/controller/commands/repositoryCloneCommands';
+import { RepositoryCloneCommands } from '@extension/controller/commands/repositoryCloneCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+import type { GitService } from '@extension/services/workspace';
+
+suite('RepositoryCloneCommands', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let showWarningMessage: sinon.SinonStub;
+    let showInformationMessage: sinon.SinonStub;
+    let showOpenDialog: sinon.SinonStub;
+    let executeCommand: sinon.SinonStub;
+    let openExternal: sinon.SinonStub;
+    let clipboardWrite: sinon.SinonStub;
+    let cloneRepositoryProgrammatic: sinon.SinonStub;
+    let getTheiaEnvironment: sinon.SinonStub;
+    let getWorkspaceRepositoryUrl: sinon.SinonStub;
+    let normalizeRepositoryUrl: sinon.SinonStub;
+    let statAsync: sinon.SinonStub;
+    let statSync: sinon.SinonStub;
+    let configValues: Map<string, unknown>;
+
+    function makeGitService(isAvailable: boolean): GitService {
+        return { isGitAvailable: sandbox.stub().resolves(isAvailable) } as unknown as GitService;
+    }
+
+    function makeDeps(): Partial<RepositoryCloneCommandsDeps> {
+        return {
+            getWorkspaceRepositoryUrl,
+            normalizeRepositoryUrl,
+            cloneRepositoryProgrammatic,
+            getTheiaEnvironment,
+            statSync: statSync as unknown as RepositoryCloneCommandsDeps['statSync'],
+            statAsync: statAsync as unknown as RepositoryCloneCommandsDeps['statAsync'],
+        };
+    }
+
+    function buildContext(overrides: {
+        getOrCreateVcsAccessToken?: sinon.SinonStub;
+        getCurrentUser?: sinon.SinonStub;
+        sendMessage?: sinon.SinonStub;
+    } = {}): { ctx: CommandContext; sendMessage: sinon.SinonStub } {
+        const sendMessage = overrides.sendMessage ?? sandbox.stub();
+        const ctx = {
+            artemisApi: {
+                getOrCreateVcsAccessToken: overrides.getOrCreateVcsAccessToken ?? sandbox.stub().resolves('vcs-token-xyz'),
+                getCurrentUser: overrides.getCurrentUser ?? sandbox.stub().resolves({ login: 'alice' }),
+            },
+            sendMessage,
+        } as unknown as CommandContext;
+        return { ctx, sendMessage };
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showWarningMessage = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+        showOpenDialog = sandbox.stub(vscode.window, 'showOpenDialog').resolves(undefined);
+        executeCommand = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined as never);
+        openExternal = sandbox.stub(vscode.env, 'openExternal').resolves(true as never);
+        clipboardWrite = sandbox.stub().resolves(undefined);
+        sandbox.replaceGetter(vscode.env, 'clipboard', () => ({
+            writeText: clipboardWrite,
+            readText: sandbox.stub().resolves(''),
+        } as unknown as vscode.Clipboard));
+
+        configValues = new Map<string, unknown>();
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+            get: (key: string, fallback?: unknown) => (configValues.has(key) ? configValues.get(key) : fallback),
+            update: sandbox.stub().resolves(undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+
+        cloneRepositoryProgrammatic = sandbox.stub().resolves(undefined);
+        getTheiaEnvironment = sandbox.stub().returns({ isTheia: false });
+        getWorkspaceRepositoryUrl = sandbox.stub().resolves(undefined);
+        normalizeRepositoryUrl = sandbox.stub().callsFake((u: string) => u);
+        statAsync = sandbox.stub();
+        statSync = sandbox.stub();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('getHandlers returns exactly cloneRepository, copyAuthenticatedCloneUrl, openRepository, openClonedRepository', () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        const keys = Object.keys(mod.getHandlers()).sort();
+
+        assert.deepStrictEqual(
+            keys,
+            [
+                WebviewCmd.CloneRepository,
+                WebviewCmd.CopyAuthenticatedCloneUrl,
+                WebviewCmd.OpenClonedRepository,
+                WebviewCmd.OpenRepository,
+            ].sort(),
+        );
+    });
+
+    test('copyAuthenticatedCloneUrl builds URL with VCS token + current user login and writes it to clipboard', async () => {
+        const { ctx } = buildContext({
+            getOrCreateVcsAccessToken: sandbox.stub().resolves('secret-token'),
+            getCurrentUser: sandbox.stub().resolves({ login: 'bob' }),
+        });
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CopyAuthenticatedCloneUrl]({
+            type: 'command',
+            command: WebviewCmd.CopyAuthenticatedCloneUrl,
+            payload: { participationId: 7, repositoryUri: 'https://artemis.example.com/git/repo.git' },
+        } as never);
+
+        sinon.assert.calledOnce(clipboardWrite);
+        const written = clipboardWrite.firstCall.args[0] as string;
+        assert.ok(
+            written.includes('bob:secret-token@artemis.example.com'),
+            `Expected clipboard URL to embed "bob:secret-token@artemis.example.com"; got: ${written}`,
+        );
+    });
+
+    test('copyAuthenticatedCloneUrl surfaces an error message when getOrCreateVcsAccessToken throws', async () => {
+        const { ctx } = buildContext({
+            getOrCreateVcsAccessToken: sandbox.stub().rejects(new Error('forbidden')),
+        });
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CopyAuthenticatedCloneUrl]({
+            type: 'command',
+            command: WebviewCmd.CopyAuthenticatedCloneUrl,
+            payload: { participationId: 7, repositoryUri: 'https://artemis.example.com/git/repo.git' },
+        } as never);
+
+        sinon.assert.notCalled(clipboardWrite);
+        sinon.assert.calledOnceWithExactly(showErrorMessage, 'Failed to obtain VCS access token.');
+    });
+
+    test('cloneRepository aborts (no clone) when gitService.isGitAvailable is false', async () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(false), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 1, repositoryUri: 'https://x/y.git', exerciseTitle: 'T' },
+        } as never);
+
+        sinon.assert.notCalled(cloneRepositoryProgrammatic);
+        sinon.assert.calledOnce(showErrorMessage);
+        const msg = showErrorMessage.firstCall.args[0] as string;
+        assert.ok(msg.toLowerCase().includes('git'), `Expected error to mention git; got: ${msg}`);
+    });
+
+    test('cloneRepository aborts with an error message when payload lacks participationId or repositoryUri', async () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 0, repositoryUri: '', exerciseTitle: 'T' },
+        } as never);
+
+        sinon.assert.notCalled(cloneRepositoryProgrammatic);
+        sinon.assert.calledOnce(showErrorMessage);
+    });
+
+    test('cloneRepository records the cloned repo in the FIFO cache and sends ShowClonedRepoNotice on success', async () => {
+        // Configure a default clone path so destination resolution succeeds without modal interaction.
+        configValues.set('defaultClonePath', '/tmp/clones');
+        configValues.set('showSetDefaultClonePathPrompt', false);
+        statAsync.resolves({ isDirectory: () => true } as fs.Stats);
+        // Make the post-clone "Open Folder?" prompt resolve to 'Skip'.
+        showInformationMessage.resolves('Skip' as never);
+
+        const { ctx, sendMessage } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 42, repositoryUri: 'https://artemis.example.com/git/foo.git', exerciseTitle: 'Foo' },
+        } as never);
+
+        sinon.assert.calledOnce(cloneRepositoryProgrammatic);
+        const sentNotice = sendMessage.getCalls().find(c => (c.args[0] as { type: string }).type === ExtensionMsg.ShowClonedRepoNotice);
+        assert.ok(sentNotice, 'Expected ShowClonedRepoNotice message to be sent');
+        assert.deepStrictEqual(sentNotice.args[0], {
+            type: ExtensionMsg.ShowClonedRepoNotice,
+            exerciseTitle: 'Foo',
+            participationId: 42,
+        });
+    });
+
+    test('FIFO eviction: after 11 successful clones, the first participationId is no longer retrievable via openClonedRepository', async () => {
+        configValues.set('defaultClonePath', '/tmp/clones');
+        configValues.set('showSetDefaultClonePathPrompt', false);
+        statAsync.resolves({ isDirectory: () => true } as fs.Stats);
+        showInformationMessage.resolves('Skip' as never);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        for (let i = 1; i <= 11; i++) {
+            await mod.getHandlers()[WebviewCmd.CloneRepository]({
+                type: 'command',
+                command: WebviewCmd.CloneRepository,
+                payload: { participationId: i, repositoryUri: `https://x/repo${i}.git`, exerciseTitle: `T${i}` },
+            } as never);
+        }
+
+        sinon.assert.callCount(cloneRepositoryProgrammatic, 11);
+        showWarningMessage.resetHistory();
+
+        await mod.getHandlers()[WebviewCmd.OpenClonedRepository]({
+            type: 'command',
+            command: WebviewCmd.OpenClonedRepository,
+            payload: { participationId: 1 },
+        } as never);
+
+        sinon.assert.calledOnce(showWarningMessage);
+        const msg = showWarningMessage.firstCall.args[0] as string;
+        assert.ok(msg.toLowerCase().includes('not found'), `Expected "not found" warning; got: ${msg}`);
+    });
+
+    test('openClonedRepository opens the recorded path when the cache contains the participation id and the directory exists', async () => {
+        configValues.set('defaultClonePath', '/tmp/clones');
+        configValues.set('showSetDefaultClonePathPrompt', false);
+        statAsync.resolves({ isDirectory: () => true } as fs.Stats);
+        statSync.returns({ isDirectory: () => true } as fs.Stats);
+        showInformationMessage.resolves('Skip' as never);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        // Pre-populate the cache via a successful clone.
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 99, repositoryUri: 'https://x/foo.git', exerciseTitle: 'Foo' },
+        } as never);
+
+        executeCommand.resetHistory();
+        showWarningMessage.resetHistory();
+
+        await mod.getHandlers()[WebviewCmd.OpenClonedRepository]({
+            type: 'command',
+            command: WebviewCmd.OpenClonedRepository,
+            payload: { participationId: 99 },
+        } as never);
+
+        sinon.assert.notCalled(showWarningMessage);
+        const openFolderCalls = executeCommand.getCalls().filter(c => c.args[0] === 'vscode.openFolder');
+        assert.strictEqual(openFolderCalls.length, 1, 'Expected exactly one vscode.openFolder execution');
+    });
+
+    test('openClonedRepository warns when the participation id is NOT in the cache', async () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.OpenClonedRepository]({
+            type: 'command',
+            command: WebviewCmd.OpenClonedRepository,
+            payload: { participationId: 12345 },
+        } as never);
+
+        sinon.assert.calledOnce(showWarningMessage);
+        const msg = showWarningMessage.firstCall.args[0] as string;
+        assert.ok(msg.toLowerCase().includes('not found'), `Expected "not found" warning; got: ${msg}`);
+    });
+
+    test('openRepository reveals the explorer when the workspace already matches the requested repositoryUri', async () => {
+        const repoUri = 'https://artemis.example.com/git/match.git';
+        getWorkspaceRepositoryUrl.resolves(repoUri);
+        normalizeRepositoryUrl.callsFake((u: string) => u);
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+            { uri: vscode.Uri.file('/ws'), name: 'ws', index: 0 } as vscode.WorkspaceFolder,
+        ]);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.OpenRepository]({
+            type: 'command',
+            command: WebviewCmd.OpenRepository,
+            payload: { repositoryUri: repoUri },
+        } as never);
+
+        const explorerCalls = executeCommand.getCalls().filter(c => c.args[0] === 'workbench.view.explorer');
+        assert.strictEqual(explorerCalls.length, 1, 'Expected one workbench.view.explorer execution');
+        sinon.assert.notCalled(openExternal);
+    });
+
+    test('openRepository falls back to vscode.env.openExternal when no workspace match', async () => {
+        getWorkspaceRepositoryUrl.resolves(undefined);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.OpenRepository]({
+            type: 'command',
+            command: WebviewCmd.OpenRepository,
+            payload: { repositoryUri: 'https://x/y.git' },
+        } as never);
+
+        sinon.assert.calledOnce(openExternal);
+    });
+
+    test('Theia branch in _selectFolder: when running under Theia, the clone destination is workspaceFolders[0].uri.fsPath and showOpenDialog is NOT called', async () => {
+        getTheiaEnvironment.returns({ isTheia: true });
+        // No defaultClonePath, no prompt -> falls through to _pickFolderOrCancelClone -> _selectFolder
+        configValues.set('showSetDefaultClonePathPrompt', false);
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+            { uri: vscode.Uri.file('/theia-ws'), name: 'ws', index: 0 } as vscode.WorkspaceFolder,
+        ]);
+        showInformationMessage.resolves('Skip' as never);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 1, repositoryUri: 'https://x/y.git', exerciseTitle: 'T' },
+        } as never);
+
+        sinon.assert.notCalled(showOpenDialog);
+        sinon.assert.calledOnce(cloneRepositoryProgrammatic);
+        const repoPathArg = cloneRepositoryProgrammatic.firstCall.args[1] as string;
+        assert.ok(repoPathArg.startsWith('/theia-ws'), `Expected repoPath to start with /theia-ws; got: ${repoPathArg}`);
+    });
+
+    test('_resolveCloneDestination warns and falls back to picker when the configured default-clone-path does not exist', async () => {
+        configValues.set('defaultClonePath', '/does/not/exist');
+        configValues.set('showSetDefaultClonePathPrompt', true);
+        statAsync.rejects(new Error('ENOENT'));
+        // The fallback picker calls showOpenDialog; we make it return undefined (user cancels) so the clone aborts cleanly.
+        showOpenDialog.resolves(undefined);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 5, repositoryUri: 'https://x/y.git', exerciseTitle: 'Ex' },
+        } as never);
+
+        sinon.assert.calledOnce(showWarningMessage);
+        const warnMsg = showWarningMessage.firstCall.args[0] as string;
+        assert.ok(
+            warnMsg.includes('/does/not/exist'),
+            `Expected warning to mention the invalid path; got: ${warnMsg}`,
+        );
+        sinon.assert.calledOnce(showOpenDialog);
+        sinon.assert.notCalled(cloneRepositoryProgrammatic);
+    });
+
+    test('_resolveCloneDestination returns undefined (and shows a Clone cancelled notice) when the user dismisses the modal', async () => {
+        configValues.set('showSetDefaultClonePathPrompt', true);
+        // No defaultClonePath set. Modal dismiss -> showInformationMessage returns undefined.
+        showInformationMessage.resolves(undefined as never);
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryCloneCommands(ctx, makeGitService(true), makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CloneRepository]({
+            type: 'command',
+            command: WebviewCmd.CloneRepository,
+            payload: { participationId: 5, repositoryUri: 'https://x/y.git', exerciseTitle: 'Ex' },
+        } as never);
+
+        sinon.assert.notCalled(cloneRepositoryProgrammatic);
+        const cancelledNotice = showInformationMessage.getCalls().find(c => {
+            const arg = c.args[0] as string;
+            return typeof arg === 'string' && arg.toLowerCase().includes('clone cancelled');
+        });
+        assert.ok(cancelledNotice, 'Expected a "Clone cancelled" information message');
+    });
+});

--- a/extension/test/unit/controller/repositoryStatusCommands.test.ts
+++ b/extension/test/unit/controller/repositoryStatusCommands.test.ts
@@ -1,0 +1,358 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg, WebviewCmd } from '@shared/messageContracts';
+
+import type { RepositoryStatusCommandsDeps } from '@extension/controller/commands/repositoryStatusCommands';
+import { RepositoryStatusCommands } from '@extension/controller/commands/repositoryStatusCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+
+type SaveListener = (document: vscode.TextDocument) => void;
+type CreateDeleteListener = (event: vscode.FileCreateEvent | vscode.FileDeleteEvent) => void;
+type RenameListener = (event: vscode.FileRenameEvent) => void;
+type ChangeListener = (event: vscode.TextDocumentChangeEvent) => void;
+
+interface ListenerHolder {
+    save?: SaveListener;
+    create?: CreateDeleteListener;
+    delete?: CreateDeleteListener;
+    rename?: RenameListener;
+    change?: ChangeListener;
+    disposables: sinon.SinonStub[];
+}
+
+suite('RepositoryStatusCommands', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let getWorkspaceStatus: sinon.SinonStub;
+    let listeners: ListenerHolder;
+    let configValues: Map<string, unknown>;
+    let textDocuments: vscode.TextDocument[];
+
+    function makeDeps(): Partial<RepositoryStatusCommandsDeps> {
+        return {
+            getWorkspaceStatus: getWorkspaceStatus as unknown as RepositoryStatusCommandsDeps['getWorkspaceStatus'],
+        };
+    }
+
+    function buildContext(overrides: {
+        sendMessage?: sinon.SinonStub;
+        currentExerciseData?: unknown;
+    } = {}): { ctx: CommandContext; sendMessage: sinon.SinonStub } {
+        const sendMessage = overrides.sendMessage ?? sandbox.stub();
+        const ctx = {
+            appStateManager: {
+                currentExerciseData: overrides.currentExerciseData,
+            },
+            sendMessage,
+        } as unknown as CommandContext;
+        return { ctx, sendMessage };
+    }
+
+    function stubWorkspaceListeners(): ListenerHolder {
+        const holder: ListenerHolder = { disposables: [] };
+        const makeDisposable = (): vscode.Disposable => {
+            const dispose = sandbox.stub();
+            holder.disposables.push(dispose);
+            return { dispose } as unknown as vscode.Disposable;
+        };
+        sandbox.stub(vscode.workspace, 'onDidSaveTextDocument').callsFake(((l: SaveListener) => {
+            holder.save = l;
+            return makeDisposable();
+        }) as never);
+        sandbox.stub(vscode.workspace, 'onDidCreateFiles').callsFake(((l: CreateDeleteListener) => {
+            holder.create = l;
+            return makeDisposable();
+        }) as never);
+        sandbox.stub(vscode.workspace, 'onDidDeleteFiles').callsFake(((l: CreateDeleteListener) => {
+            holder.delete = l;
+            return makeDisposable();
+        }) as never);
+        sandbox.stub(vscode.workspace, 'onDidRenameFiles').callsFake(((l: RenameListener) => {
+            holder.rename = l;
+            return makeDisposable();
+        }) as never);
+        sandbox.stub(vscode.workspace, 'onDidChangeTextDocument').callsFake(((l: ChangeListener) => {
+            holder.change = l;
+            return makeDisposable();
+        }) as never);
+        return holder;
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+
+        // Default workspace folder
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+            { uri: vscode.Uri.file('/ws'), name: 'ws', index: 0 } as vscode.WorkspaceFolder,
+        ]);
+
+        // Configuration stub: defaults
+        configValues = new Map<string, unknown>();
+        configValues.set('showUnsavedChangesWarning', true);
+        configValues.set('autoSave', 'off');
+        sandbox.stub(vscode.workspace, 'getConfiguration').callsFake(((_section?: string) => ({
+            get: (key: string, fallback?: unknown) => (configValues.has(key) ? configValues.get(key) : fallback),
+            has: sandbox.stub(),
+            inspect: sandbox.stub(),
+            update: sandbox.stub().resolves(undefined),
+        })) as unknown as typeof vscode.workspace.getConfiguration);
+
+        textDocuments = [];
+        sandbox.stub(vscode.workspace, 'textDocuments').get(() => textDocuments);
+
+        getWorkspaceStatus = sandbox.stub();
+        listeners = stubWorkspaceListeners();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('getHandlers returns exactly checkRepositoryStatus', () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        const keys = Object.keys(mod.getHandlers());
+
+        assert.deepStrictEqual(keys, [WebviewCmd.CheckRepositoryStatus]);
+    });
+
+    test('setRepositoryContext stores context and debounced save listener triggers getWorkspaceStatus after 500ms', async () => {
+        const clock = sandbox.useFakeTimers();
+        getWorkspaceStatus.resolves({ isConnected: true, hasChanges: false, isPracticeRepo: false });
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        mod.setRepositoryContext('https://artemis.example.com/git/repo.git', 42);
+        assert.ok(listeners.save, 'save listener should be registered');
+
+        // Fire a save event for a doc inside the workspace
+        listeners.save({ uri: vscode.Uri.file('/ws/Main.java') } as vscode.TextDocument);
+
+        // Before 500ms, getWorkspaceStatus should NOT be called
+        await clock.tickAsync(499);
+        sinon.assert.notCalled(getWorkspaceStatus);
+
+        // After the debounce window elapses, getWorkspaceStatus is called
+        await clock.tickAsync(1);
+        sinon.assert.called(getWorkspaceStatus);
+        assert.strictEqual(getWorkspaceStatus.firstCall.args[0], 'https://artemis.example.com/git/repo.git');
+    });
+
+    test('outside-workspace save: debounce is NOT scheduled when saved doc is outside currentWorkspacePath', async () => {
+        const clock = sandbox.useFakeTimers();
+        getWorkspaceStatus.resolves({ isConnected: false, hasChanges: false, isPracticeRepo: false });
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+        mod.setRepositoryContext('https://x/y.git', 7);
+
+        // Saved doc lives outside the workspace -> path.relative -> '..'
+        listeners.save?.({ uri: vscode.Uri.file('/some/other/place/Foo.java') } as vscode.TextDocument);
+
+        await clock.tickAsync(1000);
+
+        sinon.assert.notCalled(getWorkspaceStatus);
+    });
+
+    test('clearRepositoryContext: subsequent saves do not trigger status checks', async () => {
+        const clock = sandbox.useFakeTimers();
+        getWorkspaceStatus.resolves({ isConnected: true, hasChanges: false, isPracticeRepo: false });
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        mod.setRepositoryContext('https://x/y.git', 1);
+        mod.clearRepositoryContext();
+
+        listeners.save?.({ uri: vscode.Uri.file('/ws/A.java') } as vscode.TextDocument);
+
+        await clock.tickAsync(1000);
+
+        sinon.assert.notCalled(getWorkspaceStatus);
+    });
+
+    test('dispose: registered disposables are disposed and pending debounce timers do not fire', async () => {
+        const clock = sandbox.useFakeTimers();
+        getWorkspaceStatus.resolves({ isConnected: true, hasChanges: false, isPracticeRepo: false });
+
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        // Should have registered 5 listeners with corresponding disposables
+        assert.strictEqual(listeners.disposables.length, 5);
+
+        mod.setRepositoryContext('https://x/y.git', 1);
+        // Schedule a debounced check
+        listeners.save?.({ uri: vscode.Uri.file('/ws/A.java') } as vscode.TextDocument);
+
+        mod.dispose();
+
+        // All registered disposables were called
+        for (const d of listeners.disposables) {
+            sinon.assert.calledOnce(d);
+        }
+
+        // Pending debounce timer should not fire after dispose
+        await clock.tickAsync(1000);
+        sinon.assert.notCalled(getWorkspaceStatus);
+    });
+
+    test('checkRepositoryStatus sends UpdateRepoStatus { isConnected:false,... } when no URI matches', async () => {
+        getWorkspaceStatus.resolves({ isConnected: false, hasChanges: false, isPracticeRepo: false });
+
+        const exerciseData = {
+            exercise: {
+                id: 11,
+                studentParticipations: [
+                    { repositoryUri: 'https://a/repo1.git' },
+                    { repositoryUri: 'https://b/repo2.git' },
+                ],
+            },
+        };
+        const { ctx, sendMessage } = buildContext({ currentExerciseData: exerciseData });
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CheckRepositoryStatus]({
+            type: 'command', command: WebviewCmd.CheckRepositoryStatus,
+        } as never);
+
+        sinon.assert.callCount(getWorkspaceStatus, 2);
+        const updateCalls = sendMessage.getCalls().filter(c => (c.args[0] as { type: string }).type === ExtensionMsg.UpdateRepoStatus);
+        assert.strictEqual(updateCalls.length, 1);
+        assert.deepStrictEqual(updateCalls[0].args[0], {
+            type: ExtensionMsg.UpdateRepoStatus,
+            isConnected: false,
+            hasChanges: false,
+            isPracticeRepo: false,
+        });
+    });
+
+    test('checkRepositoryStatus sends UpdateRepoStatus { isConnected:true,... } when a URI matches', async () => {
+        getWorkspaceStatus
+            .onFirstCall().resolves({ isConnected: false, hasChanges: false, isPracticeRepo: false })
+            .onSecondCall().resolves({ isConnected: true, hasChanges: true, isPracticeRepo: false });
+
+        const exerciseData = {
+            exercise: {
+                id: 12,
+                studentParticipations: [
+                    { repositoryUri: 'https://a/repo1.git' },
+                    { repositoryUri: 'https://b/repo2.git' },
+                ],
+            },
+        };
+        const { ctx, sendMessage } = buildContext({ currentExerciseData: exerciseData });
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.CheckRepositoryStatus]({
+            type: 'command', command: WebviewCmd.CheckRepositoryStatus,
+        } as never);
+
+        const updateCalls = sendMessage.getCalls().filter(c => (c.args[0] as { type: string }).type === ExtensionMsg.UpdateRepoStatus);
+        assert.strictEqual(updateCalls.length, 1);
+        assert.deepStrictEqual(updateCalls[0].args[0], {
+            type: ExtensionMsg.UpdateRepoStatus,
+            isConnected: true,
+            hasChanges: true,
+            isPracticeRepo: false,
+        });
+        sinon.assert.notCalled(showErrorMessage);
+    });
+
+    test('recheckCurrentRepoStatus is a no-op when no context is set', async () => {
+        const { ctx } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        await mod.recheckCurrentRepoStatus();
+
+        sinon.assert.notCalled(getWorkspaceStatus);
+    });
+
+    test('recheckCurrentRepoStatus triggers a fresh status check using the stored context', async () => {
+        getWorkspaceStatus.resolves({ isConnected: true, hasChanges: false, isPracticeRepo: false });
+
+        const { ctx, sendMessage } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        mod.setRepositoryContext('https://artemis.example.com/git/stored.git', 99);
+
+        await mod.recheckCurrentRepoStatus();
+
+        sinon.assert.calledOnce(getWorkspaceStatus);
+        assert.strictEqual(getWorkspaceStatus.firstCall.args[0], 'https://artemis.example.com/git/stored.git');
+        const updateCalls = sendMessage.getCalls().filter(c => (c.args[0] as { type: string }).type === ExtensionMsg.UpdateRepoStatus);
+        assert.strictEqual(updateCalls.length, 1);
+    });
+
+    test('dirty-page warning disabled: checkDirtyPages sends empty status without inspecting any text documents', async () => {
+        const clock = sandbox.useFakeTimers();
+        configValues.set('showUnsavedChangesWarning', false);
+
+        // Even if a dirty doc exists, it should NOT be inspected.
+        textDocuments = [
+            { uri: vscode.Uri.file('/ws/dirty.java'), isDirty: true } as vscode.TextDocument,
+        ];
+
+        const { ctx, sendMessage } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        // Trigger scheduleDirtyPagesCheck via the change listener (file-scheme doc).
+        listeners.change?.({
+            document: { uri: vscode.Uri.file('/ws/dirty.java') } as vscode.TextDocument,
+        } as unknown as vscode.TextDocumentChangeEvent);
+
+        await clock.tickAsync(300);
+
+        const dirtyCalls = sendMessage.getCalls().filter(c => (c.args[0] as { type: string }).type === ExtensionMsg.UpdateDirtyPagesStatus);
+        assert.strictEqual(dirtyCalls.length, 1, 'Expected exactly one UpdateDirtyPagesStatus message');
+        assert.deepStrictEqual(dirtyCalls[0].args[0], {
+            type: ExtensionMsg.UpdateDirtyPagesStatus,
+            hasDirtyPages: false,
+            dirtyFileCount: 0,
+            autoSaveEnabled: false,
+        });
+
+        // Ensure dispose is invoked safely
+        mod.dispose();
+    });
+
+    test('dirty-page detection: when warning enabled, dirty workspace doc results in hasDirtyPages=true with autoSaveEnabled reflecting files.autoSave', async () => {
+        const clock = sandbox.useFakeTimers();
+        configValues.set('showUnsavedChangesWarning', true);
+        configValues.set('autoSave', 'afterDelay');
+
+        textDocuments = [
+            { uri: vscode.Uri.file('/ws/A.java'), isDirty: true } as vscode.TextDocument,
+            { uri: vscode.Uri.file('/ws/B.java'), isDirty: false } as vscode.TextDocument,
+            // Outside-workspace doc is filtered out
+            { uri: vscode.Uri.file('/other/C.java'), isDirty: true } as vscode.TextDocument,
+            // Non-file scheme is filtered out
+            { uri: vscode.Uri.parse('untitled:Foo.java'), isDirty: true } as vscode.TextDocument,
+        ];
+
+        const { ctx, sendMessage } = buildContext();
+        const mod = new RepositoryStatusCommands(ctx, makeDeps());
+
+        listeners.change?.({
+            document: { uri: vscode.Uri.file('/ws/A.java') } as vscode.TextDocument,
+        } as unknown as vscode.TextDocumentChangeEvent);
+
+        await clock.tickAsync(300);
+
+        const dirtyCalls = sendMessage.getCalls().filter(c => (c.args[0] as { type: string }).type === ExtensionMsg.UpdateDirtyPagesStatus);
+        assert.strictEqual(dirtyCalls.length, 1);
+        assert.deepStrictEqual(dirtyCalls[0].args[0], {
+            type: ExtensionMsg.UpdateDirtyPagesStatus,
+            hasDirtyPages: true,
+            dirtyFileCount: 1,
+            autoSaveEnabled: true,
+        });
+
+        mod.dispose();
+    });
+});

--- a/extension/test/unit/controller/repositorySubmitCommands.test.ts
+++ b/extension/test/unit/controller/repositorySubmitCommands.test.ts
@@ -1,0 +1,427 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg, WebviewCmd } from '@shared/messageContracts';
+
+import type { RepositorySubmitCommandsDeps } from '@extension/controller/commands/repositorySubmitCommands';
+import { RepositorySubmitCommands } from '@extension/controller/commands/repositorySubmitCommands';
+import type { CommandContext } from '@extension/controller/commands/types';
+import type { GitService } from '@extension/services/workspace';
+
+interface GitServiceStubs {
+    isGitAvailable: sinon.SinonStub;
+    addAll: sinon.SinonStub;
+    commit: sinon.SinonStub;
+    pullWithRebase: sinon.SinonStub;
+    push: sinon.SinonStub;
+    getConfigValue: sinon.SinonStub;
+    getIdentity: sinon.SinonStub;
+    setGlobalIdentity: sinon.SinonStub;
+}
+
+suite('RepositorySubmitCommands', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let showWarningMessage: sinon.SinonStub;
+    let showInformationMessage: sinon.SinonStub;
+    let withProgress: sinon.SinonStub;
+    let checkWorkspaceFiles: sinon.SinonStub;
+    let configValues: Map<string, unknown>;
+
+    function makeGitService(overrides: Partial<GitServiceStubs> = {}): { svc: GitService; stubs: GitServiceStubs } {
+        const stubs: GitServiceStubs = {
+            isGitAvailable: overrides.isGitAvailable ?? sandbox.stub().resolves(true),
+            addAll: overrides.addAll ?? sandbox.stub().resolves(undefined),
+            commit: overrides.commit ?? sandbox.stub().resolves(undefined),
+            pullWithRebase: overrides.pullWithRebase ?? sandbox.stub().resolves(undefined),
+            push: overrides.push ?? sandbox.stub().resolves(undefined),
+            getConfigValue: overrides.getConfigValue ?? sandbox.stub().resolves(undefined),
+            getIdentity: overrides.getIdentity ?? sandbox.stub().resolves({ name: 'Alice', email: 'alice@example.com' }),
+            setGlobalIdentity: overrides.setGlobalIdentity ?? sandbox.stub().resolves(undefined),
+        };
+        return { svc: stubs as unknown as GitService, stubs };
+    }
+
+    function makeDeps(): Partial<RepositorySubmitCommandsDeps> {
+        return {
+            checkWorkspaceFiles: checkWorkspaceFiles as unknown as RepositorySubmitCommandsDeps['checkWorkspaceFiles'],
+        };
+    }
+
+    function buildContext(overrides: {
+        sendMessage?: sinon.SinonStub;
+        recheckRepoStatus?: sinon.SinonStub;
+        getWebsocketService?: () => unknown;
+        showGitCredentials?: sinon.SinonStub;
+    } = {}): {
+        ctx: CommandContext;
+        sendMessage: sinon.SinonStub;
+        showGitCredentials: sinon.SinonStub;
+        recheckRepoStatus: sinon.SinonStub;
+    } {
+        const sendMessage = overrides.sendMessage ?? sandbox.stub();
+        const recheckRepoStatus = overrides.recheckRepoStatus ?? sandbox.stub().resolves();
+        const showGitCredentials = overrides.showGitCredentials ?? sandbox.stub();
+        const ctx = {
+            actionHandler: { showGitCredentials },
+            sendMessage,
+            recheckRepoStatus,
+            getWebsocketService: overrides.getWebsocketService,
+        } as unknown as CommandContext;
+        return { ctx, sendMessage, showGitCredentials, recheckRepoStatus };
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showWarningMessage = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+
+        // Default workspace folder so submitExercise proceeds past the open-folder check.
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+            { uri: vscode.Uri.file('/ws'), name: 'ws', index: 0 } as vscode.WorkspaceFolder,
+        ]);
+
+        // Configuration stub for the default commit message lookup.
+        configValues = new Map<string, unknown>();
+        sandbox.stub(vscode.workspace, 'getConfiguration').callsFake(((_section?: string) => ({
+            get: (key: string, fallback?: unknown) => (configValues.has(key) ? configValues.get(key) : fallback),
+            has: sandbox.stub(),
+            inspect: sandbox.stub(),
+            update: sandbox.stub().resolves(undefined),
+        }) as unknown as vscode.WorkspaceConfiguration));
+
+        // withProgress runs its task immediately with a no-op progress object.
+        withProgress = sandbox.stub(vscode.window, 'withProgress').callsFake(async (_opts, task) => {
+            return task({ report: sandbox.stub() } as unknown as vscode.Progress<{ message?: string; increment?: number }>, {
+                isCancellationRequested: false,
+                onCancellationRequested: sandbox.stub(),
+            } as unknown as vscode.CancellationToken);
+        });
+
+        checkWorkspaceFiles = sandbox.stub().resolves({ hasChanges: true, files: [] });
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('getHandlers returns exactly submitExercise, saveGitIdentity, requestGitIdentity', () => {
+        const { ctx } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        const keys = Object.keys(mod.getHandlers()).sort();
+
+        assert.deepStrictEqual(
+            keys,
+            [
+                WebviewCmd.SubmitExercise,
+                WebviewCmd.SaveGitIdentity,
+                WebviewCmd.RequestGitIdentity,
+            ].sort(),
+        );
+    });
+
+    test('submitExercise aborts with an error message when no workspace folder is open', async () => {
+        // Override the default to "no workspace folders".
+        sandbox.restore();
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showWarningMessage = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+        withProgress = sandbox.stub(vscode.window, 'withProgress');
+        checkWorkspaceFiles = sandbox.stub();
+
+        const { ctx } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Ex', commitMessage: '' },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(
+            showErrorMessage,
+            'Open the exercise repository in VS Code before submitting.',
+        );
+        sinon.assert.notCalled(withProgress);
+        sinon.assert.notCalled(stubs.addAll);
+    });
+
+    test('submitExercise surfaces "No local changes detected to submit." when checkWorkspaceFiles returns hasChanges: false', async () => {
+        checkWorkspaceFiles.resolves({ hasChanges: false, files: [] });
+
+        const { ctx } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Ex', commitMessage: '' },
+        } as never);
+
+        sinon.assert.notCalled(stubs.addAll);
+        const errorCall = showErrorMessage.getCalls().find(c => (c.args[0] as string) === 'No local changes detected to submit.');
+        assert.ok(errorCall, 'Expected "No local changes detected to submit." error message');
+    });
+
+    test('happy path: submitExercise calls gitService methods in order addAll -> commit -> pullWithRebase -> push and shows success', async () => {
+        const { ctx, recheckRepoStatus } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: 'My change' },
+        } as never);
+
+        sinon.assert.callOrder(stubs.addAll, stubs.commit, stubs.pullWithRebase, stubs.push);
+        sinon.assert.calledOnce(stubs.addAll);
+        sinon.assert.calledOnce(stubs.commit);
+        sinon.assert.calledOnce(stubs.pullWithRebase);
+        sinon.assert.calledOnce(stubs.push);
+
+        // Success information message
+        const successCall = showInformationMessage.getCalls().find(c => {
+            const arg = c.args[0] as string;
+            return typeof arg === 'string' && arg.includes('Successfully submitted "Foo"');
+        });
+        assert.ok(successCall, 'Expected success information message mentioning "Foo"');
+
+        // recheckRepoStatus invoked (fire-and-forget). The implementation uses `void ctx.recheckRepoStatus?.();`
+        // so we only assert it was called, not awaited.
+        sinon.assert.calledOnce(recheckRepoStatus);
+    });
+
+    test('submitExercise awaits websocket.connect when isConnected() is false; logs but does not surface user error if connect throws', async () => {
+        const isConnected = sandbox.stub().returns(false);
+        const connect = sandbox.stub().rejects(new Error('ws boom'));
+        const wsService = { isConnected, connect };
+
+        const { ctx } = buildContext({ getWebsocketService: () => wsService });
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        sinon.assert.calledOnce(isConnected);
+        sinon.assert.calledOnce(connect);
+
+        // The catch block in the outer try should NOT have shown an error message,
+        // because the websocket reconnect logic runs AFTER the success notification and
+        // its failure is logger.error()'d, not surfaced to the user.
+        const userFacingErrorCalls = showErrorMessage.getCalls().filter(c => {
+            const arg = c.args[0] as string;
+            return typeof arg === 'string' && (arg.toLowerCase().includes('ws boom') || arg.toLowerCase().includes('websocket'));
+        });
+        assert.strictEqual(userFacingErrorCalls.length, 0, 'WebSocket connect failure must not surface a user-facing error message');
+    });
+
+    test('submitExercise shows "Merge conflict detected" when pullWithRebase throws an error containing "CONFLICT"', async () => {
+        const conflictError = new Error('CONFLICT (content): Merge conflict in foo.ts');
+        const { ctx } = buildContext();
+        const { svc, stubs } = makeGitService({
+            pullWithRebase: sandbox.stub().rejects(conflictError),
+        });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        // push must NOT run after a conflict error
+        sinon.assert.notCalled(stubs.push);
+
+        const conflictMessage = 'Merge conflict detected. Please resolve conflicts manually using git and try again.';
+        const conflictCall = showErrorMessage.getCalls().find(c => (c.args[0] as string) === conflictMessage);
+        assert.ok(conflictCall, 'Expected the merge conflict error message to be shown');
+    });
+
+    test('submitExercise continues to push (no error message) when pullWithRebase throws a non-conflict error', async () => {
+        const networkError = new Error('fatal: unable to access remote: network down');
+        const { ctx } = buildContext();
+        const { svc, stubs } = makeGitService({
+            pullWithRebase: sandbox.stub().rejects(networkError),
+        });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        // push MUST still run after a non-conflict pull failure
+        sinon.assert.calledOnce(stubs.push);
+
+        // No user-facing error message: the non-conflict pull failure is logged as a warning only.
+        sinon.assert.notCalled(showErrorMessage);
+    });
+
+    test('submitExercise does NOT show an error message when the inner pipeline throws GIT_IDENTITY_NOT_CONFIGURED', async () => {
+        // Identity not present -> ensureGitIdentityConfigured throws the sentinel
+        const { ctx, showGitCredentials } = buildContext();
+        const { svc } = makeGitService({
+            getIdentity: sandbox.stub().resolves(undefined),
+        });
+        // User accepts the warning so showGitCredentials is invoked
+        showWarningMessage.resolves('Configure Git Identity' as never);
+
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        sinon.assert.calledOnce(showGitCredentials);
+        // The outer catch suppresses error messages when the inner error is the sentinel.
+        sinon.assert.notCalled(showErrorMessage);
+    });
+
+    test('identity-not-configured path: when user selects "Configure Git Identity", actionHandler.showGitCredentials is invoked and the pipeline aborts', async () => {
+        const { ctx, showGitCredentials } = buildContext();
+        const { svc, stubs } = makeGitService({
+            getIdentity: sandbox.stub().resolves(undefined),
+        });
+        showWarningMessage.resolves('Configure Git Identity' as never);
+
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command',
+            command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        sinon.assert.calledOnce(showGitCredentials);
+        // commit is called AFTER ensureGitIdentityConfigured in the production flow, so when the identity
+        // check throws, commit/pull/push must not run.
+        sinon.assert.notCalled(stubs.commit);
+        sinon.assert.notCalled(stubs.pullWithRebase);
+        sinon.assert.notCalled(stubs.push);
+    });
+
+    test('saveGitIdentity rejects empty name with a "warning" GitCredentialsResult and an error popup', async () => {
+        const { ctx, sendMessage } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SaveGitIdentity]({
+            type: 'command',
+            command: WebviewCmd.SaveGitIdentity,
+            payload: { name: '   ', email: 'alice@example.com' },
+        } as never);
+
+        sinon.assert.notCalled(stubs.setGlobalIdentity);
+
+        const warningMessage = sendMessage.getCalls().find(c => {
+            const arg = c.args[0] as { type: string; status?: string };
+            return arg.type === ExtensionMsg.GitCredentialsResult && arg.status === 'warning';
+        });
+        assert.ok(warningMessage, 'Expected a "warning" GitCredentialsResult');
+
+        const popup = showErrorMessage.getCalls().find(c => {
+            const arg = c.args[0] as string;
+            return typeof arg === 'string' && arg.toLowerCase().includes('provide a name');
+        });
+        assert.ok(popup, 'Expected an error popup mentioning "provide a name"');
+    });
+
+    test('saveGitIdentity rejects invalid email with a "warning" GitCredentialsResult and an error popup', async () => {
+        const { ctx, sendMessage } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SaveGitIdentity]({
+            type: 'command',
+            command: WebviewCmd.SaveGitIdentity,
+            payload: { name: 'Alice', email: 'not-an-email' },
+        } as never);
+
+        sinon.assert.notCalled(stubs.setGlobalIdentity);
+
+        const warningMessage = sendMessage.getCalls().find(c => {
+            const arg = c.args[0] as { type: string; status?: string };
+            return arg.type === ExtensionMsg.GitCredentialsResult && arg.status === 'warning';
+        });
+        assert.ok(warningMessage, 'Expected a "warning" GitCredentialsResult for invalid email');
+
+        const popup = showErrorMessage.getCalls().find(c => {
+            const arg = c.args[0] as string;
+            return typeof arg === 'string' && arg.toLowerCase().includes('valid email');
+        });
+        assert.ok(popup, 'Expected an error popup mentioning a valid email');
+    });
+
+    test('saveGitIdentity calls gitService.setGlobalIdentity, sends a success result, and shows an information popup', async () => {
+        const { ctx, sendMessage } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SaveGitIdentity]({
+            type: 'command',
+            command: WebviewCmd.SaveGitIdentity,
+            payload: { name: 'Alice', email: 'alice@example.com' },
+        } as never);
+
+        sinon.assert.calledOnceWithExactly(stubs.setGlobalIdentity, { name: 'Alice', email: 'alice@example.com' });
+
+        const successMessage = sendMessage.getCalls().find(c => {
+            const arg = c.args[0] as { type: string; status?: string };
+            return arg.type === ExtensionMsg.GitCredentialsResult && arg.status === 'success';
+        });
+        assert.ok(successMessage, 'Expected a "success" GitCredentialsResult');
+
+        sinon.assert.calledOnce(showInformationMessage);
+    });
+
+    test('requestGitIdentity reads local config first then global; sends GitIdentityInfo with empty-string fallbacks when neither has a value', async () => {
+        const { ctx, sendMessage } = buildContext();
+        // Always return undefined so we exercise both local AND global lookups
+        const getConfigValue = sandbox.stub().resolves(undefined);
+        const { svc } = makeGitService({ getConfigValue });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.RequestGitIdentity]({
+            type: 'command',
+            command: WebviewCmd.RequestGitIdentity,
+            payload: {},
+        } as never);
+
+        // For each of user.name and user.email: local (globalScope=false) is tried first,
+        // then global (globalScope=true) when local is empty. So 4 calls total, in this order:
+        //   (user.name, _, false), (user.name, _, true), (user.email, _, false), (user.email, _, true)
+        sinon.assert.callCount(getConfigValue, 4);
+        assert.strictEqual(getConfigValue.getCall(0).args[0], 'user.name');
+        assert.strictEqual(getConfigValue.getCall(0).args[2], false);
+        assert.strictEqual(getConfigValue.getCall(1).args[0], 'user.name');
+        assert.strictEqual(getConfigValue.getCall(1).args[2], true);
+        assert.strictEqual(getConfigValue.getCall(2).args[0], 'user.email');
+        assert.strictEqual(getConfigValue.getCall(2).args[2], false);
+        assert.strictEqual(getConfigValue.getCall(3).args[0], 'user.email');
+        assert.strictEqual(getConfigValue.getCall(3).args[2], true);
+
+        const identityInfo = sendMessage.getCalls().find(c => (c.args[0] as { type: string }).type === ExtensionMsg.GitIdentityInfo);
+        assert.ok(identityInfo, 'Expected a GitIdentityInfo message');
+        assert.deepStrictEqual(identityInfo.args[0], {
+            type: ExtensionMsg.GitIdentityInfo,
+            name: '',
+            email: '',
+        });
+    });
+});

--- a/extension/test/unit/controller/webViewMessageHandler.test.ts
+++ b/extension/test/unit/controller/webViewMessageHandler.test.ts
@@ -295,7 +295,7 @@ suite('WebViewMessageHandler - handleMessageWithSender', () => {
     });
 
     suite('real command module integration', () => {
-        test('registered handlers include representative commands from all 7 modules', () => {
+        test('registered handlers include representative commands from all 11 modules', () => {
             const registeredHandlers = (handler as any).commandHandlers as Map<string, unknown>;
 
             // Must have entries
@@ -310,8 +310,8 @@ suite('WebViewMessageHandler - handleMessageWithSender', () => {
             assert.ok(registeredHandlers.has('viewCourseDetails'), 'Should have "viewCourseDetails" handler (NavigationCommandModule)');
 
             // Repository module commands
-            assert.ok(registeredHandlers.has('cloneRepository'), 'Should have "cloneRepository" handler (RepositoryCommandModule)');
-            assert.ok(registeredHandlers.has('submitExercise'), 'Should have "submitExercise" handler (RepositoryCommandModule)');
+            assert.ok(registeredHandlers.has('cloneRepository'), 'Should have "cloneRepository" handler (RepositoryCloneCommands)');
+            assert.ok(registeredHandlers.has('submitExercise'), 'Should have "submitExercise" handler (RepositorySubmitCommands)');
 
             // Iris module commands
             assert.ok(registeredHandlers.has('askIrisAboutExercise'), 'Should have "askIrisAboutExercise" handler (IrisCommandModule)');

--- a/extension/test/unit/controller/webViewMessageHandler.test.ts
+++ b/extension/test/unit/controller/webViewMessageHandler.test.ts
@@ -316,5 +316,46 @@ suite('WebViewMessageHandler - handleMessageWithSender', () => {
             // Iris module commands
             assert.ok(registeredHandlers.has('askIrisAboutExercise'), 'Should have "askIrisAboutExercise" handler (IrisCommandModule)');
         });
+
+        test('context.recheckRepoStatus is wired to the status module and routes setRepositoryContext through it', async () => {
+            // The handler builds the context, constructs the status module, then assigns
+            // context.recheckRepoStatus = () => statusModule.recheckCurrentRepoStatus().
+            // We verify two things in one test:
+            //   1. context.recheckRepoStatus is non-null (callback wired)
+            //   2. Calling it actually reaches the status module (routes via setRepositoryContext)
+
+            const statusModule = (handler as any).repositoryStatusModule;
+            assert.ok(statusModule, 'WebViewMessageHandler should expose repositoryStatusModule');
+
+            // Status module's handler must be registered in the command map
+            // (catches the failure mode where the module is constructed but omitted from modules[]).
+            const registeredHandlers = (handler as any).commandHandlers as Map<string, unknown>;
+            assert.ok(registeredHandlers.has('checkRepositoryStatus'),
+                'Should have "checkRepositoryStatus" handler (RepositoryStatusCommands)');
+
+            // Grab the shared context that was passed to the status module on construction
+            const sharedContext = (statusModule as any).context;
+            assert.ok(sharedContext, 'Status module should have a stored context');
+            assert.strictEqual(
+                typeof sharedContext.recheckRepoStatus,
+                'function',
+                'context.recheckRepoStatus must be wired',
+            );
+
+            // Replace the status module's recheckCurrentRepoStatus with a spy to assert routing
+            const recheckSpy = sandbox.stub().resolves();
+            (statusModule as any).recheckCurrentRepoStatus = recheckSpy;
+
+            // Invoke the wired callback as the submit shell would
+            await sharedContext.recheckRepoStatus();
+
+            sinon.assert.calledOnce(recheckSpy);
+
+            // Sanity: setRepositoryContext on the handler reaches the same status module
+            const setSpy = sandbox.stub();
+            (statusModule as any).setRepositoryContext = setSpy;
+            handler.setRepositoryContext('https://artemis.example.com/git/x.git', 7);
+            sinon.assert.calledOnceWithExactly(setSpy, 'https://artemis.example.com/git/x.git', 7);
+        });
     });
 });


### PR DESCRIPTION
Closes #205. Sub-task of #170.

Splits the 814-line god class `RepositoryCommandModule` (12 unrelated webview-command handlers + workspace listeners + 2 debounce timers + FIFO cache) into 5 cohesive modules.

## Final layout

| Module | Lines | Responsibility |
|---|---|---|
| `repositoryStatusCommands.ts` | 283 | `checkRepositoryStatus`, workspace listeners, dirty-pages tracker, owns the public `setRepositoryContext` / `clearRepositoryContext` / `dispose` surface |
| `repositoryCloneCommands.ts` | 369 | `cloneRepository`, `copyAuthenticatedCloneUrl`, `openRepository`, `openClonedRepository`, FIFO cache, destination resolver |
| `repositorySubmitCommands.ts` | 215 | `submitExercise`, `saveGitIdentity`, `requestGitIdentity`, `ensureGitIdentityConfigured` |
| `exerciseLifecycleCommands.ts` | 61 | `startExercise`, `startPractice` |
| `buildLogCommands.ts` | 49 | `viewBuildLog`, `goToSource` |

All modules under 400 lines. Previous second-largest command module was 423.

## Architecture

Submit-after-push refresh uses a new `CommandContext.recheckRepoStatus?: () => Promise<void>` callback (same pattern as the existing `getWebsocketService?` callback). Status module provides the callback; Submit consumes it. No direct cross-module imports.

`WebViewMessageHandler` builds the context with a mutable-holder pattern: build context, construct Status with it, assign `context.recheckRepoStatus`, construct the rest. Public API of `WebViewMessageHandler` is unchanged. Internal field renamed from `repositoryModule` to `repositoryStatusModule` for the disposable surface.

## Testability

Sinon namespace stubbing fails on the workspace and theia barrel exports (non-configurable getter descriptors from TS `__exportStar`). Each new module exposes a small typed `RepositoryXxxCommandsDeps` interface plus a `defaultDeps` const so tests can override individual helpers. `GitService` is injected via constructor with a default. Production behavior unchanged.

## Test coverage

Adds ~51 new behavior tests across the five modules plus 1 callback-wiring integration test in `webViewMessageHandler.test.ts`. Prior coverage for this class was effectively zero.

```
Before: tests=978 failures=0
After:  tests=1029 failures=0
```

## Commits

7 commits, each leaving the tree green:

1. `230de3e9` Add `recheckRepoStatus` callback to `CommandContext` (prep)
2. `9ed39300` Extract `BuildLogCommands`
3. `166bdb4d` Extract `ExerciseLifecycleCommands`
4. `c264ff3b` Extract `RepositoryCloneCommands` (FIFO cache + DI seams)
5. `0dbc8ea6` Extract `RepositoryStatusCommands`; old module becomes submit-only shell
6. `2e4ad53b` Rename `RepositoryCommandModule` to `RepositorySubmitCommands`; delete old file

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run knip`: clean
- `npm run test:unit`: 1029 tests, 0 failures
- `npm run test:react`: 723 tests, 0 failures
- `npm run package`: clean
- Bundle: 398189 bytes (vs 396949 pre-refactor, +0.3% within tolerance)

## Manual testing checklist

Structural refactor with no intended behavior change. The riskiest spots are the cross-module callback (`recheckRepoStatus`), the mutable context wiring in `WebViewMessageHandler`, and the workspace listener registration. Walk through these flows on a real Artemis instance:

### Status + workspace listeners (`RepositoryStatusCommands`)

- [ ] Open VS Code in a cloned Artemis exercise. Status panel shows "Connected".
- [ ] Edit a file and save. Within ~500 ms the status updates to "Has Changes".
- [ ] Discard the change via `git checkout`. Status updates back to "No Changes".
- [ ] Create a new file. Status updates.
- [ ] Delete a file. Status updates.
- [ ] Rename a file. Status updates.
- [ ] Save a file outside the workspace (e.g. an open scratch file from elsewhere). Status does NOT trigger.
- [ ] Type in a file without saving. Within ~300 ms the dirty-pages indicator appears.
- [ ] Save. The indicator clears (or stays if other files are still dirty).
- [ ] Settings: set `artemis.showUnsavedChangesWarning` to `false`. Indicator never appears.
- [ ] Enable VS Code auto-save. Indicator reports auto-save enabled.
- [ ] Close and reopen VS Code multiple times. No errors in the developer console; no leaked listeners.

### Submit (`RepositorySubmitCommands`)

- [ ] Make a change and submit (with empty commit message). Progress shows: Preparing → Staging → Committing → Syncing → Pushing. Success popup appears.
- [ ] **After submit, the exercise status auto-refreshes without a manual check.** This exercises the new `recheckRepoStatus` callback wiring.
- [ ] If the websocket was disconnected before submit, it reconnects after.
- [ ] Build result eventually arrives via websocket.
- [ ] Submit with a non-empty commit message. Used instead of the default.
- [ ] Submit on a clean tree. Error: "No local changes detected to submit."
- [ ] Submit outside any workspace folder. Error: "Open the exercise repository in VS Code before submitting."
- [ ] Force a merge conflict (edit a file remotely + locally, then submit). Error: "Merge conflict detected. Please resolve conflicts manually using git and try again."
- [ ] Clear global git identity (`git config --global --unset user.name`). Submit. Modal asks to configure. Click "Configure Git Identity" → navigates to the Git Credentials view.
- [ ] In the Git Credentials view, submit empty name. Warning + error popup.
- [ ] Submit invalid email (`foo`). Warning + error popup.
- [ ] Submit valid name + email. Success popup. `~/.gitconfig` updated globally.
- [ ] Reopen the Git Credentials view. Fields prefilled from global config.

### Clone + open (`RepositoryCloneCommands`)

- [ ] From dashboard, pick an exercise not yet cloned. Click Clone.
- [ ] If no `artemis.defaultClonePath` set and `artemis.showSetDefaultClonePathPrompt` is true: 3-button modal appears (Set Default Folder / Choose Each Time / Don't Ask Again).
- [ ] Pick "Choose Each Time" → folder picker appears → clone completes → "Open Folder?" prompt.
- [ ] Click "Skip". Notice with "Open Cloned Repository" link appears.
- [ ] Click the link. The cloned folder opens in a new VS Code window.
- [ ] Delete the cloned folder. Click "Open Cloned Repository" again. Warning: "not found".
- [ ] Settings: set `artemis.defaultClonePath` to a valid folder. Clone a new exercise. Uses the default directly (no modal).
- [ ] Settings: set `artemis.defaultClonePath` to a nonexistent path. Clone. Warning shown, then folder picker.
- [ ] Pick "Don't Ask Again" in the modal once. Future clones without a default path go straight to the folder picker (no modal).
- [ ] **FIFO cache:** clone 11 different exercises in one session. Try "Open Cloned Repository" on the very first one. Warning: "not found" (evicted at cap of 10).
- [ ] Click "Copy Authenticated Clone URL" on an exercise. Paste in terminal. URL has `username:token@host` form. Info popup confirms.
- [ ] In an exercise detail view, click "Open Repository" while NOT in the cloned workspace. Browser opens to the repo URL.
- [ ] Open VS Code IN the cloned exercise folder. Click "Open Repository". Explorer panel reveals (no browser).

### Exercise lifecycle (`ExerciseLifecycleCommands`)

- [ ] Open an exercise that hasn't been started. Click "Start Exercise". Participation created. Exercise detail view opens.
- [ ] For a practice-allowed exercise (after deadline): click "Start Practice". Practice participation created. Exercise detail opens with practice-repo affordances.
- [ ] If the API call fails (e.g. server down), error popup shows.

### Build logs (`BuildLogCommands`)

- [ ] Submit a broken solution. Wait for build result with errors.
- [ ] Click "View Build Log" in the result panel. Log opens in a read-only editor.
- [ ] Click "Go to Source" on an error. Jumps to the file + line + column.
- [ ] On a passing build (no errors): "Go to Source" → info popup "No source error location found in build logs".

### Theia path (only if you have a Theia/EduIDE instance handy)

- [ ] In Theia, clone an exercise. The folder picker does NOT appear; the clone goes to the workspace root.

### Smoke test

- [ ] Open the dashboard. Open Iris chat. Send a message. Response arrives. Auth flow still works.

## Out of scope

- Em-dash cleanup: 3 em-dashes were preserved inside moved code comments in `repositoryCloneCommands.ts` to honor 'move verbatim'. Codebase already contains ~221 em-dashes in `src/`. A separate cleanup PR is appropriate scope.
- Webview Provider decomposition (#206)
- Websocket Service decomposition (#207)
