### PR TITLE
refactor(recorder): Stage 2 extract TerminalCollector with characterization tests

### DIFF
--- a/extension/src/extension/services/telemetry/recording/observation/observationRegistry.ts
+++ b/extension/src/extension/services/telemetry/recording/observation/observationRegistry.ts
@@ -16,21 +16,7 @@ import type { RecordedEvent } from '@extension/services/telemetry/recording/type
 import { shouldRecordUri } from '@extension/services/telemetry/recording/uriFilter';
 import type { PlatformCapabilities } from '@extension/theia';
 
-interface PendingExecution {
-    output: string;
-    startTime: number;
-    truncated: boolean;
-    readerDone: boolean;
-    endInfo: {
-        exitCode: number | undefined;
-        terminalName: string;
-        command: string;
-        cwd: string | undefined;
-    } | undefined;
-    aborted: boolean;
-    /** Generation token captured when the execution started. */
-    generation: number;
-}
+import { TerminalCollector } from './terminalCollector';
 
 interface ObservationRegistryDeps {
     state: RecorderLifecycleState;
@@ -45,8 +31,7 @@ interface ObservationRegistryDeps {
 
 /**
  * Owns every VS Code `onDidChange*` subscription used by the recorder, plus
- * the debounce state for selection/visibleRange events and the pending-
- * execution state for terminal shell-integration output.
+ * the debounce state for selection/visibleRange events.
  *
  * Listener lifetime matches the consent enable/disable cycle, not the
  * session lifecycle: once enabled, subscriptions persist across session
@@ -56,15 +41,13 @@ interface ObservationRegistryDeps {
  * Three explicit teardown paths replace the old single `_disposeEventListeners`:
  *   - `flushDebouncesForEnd(gen)`: on regular sessionEnd, flushes buffered
  *     debounce payloads into the record sink with `allowDuringEnding`.
- *   - `discardDebouncesForConsentDowngrade()`: GDPR path — drops all pending
- *     debounce payloads AND aborts terminal pending executions without any
+ *   - `discardDebouncesForConsentDowngrade()`: GDPR path, drops all pending
+ *     debounce payloads and aborts terminal pending executions without any
  *     record call.
  *   - `disposeSubscriptions()`: final cleanup on consent-disable or dispose.
  *     Clears timers + disposes all vscode.Disposable subscriptions. Idempotent.
  */
 export class ObservationRegistry {
-    static readonly MAX_OUTPUT_CHARS = 10240;
-
     /**
      * Debounce windows for selection and visible-range events. Engineering
      * choice calibrated by manual testing during recorder development, not a
@@ -91,9 +74,14 @@ export class ObservationRegistry {
     private readonly _visibleRangeDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly _pendingSelectionPayloads = new Map<string, RecordedEvent>();
     private readonly _pendingVisibleRangePayloads = new Map<string, RecordedEvent>();
-    private readonly _pendingExecutions = new Map<vscode.TerminalShellExecution, PendingExecution>();
+    private readonly _terminalCollector: TerminalCollector;
 
-    constructor(private readonly _deps: ObservationRegistryDeps) {}
+    constructor(private readonly _deps: ObservationRegistryDeps) {
+        this._terminalCollector = new TerminalCollector({
+            state: this._deps.state,
+            record: this._deps.record,
+        });
+    }
 
     setExerciseContext(root: vscode.Uri | undefined): void {
         this._exerciseRootUri = root;
@@ -268,34 +256,7 @@ export class ObservationRegistry {
 
         // Terminal shell execution tracking — only available in VS Code Desktop
         if (this._deps.capabilities?.hasTerminalShellExecution !== false) {
-            const shellExecStart = vscode.window.onDidStartTerminalShellExecution(event => {
-                if (!recordingPhase()) { return; }
-                const entry: PendingExecution = {
-                    output: '', startTime: Date.now(), truncated: false,
-                    readerDone: false, endInfo: undefined, aborted: false,
-                    generation: this._deps.state.currentGeneration,
-                };
-                this._pendingExecutions.set(event.execution, entry);
-                void this._collectExecutionOutput(event.execution, entry);
-            });
-            this._eventListenerDisposables.push(shellExecStart);
-
-            const shellExecEnd = vscode.window.onDidEndTerminalShellExecution(event => {
-                if (!recordingPhase()) { return; }
-                const entry = this._pendingExecutions.get(event.execution);
-                if (!entry) { return; }
-                this._pendingExecutions.delete(event.execution);
-                entry.endInfo = {
-                    exitCode: event.exitCode,
-                    terminalName: event.terminal.name,
-                    command: event.execution.commandLine.value,
-                    cwd: event.execution.cwd?.toString(),
-                };
-                if (entry.readerDone) {
-                    this._emitTerminalCommand(entry);
-                }
-            });
-            this._eventListenerDisposables.push(shellExecEnd);
+            this._terminalCollector.register(this._eventListenerDisposables);
         }
     }
 
@@ -327,10 +288,7 @@ export class ObservationRegistry {
         this._pendingVisibleRangePayloads.clear();
 
         // Abort any still-running terminal shell executions.
-        for (const entry of this._pendingExecutions.values()) {
-            entry.aborted = true;
-        }
-        this._pendingExecutions.clear();
+        this._terminalCollector.abortAllPending();
     }
 
     /**
@@ -352,10 +310,7 @@ export class ObservationRegistry {
         this._visibleRangeDebounceTimers.clear();
         this._pendingVisibleRangePayloads.clear();
 
-        for (const entry of this._pendingExecutions.values()) {
-            entry.aborted = true;
-        }
-        this._pendingExecutions.clear();
+        this._terminalCollector.abortAllPending();
     }
 
     /**
@@ -384,10 +339,7 @@ export class ObservationRegistry {
         }
         this._visibleRangeDebounceTimers.clear();
         this._pendingVisibleRangePayloads.clear();
-        for (const entry of this._pendingExecutions.values()) {
-            entry.aborted = true;
-        }
-        this._pendingExecutions.clear();
+        this._terminalCollector.abortAllPending();
         while (this._eventListenerDisposables.length > 0) {
             const disposable = this._eventListenerDisposables.pop();
             disposable?.dispose();
@@ -436,48 +388,4 @@ export class ObservationRegistry {
         }, {}, this._deps.state.currentGeneration);
     }
 
-    // ── Terminal output helpers ───────────────────────────────────────
-
-    private async _collectExecutionOutput(
-        execution: vscode.TerminalShellExecution,
-        entry: PendingExecution,
-    ): Promise<void> {
-        try {
-            for await (const data of execution.read()) {
-                if (entry.aborted) { return; }
-                if (!entry.truncated) {
-                    const remaining = ObservationRegistry.MAX_OUTPUT_CHARS - entry.output.length;
-                    if (data.length <= remaining) {
-                        entry.output += data;
-                    } else {
-                        entry.output += data.substring(0, remaining);
-                        entry.truncated = true;
-                    }
-                }
-            }
-        } catch (err) {
-            logger.error('Failed to read terminal execution output', LogCategory.TELEMETRY, err);
-        }
-        entry.readerDone = true;
-        if (entry.endInfo && !entry.aborted) {
-            this._emitTerminalCommand(entry);
-        }
-    }
-
-    private _emitTerminalCommand(entry: PendingExecution): void {
-        if (!entry.endInfo) { return; }
-        if (this._deps.state.phase !== 'recording') { return; }
-        const now = Date.now();
-        this._deps.record({
-            type: 'terminalCommand',
-            timestamp: now,
-            command: entry.endInfo.command,
-            exitCode: entry.endInfo.exitCode,
-            output: entry.output,
-            outputTruncated: entry.truncated,
-            cwd: entry.endInfo.cwd,
-            terminalName: entry.endInfo.terminalName,
-            durationMs: now - entry.startTime,
-        }, {}, entry.generation);
-    }
 }

--- a/extension/src/extension/services/telemetry/recording/observation/terminalCollector.ts
+++ b/extension/src/extension/services/telemetry/recording/observation/terminalCollector.ts
@@ -1,0 +1,130 @@
+import * as vscode from 'vscode';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import type { RecorderLifecycleState } from '@extension/services/telemetry/recording/lifecycle/recorderLifecycleState';
+import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
+
+interface PendingExecution {
+    output: string;
+    startTime: number;
+    truncated: boolean;
+    readerDone: boolean;
+    endInfo: {
+        exitCode: number | undefined;
+        terminalName: string;
+        command: string;
+        cwd: string | undefined;
+    } | undefined;
+    aborted: boolean;
+    /** Generation token captured when the execution started. */
+    generation: number;
+}
+
+interface TerminalCollectorDeps {
+    state: RecorderLifecycleState;
+    record: (
+        event: RecordedEvent,
+        opts: { allowDuringStartup?: boolean; allowDuringEnding?: boolean },
+        generation: number,
+    ) => void;
+}
+
+export class TerminalCollector {
+    static readonly MAX_OUTPUT_CHARS = 10240;
+
+    private readonly _pendingExecutions = new Map<vscode.TerminalShellExecution, PendingExecution>();
+
+    constructor(private readonly _deps: TerminalCollectorDeps) {}
+
+    /**
+     * Register shellExecStart/End listeners. The caller pushes the returned
+     * disposables into its own tracking array.
+     */
+    register(disposables: vscode.Disposable[]): void {
+        const recordingPhase = (): boolean => this._deps.state.phase === 'recording';
+
+        const shellExecStart = vscode.window.onDidStartTerminalShellExecution(event => {
+            if (!recordingPhase()) { return; }
+            const entry: PendingExecution = {
+                output: '', startTime: Date.now(), truncated: false,
+                readerDone: false, endInfo: undefined, aborted: false,
+                generation: this._deps.state.currentGeneration,
+            };
+            this._pendingExecutions.set(event.execution, entry);
+            void this._collectExecutionOutput(event.execution, entry);
+        });
+        disposables.push(shellExecStart);
+
+        const shellExecEnd = vscode.window.onDidEndTerminalShellExecution(event => {
+            if (!recordingPhase()) { return; }
+            const entry = this._pendingExecutions.get(event.execution);
+            if (!entry) { return; }
+            this._pendingExecutions.delete(event.execution);
+            entry.endInfo = {
+                exitCode: event.exitCode,
+                terminalName: event.terminal.name,
+                command: event.execution.commandLine.value,
+                cwd: event.execution.cwd?.toString(),
+            };
+            if (entry.readerDone) {
+                this._emitTerminalCommand(entry);
+            }
+        });
+        disposables.push(shellExecEnd);
+    }
+
+    /**
+     * Abort all pending executions and clear the map. Used by all three
+     * teardown paths in ObservationRegistry (flushDebouncesForEnd,
+     * discardDebouncesForConsentDowngrade, disposeSubscriptions).
+     */
+    abortAllPending(): void {
+        for (const entry of this._pendingExecutions.values()) {
+            entry.aborted = true;
+        }
+        this._pendingExecutions.clear();
+    }
+
+    private async _collectExecutionOutput(
+        execution: vscode.TerminalShellExecution,
+        entry: PendingExecution,
+    ): Promise<void> {
+        try {
+            for await (const data of execution.read()) {
+                if (entry.aborted) { return; }
+                if (!entry.truncated) {
+                    const remaining = TerminalCollector.MAX_OUTPUT_CHARS - entry.output.length;
+                    if (data.length <= remaining) {
+                        entry.output += data;
+                    } else {
+                        entry.output += data.substring(0, remaining);
+                        entry.truncated = true;
+                    }
+                }
+            }
+        } catch (err) {
+            logger.error('Failed to read terminal execution output', LogCategory.TELEMETRY, err);
+        }
+        entry.readerDone = true;
+        if (entry.endInfo && !entry.aborted) {
+            this._emitTerminalCommand(entry);
+        }
+    }
+
+    private _emitTerminalCommand(entry: PendingExecution): void {
+        if (!entry.endInfo) { return; }
+        if (this._deps.state.phase !== 'recording') { return; }
+        const now = Date.now();
+        this._deps.record({
+            type: 'terminalCommand',
+            timestamp: now,
+            command: entry.endInfo.command,
+            exitCode: entry.endInfo.exitCode,
+            output: entry.output,
+            outputTruncated: entry.truncated,
+            cwd: entry.endInfo.cwd,
+            terminalName: entry.endInfo.terminalName,
+            durationMs: now - entry.startTime,
+        }, {}, entry.generation);
+    }
+}

--- a/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
+++ b/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Characterization tests for the terminal-shell-execution capture path
+ * inside ObservationRegistry / SessionRecorder.
+ *
+ * These tests pin the pre-extraction behavior so that the Stage 2
+ * TerminalCollector extraction can be verified as behavior-preserving.
+ * They are whitebox: they seed internal state directly and call private
+ * helpers via unsafe casts.
+ *
+ * The two whitebox helper functions at the top are the SINGLE point that
+ * will change after Stage 2's refactor: their bodies will be updated to
+ * reach through _terminalCollector instead of directly into _observation.
+ * The 5 test cases themselves remain byte-identical.
+ */
+
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+import { SessionRecorder } from '@extension/services/telemetry/recording/sessionRecorder';
+import type { RecordingFs } from '@extension/services/telemetry/recording/storageWriter';
+import { RecordingStorageWriter } from '@extension/services/telemetry/recording/storageWriter';
+import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
+
+// ── Whitebox helpers (bodies change after Stage 2 extraction) ──────────────
+
+function pendingExecutions(
+    recorder: SessionRecorder,
+): Map<vscode.TerminalShellExecution, any> {
+    return (recorder as unknown as {
+        _observation: { _pendingExecutions: Map<vscode.TerminalShellExecution, any> };
+    })._observation._pendingExecutions;
+}
+
+function emitTerminalCommand(recorder: SessionRecorder, entry: any): void {
+    (recorder as unknown as {
+        _observation: { _emitTerminalCommand: (e: any) => void };
+    })._observation._emitTerminalCommand(entry);
+}
+
+// ── Fake FS ────────────────────────────────────────────────────────────────
+
+class FakeFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    writtenFiles: { path: string; data: string }[] = [];
+    removedPaths: string[] = [];
+    syncChunks: string[] = [];
+    mkdirCalls = 0;
+
+    mkdir(_p: string, _opts: { recursive: boolean }): Promise<string | undefined> {
+        this.mkdirCalls++;
+        return Promise.resolve(undefined);
+    }
+
+    writeFile(p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.writtenFiles.push({ path: p, data });
+        return Promise.resolve();
+    }
+
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> {
+        this.appendedChunks.push(data);
+        return Promise.resolve();
+    }
+
+    rm(p: string, _opts: { recursive: boolean; force: boolean }): Promise<void> {
+        this.removedPaths.push(p);
+        return Promise.resolve();
+    }
+
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void {
+        this.syncChunks.push(data);
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function collectWrittenEvents(fakeFs: FakeFs): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+    for (const chunk of fakeFs.appendedChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip */ }
+        }
+    }
+    for (const chunk of fakeFs.syncChunks) {
+        for (const line of chunk.split('\n').filter(Boolean)) {
+            try { events.push(JSON.parse(line) as RecordedEvent); } catch { /* skip */ }
+        }
+    }
+    return events;
+}
+
+/**
+ * Create a SessionRecorder with hasTerminalShellExecution: true so the
+ * terminal listeners actually subscribe (unlike the default test factory
+ * in sessionRecorder.test.ts which sets it to false).
+ */
+function makeRecorder(): { recorder: SessionRecorder; fs: FakeFs } {
+    const fs = new FakeFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const fakeUri = vscode.Uri.file('/fake-base');
+    const recorder = new SessionRecorder(
+        fakeUri,
+        { hasTerminalShellExecution: true, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+    );
+    return { recorder, fs };
+}
+
+/** Build a minimal PendingExecution entry with sensible defaults. */
+function makeEntry(overrides: Partial<{
+    output: string;
+    startTime: number;
+    truncated: boolean;
+    readerDone: boolean;
+    endInfo: { exitCode: number | undefined; terminalName: string; command: string; cwd: string | undefined } | undefined;
+    aborted: boolean;
+    generation: number;
+}> = {}): any {
+    return {
+        output: '',
+        startTime: Date.now() - 1000,
+        truncated: false,
+        readerDone: false,
+        endInfo: undefined,
+        aborted: false,
+        generation: 0,
+        ...overrides,
+    };
+}
+
+// ── Suite ──────────────────────────────────────────────────────────────────
+
+suite('TerminalCollector — characterization tests (pre-extraction)', () => {
+    let recorder: SessionRecorder;
+    let fs: FakeFs;
+
+    setup(() => {
+        const ctx = makeRecorder();
+        recorder = ctx.recorder;
+        fs = ctx.fs;
+    });
+
+    teardown(async () => {
+        try { await recorder.dispose(); } catch { /* ignore */ }
+    });
+
+    // ── Test 1: abortAllPending via disable() ─────────────────────────────
+
+    test('disable() aborts all pending executions and clears the map without emitting terminalCommand', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const fakeExecA = {} as vscode.TerminalShellExecution;
+        const fakeExecB = {} as vscode.TerminalShellExecution;
+
+        const entryA = makeEntry({ generation: 1 });
+        const entryB = makeEntry({ generation: 1 });
+
+        pendingExecutions(recorder).set(fakeExecA, entryA);
+        pendingExecutions(recorder).set(fakeExecB, entryB);
+
+        recorder.disable();
+        await new Promise(resolve => setTimeout(resolve, 30));
+
+        // Both entries must have aborted set to true (still reachable via our
+        // references even though the map was cleared).
+        assert.strictEqual(entryA.aborted, true, 'entryA must be aborted');
+        assert.strictEqual(entryB.aborted, true, 'entryB must be aborted');
+
+        // The map must be empty after disable.
+        assert.strictEqual(pendingExecutions(recorder).size, 0,
+            '_pendingExecutions must be cleared after disable()');
+
+        // No terminalCommand event must appear in the JSONL stream.
+        const events = collectWrittenEvents(fs);
+        const termEvents = events.filter(e => e.type === 'terminalCommand');
+        assert.strictEqual(termEvents.length, 0,
+            'disable() must not emit any terminalCommand events');
+    });
+
+    // ── Test 2: abortAllPending via endSession() ──────────────────────────
+
+    test('endSession() aborts all pending executions and clears the map without emitting terminalCommand', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const fakeExec = {} as vscode.TerminalShellExecution;
+        const entry = makeEntry({ generation: 1 });
+
+        pendingExecutions(recorder).set(fakeExec, entry);
+
+        await recorder.endSession();
+
+        // Entry must be aborted (still reachable via our reference).
+        assert.strictEqual(entry.aborted, true, 'entry must be aborted after endSession()');
+
+        // The map must be empty.
+        assert.strictEqual(pendingExecutions(recorder).size, 0,
+            '_pendingExecutions must be cleared after endSession()');
+
+        // No terminalCommand event in JSONL.
+        const events = collectWrittenEvents(fs);
+        const termEvents = events.filter(e => e.type === 'terminalCommand');
+        assert.strictEqual(termEvents.length, 0,
+            'endSession() without completed executions must not emit terminalCommand events');
+    });
+
+    // ── Test 3: _emitTerminalCommand happy path ───────────────────────────
+
+    test('_emitTerminalCommand emits a correct terminalCommand event when all conditions are met', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        // Capture the live generation before seeding the entry so it matches.
+        const liveGeneration: number = (recorder as unknown as { _currentGeneration: number })._currentGeneration;
+
+        const entry = makeEntry({
+            output: 'Hello world\n',
+            startTime: Date.now() - 500,
+            truncated: false,
+            readerDone: true,
+            generation: liveGeneration,
+            endInfo: {
+                exitCode: 0,
+                terminalName: 'bash',
+                command: 'echo Hello world',
+                cwd: '/home/student',
+            },
+        });
+
+        emitTerminalCommand(recorder, entry);
+
+        // End the session to drain the storage writer buffer before asserting.
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const termEvents = events.filter(e => e.type === 'terminalCommand') as Array<{
+            type: string;
+            timestamp: number;
+            command: string;
+            exitCode: number | undefined;
+            output: string;
+            outputTruncated: boolean;
+            cwd: string | undefined;
+            terminalName: string;
+            durationMs: number;
+        }>;
+
+        assert.strictEqual(termEvents.length, 1, 'exactly one terminalCommand event must be emitted');
+        const ev = termEvents[0]!;
+        assert.strictEqual(ev.command, 'echo Hello world', 'command field');
+        assert.strictEqual(ev.exitCode, 0, 'exitCode field');
+        assert.strictEqual(ev.output, 'Hello world\n', 'output field');
+        assert.strictEqual(ev.outputTruncated, false, 'outputTruncated field');
+        assert.strictEqual(ev.cwd, '/home/student', 'cwd field');
+        assert.strictEqual(ev.terminalName, 'bash', 'terminalName field');
+        assert.ok(typeof ev.durationMs === 'number' && ev.durationMs >= 0, 'durationMs must be a non-negative number');
+        assert.ok(typeof ev.timestamp === 'number' && ev.timestamp > 0, 'timestamp must be a positive number');
+    });
+
+    // ── Test 4: _emitTerminalCommand phase guard ──────────────────────────
+
+    test('_emitTerminalCommand does NOT emit when the recorder is not in recording phase', async () => {
+        recorder.enable();
+        await recorder.startSession(1);
+
+        const liveGeneration: number = (recorder as unknown as { _currentGeneration: number })._currentGeneration;
+
+        const entry = makeEntry({
+            output: 'output',
+            readerDone: true,
+            generation: liveGeneration,
+            endInfo: {
+                exitCode: 1,
+                terminalName: 'zsh',
+                command: 'failing-cmd',
+                cwd: undefined,
+            },
+        });
+
+        // End the session: phase transitions out of 'recording'.
+        await recorder.endSession();
+
+        // Capture the event count before attempting the emission.
+        const countBefore = collectWrittenEvents(fs).length;
+
+        emitTerminalCommand(recorder, entry);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const countAfter = collectWrittenEvents(fs).length;
+
+        assert.strictEqual(countAfter, countBefore,
+            '_emitTerminalCommand must not write any event when phase != recording');
+
+        const termEvents = collectWrittenEvents(fs).filter(e => e.type === 'terminalCommand');
+        assert.strictEqual(termEvents.length, 0, 'no terminalCommand event must be emitted after session ends');
+    });
+
+    // ── Test 5: _emitTerminalCommand generation gate via stale generation ─
+
+    test('stale-generation entry does not emit terminalCommand into a newer session', async () => {
+        recorder.enable();
+
+        // Start first session and capture its generation.
+        await recorder.startSession(10);
+        const gen1: number = (recorder as unknown as { _currentGeneration: number })._currentGeneration;
+
+        // End the first session and begin a second one.
+        await recorder.endSession();
+        await recorder.startSession(11);
+
+        // Build an entry stamped with the stale first-session generation.
+        const staleEntry = makeEntry({
+            output: 'stale output',
+            readerDone: true,
+            generation: gen1,
+            endInfo: {
+                exitCode: 0,
+                terminalName: 'fish',
+                command: 'stale-cmd',
+                cwd: '/tmp',
+            },
+        });
+
+        emitTerminalCommand(recorder, staleEntry);
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        // Only look at events written during the second session. We check that
+        // no terminalCommand with command='stale-cmd' appears.
+        const events = collectWrittenEvents(fs);
+        const staleTermEvents = events.filter(e =>
+            e.type === 'terminalCommand' &&
+            (e as { command?: string }).command === 'stale-cmd',
+        );
+        assert.strictEqual(staleTermEvents.length, 0,
+            'a stale-generation entry must not produce a terminalCommand event in the current session');
+
+        await recorder.endSession();
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
+++ b/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
@@ -130,7 +130,7 @@ function makeEntry(overrides: Partial<{
 
 // ── Suite ──────────────────────────────────────────────────────────────────
 
-suite('TerminalCollector — characterization tests (pre-extraction)', () => {
+suite('TerminalCollector characterization tests', () => {
     let recorder: SessionRecorder;
     let fs: FakeFs;
 
@@ -338,5 +338,121 @@ suite('TerminalCollector — characterization tests (pre-extraction)', () => {
             'a stale-generation entry must not produce a terminalCommand event in the current session');
 
         await recorder.endSession();
+    });
+
+    // ── Test 6: full integration via captured listeners + fake execution.read()
+
+    test('full lifecycle: shellExecStart, async read, shellExecEnd emits terminalCommand with captured output, end fields, and start-time generation', async () => {
+        // Monkey-patch vscode.window so we can capture the listener bodies that
+        // TerminalCollector.register() registers, then trigger them by hand.
+        // This exercises the registration path, the async read consumer, the
+        // end-listener emission gate, and the generation flow end-to-end. The
+        // earlier whitebox tests cover the abort and emission predicates;
+        // this test covers the path that actually wires the recorder up to
+        // VS Code's terminal events.
+        let startListener: ((event: { execution: vscode.TerminalShellExecution }) => void) | undefined;
+        let endListener: ((event: {
+            execution: vscode.TerminalShellExecution;
+            exitCode: number | undefined;
+            terminal: vscode.Terminal;
+        }) => void) | undefined;
+
+        const originalOnDidStart = vscode.window.onDidStartTerminalShellExecution;
+        const originalOnDidEnd = vscode.window.onDidEndTerminalShellExecution;
+
+        (vscode.window as unknown as {
+            onDidStartTerminalShellExecution: (listener: typeof startListener) => vscode.Disposable;
+        }).onDidStartTerminalShellExecution = (listener) => {
+            startListener = listener;
+            return { dispose: () => { startListener = undefined; } };
+        };
+        (vscode.window as unknown as {
+            onDidEndTerminalShellExecution: (listener: typeof endListener) => vscode.Disposable;
+        }).onDidEndTerminalShellExecution = (listener) => {
+            endListener = listener;
+            return { dispose: () => { endListener = undefined; } };
+        };
+
+        try {
+            recorder.enable();
+            await recorder.startSession(42);
+
+            const startGen = (recorder as unknown as { _currentGeneration: number })._currentGeneration;
+
+            assert.ok(startListener, 'shellExecStart listener must be registered after enable()');
+            assert.ok(endListener, 'shellExecEnd listener must be registered after enable()');
+
+            // Fake execution that yields two output chunks then completes.
+            const fakeExecution = {
+                commandLine: { value: 'npm test', confidence: 2, isTrusted: true },
+                cwd: vscode.Uri.file('/tmp/proj'),
+                read: async function* () {
+                    yield 'first chunk\n';
+                    yield 'second chunk\n';
+                },
+            } as unknown as vscode.TerminalShellExecution;
+
+            const fakeTerminal = { name: 'zsh' } as vscode.Terminal;
+
+            startListener!({ execution: fakeExecution });
+
+            const pending = pendingExecutions(recorder);
+            assert.strictEqual(pending.size, 1, 'exactly one pending execution after shellExecStart');
+            const entry = pending.get(fakeExecution);
+            assert.ok(entry, 'pending execution entry must be present');
+            assert.strictEqual(entry.generation, startGen, 'entry generation captured at start time matches the current session');
+            assert.strictEqual(entry.aborted, false, 'fresh entry must not be aborted');
+
+            // Drain microtasks so the async generator iterator runs to completion.
+            for (let i = 0; i < 20; i++) { await Promise.resolve(); }
+
+            assert.strictEqual(entry.readerDone, true, 'reader must complete after the iterator drains');
+            assert.strictEqual(entry.output, 'first chunk\nsecond chunk\n', 'output must accumulate both chunks in order');
+            assert.strictEqual(entry.truncated, false, 'short output must not be truncated');
+
+            // No terminalCommand event yet because endInfo is still unset.
+            const termBeforeEnd = collectWrittenEvents(fs).filter(e => e.type === 'terminalCommand');
+            assert.strictEqual(termBeforeEnd.length, 0, 'no terminalCommand before shellExecEnd fires');
+
+            endListener!({
+                execution: fakeExecution,
+                exitCode: 0,
+                terminal: fakeTerminal,
+            });
+
+            assert.strictEqual(pending.has(fakeExecution), false, 'execution must be removed from pending map after end');
+
+            await recorder.endSession();
+
+            const termEvents = collectWrittenEvents(fs).filter(e => e.type === 'terminalCommand') as Array<{
+                type: 'terminalCommand';
+                command: string;
+                exitCode: number | undefined;
+                output: string;
+                outputTruncated: boolean;
+                cwd: string | undefined;
+                terminalName: string;
+                durationMs: number;
+                timestamp: number;
+            }>;
+            assert.strictEqual(termEvents.length, 1, 'exactly one terminalCommand event must be emitted');
+            const tc = termEvents[0];
+            assert.strictEqual(tc.command, 'npm test', 'command preserved');
+            assert.strictEqual(tc.exitCode, 0, 'exitCode preserved');
+            assert.strictEqual(tc.output, 'first chunk\nsecond chunk\n', 'output preserved');
+            assert.strictEqual(tc.outputTruncated, false);
+            assert.strictEqual(tc.terminalName, 'zsh');
+            assert.strictEqual(tc.cwd, vscode.Uri.file('/tmp/proj').toString(), 'cwd preserved as the fake URI');
+            assert.ok(tc.durationMs >= 0, 'durationMs must be non-negative');
+        } finally {
+            // Restore the real vscode.window APIs so other tests in the run
+            // are not affected by the monkey-patch.
+            (vscode.window as unknown as {
+                onDidStartTerminalShellExecution: typeof originalOnDidStart;
+            }).onDidStartTerminalShellExecution = originalOnDidStart;
+            (vscode.window as unknown as {
+                onDidEndTerminalShellExecution: typeof originalOnDidEnd;
+            }).onDidEndTerminalShellExecution = originalOnDidEnd;
+        }
     });
 });

--- a/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
+++ b/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
@@ -27,14 +27,14 @@ function pendingExecutions(
     recorder: SessionRecorder,
 ): Map<vscode.TerminalShellExecution, any> {
     return (recorder as unknown as {
-        _observation: { _pendingExecutions: Map<vscode.TerminalShellExecution, any> };
-    })._observation._pendingExecutions;
+        _observation: { _terminalCollector: { _pendingExecutions: Map<vscode.TerminalShellExecution, any> } };
+    })._observation._terminalCollector._pendingExecutions;
 }
 
 function emitTerminalCommand(recorder: SessionRecorder, entry: any): void {
     (recorder as unknown as {
-        _observation: { _emitTerminalCommand: (e: any) => void };
-    })._observation._emitTerminalCommand(entry);
+        _observation: { _terminalCollector: { _emitTerminalCommand: (e: any) => void } };
+    })._observation._terminalCollector._emitTerminalCommand(entry);
 }
 
 // ── Fake FS ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Stage 2 of the recorder refactor plan. Codex-approved through 2 review rounds. Three commits on the branch:

1. `2f8bc415`: 5 whitebox characterization tests pinning the pre-extraction behavior of the terminal-shell-execution capture path.
2. `bfde2458`: extract `TerminalCollector` from `ObservationRegistry`.
3. `743bda69`: 6th test, a full-lifecycle integration test that captures the actual VS Code listener bodies via monkey-patch and exercises `register` plus async `read` plus the `shellExecEnd` emission gate end-to-end. Plus em-dash removal from the suite name.

The terminal-shell-execution capture logic was ~90 LOC across 6 touch points in `observationRegistry.ts` (the `PendingExecution` interface, `MAX_OUTPUT_CHARS` constant, `_pendingExecutions` map, shellExecStart/shellExecEnd listener registration, abort blocks in all 3 teardown paths, plus `_collectExecutionOutput` and `_emitTerminalCommand`). It is now in its own `observation/terminalCollector.ts` (~120 LOC) with a minimal public surface: `register(disposables)` and `abortAllPending()`. `ObservationRegistry` keeps selection / visibleRange debounce and file-event listeners.

## Behavior preservation

Tests written FIRST, against the pre-extraction code (commit 1). Post-extraction code (commit 2) verified by the same tests with only the whitebox helper bodies updated (committed in commit 2); the 5 test cases themselves are byte-identical pre- and post-extraction. Commit 3 adds a 6th test that exercises the listener-registration / async-read / end-emission-gate path with captured listeners and a fake `TerminalShellExecution.read()` async iterator.

### Coverage delta

Before:
- 0 unit tests exercised the terminal path (`hasTerminalShellExecution: false` in every unit-test factory)
- Only `recording.e2e.test.ts` tested terminal capture end-to-end

After:
- 6 unit tests cover abort semantics (via `disable()` and `endSession()`), the `_emitTerminalCommand` happy path, phase guard, stale-generation gate, and full lifecycle integration (registration plus async read plus end emission)

## Test Plan

- [x] `npm run compile-tests`: pass
- [x] `npm run test:unit`: 1035 tests, 0 failures, 3 skipped
- [x] `npx eslint` on `terminalCollector.ts`, `observationRegistry.ts`, `terminalShellExecution.test.ts`: clean

## Out of scope

Stages 3-5 of the recorder refactor plan land in separate PRs:
- Stage 3: lifecycle FSM unification (`_doEnd` and `_doFinalizeAfterDisable` via `terminationReason` parameter, with characterization tests)
- Stage 4: snapshot post-write consent-race decision (fix / document / justify)
- Stage 5: schema-source-of-truth decision (do nothing / shared location / zod)