### PR TITLE
refactor(extension): decompose ArtemisWebviewProvider into provider + navigation facade + SSR coordinator (#206)

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -115,12 +115,19 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	}));
 
-	const artemisWebviewProvider = new ArtemisWebviewProvider(
-		context.extensionUri, context, authManager, artemisApiService,
-		exerciseRegistry, providerRegistry,
-		artemisWebsocketService, buildErrorCodeLensProvider, telemetryManager, updateAuthContext,
+	const artemisWebviewProvider = new ArtemisWebviewProvider({
+		extensionUri: context.extensionUri,
+		extensionContext: context,
+		authManager,
+		artemisApi: artemisApiService,
+		exerciseRegistry,
+		providerRegistry,
+		websocketService: artemisWebsocketService,
+		buildErrorCodeLensProvider,
+		telemetryManager,
+		updateAuthContext,
 		courseDataCache,
-	);
+	});
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(ArtemisWebviewProvider.viewType, artemisWebviewProvider)
 	);

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-import type { CourseDetailData, ExtensionToWebviewMessage, WebviewToExtensionMessage } from '@shared/messageContracts';
-import { ExtensionMsg, toCourseDetailData } from '@shared/messageContracts';
+import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '@shared/messageContracts';
+import { ExtensionMsg } from '@shared/messageContracts';
 import type {
     TaskFeedbackClosedPayload,
     TaskFeedbackOpenedPayload,
@@ -10,9 +10,8 @@ import type {
 } from '@shared/messageContracts/webviewCommands';
 
 import { ArtemisApiService } from '@extension/api';
-import { AppStateManager, type UserInfo } from '@extension/controller/appStateManager';
+import { AppStateManager } from '@extension/controller/appStateManager';
 import { fetchAndEnrichExerciseDetails } from '@extension/controller/exerciseDataLoader';
-import type { WebViewActionHandler } from '@extension/controller/types';
 import { getViewHtml } from '@extension/controller/viewRouter';
 import { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
 import { AuthFlowHandler, AuthManager } from '@extension/services/auth';
@@ -32,34 +31,26 @@ import {
     ViewInitDataService,
 } from '@extension/services/ui';
 import { ArtemisWebsocketService } from '@extension/services/websocket';
-import {
-    collectExerciseSources,
-    findExerciseByRepositoryUrl,
-    findWorkspaceCourseInArchive,
-    getWorkspaceRepositoryUrl,
-} from '@extension/services/workspace';
 import type { ExerciseDetailsResponse } from '@extension/types';
 import { WebSocketMessageHandler } from '@extension/types';
 import type { IArtemisWebviewProvider } from '@extension/types/IArtemisWebviewProvider';
-import {
-    AI_EXTENSIONS_BLOCKLIST,
-    CONFIG,
-    getRecommendedExtensionsByCategory,
-    resolveServerUrl,
-    VSCODE_CONFIG,
-} from '@extension/utils';
+import { CONFIG, resolveServerUrl } from '@extension/utils';
 
 import type { ArtemisWebviewProviderDeps } from './artemisWebviewProviderDeps';
 import { BaseWebviewProvider } from './baseWebviewProvider';
+import { WebviewNavigationFacade } from './webviewNavigationFacade';
 
 /**
  * Main webview provider for the Artemis sidebar panel.
  *
- * NOTE: This class (~1100 lines) coordinates view lifecycle, message routing,
- * state sync, and service integration. A future refactor could extract
- * render-data preparation into a dedicated ViewDataService.
+ * After #206 this class is the thin coordinator that owns the
+ * `vscode.WebviewView` and wires services together. Navigation actions live in
+ * `WebviewNavigationFacade`; a follow-up will extract SSR coordination into a
+ * dedicated coordinator. Provider keeps `showLogin()` as a public delegation
+ * so external callers in `extension.ts` and `extensionCommands.ts` do not need
+ * to know about the facade.
  */
-export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscode.WebviewViewProvider, WebViewActionHandler, vscode.Disposable, IArtemisWebviewProvider {
+export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscode.WebviewViewProvider, vscode.Disposable, IArtemisWebviewProvider {
     // ── Static properties ──────────────────────────────────────────────
     public static readonly viewType = CONFIG.WEBVIEW.VIEW_TYPE;
 
@@ -86,6 +77,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     private _websocketHandler: WebSocketMessageHandler;
     private readonly _telemetryManager: TelemetryManager;
     private readonly _renderService: ProblemStatementRenderService;
+    private readonly _navigationFacade: WebviewNavigationFacade;
 
     private readonly _onDidChangeViewNavigation = new vscode.EventEmitter<{ from: string; to: string }>();
     public readonly onDidChangeViewNavigation = this._onDidChangeViewNavigation.event;
@@ -118,19 +110,69 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         this._courseDataCache = deps.courseDataCache;
         const buildErrorCodeLensProvider = deps.buildErrorCodeLensProvider;
 
+        // 1. AppStateManager — depends on nothing.
         this._appStateManager = new AppStateManager();
         if (this._courseDataCache) {
             this._appStateManager.setCourseDataCache(this._courseDataCache);
         }
+
+        // 2. CourseAccessStorage — its scope callback resolves on the provider.
         this._courseAccessStorage = new CourseAccessStorageService(
             this._extensionContext.globalState,
             () => this._currentCourseAccessScope(),
         );
+
+        // 3. SSR render service.
+        this._renderService = new ProblemStatementRenderService(this._artemisApi);
+        this._disposables.push(this._renderService);
+
+        // 4. Build diagnostics — wires the build-error code lens.
+        this._buildDiagnosticsService = new BuildDiagnosticsService(this._artemisApi);
+        this._buildDiagnosticsService.setCodeLensProvider(buildErrorCodeLensProvider);
+
+        // 5. Exercise opening side-effects (registry, telemetry, chat).
+        this._exerciseOpeningService = new ExerciseOpeningService(
+            this._exerciseRegistry,
+            this._providerRegistry,
+            this._telemetryManager,
+            this._courseAccessStorage,
+        );
+
+        // 6. Start page resolver.
+        this._startPageResolver = new StartPageResolver(this._artemisApi, this._courseDataCache);
+
+        // 7. Fullscreen panel manager — only stores the getter, safe before _messageHandler exists.
+        this._fullscreenPanelManager = new FullscreenPanelManager(
+            this._extensionUri,
+            this._extensionContext,
+            () => this._messageHandler,
+        );
+
+        // 8. Navigation facade — constructed BEFORE the message handler because
+        //    the message handler receives the facade as its actionHandler.
+        this._navigationFacade = new WebviewNavigationFacade({
+            appStateManager: this._appStateManager,
+            artemisApi: this._artemisApi,
+            websocketService: this._websocketService,
+            exerciseRegistry: this._exerciseRegistry,
+            courseAccessStorage: this._courseAccessStorage,
+            fullscreenPanelManager: this._fullscreenPanelManager,
+            exerciseOpeningService: this._exerciseOpeningService,
+            startPageResolver: this._startPageResolver,
+            courseDataCache: this._courseDataCache,
+            postMessage: (msg) => this._postMessageSafe(msg),
+            render: () => this.render(),
+            sendInitData: () => this.sendInitData(),
+            backgroundRenderProblemStatement: () => this._backgroundRenderProblemStatement(),
+            getServerUrl: () => resolveServerUrl(),
+        });
+
+        // 9. Webview message handler — now routes commands through the facade.
         this._messageHandler = new WebViewMessageHandler(
             this._authManager,
             this._artemisApi,
             this._appStateManager,
-            this,
+            this._navigationFacade,
             this._extensionContext,
             this._exerciseRegistry,
             this._providerRegistry,
@@ -139,6 +181,8 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             this._courseAccessStorage,
         );
         this._messageHandler.setAuthContextUpdater(this._authContextUpdater);
+
+        // 10. Init data service — depends on the message handler being ready.
         this._viewInitDataService = new ViewInitDataService(
             this._appStateManager,
             this._telemetryManager,
@@ -146,42 +190,31 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             (msg) => this._postMessageSafe(msg),
             this._courseAccessStorage,
         );
-        this._renderService = new ProblemStatementRenderService(this._artemisApi);
-        this._disposables.push(this._renderService);
-        this._buildDiagnosticsService = new BuildDiagnosticsService(this._artemisApi);
-        this._buildDiagnosticsService.setCodeLensProvider(buildErrorCodeLensProvider);
-        this._exerciseOpeningService = new ExerciseOpeningService(
-            this._exerciseRegistry,
-            this._providerRegistry,
-            this._telemetryManager,
-            this._courseAccessStorage,
-        );
-        this._startPageResolver = new StartPageResolver(this._artemisApi, this._courseDataCache);
+
+        // 11. Submission WS handler — fans build results into diagnostics.
         this._submissionWsHandler = new SubmissionWebSocketHandler(
             (msg) => this._postMessageSafe(msg),
             (result) => this._buildDiagnosticsService.handleBuildResult(result),
         );
-        this._fullscreenPanelManager = new FullscreenPanelManager(
-            this._extensionUri,
-            this._extensionContext,
-            () => this._messageHandler,
-        );
+
+        // 12. Auth flow handler — callbacks route through the navigation facade.
         this._authFlowHandler = new AuthFlowHandler(
             this._authManager,
             this._artemisApi,
             () => this._authContextUpdater,
             (msg) => this._postMessageSafe(msg),
             {
-                onAuthenticated: (userInfo) => this.navigateToStartPage(userInfo),
-                hideLoadingAndSendServerUrl: () => this.hideLoadingAndSendServerUrl(),
-                showLogin: () => this.showLogin(),
+                onAuthenticated: (userInfo) => this._navigationFacade.navigateToStartPage(userInfo),
+                hideLoadingAndSendServerUrl: () => this._navigationFacade.hideLoadingAndSendServerUrl(),
+                showLogin: () => this._navigationFacade.showLogin(),
             },
         );
 
-        // Wire WebSocket subscription handler
+        // 13. Wire WebSocket subscription handler
         this._websocketHandler = this._submissionWsHandler.createHandler();
         this._websocketService.registerMessageHandler(this._websocketHandler);
 
+        // 14. Forward state changes as view navigation events.
         this._appStateManager.onStateChange = (from, to) => {
             this._onDidChangeViewNavigation.fire({ from, to });
         };
@@ -195,7 +228,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             this._onDidCloseTaskFeedback,
         );
 
-        // Re-render SSR when VS Code theme changes (darkMode parameter differs)
+        // 15. Re-render SSR when VS Code theme changes (darkMode parameter differs).
         this._disposables.push(
             vscode.window.onDidChangeActiveColorTheme(() => {
                 this._renderService.invalidateAll();
@@ -254,7 +287,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         });
         this._viewDisposables.push(messageListener);
 
-        // Handle visibility changes — resend data when panel becomes visible
+        // Handle visibility changes - resend data when panel becomes visible
         const visibilityListener = webviewView.onDidChangeVisibility(() => {
             this._onDidChangePanelVisibility.fire(webviewView.visible);
             if (webviewView.visible) {
@@ -269,7 +302,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
                     }
 
                     // Re-fetch exercise data to capture any WebSocket updates missed while hidden.
-                    // Swallow fetch errors only — state-transition errors (invariant breaches)
+                    // Swallow fetch errors only - state-transition errors (invariant breaches)
                     // must propagate so latent bugs don't get hidden by this refresh path.
                     if (currentState === 'exercise-detail') {
                         const exerciseData = this._appStateManager.currentExerciseData;
@@ -327,10 +360,6 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         this._viewInitDataService.sendInitData();
     }
 
-    public backgroundRenderProblemStatement(): void {
-        this._backgroundRenderProblemStatement();
-    }
-
     // ── IArtemisWebviewProvider: fire methods ──────────────────────────
 
     public fireTestResultsOverviewOpened(payload: TestResultsOverviewOpenedPayload): void {
@@ -349,297 +378,14 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         this._onDidCloseTaskFeedback.fire(payload);
     }
 
-    // ── Public API ─────────────────────────────────────────────────────
+    // ── Public API: navigation delegation ──────────────────────────────
 
-    // WebViewActionHandler interface implementation
-    public async openJsonInEditor(data: Record<string, unknown>): Promise<void> {
-        try {
-            const document = await vscode.workspace.openTextDocument({
-                content: JSON.stringify(data, null, 2),
-                language: 'json',
-            });
-            await vscode.window.showTextDocument(document, {
-                preview: false,
-                viewColumn: vscode.ViewColumn.One,
-            });
-        } catch (error) {
-            logger.error('Error opening JSON in editor:', LogCategory.VIEW, error);
-            vscode.window.showErrorMessage('Failed to open JSON in editor');
-        }
-    }
-
-    public async openExerciseDetails(exerciseId: number): Promise<void> {
-        // Split fetch failures (user-facing I/O errors) from state-transition
-        // failures (programmer errors that violate the navigation invariant):
-        // only the fetch is caught and user-reported; invariant breaks propagate.
-        let data: ExerciseDetailsResponse;
-        try {
-            data = await fetchAndEnrichExerciseDetails(this._artemisApi, exerciseId);
-        } catch (error) {
-            logger.error('Error fetching exercise details:', LogCategory.VIEW, error);
-            vscode.window.showErrorMessage('Failed to fetch exercise details');
-            return;
-        }
-        this._appStateManager.showExerciseDetail(data);
-        this.render();
-
-        // Fire background server render for progressive enhancement
-        this._backgroundRenderProblemStatement();
-
-        // Ensure WebSocket is connected for real-time updates
-        if (this._websocketService && !this._websocketService.isConnected()) {
-            logger.websocket('Exercise opened - ensuring WebSocket connection for real-time updates...');
-            try {
-                await this._websocketService.connect();
-            } catch (error) {
-                logger.websocketWarn('Failed to connect WebSocket', error);
-            }
-        }
-
-        // Handle post-open side effects (registry, telemetry, chat notify).
-        const exerciseData = this._appStateManager.currentExerciseData;
-        if (exerciseData?.exercise) {
-            this._exerciseOpeningService.handleExerciseOpened(exerciseData, exerciseId);
-        }
-    }
-
-    public async showDashboard(userInfo: UserInfo): Promise<void> {
-        // Set state immediately so concurrent logic sees 'dashboard' during fetch
-        this._appStateManager.showDashboard(userInfo);
-
-        // Fetch courses into the shared cache (swallow error — dashboard renders with empty state)
-        try {
-            await this._courseDataCache?.fetch();
-        } catch (error) {
-            logger.error('Error loading courses for dashboard', LogCategory.VIEW, error);
-        }
-
-        if (this._view) {
-            this.render();
-        }
-
-        // Check archived courses in the background.
-        // Flag prevents sendDashboardInit from publishing workspace result too early.
-        this._appStateManager.archiveCheckComplete = false;
-        void findWorkspaceCourseInArchive(
-            this._artemisApi, this._appStateManager.coursesData?.courses || []
-        ).then(archivedEntry => {
-            if (archivedEntry) {
-                this._appStateManager.injectCourseEntry(archivedEntry);
-            }
-        }).catch((err: unknown) => {
-            logger.error('Failed to check archived courses for dashboard', LogCategory.VIEW, err);
-        }).finally(() => {
-            this._appStateManager.archiveCheckComplete = true;
-            this.sendInitData();
-            void this._suggestWorkspaceStartPage().catch((err: unknown) => {
-                logger.error('Failed to suggest workspace start page', LogCategory.VIEW, err);
-            });
-        });
-    }
-
-    public async navigateToStartPage(userInfo: UserInfo): Promise<void> {
-        const result = await this._startPageResolver.resolve();
-
-        switch (result.type) {
-            case 'course-list':
-                this._appStateManager.seedAuthenticatedSession(userInfo);
-                this._appStateManager.showCourseList();
-                if (this._view) { this.render(); }
-                return;
-
-            case 'workspace-exercise': {
-                this._appStateManager.seedAuthenticatedSession(userInfo);
-                const entry = result.allCourses.find(e => e.course?.id === result.courseId);
-                const detail = toCourseDetailData(entry?.course);
-                if (detail) {
-                    this._appStateManager.showCourseDetail(detail);
-                    this._postMessageSafe({ type: ExtensionMsg.UpdateLoading, message: 'Loading exercise...' });
-                    await this.openExerciseDetails(result.exerciseId);
-                    if (this._appStateManager.currentState === 'exercise-detail') {
-                        return;
-                    }
-                } else {
-                    logger.viewError(`workspace-exercise start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
-                }
-                break;
-            }
-
-            case 'workspace-course': {
-                this._appStateManager.seedAuthenticatedSession(userInfo);
-                const entry = result.allCourses.find(e => e.course?.id === result.courseId);
-                const detail = toCourseDetailData(entry?.course);
-                if (detail) {
-                    this._courseAccessStorage.onCourseAccessed(result.courseId);
-                    this.showCourseDetail(detail);
-                    return;
-                }
-                logger.viewError(`workspace-course start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
-                break;
-            }
-
-            case 'dashboard':
-                break;
-        }
-
-        // Default: full dashboard with archive check
-        await this.showDashboard(userInfo);
-    }
-
+    /**
+     * Thin delegation so external callers (extension.ts, extensionCommands.ts)
+     * do not need to reach into the facade.
+     */
     public showLogin(): void {
-        this._appStateManager.showLogin();
-        if (this._view) {
-            this.render();
-
-            // Send the server URL to the login page for status checking
-            this.postServerUrl();
-        }
-    }
-
-    public async showCourseList(): Promise<void> {
-        try {
-            // Ensure courses are in the cache before navigating
-            if (this._courseDataCache) {
-                await this._courseDataCache.fetch();
-            }
-            this._appStateManager.showCourseList();
-            if (this._view) {
-                this.render();
-            }
-        } catch (error) {
-            logger.error('Error loading courses', LogCategory.VIEW, error);
-            vscode.window.showErrorMessage('Failed to load courses');
-        }
-    }
-
-    public showAiConfig(): void {
-        // Map installed extensions by ID for quick lookup
-        const installedExtensions = new Map<string, vscode.Extension<unknown>>();
-        for (const ext of vscode.extensions.all) {
-            installedExtensions.set(ext.id.toLowerCase(), ext);
-        }
-
-        const aiExtensions = Object.entries(AI_EXTENSIONS_BLOCKLIST)
-            .flatMap(([providerName, providerData]) => {
-                return providerData.extensions.map(blocklistExt => {
-                    const installedExt = installedExtensions.get(blocklistExt.id.toLowerCase());
-                    const packageJson = (installedExt?.packageJSON ?? {}) as { publisher?: string; version?: string };
-
-                    return {
-                        id: blocklistExt.id,
-                        name: blocklistExt.name,
-                        publisher: packageJson.publisher ?? 'Not installed',
-                        version: packageJson.version ?? '—',
-                        description: blocklistExt.description,
-                        isInstalled: installedExt !== undefined,
-                        provider: providerName,
-                        providerColor: providerData.color
-                    };
-                });
-            });
-
-        this._appStateManager.showAiConfig(aiExtensions);
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public showRecommendedExtensions(): void {
-        const installedExtensions = new Map<string, vscode.Extension<unknown>>();
-        for (const ext of vscode.extensions.all) {
-            installedExtensions.set(ext.id.toLowerCase(), ext);
-        }
-
-        const recommendedCategories = getRecommendedExtensionsByCategory().map(category => ({
-            ...category,
-            extensions: category.extensions.map(extension => {
-                const installedExt = installedExtensions.get(extension.id.toLowerCase());
-                const packageJson = (installedExt?.packageJSON ?? {}) as { version?: string };
-
-                return {
-                    ...extension,
-                    isInstalled: installedExt !== undefined,
-                    version: packageJson.version ?? extension.version
-                };
-            })
-        }));
-
-        this._appStateManager.showRecommendedExtensions(recommendedCategories);
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public showServiceStatus(): void {
-        this._appStateManager.showServiceStatus();
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public showStruggleDetection(): void {
-        this._appStateManager.showStruggleDetection();
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public showGitCredentials(): void {
-        this._appStateManager.showGitCredentials();
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public showCourseDetail(courseData: CourseDetailData): void {
-        this._appStateManager.showCourseDetail(courseData);
-
-        // Populate exercise registry with repository URLs for workspace matching
-        const registry = this._exerciseRegistry;
-        const courseName = courseData?.course?.title || 'Unknown Course';
-        logger.info(`Loading course: ${courseName}`, LogCategory.VIEW);
-
-        registry.registerFromCourseData(courseData);
-
-        // Log what was registered
-        const allExercises = registry.getAllExercises();
-        logger.info(`Registry now contains ${allExercises.length} exercises total`, LogCategory.VIEW);
-        if (allExercises.length > 0) {
-            logger.debug('Exercises in registry:', LogCategory.VIEW);
-            allExercises.forEach(ex => {
-                logger.debug(`   - ${ex.id}: ${ex.title}`, LogCategory.VIEW);
-                logger.debug(`     Repository: ${ex.repositoryUri}`, LogCategory.VIEW);
-            });
-        }
-
-        if (this._view) {
-            this.render();
-        }
-    }
-
-    public async openExerciseFullscreen(exerciseData: ExerciseDetailsResponse): Promise<void> {
-        this._fullscreenPanelManager.openExerciseFullscreen(exerciseData);
-    }
-
-    public async openCourseFullscreen(courseData: CourseDetailData): Promise<void> {
-        this._fullscreenPanelManager.openCourseFullscreen(courseData);
-    }
-
-    public async openCourseListFullscreen(): Promise<void> {
-        const coursesData = this._appStateManager.coursesData;
-        const courses = coursesData?.courses || [];
-        const archivedCourses = this._appStateManager.archivedCoursesData || undefined;
-
-        const mappedCourses: CourseDetailData[] = courses.flatMap((entry) => {
-            const detail = toCourseDetailData(entry.course);
-            if (!detail) {
-                logger.warn(`Course list fullscreen: dropping course without numeric id (title=${entry.course?.title ?? '<unknown>'})`, LogCategory.VIEW);
-                return [];
-            }
-            return [detail];
-        });
-
-        this._fullscreenPanelManager.openCourseListFullscreen(mappedCourses, archivedCourses);
+        this._navigationFacade.showLogin();
     }
 
     // ── BaseWebviewProvider hooks ──────────────────────────────────────
@@ -654,59 +400,11 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
 
     // ── Private: Helpers ───────────────────────────────────────────────
 
-    private postServerUrl(serverUrl?: string): void {
-        this._postMessageSafe({
-            type: ExtensionMsg.SetServerUrl,
-            serverUrl: serverUrl ?? this._getServerUrl()
-        });
-    }
-
-    private hideLoadingAndSendServerUrl(): void {
-        this._postMessageSafe({ type: ExtensionMsg.HideLoading });
-        this.postServerUrl();
-    }
-
-    private _getServerUrl(): string {
-        return resolveServerUrl();
-    }
-
     /**
-     * Shows a one-time notification suggesting workspace-aware start page
-     * when a workspace exercise is detected on the dashboard.
+     * Scope key for `CourseAccessStorageService`. Stays on the provider because
+     * the storage service is constructed in this ctor with this getter as a
+     * callback - moving it to the facade would create a cycle.
      */
-    private async _suggestWorkspaceStartPage(): Promise<void> {
-        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-
-        // Only suggest if the user is on the default dashboard start page
-        const startPage = config.get<string>(VSCODE_CONFIG.START_PAGE_KEY, 'dashboard');
-        if (startPage !== 'dashboard') { return; }
-
-        // Check the "don't show again" flag
-        if (!config.get<boolean>(VSCODE_CONFIG.SHOW_START_PAGE_SUGGESTION_KEY, true)) { return; }
-
-        // Check if there's a workspace exercise match in the loaded courses
-        const repoUrl = await getWorkspaceRepositoryUrl();
-        if (!repoUrl) { return; }
-
-        const courses = this._appStateManager.coursesData?.courses || [];
-        if (courses.length === 0) { return; }
-
-        const detected = findExerciseByRepositoryUrl(repoUrl, collectExerciseSources(courses));
-        if (!detected) { return; }
-
-        const result = await vscode.window.showInformationMessage(
-            `Detected "${detected.title}" in your workspace. You can configure Artemis to open it automatically on login. You can change this later in Settings.`,
-            'Always open exercise',
-            "Don't show again"
-        );
-
-        if (result === 'Always open exercise') {
-            await config.update(VSCODE_CONFIG.START_PAGE_KEY, 'workspace-exercise', vscode.ConfigurationTarget.Global);
-        } else if (result === "Don't show again") {
-            await config.update(VSCODE_CONFIG.SHOW_START_PAGE_SUGGESTION_KEY, false, vscode.ConfigurationTarget.Global);
-        }
-    }
-
     private _currentCourseAccessScope(): CourseAccessScope | null {
         const info = this._appStateManager.userInfo;
         if (!info) { return null; }

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -49,8 +49,8 @@ import {
     VSCODE_CONFIG,
 } from '@extension/utils';
 
+import type { ArtemisWebviewProviderDeps } from './artemisWebviewProviderDeps';
 import { BaseWebviewProvider } from './baseWebviewProvider';
-import type { BuildErrorCodeLensProvider } from './buildErrorCodeLensProvider';
 
 /**
  * Main webview provider for the Artemis sidebar panel.
@@ -64,6 +64,13 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     public static readonly viewType = CONFIG.WEBVIEW.VIEW_TYPE;
 
     // ── Instance properties ────────────────────────────────────────────
+    private readonly _extensionUri: vscode.Uri;
+    private readonly _extensionContext: vscode.ExtensionContext;
+    private readonly _authManager: AuthManager;
+    private readonly _artemisApi: ArtemisApiService;
+    private readonly _exerciseRegistry: ExerciseRegistry;
+    private readonly _providerRegistry: IProviderRegistry;
+    private readonly _courseDataCache?: CourseDataCache;
     private _appStateManager: AppStateManager;
     private _messageHandler: WebViewMessageHandler;
     private _viewInitDataService: ViewInitDataService;
@@ -97,23 +104,19 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     public readonly onDidCloseTaskFeedback = this._onDidCloseTaskFeedback.event;
 
     // ── Constructor ────────────────────────────────────────────────────
-    constructor(
-        private readonly _extensionUri: vscode.Uri,
-        private readonly _extensionContext: vscode.ExtensionContext,
-        private readonly _authManager: AuthManager,
-        private readonly _artemisApi: ArtemisApiService,
-        private readonly _exerciseRegistry: ExerciseRegistry,
-        private readonly _providerRegistry: IProviderRegistry,
-        websocketService: ArtemisWebsocketService,
-        buildErrorCodeLensProvider: BuildErrorCodeLensProvider,
-        telemetryManager: TelemetryManager,
-        updateAuthContext: (isAuthenticated: boolean) => Promise<void>,
-        private readonly _courseDataCache?: CourseDataCache,
-    ) {
+    constructor(deps: ArtemisWebviewProviderDeps) {
         super();
-        this._websocketService = websocketService;
-        this._telemetryManager = telemetryManager;
-        this._authContextUpdater = updateAuthContext;
+        this._extensionUri = deps.extensionUri;
+        this._extensionContext = deps.extensionContext;
+        this._authManager = deps.authManager;
+        this._artemisApi = deps.artemisApi;
+        this._exerciseRegistry = deps.exerciseRegistry;
+        this._providerRegistry = deps.providerRegistry;
+        this._websocketService = deps.websocketService;
+        this._telemetryManager = deps.telemetryManager;
+        this._authContextUpdater = deps.updateAuthContext;
+        this._courseDataCache = deps.courseDataCache;
+        const buildErrorCodeLensProvider = deps.buildErrorCodeLensProvider;
 
         this._appStateManager = new AppStateManager();
         if (this._courseDataCache) {

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 
 import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '@shared/messageContracts';
-import { ExtensionMsg } from '@shared/messageContracts';
 import type {
     TaskFeedbackClosedPayload,
     TaskFeedbackOpenedPayload,
@@ -39,14 +38,16 @@ import { CONFIG, resolveServerUrl } from '@extension/utils';
 import type { ArtemisWebviewProviderDeps } from './artemisWebviewProviderDeps';
 import { BaseWebviewProvider } from './baseWebviewProvider';
 import { WebviewNavigationFacade } from './webviewNavigationFacade';
+import { WebviewSSRCoordinator } from './webviewSSRCoordinator';
 
 /**
  * Main webview provider for the Artemis sidebar panel.
  *
  * After #206 this class is the thin coordinator that owns the
  * `vscode.WebviewView` and wires services together. Navigation actions live in
- * `WebviewNavigationFacade`; a follow-up will extract SSR coordination into a
- * dedicated coordinator. Provider keeps `showLogin()` as a public delegation
+ * `WebviewNavigationFacade`; background problem-statement SSR (including the
+ * theme-change listener that invalidates the render cache) lives in
+ * `WebviewSSRCoordinator`. Provider keeps `showLogin()` as a public delegation
  * so external callers in `extension.ts` and `extensionCommands.ts` do not need
  * to know about the facade.
  */
@@ -77,6 +78,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     private _websocketHandler: WebSocketMessageHandler;
     private readonly _telemetryManager: TelemetryManager;
     private readonly _renderService: ProblemStatementRenderService;
+    private readonly _ssrCoordinator: WebviewSSRCoordinator;
     private readonly _navigationFacade: WebviewNavigationFacade;
 
     private readonly _onDidChangeViewNavigation = new vscode.EventEmitter<{ from: string; to: string }>();
@@ -148,6 +150,16 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             () => this._messageHandler,
         );
 
+        // 7b. SSR coordinator — owns the theme listener and background SSR.
+        //     Must be built BEFORE the navigation facade because the facade's
+        //     backgroundRenderProblemStatement callback routes through it.
+        this._ssrCoordinator = new WebviewSSRCoordinator({
+            appStateManager: this._appStateManager,
+            renderService: this._renderService,
+            postMessage: (msg) => this._postMessageSafe(msg),
+        });
+        this._disposables.push(this._ssrCoordinator);
+
         // 8. Navigation facade — constructed BEFORE the message handler because
         //    the message handler receives the facade as its actionHandler.
         this._navigationFacade = new WebviewNavigationFacade({
@@ -163,7 +175,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             postMessage: (msg) => this._postMessageSafe(msg),
             render: () => this.render(),
             sendInitData: () => this.sendInitData(),
-            backgroundRenderProblemStatement: () => this._backgroundRenderProblemStatement(),
+            backgroundRenderProblemStatement: () => void this._ssrCoordinator.scheduleRender(),
             getServerUrl: () => resolveServerUrl(),
         });
 
@@ -226,15 +238,6 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             this._onDidCloseTestResultsOverview,
             this._onDidOpenTaskFeedback,
             this._onDidCloseTaskFeedback,
-        );
-
-        // 15. Re-render SSR when VS Code theme changes (darkMode parameter differs).
-        this._disposables.push(
-            vscode.window.onDidChangeActiveColorTheme(() => {
-                this._renderService.invalidateAll();
-                this._appStateManager.serverRenderedProblemStatement = null;
-                this._backgroundRenderProblemStatement();
-            }),
         );
     }
 
@@ -414,48 +417,6 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             serverUrl,
             principal: { id: info.user?.id, login: info.username || info.user?.login },
         };
-    }
-
-    // ── Server-side problem statement rendering ─────────────────────
-
-    private async _backgroundRenderProblemStatement(): Promise<void> {
-        // SSR is for the exercise detail view only.
-        if (this._appStateManager.currentState !== 'exercise-detail') { return; }
-
-        const exerciseData = this._appStateManager.currentExerciseData;
-        if (!exerciseData?.exercise?.problemStatement) {
-            logger.info('[SSR] No exercise data or problemStatement, skipping', LogCategory.GENERAL);
-            return;
-        }
-
-        const exercise = exerciseData.exercise;
-        const exerciseId = exercise.id;
-        const participation = exercise.studentParticipations?.[0];
-
-        logger.info(`[SSR] Starting background render for exercise ${exerciseId}`, LogCategory.GENERAL);
-
-        try {
-            const rendered = await this._renderService.render(exercise, { participation });
-
-            // Guard: verify same exercise is still active after await
-            const current = this._appStateManager.currentExerciseData;
-            if (current?.exercise?.id !== exerciseId) { return; }
-
-            if (rendered) {
-                // Store in app state so sendExerciseDetailInit includes it
-                this._appStateManager.serverRenderedProblemStatement = {
-                    html: rendered.html,
-                };
-                // Also send as separate message for cases where init was already sent
-                this._postMessageSafe({
-                    type: ExtensionMsg.ProblemStatementRendered,
-                    html: rendered.html,
-                });
-                logger.info(`[SSR] Server render cached + sent (hash: ${rendered.contentHash.slice(0, 8)})`, LogCategory.GENERAL);
-            }
-        } catch (error) {
-            logger.info(`[SSR] Background render failed: ${error}`, LogCategory.GENERAL);
-        }
     }
 
 }

--- a/extension/src/extension/provider/artemisWebviewProviderDeps.ts
+++ b/extension/src/extension/provider/artemisWebviewProviderDeps.ts
@@ -1,0 +1,25 @@
+import type * as vscode from 'vscode';
+
+import type { ArtemisApiService } from '@extension/api';
+import type { AuthManager } from '@extension/services/auth';
+import type { CourseDataCache } from '@extension/services/courseDataCache';
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import type { TelemetryManager } from '@extension/services/telemetry';
+import type { IProviderRegistry } from '@extension/services/ui';
+import type { ArtemisWebsocketService } from '@extension/services/websocket';
+
+import type { BuildErrorCodeLensProvider } from './buildErrorCodeLensProvider';
+
+export interface ArtemisWebviewProviderDeps {
+    extensionUri: vscode.Uri;
+    extensionContext: vscode.ExtensionContext;
+    authManager: AuthManager;
+    artemisApi: ArtemisApiService;
+    exerciseRegistry: ExerciseRegistry;
+    providerRegistry: IProviderRegistry;
+    websocketService: ArtemisWebsocketService;
+    buildErrorCodeLensProvider: BuildErrorCodeLensProvider;
+    telemetryManager: TelemetryManager;
+    updateAuthContext: (isAuthenticated: boolean) => Promise<void>;
+    courseDataCache?: CourseDataCache;
+}

--- a/extension/src/extension/provider/webviewNavigationFacade.ts
+++ b/extension/src/extension/provider/webviewNavigationFacade.ts
@@ -1,0 +1,410 @@
+import * as vscode from 'vscode';
+
+import type { CourseDetailData, ExtensionToWebviewMessage } from '@shared/messageContracts';
+import { ExtensionMsg, toCourseDetailData } from '@shared/messageContracts';
+
+import type { ArtemisApiService } from '@extension/api';
+import type { AppStateManager, UserInfo } from '@extension/controller/appStateManager';
+import { fetchAndEnrichExerciseDetails } from '@extension/controller/exerciseDataLoader';
+import type { WebViewActionHandler } from '@extension/controller/types';
+import type { CourseAccessStorageService } from '@extension/services/courseAccessStorageService';
+import type { CourseDataCache } from '@extension/services/courseDataCache';
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import { LogCategory, logger } from '@extension/services/loggingService';
+import type {
+    ExerciseOpeningService,
+    FullscreenPanelManager,
+    StartPageResolver,
+} from '@extension/services/ui';
+import type { ArtemisWebsocketService } from '@extension/services/websocket';
+import {
+    collectExerciseSources,
+    findExerciseByRepositoryUrl,
+    findWorkspaceCourseInArchive,
+    getWorkspaceRepositoryUrl,
+} from '@extension/services/workspace';
+import type { ExerciseDetailsResponse } from '@extension/types';
+import {
+    AI_EXTENSIONS_BLOCKLIST,
+    getRecommendedExtensionsByCategory,
+    VSCODE_CONFIG,
+} from '@extension/utils';
+
+/**
+ * Dependencies for `WebviewNavigationFacade`.
+ *
+ * Services are passed in as already-constructed instances. The 5 callbacks
+ * (postMessage, render, sendInitData, backgroundRenderProblemStatement,
+ * getServerUrl) bridge back to the provider, which still owns the webview
+ * surface and the SSR coordination path.
+ */
+export interface WebviewNavigationFacadeDeps {
+    appStateManager: AppStateManager;
+    artemisApi: ArtemisApiService;
+    websocketService: ArtemisWebsocketService;
+    exerciseRegistry: ExerciseRegistry;
+    courseAccessStorage: CourseAccessStorageService;
+    fullscreenPanelManager: FullscreenPanelManager;
+    exerciseOpeningService: ExerciseOpeningService;
+    startPageResolver: StartPageResolver;
+    courseDataCache?: CourseDataCache;
+    postMessage: (msg: ExtensionToWebviewMessage) => void;
+    render: () => void;
+    sendInitData: () => void;
+    backgroundRenderProblemStatement: () => void;
+    getServerUrl: () => string;
+}
+
+/**
+ * Concentrates all navigation actions and server-URL plumbing that used to
+ * live on `ArtemisWebviewProvider`. Implements `WebViewActionHandler` so the
+ * webview message handler can route commands here without going through the
+ * provider.
+ *
+ * The facade does not own a `vscode.WebviewView`. All view-level concerns
+ * (rendering HTML, posting messages, scheduling SSR) are exposed as callbacks
+ * via `WebviewNavigationFacadeDeps`.
+ */
+export class WebviewNavigationFacade implements WebViewActionHandler {
+    constructor(private readonly deps: WebviewNavigationFacadeDeps) { }
+
+    public async openExerciseDetails(exerciseId: number): Promise<void> {
+        // Split fetch failures (user-facing I/O errors) from state-transition
+        // failures (programmer errors that violate the navigation invariant):
+        // only the fetch is caught and user-reported; invariant breaks propagate.
+        let data: ExerciseDetailsResponse;
+        try {
+            data = await fetchAndEnrichExerciseDetails(this.deps.artemisApi, exerciseId);
+        } catch (error) {
+            logger.error('Error fetching exercise details:', LogCategory.VIEW, error);
+            vscode.window.showErrorMessage('Failed to fetch exercise details');
+            return;
+        }
+        this.deps.appStateManager.showExerciseDetail(data);
+        this.deps.render();
+
+        // Fire background server render for progressive enhancement
+        this.deps.backgroundRenderProblemStatement();
+
+        // Ensure WebSocket is connected for real-time updates
+        if (this.deps.websocketService && !this.deps.websocketService.isConnected()) {
+            logger.websocket('Exercise opened - ensuring WebSocket connection for real-time updates...');
+            try {
+                await this.deps.websocketService.connect();
+            } catch (error) {
+                logger.websocketWarn('Failed to connect WebSocket', error);
+            }
+        }
+
+        // Handle post-open side effects (registry, telemetry, chat notify).
+        const exerciseData = this.deps.appStateManager.currentExerciseData;
+        if (exerciseData?.exercise) {
+            this.deps.exerciseOpeningService.handleExerciseOpened(exerciseData, exerciseId);
+        }
+    }
+
+    public async showCourseList(): Promise<void> {
+        try {
+            // Ensure courses are in the cache before navigating
+            if (this.deps.courseDataCache) {
+                await this.deps.courseDataCache.fetch();
+            }
+            this.deps.appStateManager.showCourseList();
+            this.deps.render();
+        } catch (error) {
+            logger.error('Error loading courses', LogCategory.VIEW, error);
+            vscode.window.showErrorMessage('Failed to load courses');
+        }
+    }
+
+    public async showDashboard(userInfo: UserInfo): Promise<void> {
+        // Set state immediately so concurrent logic sees 'dashboard' during fetch
+        this.deps.appStateManager.showDashboard(userInfo);
+
+        // Fetch courses into the shared cache (swallow error - dashboard renders with empty state)
+        try {
+            await this.deps.courseDataCache?.fetch();
+        } catch (error) {
+            logger.error('Error loading courses for dashboard', LogCategory.VIEW, error);
+        }
+
+        this.deps.render();
+
+        // Check archived courses in the background.
+        // Flag prevents sendDashboardInit from publishing workspace result too early.
+        this.deps.appStateManager.archiveCheckComplete = false;
+        void findWorkspaceCourseInArchive(
+            this.deps.artemisApi, this.deps.appStateManager.coursesData?.courses || []
+        ).then(archivedEntry => {
+            if (archivedEntry) {
+                this.deps.appStateManager.injectCourseEntry(archivedEntry);
+            }
+        }).catch((err: unknown) => {
+            logger.error('Failed to check archived courses for dashboard', LogCategory.VIEW, err);
+        }).finally(() => {
+            this.deps.appStateManager.archiveCheckComplete = true;
+            this.deps.sendInitData();
+            void this._suggestWorkspaceStartPage().catch((err: unknown) => {
+                logger.error('Failed to suggest workspace start page', LogCategory.VIEW, err);
+            });
+        });
+    }
+
+    public async navigateToStartPage(userInfo: UserInfo): Promise<void> {
+        const result = await this.deps.startPageResolver.resolve();
+
+        switch (result.type) {
+            case 'course-list':
+                this.deps.appStateManager.seedAuthenticatedSession(userInfo);
+                this.deps.appStateManager.showCourseList();
+                this.deps.render();
+                return;
+
+            case 'workspace-exercise': {
+                this.deps.appStateManager.seedAuthenticatedSession(userInfo);
+                const entry = result.allCourses.find(e => e.course?.id === result.courseId);
+                const detail = toCourseDetailData(entry?.course);
+                if (detail) {
+                    this.deps.appStateManager.showCourseDetail(detail);
+                    this.deps.postMessage({ type: ExtensionMsg.UpdateLoading, message: 'Loading exercise...' });
+                    await this.openExerciseDetails(result.exerciseId);
+                    if (this.deps.appStateManager.currentState === 'exercise-detail') {
+                        return;
+                    }
+                } else {
+                    logger.viewError(`workspace-exercise start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
+                }
+                break;
+            }
+
+            case 'workspace-course': {
+                this.deps.appStateManager.seedAuthenticatedSession(userInfo);
+                const entry = result.allCourses.find(e => e.course?.id === result.courseId);
+                const detail = toCourseDetailData(entry?.course);
+                if (detail) {
+                    this.deps.courseAccessStorage.onCourseAccessed(result.courseId);
+                    this.showCourseDetail(detail);
+                    return;
+                }
+                logger.viewError(`workspace-course start: course ${result.courseId} resolved without a valid id; falling back to dashboard`);
+                break;
+            }
+
+            case 'dashboard':
+                break;
+        }
+
+        // Default: full dashboard with archive check
+        await this.showDashboard(userInfo);
+    }
+
+    public showLogin(): void {
+        this.deps.appStateManager.showLogin();
+        this.deps.render();
+        // Send the server URL to the login page for status checking
+        this.postServerUrl();
+    }
+
+    public showAiConfig(): void {
+        // Map installed extensions by ID for quick lookup
+        const installedExtensions = new Map<string, vscode.Extension<unknown>>();
+        for (const ext of vscode.extensions.all) {
+            installedExtensions.set(ext.id.toLowerCase(), ext);
+        }
+
+        const aiExtensions = Object.entries(AI_EXTENSIONS_BLOCKLIST)
+            .flatMap(([providerName, providerData]) => {
+                return providerData.extensions.map(blocklistExt => {
+                    const installedExt = installedExtensions.get(blocklistExt.id.toLowerCase());
+                    const packageJson = (installedExt?.packageJSON ?? {}) as { publisher?: string; version?: string };
+
+                    return {
+                        id: blocklistExt.id,
+                        name: blocklistExt.name,
+                        publisher: packageJson.publisher ?? 'Not installed',
+                        version: packageJson.version ?? '-',
+                        description: blocklistExt.description,
+                        isInstalled: installedExt !== undefined,
+                        provider: providerName,
+                        providerColor: providerData.color
+                    };
+                });
+            });
+
+        this.deps.appStateManager.showAiConfig(aiExtensions);
+        this.deps.render();
+    }
+
+    public showRecommendedExtensions(): void {
+        const installedExtensions = new Map<string, vscode.Extension<unknown>>();
+        for (const ext of vscode.extensions.all) {
+            installedExtensions.set(ext.id.toLowerCase(), ext);
+        }
+
+        const recommendedCategories = getRecommendedExtensionsByCategory().map(category => ({
+            ...category,
+            extensions: category.extensions.map(extension => {
+                const installedExt = installedExtensions.get(extension.id.toLowerCase());
+                const packageJson = (installedExt?.packageJSON ?? {}) as { version?: string };
+
+                return {
+                    ...extension,
+                    isInstalled: installedExt !== undefined,
+                    version: packageJson.version ?? extension.version
+                };
+            })
+        }));
+
+        this.deps.appStateManager.showRecommendedExtensions(recommendedCategories);
+        this.deps.render();
+    }
+
+    public showServiceStatus(): void {
+        this.deps.appStateManager.showServiceStatus();
+        this.deps.render();
+    }
+
+    public showStruggleDetection(): void {
+        this.deps.appStateManager.showStruggleDetection();
+        this.deps.render();
+    }
+
+    public showGitCredentials(): void {
+        this.deps.appStateManager.showGitCredentials();
+        this.deps.render();
+    }
+
+    public showCourseDetail(courseData: CourseDetailData): void {
+        this.deps.appStateManager.showCourseDetail(courseData);
+
+        // Populate exercise registry with repository URLs for workspace matching
+        const registry = this.deps.exerciseRegistry;
+        const courseName = courseData?.course?.title || 'Unknown Course';
+        logger.info(`Loading course: ${courseName}`, LogCategory.VIEW);
+
+        registry.registerFromCourseData(courseData);
+
+        // Log what was registered
+        const allExercises = registry.getAllExercises();
+        logger.info(`Registry now contains ${allExercises.length} exercises total`, LogCategory.VIEW);
+        if (allExercises.length > 0) {
+            logger.debug('Exercises in registry:', LogCategory.VIEW);
+            allExercises.forEach(ex => {
+                logger.debug(`   - ${ex.id}: ${ex.title}`, LogCategory.VIEW);
+                logger.debug(`     Repository: ${ex.repositoryUri}`, LogCategory.VIEW);
+            });
+        }
+
+        this.deps.render();
+    }
+
+    public async openExerciseFullscreen(exerciseData: ExerciseDetailsResponse): Promise<void> {
+        this.deps.fullscreenPanelManager.openExerciseFullscreen(exerciseData);
+    }
+
+    public async openCourseFullscreen(courseData: CourseDetailData): Promise<void> {
+        this.deps.fullscreenPanelManager.openCourseFullscreen(courseData);
+    }
+
+    public async openCourseListFullscreen(): Promise<void> {
+        const coursesData = this.deps.appStateManager.coursesData;
+        const courses = coursesData?.courses || [];
+        const archivedCourses = this.deps.appStateManager.archivedCoursesData || undefined;
+
+        const mappedCourses: CourseDetailData[] = courses.flatMap((entry) => {
+            const detail = toCourseDetailData(entry.course);
+            if (!detail) {
+                logger.warn(`Course list fullscreen: dropping course without numeric id (title=${entry.course?.title ?? '<unknown>'})`, LogCategory.VIEW);
+                return [];
+            }
+            return [detail];
+        });
+
+        this.deps.fullscreenPanelManager.openCourseListFullscreen(mappedCourses, archivedCourses);
+    }
+
+    public async openJsonInEditor(data: Record<string, unknown>): Promise<void> {
+        try {
+            const document = await vscode.workspace.openTextDocument({
+                content: JSON.stringify(data, null, 2),
+                language: 'json',
+            });
+            await vscode.window.showTextDocument(document, {
+                preview: false,
+                viewColumn: vscode.ViewColumn.One,
+            });
+        } catch (error) {
+            logger.error('Error opening JSON in editor:', LogCategory.VIEW, error);
+            vscode.window.showErrorMessage('Failed to open JSON in editor');
+        }
+    }
+
+    // ── View-callback delegations ──────────────────────────────────────
+
+    public render(): void {
+        this.deps.render();
+    }
+
+    public sendInitData(): void {
+        this.deps.sendInitData();
+    }
+
+    public backgroundRenderProblemStatement(): void {
+        this.deps.backgroundRenderProblemStatement();
+    }
+
+    // ── Server-URL helpers ─────────────────────────────────────────────
+
+    /**
+     * Public because the provider's AuthFlowHandler callback bag invokes this
+     * through the facade reference. No other call sites exist.
+     */
+    public hideLoadingAndSendServerUrl(): void {
+        this.deps.postMessage({ type: ExtensionMsg.HideLoading });
+        this.postServerUrl();
+    }
+
+    private postServerUrl(serverUrl?: string): void {
+        this.deps.postMessage({
+            type: ExtensionMsg.SetServerUrl,
+            serverUrl: serverUrl ?? this.deps.getServerUrl(),
+        });
+    }
+
+    /**
+     * Shows a one-time notification suggesting workspace-aware start page
+     * when a workspace exercise is detected on the dashboard.
+     */
+    private async _suggestWorkspaceStartPage(): Promise<void> {
+        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
+
+        // Only suggest if the user is on the default dashboard start page
+        const startPage = config.get<string>(VSCODE_CONFIG.START_PAGE_KEY, 'dashboard');
+        if (startPage !== 'dashboard') { return; }
+
+        // Check the "don't show again" flag
+        if (!config.get<boolean>(VSCODE_CONFIG.SHOW_START_PAGE_SUGGESTION_KEY, true)) { return; }
+
+        // Check if there's a workspace exercise match in the loaded courses
+        const repoUrl = await getWorkspaceRepositoryUrl();
+        if (!repoUrl) { return; }
+
+        const courses = this.deps.appStateManager.coursesData?.courses || [];
+        if (courses.length === 0) { return; }
+
+        const detected = findExerciseByRepositoryUrl(repoUrl, collectExerciseSources(courses));
+        if (!detected) { return; }
+
+        const result = await vscode.window.showInformationMessage(
+            `Detected "${detected.title}" in your workspace. You can configure Artemis to open it automatically on login. You can change this later in Settings.`,
+            'Always open exercise',
+            "Don't show again"
+        );
+
+        if (result === 'Always open exercise') {
+            await config.update(VSCODE_CONFIG.START_PAGE_KEY, 'workspace-exercise', vscode.ConfigurationTarget.Global);
+        } else if (result === "Don't show again") {
+            await config.update(VSCODE_CONFIG.SHOW_START_PAGE_SUGGESTION_KEY, false, vscode.ConfigurationTarget.Global);
+        }
+    }
+}

--- a/extension/src/extension/provider/webviewSSRCoordinator.ts
+++ b/extension/src/extension/provider/webviewSSRCoordinator.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+
+import type { ExtensionToWebviewMessage } from '@shared/messageContracts';
+import { ExtensionMsg } from '@shared/messageContracts';
+
+import type { AppStateManager } from '@extension/controller/appStateManager';
+import { LogCategory, logger } from '@extension/services/loggingService';
+import type { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
+
+export interface WebviewSSRCoordinatorDeps {
+    appStateManager: AppStateManager;
+    renderService: ProblemStatementRenderService;
+    postMessage: (msg: ExtensionToWebviewMessage) => void;
+}
+
+/**
+ * Coordinates server-side rendering (SSR) of problem statements for the
+ * exercise-detail view. Owns the theme-change listener that invalidates the
+ * render cache and schedules a fresh render whenever the active color theme
+ * changes (because darkMode is part of the render request).
+ */
+export class WebviewSSRCoordinator implements vscode.Disposable {
+    private readonly _themeListener: vscode.Disposable;
+
+    constructor(private readonly deps: WebviewSSRCoordinatorDeps) {
+        this._themeListener = vscode.window.onDidChangeActiveColorTheme(() => {
+            this.deps.renderService.invalidateAll();
+            this.deps.appStateManager.serverRenderedProblemStatement = null;
+            void this.scheduleRender();
+        });
+    }
+
+    public async scheduleRender(): Promise<void> {
+        // SSR is for the exercise detail view only.
+        if (this.deps.appStateManager.currentState !== 'exercise-detail') { return; }
+
+        const exerciseData = this.deps.appStateManager.currentExerciseData;
+        if (!exerciseData?.exercise?.problemStatement) {
+            logger.info('[SSR] No exercise data or problemStatement, skipping', LogCategory.GENERAL);
+            return;
+        }
+
+        const exercise = exerciseData.exercise;
+        const exerciseId = exercise.id;
+        const participation = exercise.studentParticipations?.[0];
+
+        logger.info(`[SSR] Starting background render for exercise ${exerciseId}`, LogCategory.GENERAL);
+
+        try {
+            const rendered = await this.deps.renderService.render(exercise, { participation });
+
+            // Guard: verify same exercise is still active after await
+            const current = this.deps.appStateManager.currentExerciseData;
+            if (current?.exercise?.id !== exerciseId) { return; }
+
+            if (rendered) {
+                // Store in app state so sendExerciseDetailInit includes it
+                this.deps.appStateManager.serverRenderedProblemStatement = {
+                    html: rendered.html,
+                };
+                // Also send as separate message for cases where init was already sent
+                this.deps.postMessage({
+                    type: ExtensionMsg.ProblemStatementRendered,
+                    html: rendered.html,
+                });
+                logger.info(`[SSR] Server render cached + sent (hash: ${rendered.contentHash.slice(0, 8)})`, LogCategory.GENERAL);
+            }
+        } catch (error) {
+            logger.info(`[SSR] Background render failed: ${error}`, LogCategory.GENERAL);
+        }
+    }
+
+    public dispose(): void {
+        this._themeListener.dispose();
+    }
+}

--- a/extension/test/unit/provider/artemisWebviewProvider.test.ts
+++ b/extension/test/unit/provider/artemisWebviewProvider.test.ts
@@ -135,18 +135,18 @@ suite('ArtemisWebviewProvider Test Suite', () => {
         const mockTelemetry = new TelemetryManager();
         const mockUpdateAuth = async (_isAuthenticated: boolean) => {};
 
-        provider = new ArtemisWebviewProvider(
-            vscode.Uri.file('/'),
-            mockContext,
-            mockAuthManager,
-            mockApiService,
-            new ExerciseRegistry(),
-            createProviderRegistry(),
-            mockWebsocket,
-            mockCodeLens,
-            mockTelemetry,
-            mockUpdateAuth,
-        );
+        provider = new ArtemisWebviewProvider({
+            extensionUri: vscode.Uri.file('/'),
+            extensionContext: mockContext,
+            authManager: mockAuthManager,
+            artemisApi: mockApiService,
+            exerciseRegistry: new ExerciseRegistry(),
+            providerRegistry: createProviderRegistry(),
+            websocketService: mockWebsocket,
+            buildErrorCodeLensProvider: mockCodeLens,
+            telemetryManager: mockTelemetry,
+            updateAuthContext: mockUpdateAuth,
+        });
     });
 
     teardown(() => {
@@ -164,11 +164,18 @@ suite('ArtemisWebviewProvider Test Suite', () => {
         ws.connect = async () => { connectCalls++; };
 
         const mockCodeLens = {} as unknown as BuildErrorCodeLensProvider;
-        const p = new ArtemisWebviewProvider(
-            vscode.Uri.file('/'), mockContext, mockAuthManager, mockApiService,
-            new ExerciseRegistry(), createProviderRegistry(),
-            ws, mockCodeLens, new TelemetryManager(), async () => {},
-        );
+        const p = new ArtemisWebviewProvider({
+            extensionUri: vscode.Uri.file('/'),
+            extensionContext: mockContext,
+            authManager: mockAuthManager,
+            artemisApi: mockApiService,
+            exerciseRegistry: new ExerciseRegistry(),
+            providerRegistry: createProviderRegistry(),
+            websocketService: ws,
+            buildErrorCodeLensProvider: mockCodeLens,
+            telemetryManager: new TelemetryManager(),
+            updateAuthContext: async () => {},
+        });
 
         const mockView = new MockWebviewView();
         p.resolveWebviewView(mockView, {} as any, {} as any);
@@ -253,18 +260,18 @@ suite('Panel hide/show state persistence', () => {
         const mockTelemetry = new TelemetryManager();
         const mockUpdateAuth = async (_isAuthenticated: boolean) => {};
 
-        provider = new ArtemisWebviewProvider(
-            vscode.Uri.file('/'),
-            mockContext,
-            mockAuthManager,
-            mockApiService,
-            new ExerciseRegistry(),
-            createProviderRegistry(),
-            mockWebsocket,
-            mockCodeLens,
-            mockTelemetry,
-            mockUpdateAuth,
-        );
+        provider = new ArtemisWebviewProvider({
+            extensionUri: vscode.Uri.file('/'),
+            extensionContext: mockContext,
+            authManager: mockAuthManager,
+            artemisApi: mockApiService,
+            exerciseRegistry: new ExerciseRegistry(),
+            providerRegistry: createProviderRegistry(),
+            websocketService: mockWebsocket,
+            buildErrorCodeLensProvider: mockCodeLens,
+            telemetryManager: mockTelemetry,
+            updateAuthContext: mockUpdateAuth,
+        });
 
         spyWebview = new SpyWebview();
         controllableView = new ControllableWebviewView(spyWebview);

--- a/extension/test/unit/provider/artemisWebviewProvider.test.ts
+++ b/extension/test/unit/provider/artemisWebviewProvider.test.ts
@@ -157,35 +157,6 @@ suite('ArtemisWebviewProvider Test Suite', () => {
         assert.ok(provider);
     });
 
-    test('should register websocket handler and connect when opening exercise', async () => {
-        const ws = new MockArtemisWebsocketService(mockAuthManager);
-        let connectCalls = 0;
-        ws.isConnected = () => false;
-        ws.connect = async () => { connectCalls++; };
-
-        const mockCodeLens = {} as unknown as BuildErrorCodeLensProvider;
-        const p = new ArtemisWebviewProvider({
-            extensionUri: vscode.Uri.file('/'),
-            extensionContext: mockContext,
-            authManager: mockAuthManager,
-            artemisApi: mockApiService,
-            exerciseRegistry: new ExerciseRegistry(),
-            providerRegistry: createProviderRegistry(),
-            websocketService: ws,
-            buildErrorCodeLensProvider: mockCodeLens,
-            telemetryManager: new TelemetryManager(),
-            updateAuthContext: async () => {},
-        });
-
-        const mockView = new MockWebviewView();
-        p.resolveWebviewView(mockView, {} as any, {} as any);
-        // Seed a parent course: showExerciseDetail requires it by invariant
-        p.showCourseDetail({ course: { id: 1, title: 'Parent' } } as any);
-        await p.openExerciseDetails(1);
-
-        assert.strictEqual(connectCalls, 1, 'connect should be called when not connected');
-    });
-
     test('should resolve webview view', async () => {
         const mockView = new MockWebviewView();
         const mockResolveContext = {} as vscode.WebviewViewResolveContext;
@@ -195,36 +166,6 @@ suite('ArtemisWebviewProvider Test Suite', () => {
 
         assert.ok(mockView.webview.html);
         assert.ok(mockView.webview.options.enableScripts);
-    });
-
-    test('should open exercise details', async () => {
-        const mockView = new MockWebviewView();
-        const mockResolveContext = {} as vscode.WebviewViewResolveContext;
-        const mockToken = {} as vscode.CancellationToken;
-
-        await provider.resolveWebviewView(mockView, mockResolveContext, mockToken);
-
-        // Seed a parent course: showExerciseDetail requires it by invariant
-        provider.showCourseDetail({ course: { id: 1, title: 'Parent' } } as any);
-        await provider.openExerciseDetails(1);
-
-        assert.ok(mockView.webview.html);
-    });
-
-    test('should open json in editor', async () => {
-        const localSandbox = sinon.createSandbox();
-        try {
-            const openDocSpy = localSandbox.spy(vscode.workspace, 'openTextDocument');
-            const showDocSpy = localSandbox.spy(vscode.window, 'showTextDocument');
-
-            const data = { test: 'data' };
-            await provider.openJsonInEditor(data);
-
-            assert.ok(openDocSpy.calledOnce, 'openTextDocument should be called');
-            assert.ok(showDocSpy.calledOnce, 'showTextDocument should be called');
-        } finally {
-            localSandbox.restore();
-        }
     });
 
     test('should render', async () => {

--- a/extension/test/unit/provider/webviewNavigationFacade.test.ts
+++ b/extension/test/unit/provider/webviewNavigationFacade.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Tests for WebviewNavigationFacade.
+ *
+ * These are black-box behavior tests: each case constructs the facade with a
+ * partial deps stub filled only for the fields the SUT touches, then asserts
+ * the expected side effects (state-manager calls, websocket interactions,
+ * post-message routing, render/init callbacks).
+ *
+ * For openExerciseDetails we stub the standalone
+ * `fetchAndEnrichExerciseDetails` via a sinon stub on the namespace import
+ * from `@extension/controller/exerciseDataLoader`. If the property descriptor
+ * is non-configurable in a future tsconfig change, we have a documented
+ * fallback: inject a `fetchExerciseDetails` callback through the facade deps.
+ */
+
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg } from '@shared/messageContracts';
+
+import * as exerciseDataLoader from '@extension/controller/exerciseDataLoader';
+import type {
+    WebviewNavigationFacadeDeps,
+} from '@extension/provider/webviewNavigationFacade';
+import { WebviewNavigationFacade } from '@extension/provider/webviewNavigationFacade';
+import type { ExerciseDetailsResponse } from '@extension/types';
+
+suite('WebviewNavigationFacade', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showErrorMessage: sinon.SinonStub;
+    let showInformationMessage: sinon.SinonStub;
+    let openTextDocument: sinon.SinonStub;
+    let showTextDocument: sinon.SinonStub;
+    let getConfiguration: sinon.SinonStub;
+    let fetchAndEnrichStub: sinon.SinonStub;
+
+    // Builders for stub deps. Each test fills only what it needs.
+    interface DepStubs {
+        appStateManager: {
+            showLogin: sinon.SinonStub;
+            showDashboard: sinon.SinonStub;
+            showCourseList: sinon.SinonStub;
+            showCourseDetail: sinon.SinonStub;
+            showExerciseDetail: sinon.SinonStub;
+            showAiConfig: sinon.SinonStub;
+            showServiceStatus: sinon.SinonStub;
+            showStruggleDetection: sinon.SinonStub;
+            showRecommendedExtensions: sinon.SinonStub;
+            showGitCredentials: sinon.SinonStub;
+            seedAuthenticatedSession: sinon.SinonStub;
+            injectCourseEntry: sinon.SinonStub;
+            currentState: string;
+            currentExerciseData: ExerciseDetailsResponse | undefined;
+            coursesData: { courses: unknown[] } | undefined;
+            archivedCoursesData: unknown[] | undefined;
+            userInfo: unknown;
+            archiveCheckComplete: boolean;
+        };
+        artemisApi: { dummy: true };
+        websocketService: {
+            isConnected: sinon.SinonStub;
+            connect: sinon.SinonStub;
+        };
+        exerciseRegistry: {
+            registerFromCourseData: sinon.SinonStub;
+            getAllExercises: sinon.SinonStub;
+        };
+        courseAccessStorage: {
+            onCourseAccessed: sinon.SinonStub;
+        };
+        fullscreenPanelManager: {
+            openExerciseFullscreen: sinon.SinonStub;
+            openCourseFullscreen: sinon.SinonStub;
+            openCourseListFullscreen: sinon.SinonStub;
+        };
+        exerciseOpeningService: {
+            handleExerciseOpened: sinon.SinonStub;
+        };
+        startPageResolver: {
+            resolve: sinon.SinonStub;
+        };
+        courseDataCache: {
+            fetch: sinon.SinonStub;
+        };
+        postMessage: sinon.SinonStub;
+        render: sinon.SinonStub;
+        sendInitData: sinon.SinonStub;
+        backgroundRenderProblemStatement: sinon.SinonStub;
+        getServerUrl: sinon.SinonStub;
+    }
+
+    function buildDeps(overrides: Partial<DepStubs> = {}): {
+        deps: WebviewNavigationFacadeDeps;
+        stubs: DepStubs;
+    } {
+        const stubs: DepStubs = {
+            appStateManager: overrides.appStateManager ?? {
+                showLogin: sandbox.stub(),
+                showDashboard: sandbox.stub(),
+                showCourseList: sandbox.stub(),
+                showCourseDetail: sandbox.stub(),
+                showExerciseDetail: sandbox.stub(),
+                showAiConfig: sandbox.stub(),
+                showServiceStatus: sandbox.stub(),
+                showStruggleDetection: sandbox.stub(),
+                showRecommendedExtensions: sandbox.stub(),
+                showGitCredentials: sandbox.stub(),
+                seedAuthenticatedSession: sandbox.stub(),
+                injectCourseEntry: sandbox.stub(),
+                currentState: 'login',
+                currentExerciseData: undefined,
+                coursesData: { courses: [] },
+                archivedCoursesData: undefined,
+                userInfo: undefined,
+                archiveCheckComplete: true,
+            },
+            artemisApi: overrides.artemisApi ?? { dummy: true as const },
+            websocketService: overrides.websocketService ?? {
+                isConnected: sandbox.stub().returns(true),
+                connect: sandbox.stub().resolves(),
+            },
+            exerciseRegistry: overrides.exerciseRegistry ?? {
+                registerFromCourseData: sandbox.stub(),
+                getAllExercises: sandbox.stub().returns([]),
+            },
+            courseAccessStorage: overrides.courseAccessStorage ?? {
+                onCourseAccessed: sandbox.stub(),
+            },
+            fullscreenPanelManager: overrides.fullscreenPanelManager ?? {
+                openExerciseFullscreen: sandbox.stub(),
+                openCourseFullscreen: sandbox.stub(),
+                openCourseListFullscreen: sandbox.stub(),
+            },
+            exerciseOpeningService: overrides.exerciseOpeningService ?? {
+                handleExerciseOpened: sandbox.stub(),
+            },
+            startPageResolver: overrides.startPageResolver ?? {
+                resolve: sandbox.stub().resolves({ type: 'dashboard' }),
+            },
+            courseDataCache: overrides.courseDataCache ?? {
+                fetch: sandbox.stub().resolves(),
+            },
+            postMessage: overrides.postMessage ?? sandbox.stub(),
+            render: overrides.render ?? sandbox.stub(),
+            sendInitData: overrides.sendInitData ?? sandbox.stub(),
+            backgroundRenderProblemStatement: overrides.backgroundRenderProblemStatement ?? sandbox.stub(),
+            getServerUrl: overrides.getServerUrl ?? sandbox.stub().returns('https://artemis.example/'),
+        };
+
+        const deps = {
+            appStateManager: stubs.appStateManager,
+            artemisApi: stubs.artemisApi,
+            websocketService: stubs.websocketService,
+            exerciseRegistry: stubs.exerciseRegistry,
+            courseAccessStorage: stubs.courseAccessStorage,
+            fullscreenPanelManager: stubs.fullscreenPanelManager,
+            exerciseOpeningService: stubs.exerciseOpeningService,
+            startPageResolver: stubs.startPageResolver,
+            courseDataCache: stubs.courseDataCache,
+            postMessage: stubs.postMessage,
+            render: stubs.render,
+            sendInitData: stubs.sendInitData,
+            backgroundRenderProblemStatement: stubs.backgroundRenderProblemStatement,
+            getServerUrl: stubs.getServerUrl,
+        } as unknown as WebviewNavigationFacadeDeps;
+
+        return { deps, stubs };
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+        openTextDocument = sandbox.stub(vscode.workspace, 'openTextDocument').resolves({} as vscode.TextDocument);
+        showTextDocument = sandbox.stub(vscode.window, 'showTextDocument').resolves({} as vscode.TextEditor);
+
+        // Default: workspace.getConfiguration returns config with the suggestion
+        // feature disabled so _suggestWorkspaceStartPage is a no-op unless a test
+        // overrides it.
+        getConfiguration = sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+            get: <T>(_key: string, fallback?: T): T | undefined => fallback,
+            update: sandbox.stub().resolves(undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+
+        fetchAndEnrichStub = sandbox.stub(exerciseDataLoader, 'fetchAndEnrichExerciseDetails');
+        // void marker references so unused-vars rule does not complain
+        void showErrorMessage; void showInformationMessage; void getConfiguration;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    // ── showLogin ──────────────────────────────────────────────────
+
+    test('showLogin: calls appStateManager.showLogin', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showLogin();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showLogin);
+    });
+
+    test('showLogin: invokes render callback', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showLogin();
+
+        sinon.assert.calledOnce(stubs.render);
+    });
+
+    test('showLogin: posts SetServerUrl message with getServerUrl value', () => {
+        const { deps, stubs } = buildDeps({
+            getServerUrl: sandbox.stub().returns('https://artemis.test/'),
+        });
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showLogin();
+
+        sinon.assert.calledWith(stubs.postMessage, sinon.match({
+            type: ExtensionMsg.SetServerUrl,
+            serverUrl: 'https://artemis.test/',
+        }));
+    });
+
+    // ── showDashboard ──────────────────────────────────────────────
+
+    test('showDashboard: calls appStateManager.showDashboard, render, sendInitData', async () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+        const userInfo = { username: 'alice', serverUrl: 'https://x/' };
+
+        await facade.showDashboard(userInfo);
+        // wait for the background archive-check chain to settle
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        sinon.assert.calledWith(stubs.appStateManager.showDashboard, userInfo);
+        sinon.assert.called(stubs.render);
+        sinon.assert.called(stubs.sendInitData);
+    });
+
+    test('showDashboard: logs but does not crash when suggestion helper throws', async () => {
+        // Force the suggestion path to throw by making getConfiguration throw.
+        getConfiguration.throws(new Error('config blew up'));
+        const { deps } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+        const userInfo = { username: 'alice', serverUrl: 'https://x/' };
+
+        await facade.showDashboard(userInfo);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // No user-facing error message is shown for the suggestion path.
+        sinon.assert.notCalled(showErrorMessage);
+    });
+
+    // ── navigateToStartPage ────────────────────────────────────────
+
+    test('navigateToStartPage: dashboard branch routes to showDashboard', async () => {
+        const { deps, stubs } = buildDeps({
+            startPageResolver: { resolve: sandbox.stub().resolves({ type: 'dashboard' }) },
+        });
+        const facade = new WebviewNavigationFacade(deps);
+        const userInfo = { username: 'bob', serverUrl: 'https://x/' };
+
+        await facade.navigateToStartPage(userInfo);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        sinon.assert.calledWith(stubs.appStateManager.showDashboard, userInfo);
+    });
+
+    test('navigateToStartPage: course-list branch seeds session and shows course list', async () => {
+        const coursesData = { courses: [{ course: { id: 1 } }] };
+        const { deps, stubs } = buildDeps({
+            startPageResolver: {
+                resolve: sandbox.stub().resolves({ type: 'course-list', coursesData }),
+            },
+        });
+        const facade = new WebviewNavigationFacade(deps);
+        const userInfo = { username: 'cathy', serverUrl: 'https://x/' };
+
+        await facade.navigateToStartPage(userInfo);
+
+        sinon.assert.calledWith(stubs.appStateManager.seedAuthenticatedSession, userInfo);
+        sinon.assert.called(stubs.appStateManager.showCourseList);
+    });
+
+    test('navigateToStartPage: workspace-exercise branch opens exercise details', async () => {
+        const courseEntry = { course: { id: 5, title: 'C' } };
+        const coursesData = { courses: [courseEntry] };
+        const exerciseData: ExerciseDetailsResponse = {
+            exercise: { id: 42, title: 'Ex' } as ExerciseDetailsResponse['exercise'],
+        } as ExerciseDetailsResponse;
+        fetchAndEnrichStub.resolves(exerciseData);
+
+        const appStateOverride = {
+            showLogin: sandbox.stub(),
+            showDashboard: sandbox.stub(),
+            showCourseList: sandbox.stub(),
+            showCourseDetail: sandbox.stub(),
+            showExerciseDetail: sandbox.stub(),
+            showAiConfig: sandbox.stub(),
+            showServiceStatus: sandbox.stub(),
+            showStruggleDetection: sandbox.stub(),
+            showRecommendedExtensions: sandbox.stub(),
+            showGitCredentials: sandbox.stub(),
+            seedAuthenticatedSession: sandbox.stub(),
+            injectCourseEntry: sandbox.stub(),
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            coursesData,
+            archivedCoursesData: undefined,
+            userInfo: undefined,
+            archiveCheckComplete: true,
+        };
+        const { deps, stubs } = buildDeps({
+            appStateManager: appStateOverride,
+            startPageResolver: {
+                resolve: sandbox.stub().resolves({
+                    type: 'workspace-exercise',
+                    courseId: 5,
+                    exerciseId: 42,
+                    coursesData,
+                    allCourses: [courseEntry],
+                }),
+            },
+        });
+        const facade = new WebviewNavigationFacade(deps);
+        const userInfo = { username: 'dan', serverUrl: 'https://x/' };
+
+        await facade.navigateToStartPage(userInfo);
+
+        sinon.assert.called(fetchAndEnrichStub);
+        sinon.assert.calledWith(fetchAndEnrichStub, deps.artemisApi, 42);
+        sinon.assert.calledWith(stubs.appStateManager.showExerciseDetail, exerciseData);
+    });
+
+    // ── openExerciseDetails ────────────────────────────────────────
+
+    test('openExerciseDetails: happy path calls fetch, render, websocket connect, exerciseOpeningService', async () => {
+        const exerciseData: ExerciseDetailsResponse = {
+            exercise: { id: 7, title: 'Ex' } as ExerciseDetailsResponse['exercise'],
+        } as ExerciseDetailsResponse;
+        fetchAndEnrichStub.resolves(exerciseData);
+
+        const appStateOverride = {
+            showLogin: sandbox.stub(),
+            showDashboard: sandbox.stub(),
+            showCourseList: sandbox.stub(),
+            showCourseDetail: sandbox.stub(),
+            showExerciseDetail: sandbox.stub(),
+            showAiConfig: sandbox.stub(),
+            showServiceStatus: sandbox.stub(),
+            showStruggleDetection: sandbox.stub(),
+            showRecommendedExtensions: sandbox.stub(),
+            showGitCredentials: sandbox.stub(),
+            seedAuthenticatedSession: sandbox.stub(),
+            injectCourseEntry: sandbox.stub(),
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            coursesData: undefined,
+            archivedCoursesData: undefined,
+            userInfo: undefined,
+            archiveCheckComplete: true,
+        };
+
+        const ws = {
+            isConnected: sandbox.stub().returns(false),
+            connect: sandbox.stub().resolves(),
+        };
+
+        const { deps, stubs } = buildDeps({
+            appStateManager: appStateOverride,
+            websocketService: ws,
+        });
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.openExerciseDetails(7);
+
+        sinon.assert.calledWith(fetchAndEnrichStub, deps.artemisApi, 7);
+        sinon.assert.calledWith(stubs.appStateManager.showExerciseDetail, exerciseData);
+        sinon.assert.called(stubs.render);
+        sinon.assert.called(stubs.backgroundRenderProblemStatement);
+        sinon.assert.calledOnce(ws.connect);
+        sinon.assert.calledWith(stubs.exerciseOpeningService.handleExerciseOpened, exerciseData, 7);
+    });
+
+    test('openExerciseDetails: surfaces error message when API throws', async () => {
+        fetchAndEnrichStub.rejects(new Error('boom'));
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.openExerciseDetails(7);
+
+        sinon.assert.calledOnce(showErrorMessage);
+        sinon.assert.notCalled(stubs.appStateManager.showExerciseDetail);
+    });
+
+    // ── showCourseList ─────────────────────────────────────────────
+
+    test('showCourseList: with courseDataCache, fetches and renders', async () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.showCourseList();
+
+        sinon.assert.calledOnce(stubs.courseDataCache.fetch);
+        sinon.assert.calledOnce(stubs.appStateManager.showCourseList);
+        sinon.assert.called(stubs.render);
+    });
+
+    test('showCourseList: tolerates missing courseDataCache', async () => {
+        const { deps, stubs } = buildDeps();
+        // Replicate the optional-dep scenario: remove courseDataCache after build.
+        (deps as { courseDataCache?: unknown }).courseDataCache = undefined;
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.showCourseList();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showCourseList);
+    });
+
+    // ── Simple delegating methods ──────────────────────────────────
+
+    test('showAiConfig: delegates to appStateManager.showAiConfig and renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showAiConfig();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showAiConfig);
+        sinon.assert.called(stubs.render);
+    });
+
+    test('showServiceStatus: delegates to appStateManager.showServiceStatus and renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showServiceStatus();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showServiceStatus);
+        sinon.assert.called(stubs.render);
+    });
+
+    test('showStruggleDetection: delegates and renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showStruggleDetection();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showStruggleDetection);
+        sinon.assert.called(stubs.render);
+    });
+
+    test('showRecommendedExtensions: delegates and renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showRecommendedExtensions();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showRecommendedExtensions);
+        sinon.assert.called(stubs.render);
+    });
+
+    test('showGitCredentials: delegates and renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.showGitCredentials();
+
+        sinon.assert.calledOnce(stubs.appStateManager.showGitCredentials);
+        sinon.assert.called(stubs.render);
+    });
+
+    // ── showCourseDetail ───────────────────────────────────────────
+
+    test('showCourseDetail: stores state, registers exercises, renders', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+        const courseData = { course: { id: 9, title: 'Algorithms' } } as Parameters<WebviewNavigationFacade['showCourseDetail']>[0];
+
+        facade.showCourseDetail(courseData);
+
+        sinon.assert.calledWith(stubs.appStateManager.showCourseDetail, courseData);
+        sinon.assert.calledWith(stubs.exerciseRegistry.registerFromCourseData, courseData);
+        sinon.assert.called(stubs.render);
+    });
+
+    // ── Fullscreen delegations ─────────────────────────────────────
+
+    test('openExerciseFullscreen: delegates to fullscreenPanelManager', async () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+        const ex = { exercise: { id: 1 } } as ExerciseDetailsResponse;
+
+        await facade.openExerciseFullscreen(ex);
+
+        sinon.assert.calledWith(stubs.fullscreenPanelManager.openExerciseFullscreen, ex);
+    });
+
+    test('openCourseFullscreen: delegates to fullscreenPanelManager', async () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+        const c = { course: { id: 1, title: 'C' } } as Parameters<WebviewNavigationFacade['openCourseFullscreen']>[0];
+
+        await facade.openCourseFullscreen(c);
+
+        sinon.assert.calledWith(stubs.fullscreenPanelManager.openCourseFullscreen, c);
+    });
+
+    test('openCourseListFullscreen: delegates to fullscreenPanelManager with mapped courses', async () => {
+        const appStateOverride = {
+            showLogin: sandbox.stub(),
+            showDashboard: sandbox.stub(),
+            showCourseList: sandbox.stub(),
+            showCourseDetail: sandbox.stub(),
+            showExerciseDetail: sandbox.stub(),
+            showAiConfig: sandbox.stub(),
+            showServiceStatus: sandbox.stub(),
+            showStruggleDetection: sandbox.stub(),
+            showRecommendedExtensions: sandbox.stub(),
+            showGitCredentials: sandbox.stub(),
+            seedAuthenticatedSession: sandbox.stub(),
+            injectCourseEntry: sandbox.stub(),
+            currentState: 'course-list',
+            currentExerciseData: undefined,
+            coursesData: { courses: [{ course: { id: 1, title: 'C' } }] },
+            archivedCoursesData: undefined,
+            userInfo: undefined,
+            archiveCheckComplete: true,
+        };
+
+        const { deps, stubs } = buildDeps({ appStateManager: appStateOverride });
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.openCourseListFullscreen();
+
+        sinon.assert.calledOnce(stubs.fullscreenPanelManager.openCourseListFullscreen);
+    });
+
+    // ── openJsonInEditor ───────────────────────────────────────────
+
+    test('openJsonInEditor: opens JSON document and shows it', async () => {
+        const { deps } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        await facade.openJsonInEditor({ foo: 'bar' });
+
+        sinon.assert.calledOnce(openTextDocument);
+        sinon.assert.calledOnce(showTextDocument);
+    });
+
+    // ── render / sendInitData wiring ───────────────────────────────
+
+    test('render / sendInitData / backgroundRenderProblemStatement forward to deps callbacks', () => {
+        const { deps, stubs } = buildDeps();
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.render();
+        facade.sendInitData();
+        facade.backgroundRenderProblemStatement();
+
+        sinon.assert.calledOnce(stubs.render);
+        sinon.assert.calledOnce(stubs.sendInitData);
+        sinon.assert.calledOnce(stubs.backgroundRenderProblemStatement);
+    });
+
+    // ── hideLoadingAndSendServerUrl (used by AuthFlowHandler) ──────
+
+    test('hideLoadingAndSendServerUrl: posts HideLoading then SetServerUrl', () => {
+        const { deps, stubs } = buildDeps({
+            getServerUrl: sandbox.stub().returns('https://srv/'),
+        });
+        const facade = new WebviewNavigationFacade(deps);
+
+        facade.hideLoadingAndSendServerUrl();
+
+        // Two messages: HideLoading first, then SetServerUrl.
+        assert.strictEqual(stubs.postMessage.callCount, 2);
+        sinon.assert.calledWith(stubs.postMessage.firstCall, sinon.match({ type: ExtensionMsg.HideLoading }));
+        sinon.assert.calledWith(stubs.postMessage.secondCall, sinon.match({
+            type: ExtensionMsg.SetServerUrl,
+            serverUrl: 'https://srv/',
+        }));
+    });
+});

--- a/extension/test/unit/provider/webviewSSRCoordinator.test.ts
+++ b/extension/test/unit/provider/webviewSSRCoordinator.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for WebviewSSRCoordinator.
+ *
+ * Black-box behavior tests: each case constructs the coordinator with a
+ * partial deps stub filled only for the fields the SUT touches, then
+ * exercises the public surface (scheduleRender, dispose) and the
+ * registered theme-change callback.
+ */
+
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg } from '@shared/messageContracts';
+
+import type { WebviewSSRCoordinatorDeps } from '@extension/provider/webviewSSRCoordinator';
+import { WebviewSSRCoordinator } from '@extension/provider/webviewSSRCoordinator';
+import type { ExerciseDetailsResponse } from '@extension/types';
+
+suite('WebviewSSRCoordinator', () => {
+    let sandbox: sinon.SinonSandbox;
+    let onDidChangeActiveColorThemeStub: sinon.SinonStub;
+    let themeDisposable: { dispose: sinon.SinonStub };
+    let themeCallback: ((e: vscode.ColorTheme) => unknown) | undefined;
+
+    interface DepStubs {
+        appStateManager: {
+            currentState: string;
+            currentExerciseData: ExerciseDetailsResponse | undefined;
+            serverRenderedProblemStatement: { html: string } | null;
+        };
+        renderService: {
+            render: sinon.SinonStub;
+            invalidateAll: sinon.SinonStub;
+        };
+        postMessage: sinon.SinonStub;
+    }
+
+    function buildDeps(overrides: Partial<DepStubs> = {}): {
+        deps: WebviewSSRCoordinatorDeps;
+        stubs: DepStubs;
+    } {
+        const stubs: DepStubs = {
+            appStateManager: overrides.appStateManager ?? {
+                currentState: 'login',
+                currentExerciseData: undefined,
+                serverRenderedProblemStatement: null,
+            },
+            renderService: overrides.renderService ?? {
+                render: sandbox.stub().resolves(undefined),
+                invalidateAll: sandbox.stub(),
+            },
+            postMessage: overrides.postMessage ?? sandbox.stub(),
+        };
+
+        const deps = {
+            appStateManager: stubs.appStateManager,
+            renderService: stubs.renderService,
+            postMessage: stubs.postMessage,
+        } as unknown as WebviewSSRCoordinatorDeps;
+
+        return { deps, stubs };
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        themeCallback = undefined;
+        themeDisposable = { dispose: sandbox.stub() };
+        onDidChangeActiveColorThemeStub = sandbox
+            .stub(vscode.window, 'onDidChangeActiveColorTheme')
+            .callsFake(((cb: (e: vscode.ColorTheme) => unknown) => {
+                themeCallback = cb;
+                return themeDisposable as unknown as vscode.Disposable;
+            }) as unknown as typeof vscode.window.onDidChangeActiveColorTheme);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('constructor registers a theme-change listener exactly once', () => {
+        const { deps } = buildDeps();
+        new WebviewSSRCoordinator(deps);
+
+        sinon.assert.calledOnce(onDidChangeActiveColorThemeStub);
+    });
+
+    test('theme change invalidates the render-service cache', () => {
+        const { deps, stubs } = buildDeps();
+        new WebviewSSRCoordinator(deps);
+
+        if (!themeCallback) { throw new Error('theme callback not captured'); }
+        themeCallback({} as vscode.ColorTheme);
+
+        sinon.assert.calledOnce(stubs.renderService.invalidateAll);
+    });
+
+    test('theme change resets appStateManager.serverRenderedProblemStatement to null', () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'login',
+                currentExerciseData: undefined,
+                serverRenderedProblemStatement: { html: '<p>cached</p>' },
+            },
+        });
+        new WebviewSSRCoordinator(deps);
+
+        if (!themeCallback) { throw new Error('theme callback not captured'); }
+        themeCallback({} as vscode.ColorTheme);
+
+        sinon.assert.match(stubs.appStateManager.serverRenderedProblemStatement, null);
+    });
+
+    test('theme change triggers a fresh scheduleRender', () => {
+        const { deps } = buildDeps();
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        if (!themeCallback) { throw new Error('theme callback not captured'); }
+        themeCallback({} as vscode.ColorTheme);
+
+        sinon.assert.calledOnce(scheduleSpy);
+    });
+
+    test('scheduleRender is a no-op when currentState is not exercise-detail', async () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'dashboard',
+                currentExerciseData: undefined,
+                serverRenderedProblemStatement: null,
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        await coordinator.scheduleRender();
+
+        sinon.assert.notCalled(stubs.renderService.render);
+        sinon.assert.notCalled(stubs.postMessage);
+    });
+
+    test('scheduleRender is a no-op when currentExerciseData is undefined', async () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: undefined,
+                serverRenderedProblemStatement: null,
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        await coordinator.scheduleRender();
+
+        sinon.assert.notCalled(stubs.renderService.render);
+        sinon.assert.notCalled(stubs.postMessage);
+    });
+
+    test('scheduleRender happy path: renders, caches state, posts ProblemStatementRendered', async () => {
+        const exercise = {
+            id: 42,
+            problemStatement: '# Hello',
+            studentParticipations: [{ id: 7 }],
+        };
+        const exerciseData = { exercise } as unknown as ExerciseDetailsResponse;
+        const renderResult = { html: '<p>Hello</p>', contentHash: 'abcdef1234567890' };
+
+        const renderStub = sandbox.stub().resolves(renderResult);
+        const appStateManager = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null as { html: string } | null,
+        };
+        const { deps, stubs } = buildDeps({
+            appStateManager,
+            renderService: {
+                render: renderStub,
+                invalidateAll: sandbox.stub(),
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        await coordinator.scheduleRender();
+
+        sinon.assert.calledOnce(renderStub);
+        sinon.assert.calledWith(renderStub, exercise, { participation: exercise.studentParticipations[0] });
+        sinon.assert.match(stubs.appStateManager.serverRenderedProblemStatement, { html: '<p>Hello</p>' });
+        sinon.assert.calledWith(stubs.postMessage, sinon.match({
+            type: ExtensionMsg.ProblemStatementRendered,
+            html: '<p>Hello</p>',
+        }));
+    });
+
+    test('dispose disposes the theme listener', () => {
+        const { deps } = buildDeps();
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        coordinator.dispose();
+
+        sinon.assert.calledOnce(themeDisposable.dispose);
+    });
+});


### PR DESCRIPTION
Closes #206. Sub-task of #170.

Splits the 760-line god class `ArtemisWebviewProvider` into a focused webview lifecycle provider plus two cohesive collaborators.

## Final layout

| File | Lines | Responsibility |
|---|---|---|
| `artemisWebviewProvider.ts` | 422 | VS Code lifecycle (resolveWebviewView, dispose), event emitters, `showLogin` delegation, `_currentCourseAccessScope`, IArtemisWebviewProvider + 4 fireXxx, ready-state handling via BaseWebviewProvider |
| `webviewNavigationFacade.ts` | 410 | The 14 navigation methods (showDashboard, navigateToStartPage, openExerciseDetails, etc.) + server-URL helpers + `_suggestWorkspaceStartPage`. Implements `WebViewActionHandler` |
| `webviewSSRCoordinator.ts` | 76 | Background problem-statement render coordination + theme-change listener. Owns its own `Disposable` |
| `artemisWebviewProviderDeps.ts` | 25 | Typed deps interface for the provider's constructor |

Provider line count: **760 → 422 (-44%)**. Second-largest class in the codebase is now well below 500 LOC.

## Architecture

- **Provider stops implementing `WebViewActionHandler`.** That obligation moves to `WebviewNavigationFacade`. `WebViewMessageHandler` now receives the facade as its `actionHandler`.
- **`showLogin()` stays as a public delegation on the provider** for the 3 external callers in `extension.ts` (lines 174, 237) and `extensionCommands.ts` (line 36).
- **`_currentCourseAccessScope()` stays on the provider** because `CourseAccessStorageService` is constructed in the provider's constructor with that as a callback. Moving it would require restructuring the storage service.
- **11-argument positional constructor is gone.** Replaced with a single `ArtemisWebviewProviderDeps` named-object.
- **Constructor reordering**: facade is constructed BEFORE `WebViewMessageHandler` (since the latter takes the former as `actionHandler`); SSR coordinator is constructed BEFORE the facade (since the facade's `backgroundRenderProblemStatement` callback routes to `_ssrCoordinator.scheduleRender()`).
- **AuthFlowHandler callbacks route through the facade**: `navigateToStartPage`, `showLogin`, `hideLoadingAndSendServerUrl` all call into `this._navigationFacade.xxx`.

## Testability

Each new module uses a typed deps interface (`WebviewNavigationFacadeDeps`, `WebviewSSRCoordinatorDeps`) so tests can override individual helpers without mocking entire services. Production wiring uses defaults.

The 4 inherited methods from `BaseWebviewProvider` (`_postMessageSafe`, `_markReady`, `_resetReadyState`, `_drainDisposables`) are unchanged.

## Test coverage

| | Mocha | Vitest |
|---|---|---|
| Before | 1029 | 723 |
| After | **1058** | **723** |

- 24 new behavior tests for `WebviewNavigationFacade` (per-method coverage of all 14 nav methods + helpers)
- 8 new behavior tests for `WebviewSSRCoordinator` (theme listener, scheduleRender happy/no-op paths, dispose)
- 3 integration tests relocated from the provider test file into the facade test file (openExerciseDetails, openJsonInEditor, websocket connect on exercise open)
- 6 existing provider tests retained (lifecycle, visibility, ready-state, hide/show, auth-expiry-on-reshow)

## Commits

3 commits, each leaving the tree green:

1. `56b4887e` Convert ArtemisWebviewProvider to named-deps object
2. `a1eb0192` Extract WebviewNavigationFacade from provider
3. `41eb2a54` Extract WebviewSSRCoordinator from provider

## Verification

- `npm run check-types`: clean
- `npm run lint`: clean
- `npm run knip`: clean
- `npm run test:unit`: 1058 tests, 0 failures
- `npm run test:react`: 723 tests, 0 failures
- `npm run package`: clean
- Bundle: 399836 bytes (vs 398189 pre-refactor, +0.4% within tolerance)

## Manual testing checklist

Structural refactor with no intended behavior change. Riskiest spots: constructor reordering, callback wiring between Provider, Facade, and SSR coordinator, and `WebViewMessageHandler`'s new `actionHandler` reference.

### Lifecycle + visibility

- [ ] Open VS Code with the extension. The Artemis sidebar panel appears.
- [ ] Sign in. Dashboard loads.
- [ ] Hide the panel (collapse the sidebar). Reopen. State persists, no reload flash.
- [ ] Close and reopen VS Code. No errors in the dev console.

### Login / auth flow

- [ ] Click "Sign Out". Re-sign-in. Verify the AuthFlowHandler callbacks (navigateToStartPage, showLogin, hideLoadingAndSendServerUrl) all fire. Especially: after successful login, you land on the right start page (configured via setting).
- [ ] Change the Artemis server URL in settings. Reopen the panel. Credentials are cleared and the login view appears (this exercises `showLogin` via the WS-URL-change handler in extension.ts:237).
- [ ] When auth expires while the panel is hidden, reopening routes to the login screen.

### Navigation (Facade)

- [ ] From Dashboard, open a course. Course detail appears.
- [ ] From a course, open an exercise. Exercise detail appears with the problem statement rendered.
- [ ] Navigate back, then forward. State is restored cleanly.
- [ ] In an exercise detail view, "Open in Fullscreen" works.
- [ ] In a course detail view, "Open Course in Fullscreen" works.
- [ ] Open Course List Fullscreen from the dashboard.
- [ ] Service Status view: open it via the cog menu. Renders.
- [ ] AI Config view: open it. Renders.
- [ ] Recommended Extensions view: open it. Renders.
- [ ] Git Credentials view: open it (via submit-failed flow). Renders.
- [ ] Struggle Detection settings: open them. Renders.
- [ ] Open the JSON-in-editor action somewhere (devtools or a course-data dump). Editor opens with valid JSON.

### Workspace start-page suggestion

- [ ] Open VS Code in a cloned exercise folder. Dashboard should show a "Continue working on X?" suggestion at the top. (This exercises `_suggestWorkspaceStartPage`, which moved from provider into facade.)

### Problem-statement SSR (SSR Coordinator)

- [ ] Open an exercise. Problem statement renders.
- [ ] Switch VS Code theme (Light to Dark). Problem statement re-renders with the new theme.
- [ ] Navigate away from the exercise, change theme, navigate back. Re-render fires.

### Submission flow (sanity)

- [ ] Submit an exercise change. Status auto-refreshes. (Note: this exercises the `recheckRepoStatus` callback wiring from #209, which lives outside this PR but interacts with `WebViewMessageHandler` whose `actionHandler` changed in this PR.)

### Smoke test

- [ ] Send a message in Iris chat. Response arrives.

## Out of scope

- `resolveWebviewView` is not structurally extracted in this PR (per codex guidance). Its internal navigation calls were updated to route through `this._navigationFacade.xxx()`, but the function itself stays in the provider.
- Em-dash cleanup (~221 in `src/`; tracked separately).
- Websocket Service decomposition (#207).
