### PR TITLE
ui(ParticipationActions): group More options dropdown, merge Copy URL entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+- **Exercise "More options" Dropdown**: Grouped entries into Workspace, Share, and External sections with icons, and merged the two "Copy Clone URL" entries into a single split-button.
 - **Iris Chat Feedback Icons**: Fixed the broken thumbs-down icon on assistant messages (previously rendered as a filled blob when selected).
 - **Webview Icon Consistency**: Replaced ~25 hand-rolled inline SVG icons across the chat, exam, and shared components with their Lucide equivalents for visual consistency and to prevent future malformed-path bugs.
 - **Live Recording Viewer**: Faster live view (no more lag on long sessions), undo/redo for markers via Cmd/Ctrl+Z, and live sessions appear in the list immediately.

--- a/extension/src/webview/components/exercise/ParticipationActions.module.css
+++ b/extension/src/webview/components/exercise/ParticipationActions.module.css
@@ -260,6 +260,16 @@
   overflow: hidden;
 }
 
+.dropdownSection {
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdownDivider {
+  height: 1px;
+  background: var(--vscode-panel-border, #e0e0e0);
+}
+
 .dropdownItem {
   background: transparent;
   color: var(--vscode-foreground);
@@ -276,8 +286,44 @@
   background: var(--vscode-list-hoverBackground);
 }
 
-.dropdownItem:not(:last-child) {
-  border-bottom: 1px solid var(--vscode-panel-border, #e0e0e0);
+.cloneUrlItem {
+  display: flex;
+  align-items: stretch;
+}
+
+.cloneUrlPrimary {
+  background: transparent;
+  color: var(--vscode-foreground);
+  border: none;
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  flex: 1;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.cloneUrlPrimary:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.cloneUrlSecondary {
+  background: transparent;
+  color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+  border: none;
+  border-left: 1px solid var(--vscode-panel-border, #e0e0e0);
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.cloneUrlSecondary:hover {
+  background: var(--vscode-list-hoverBackground);
+  color: var(--vscode-foreground);
 }
 
 /* Responsive design */

--- a/extension/src/webview/components/exercise/ParticipationActions.module.css
+++ b/extension/src/webview/components/exercise/ParticipationActions.module.css
@@ -279,6 +279,9 @@
   cursor: pointer;
   width: 100%;
   text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   transition: background-color 0.15s ease;
 }
 
@@ -300,6 +303,9 @@
   cursor: pointer;
   flex: 1;
   text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   transition: background-color 0.15s ease;
 }
 

--- a/extension/src/webview/components/exercise/ParticipationActions.tsx
+++ b/extension/src/webview/components/exercise/ParticipationActions.tsx
@@ -1,7 +1,13 @@
 import clsx from 'clsx';
+import Activity from 'lucide-react/dist/esm/icons/activity';
 import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import ArrowDownToLine from 'lucide-react/dist/esm/icons/arrow-down-to-line';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import FlaskConical from 'lucide-react/dist/esm/icons/flask-conical';
+import FolderOpen from 'lucide-react/dist/esm/icons/folder-open';
+import GitBranch from 'lucide-react/dist/esm/icons/git-branch';
 import KeyRound from 'lucide-react/dist/esm/icons/key-round';
+import Link from 'lucide-react/dist/esm/icons/link';
 import Mail from 'lucide-react/dist/esm/icons/mail';
 import { useEffect, useRef, useState } from 'react';
 
@@ -277,19 +283,23 @@ export function ParticipationActions({
                 <div className={styles.dropdownSection}>
                   {isWorkspaceConnected && (
                     <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onClone?.(); }}>
-                      Clone Repository
+                      <GitBranch size={14} aria-hidden="true" />
+                      <span>Clone Repository</span>
                     </button>
                   )}
                   <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onCheckWorkspace?.(); }}>
-                    Check workspace status
+                    <Activity size={14} aria-hidden="true" />
+                    <span>Check workspace status</span>
                   </button>
                   {onOpenRepository && (
                     <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenRepository(); }}>
-                      Open Repository
+                      <FolderOpen size={14} aria-hidden="true" />
+                      <span>Open Repository</span>
                     </button>
                   )}
                   <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onPullChanges?.(); }}>
-                    Pull Changes
+                    <ArrowDownToLine size={14} aria-hidden="true" />
+                    <span>Pull Changes</span>
                   </button>
                 </div>
 
@@ -307,7 +317,8 @@ export function ParticipationActions({
                             className={styles.cloneUrlPrimary}
                             onClick={() => { setIsDropdownOpen(false); onCopyCloneUrl(); }}
                           >
-                            Copy Clone URL
+                            <Link size={14} aria-hidden="true" />
+                            <span>Copy Clone URL</span>
                           </button>
                           <button
                             className={styles.cloneUrlSecondary}
@@ -324,14 +335,16 @@ export function ParticipationActions({
                           className={styles.dropdownItem}
                           onClick={() => { setIsDropdownOpen(false); onCopyCloneUrl(); }}
                         >
-                          Copy Clone URL
+                          <Link size={14} aria-hidden="true" />
+                          <span>Copy Clone URL</span>
                         </button>
                       ) : (
                         <button
                           className={styles.dropdownItem}
                           onClick={() => { setIsDropdownOpen(false); onCopyAuthenticatedCloneUrl?.(); }}
                         >
-                          Copy Clone URL with Token
+                          <KeyRound size={14} aria-hidden="true" />
+                          <span>Copy Clone URL with Token</span>
                         </button>
                       )}
                     </div>
@@ -342,7 +355,8 @@ export function ParticipationActions({
                 <div className={styles.dropdownDivider} />
                 <div className={styles.dropdownSection}>
                   <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenInBrowser?.(); }}>
-                    Open in browser
+                    <ExternalLink size={14} aria-hidden="true" />
+                    <span>Open in browser</span>
                   </button>
                 </div>
               </div>

--- a/extension/src/webview/components/exercise/ParticipationActions.tsx
+++ b/extension/src/webview/components/exercise/ParticipationActions.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import FlaskConical from 'lucide-react/dist/esm/icons/flask-conical';
+import KeyRound from 'lucide-react/dist/esm/icons/key-round';
 import Mail from 'lucide-react/dist/esm/icons/mail';
 import { useEffect, useRef, useState } from 'react';
 
@@ -272,35 +273,78 @@ export function ParticipationActions({
             </Button>
             {isDropdownOpen && (
               <div className={styles.moreDropdown}>
-                {isWorkspaceConnected && (
-                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onClone?.(); }}>
-                    Clone Repository
+                {/* Section: Workspace */}
+                <div className={styles.dropdownSection}>
+                  {isWorkspaceConnected && (
+                    <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onClone?.(); }}>
+                      Clone Repository
+                    </button>
+                  )}
+                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onCheckWorkspace?.(); }}>
+                    Check workspace status
                   </button>
-                )}
-                <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onCheckWorkspace?.(); }}>
-                  Check workspace status
-                </button>
-                {onOpenRepository && (
-                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenRepository(); }}>
-                    Open Repository
+                  {onOpenRepository && (
+                    <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenRepository(); }}>
+                      Open Repository
+                    </button>
+                  )}
+                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onPullChanges?.(); }}>
+                    Pull Changes
                   </button>
+                </div>
+
+                {/* Section: Share (only when at least one copy callback is available).
+                    Split-button when BOTH copy callbacks are provided.
+                    Single full-width item when only one is provided (preserves
+                    visible label + focus target). */}
+                {(onCopyCloneUrl || onCopyAuthenticatedCloneUrl) && (
+                  <>
+                    <div className={styles.dropdownDivider} />
+                    <div className={styles.dropdownSection}>
+                      {onCopyCloneUrl && onCopyAuthenticatedCloneUrl ? (
+                        <div className={styles.cloneUrlItem}>
+                          <button
+                            className={styles.cloneUrlPrimary}
+                            onClick={() => { setIsDropdownOpen(false); onCopyCloneUrl(); }}
+                          >
+                            Copy Clone URL
+                          </button>
+                          <button
+                            className={styles.cloneUrlSecondary}
+                            onClick={() => { setIsDropdownOpen(false); onCopyAuthenticatedCloneUrl(); }}
+                            title="Copy Clone URL with authentication token"
+                            aria-label="Copy Clone URL with authentication token"
+                          >
+                            <KeyRound size={14} aria-hidden="true" />
+                            <span>with token</span>
+                          </button>
+                        </div>
+                      ) : onCopyCloneUrl ? (
+                        <button
+                          className={styles.dropdownItem}
+                          onClick={() => { setIsDropdownOpen(false); onCopyCloneUrl(); }}
+                        >
+                          Copy Clone URL
+                        </button>
+                      ) : (
+                        <button
+                          className={styles.dropdownItem}
+                          onClick={() => { setIsDropdownOpen(false); onCopyAuthenticatedCloneUrl?.(); }}
+                        >
+                          Copy Clone URL with Token
+                        </button>
+                      )}
+                    </div>
+                  </>
                 )}
-                <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onPullChanges?.(); }}>
-                  Pull Changes
-                </button>
-                {onCopyCloneUrl && (
-                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onCopyCloneUrl(); }}>
-                    Copy Clone URL
+
+                {/* Section: External */}
+                <div className={styles.dropdownDivider} />
+                <div className={styles.dropdownSection}>
+                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenInBrowser?.(); }}>
+                    Open in browser
                   </button>
-                )}
-                {onCopyAuthenticatedCloneUrl && (
-                  <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onCopyAuthenticatedCloneUrl(); }}>
-                    Copy Clone URL with Token
-                  </button>
-                )}
-                <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenInBrowser?.(); }}>
-                  Open in browser
-                </button>
+                </div>
               </div>
             )}
           </div>

--- a/extension/test/react/components/exercise/ParticipationActions.test.tsx
+++ b/extension/test/react/components/exercise/ParticipationActions.test.tsx
@@ -212,10 +212,9 @@ describe('ParticipationActions', () => {
 				/>
 			);
 			await userEvent.click(screen.getByRole('button', { name: /More options/ }));
-			// The dropdown Clone is a plain <button>, not a Button component
-			const dropdownClone = screen.getByText('Clone Repository');
-			expect(dropdownClone).toBeInTheDocument();
-			expect(dropdownClone.tagName).toBe('BUTTON');
+			// The dropdown Clone is a plain <button>, not a Button component.
+			// Use getByRole so the assertion is robust to icon children inside the button.
+			expect(screen.getByRole('button', { name: 'Clone Repository' })).toBeInTheDocument();
 		});
 
 		it('shows "Check workspace status" in dropdown', async () => {

--- a/extension/test/react/components/exercise/ParticipationActions.test.tsx
+++ b/extension/test/react/components/exercise/ParticipationActions.test.tsx
@@ -278,6 +278,138 @@ describe('ParticipationActions', () => {
 		});
 	});
 
+	describe('Copy Clone URL entries', () => {
+		it('renders split-button (primary + secondary) when both copy callbacks are provided', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyCloneUrl={vi.fn()}
+					onCopyAuthenticatedCloneUrl={vi.fn()}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.getByRole('button', { name: 'Copy Clone URL' })).toBeInTheDocument();
+			expect(
+				screen.getByRole('button', { name: /Copy Clone URL with authentication token/i }),
+			).toBeInTheDocument();
+		});
+
+		it('renders a single full-width "Copy Clone URL" item when only onCopyCloneUrl is provided', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyCloneUrl={vi.fn()}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.getByRole('button', { name: 'Copy Clone URL' })).toBeInTheDocument();
+			expect(
+				screen.queryByRole('button', { name: /Copy Clone URL with authentication token/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it('renders a single full-width "Copy Clone URL with Token" item when only onCopyAuthenticatedCloneUrl is provided', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyAuthenticatedCloneUrl={vi.fn()}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.getByRole('button', { name: 'Copy Clone URL with Token' })).toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Copy Clone URL' })).not.toBeInTheDocument();
+		});
+
+		it('split-button primary click calls onCopyCloneUrl, closes dropdown, does not call auth callback', async () => {
+			const handleCopy = vi.fn();
+			const handleCopyAuth = vi.fn();
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyCloneUrl={handleCopy}
+					onCopyAuthenticatedCloneUrl={handleCopyAuth}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			await userEvent.click(screen.getByRole('button', { name: 'Copy Clone URL' }));
+
+			expect(handleCopy).toHaveBeenCalledOnce();
+			expect(handleCopyAuth).not.toHaveBeenCalled();
+			expect(screen.queryByRole('button', { name: 'Copy Clone URL' })).not.toBeInTheDocument();
+		});
+
+		it('split-button secondary click calls onCopyAuthenticatedCloneUrl, closes dropdown, does not call primary callback', async () => {
+			const handleCopy = vi.fn();
+			const handleCopyAuth = vi.fn();
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyCloneUrl={handleCopy}
+					onCopyAuthenticatedCloneUrl={handleCopyAuth}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			await userEvent.click(
+				screen.getByRole('button', { name: /Copy Clone URL with authentication token/i }),
+			);
+
+			expect(handleCopyAuth).toHaveBeenCalledOnce();
+			expect(handleCopy).not.toHaveBeenCalled();
+			expect(
+				screen.queryByRole('button', { name: /Copy Clone URL with authentication token/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it('single auth-only item click calls onCopyAuthenticatedCloneUrl', async () => {
+			const handleCopyAuth = vi.fn();
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					onCopyAuthenticatedCloneUrl={handleCopyAuth}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			await userEvent.click(screen.getByRole('button', { name: 'Copy Clone URL with Token' }));
+
+			expect(handleCopyAuth).toHaveBeenCalledOnce();
+		});
+
+		it('hides the Share section entirely when neither copy callback is provided', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.queryByRole('button', { name: 'Copy Clone URL' })).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Copy Clone URL with Token' })).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole('button', { name: /Copy Clone URL with authentication token/i }),
+			).not.toBeInTheDocument();
+		});
+	});
+
 	describe('more options dropdown', () => {
 		it('toggles dropdown open and closed on click', async () => {
 			render(


### PR DESCRIPTION
Closes #210.

## Changes

Restructure the "More options" dropdown in `ParticipationActions`:

**Three visual sections** (Workspace / Share / External) separated by dividers, replacing the previous per-item `border-bottom`.

**Copy URL split-button:** the two "Copy Clone URL" entries become one item with a split-button layout when both callbacks are provided. Primary click copies the plain URL, secondary click (KeyRound icon + "with token" label) copies the token-authenticated URL.

**Single-callback fallback:** when only one of the two copy callbacks is provided, the section renders a single full-width dropdown item with the complete visible label ("Copy Clone URL" or "Copy Clone URL with Token"). This preserves the previous full-width target and screen-reader semantics. The Share section is hidden entirely when neither callback is set.

**Out of scope:** the actions themselves are unchanged.

## Tests

Existing tests for the other dropdown items (Clone Repository, Check workspace status, Open Repository, Pull Changes, Open in browser) are unaffected.

The "Copy Clone URL entries" describe block expanded from 5 to 7 cases:

1. Split-button renders when both callbacks are provided.
2. Single full-width "Copy Clone URL" item when only `onCopyCloneUrl`.
3. Single full-width "Copy Clone URL with Token" item when only `onCopyAuthenticatedCloneUrl`.
4. Split-button primary click calls `onCopyCloneUrl`, closes dropdown, does not call auth callback.
5. Split-button secondary click calls `onCopyAuthenticatedCloneUrl`, closes dropdown, does not call primary.
6. Single auth-only item click calls `onCopyAuthenticatedCloneUrl`.
7. Share section hidden when neither callback is provided.

## Validation

- 37 `ParticipationActions` tests pass (up from 35).
- 730 vitest tests pass total.
- `tsc --noEmit` clean.
- `eslint` clean on touched files.

## Issue correction

Issue #210 described "Clone Repository" as duplicating the primary button when not connected. The code actually shows the dropdown item only when `isWorkspaceConnected` and the primary button only when `!isWorkspaceConnected`, so there is no duplication. The dropdown entry is a "re-clone" affordance and remains unchanged.

## Codex review

Reviewed via codex in two turns. The first turn caught an auth-only regression (single secondary button without primary would shrink to content-width). Addressed by the three-way branching above. Second-turn explicit approval: "Both concerns are resolved."