### PR TITLE
refactor(websocket): decompose ArtemisWebsocketService (god class 3/3) (#207)

### DIFF
--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -1,18 +1,18 @@
 import * as vscode from 'vscode';
-import { Client, IMessage, StompConfig, StompSubscription } from '@stomp/stompjs';
+import { Client, StompConfig } from '@stomp/stompjs';
 
 import type { WebSocketDisplayStatus } from '@shared/messageContracts';
 
 import { AuthManager } from '@extension/services/auth';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { WebSocketMessageHandler } from '@extension/types';
-import { parseProgrammingSubmission, parseResultDTO, parseSubmissionProcessingMessage } from '@extension/types';
-import { resolveServerUrl, WEBSOCKET_TOPICS } from '@extension/utils';
+import { resolveServerUrl } from '@extension/utils';
 
 import type { ConnectionState } from './connectionState';
 import { deriveDisplayStatus } from './displayStatus';
 import { extractJwtFromHeaders } from './jwtExtractor';
 import { buildStompConfig } from './stompConfigBuilder';
+import { SubscriptionRegistry } from './subscriptionRegistry';
 import { buildWebSocketUrl } from './webSocketUrl';
 
 interface Deferred<T> {
@@ -50,9 +50,8 @@ export class ArtemisWebsocketService {
     private _wasConnectedOnce: boolean = false;
     private _connectionStateDebounceTimer?: ReturnType<typeof setTimeout>;
 
-    private _subscriptions: Map<string, StompSubscription> = new Map();
+    private readonly _subscriptions = new SubscriptionRegistry({ log: (m) => this._log(m) });
     private _sessionId: string = '';
-    private _messageHandlers: WebSocketMessageHandler[] = [];
 
     private readonly _onDidChangeConnectionState = new vscode.EventEmitter<{ connected: boolean; wasEverConnected: boolean }>();
     public readonly onDidChangeConnectionState = this._onDidChangeConnectionState.event;
@@ -73,17 +72,12 @@ export class ArtemisWebsocketService {
 
     /** Register a message handler for WebSocket events. */
     public registerMessageHandler(handler: WebSocketMessageHandler): void {
-        if (this._messageHandlers.includes(handler)) { return; }
-        this._messageHandlers.push(handler);
-        this._log(`Message handler registered. Total handlers: ${this._messageHandlers.length}`);
+        this._subscriptions.registerMessageHandler(handler);
     }
 
     /** Unregister a previously registered message handler. */
     public unregisterMessageHandler(handler: WebSocketMessageHandler): void {
-        const index = this._messageHandlers.indexOf(handler);
-        if (index !== -1) {
-            this._messageHandlers.splice(index, 1);
-        }
+        this._subscriptions.unregisterMessageHandler(handler);
     }
 
     /** Check if the WebSocket is currently connected. */
@@ -178,7 +172,8 @@ export class ArtemisWebsocketService {
         if (!this._client) { return; }
         this._log('Deactivating existing connection before reconnect');
         await this._client.deactivate();
-        this._clearSubscriptions();
+        this._subscriptions.clearAll();
+        this._subscriptions.detachClient();
         this._client = undefined;
     }
 
@@ -223,7 +218,8 @@ export class ArtemisWebsocketService {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         this._log(`❌ Failed to connect to WebSocket: ${errorMessage}`);
         logger.error(`Failed to connect to WebSocket: ${errorMessage}`, LogCategory.WEBSOCKET);
-        this._clearSubscriptions();
+        this._subscriptions.clearAll();
+        this._subscriptions.detachClient();
         this._transitionTo('disconnected');
         const settleError = error instanceof Error ? error : new Error(String(error));
         this._settleDeferred(settleError);
@@ -277,7 +273,8 @@ export class ArtemisWebsocketService {
 
         if (this._client) {
             this._log('Disconnecting from Artemis WebSocket (intentional)');
-            this._clearSubscriptions();
+            this._subscriptions.clearAll();
+            this._subscriptions.detachClient();
 
             try {
                 await this._client.deactivate();
@@ -297,109 +294,24 @@ export class ArtemisWebsocketService {
         this._transitionTo('disconnected');
     }
 
-    private _subscribeToTopic<T>(
-        topic: string,
-        parser: (data: unknown) => T,
-        dispatch: (handler: WebSocketMessageHandler, parsed: T) => void,
-        logFormatter: (parsed: T) => string,
-    ): void {
-        if (this._connectionState !== 'connected' || !this._client) {
-            this._log('Cannot subscribe: not connected');
-            return;
-        }
-
-        if (this._subscriptions.has(topic)) {
-            this._log(`Already subscribed to ${topic}`);
-            return;
-        }
-
-        const subscription = this._client.subscribe(topic, (message: IMessage) => {
-            try {
-                const parsed = parser(JSON.parse(message.body));
-                this._log(logFormatter(parsed));
-                [...this._messageHandlers].forEach(handler => dispatch(handler, parsed));
-            } catch (error) {
-                const stack = error instanceof Error ? error.stack : String(error);
-                this._log(`Error processing message on ${topic}: ${stack}`);
-            }
-        });
-
-        this._subscriptions.set(topic, subscription);
-        this._log(`Subscribed to ${topic}`);
-    }
-
     /** Subscribe to personal result updates for the authenticated user. */
     public subscribeToPersonalResults(): void {
-        this._subscribeToTopic(
-            WEBSOCKET_TOPICS.NEW_RESULTS,
-            (data) => parseResultDTO(data),
-            (handler, result) => handler.onNewResult?.(result),
-            (result) => `Received new result: score=${result.score}, successful=${result.successful}`,
-        );
+        this._subscriptions.subscribeToPersonalResults();
     }
 
     /** Subscribe to personal submission updates. */
     public subscribeToPersonalSubmissions(): void {
-        this._subscribeToTopic(
-            WEBSOCKET_TOPICS.NEW_SUBMISSIONS,
-            (data) => parseProgrammingSubmission(data),
-            (handler, submission) => handler.onNewSubmission?.(submission),
-            (submission) => `Received new submission: ${submission.id}`,
-        );
+        this._subscriptions.subscribeToPersonalSubmissions();
     }
 
     /** Subscribe to submission processing updates (build status). */
     public subscribeToSubmissionProcessing(): void {
-        this._subscribeToTopic(
-            WEBSOCKET_TOPICS.SUBMISSION_PROCESSING,
-            (data) => parseSubmissionProcessingMessage(data),
-            (handler, msg) => handler.onSubmissionProcessing?.(msg),
-            (msg) => `Received submission processing update: participationId=${msg.participationId}`,
-        );
+        this._subscriptions.subscribeToSubmissionProcessing();
     }
 
     /** Subscribe to Iris chat session updates for the given session ID. */
     public subscribeToIrisSession(sessionId: number, onMessage: (message: unknown) => void): () => void {
-        if (this._connectionState !== 'connected' || !this._client) {
-            this._log('Cannot subscribe: not connected');
-            throw new Error('WebSocket not connected');
-        }
-
-        // Use /user/topic/ prefix for user-specific authenticated messages
-        const topic = WEBSOCKET_TOPICS.irisSession(sessionId);
-
-        // Replace stale subscription if one exists (e.g. after reconnect)
-        if (this._subscriptions.has(topic)) {
-            this._log(`Replacing existing subscription for ${topic}`);
-            const oldSub = this._subscriptions.get(topic);
-            try { oldSub?.unsubscribe(); } catch { /* stale sub, ignore */ }
-            this._subscriptions.delete(topic);
-        }
-
-        const subscription = this._client.subscribe(topic, (message: IMessage) => {
-            try {
-                const data: unknown = JSON.parse(message.body);
-                this._log(`Received Iris message for session ${sessionId}`);
-                onMessage(data);
-            } catch (error) {
-                const stack = error instanceof Error ? error.stack : String(error);
-                this._log(`Error processing Iris message: ${stack}`);
-                logger.error('Full error processing Iris message', LogCategory.WEBSOCKET, error as Error);
-            }
-        });
-
-        this._subscriptions.set(topic, subscription);
-        this._log(`✅ Subscribed to Iris session: ${topic}`);
-
-        // Return unsubscribe function — capture ref to guard against stale closures
-        const capturedSub = subscription;
-        return () => {
-            capturedSub.unsubscribe();
-            if (this._subscriptions.get(topic) === capturedSub) {
-                this._subscriptions.delete(topic);
-            }
-            this._log(`Unsubscribed from ${topic}`);
-        };
+        return this._subscriptions.subscribeToIrisSession(sessionId, onMessage);
     }
 
     /** Public read-only accessor for connection state. */
@@ -441,7 +353,7 @@ export class ArtemisWebsocketService {
             clientConnected: this._client?.connected ?? false,
             clientActive: this._client?.active ?? false,
             subscriptionCount: this._subscriptions.size,
-            subscriptions: Array.from(this._subscriptions.keys()),
+            subscriptions: this._subscriptions.topics,
             reconnectAttempts: this._reconnectAttempts,
             maxReconnectAttempts: MAX_CONNECTION_ATTEMPTS,
             sessionId: this._sessionId,
@@ -454,27 +366,13 @@ export class ArtemisWebsocketService {
     public dispose(): void {
         this._log('Disposing WebSocket service');
         this._onDidChangeConnectionState.dispose();
-        this._messageHandlers = [];
+        this._subscriptions.clearMessageHandlers();
 
         if (this._connectionStateDebounceTimer) {
             clearTimeout(this._connectionStateDebounceTimer);
             this._connectionStateDebounceTimer = undefined;
         }
         void this.disconnect().catch(err => this._log(`Error during disconnect in dispose: ${err}`));
-    }
-
-    // Private helper methods
-
-    private _clearSubscriptions(): void {
-        this._subscriptions.forEach((subscription, topic) => {
-            try {
-                subscription.unsubscribe();
-                this._log(`Unsubscribed from ${topic}`);
-            } catch {
-                // Stale subscription after disconnect — safe to ignore
-            }
-        });
-        this._subscriptions.clear();
     }
 
     private _onConnected(): void {
@@ -499,6 +397,13 @@ export class ArtemisWebsocketService {
         }
 
         this._log('✅ Connected to Artemis WebSocket');
+
+        // Attach client to registry BEFORE firing the connected event.
+        // Synchronous consumers (e.g. IrisWebSocketSessionClient) may call
+        // subscribeToIrisSession during the fire callback; the registry must
+        // already own a client at that moment. Auto-subscribes below also
+        // rely on an attached client.
+        this._subscriptions.attachClient(this._client!);
 
         // Immediately notify of connection (no delay for connect events)
         this._onDidChangeConnectionState.fire({ connected: true, wasEverConnected: this._wasConnectedOnce });
@@ -529,8 +434,9 @@ export class ArtemisWebsocketService {
 
         // Transition to disconnected if we were connected
         if (this._connectionState === 'connected') {
+            this._subscriptions.detachClient();
             this._transitionTo('disconnected');
-            this._clearSubscriptions();
+            this._subscriptions.clearAll();
             this._log('Disconnected from Artemis WebSocket');
         }
 
@@ -567,8 +473,9 @@ export class ArtemisWebsocketService {
     private _onError(message: string): void {
         this._log(`❌ ${message}`);
         logger.error(message, LogCategory.WEBSOCKET);
+        this._subscriptions.detachClient();
         this._settleDeferred(new Error(message));
-        this._clearSubscriptions();
+        this._subscriptions.clearAll();
         this._transitionTo('disconnected');
     }
 

--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -88,8 +88,9 @@ export class ArtemisWebsocketService {
                 log: (m) => this._log(m),
             }));
             // Note: NO attachClient() here. The registry attaches only inside
-            // _onStompConnected (after recordConnected) so "client attached"
-            // is equivalent to "state === 'connected'" by construction.
+            // _onStompConnected (immediately before recordConnected fires the
+            // public event) so synchronous consumers reacting to the connected
+            // event always observe an attached registry.
         } catch (error) {
             const err = error instanceof Error ? error : new Error(String(error));
             this._log(`❌ Failed to connect to WebSocket: ${err.message}`);

--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import { Client, IFrame, IMessage, ReconnectionTimeMode, StompConfig, StompSubscription } from '@stomp/stompjs';
-import WebSocket from 'ws';
+import { Client, IMessage, StompConfig, StompSubscription } from '@stomp/stompjs';
 
 import type { WebSocketDisplayStatus } from '@shared/messageContracts';
 
@@ -8,11 +7,12 @@ import { AuthManager } from '@extension/services/auth';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { WebSocketMessageHandler } from '@extension/types';
 import { parseProgrammingSubmission, parseResultDTO, parseSubmissionProcessingMessage } from '@extension/types';
-import { getUserAgent, resolveServerUrl, WEBSOCKET_TOPICS } from '@extension/utils';
+import { resolveServerUrl, WEBSOCKET_TOPICS } from '@extension/utils';
 
 import type { ConnectionState } from './connectionState';
 import { deriveDisplayStatus } from './displayStatus';
 import { extractJwtFromHeaders } from './jwtExtractor';
+import { buildStompConfig } from './stompConfigBuilder';
 import { buildWebSocketUrl } from './webSocketUrl';
 
 interface Deferred<T> {
@@ -34,11 +34,6 @@ const SAFETY_TIMEOUT_MS = 15000;
 const CONNECTION_STATE_DELAY_MS = 5000;
 
 const MAX_CONNECTION_ATTEMPTS = 20;
-
-const INITIAL_RECONNECT_DELAY_MS = 500;
-const MAX_RECONNECT_DELAY_MS = 10000;
-const CONNECTION_TIMEOUT_MS = 10000;
-const HEARTBEAT_INTERVAL_MS = 10000;
 
 /**
  * Manages STOMP/WebSocket connections to Artemis for real-time updates
@@ -123,7 +118,18 @@ export class ArtemisWebsocketService {
         try {
             await this._teardownExistingClient();
             const { authHeaders, wsUrl } = await this._prepareConnectionContext();
-            this._client = this._createClient(this._buildStompConfig(generation, authHeaders, wsUrl));
+            this._client = this._createClient(buildStompConfig({
+                generation,
+                authHeaders,
+                wsUrl,
+                currentGeneration: () => this._connectionGeneration,
+                onConnected: () => this._onConnected(),
+                onStompError: (msg) => this._onError(msg),
+                onWebSocketError: (msg) => this._onError(msg),
+                onDisconnected: () => this._onDisconnected(),
+                onWebSocketBeforeOpen: () => { this._disconnectCountedThisAttempt = false; },
+                log: (msg) => this._log(msg),
+            }));
         } catch (error) {
             this._handleConnectError(error);
             throw error;
@@ -205,73 +211,6 @@ export class ArtemisWebsocketService {
         const wsUrl = buildWebSocketUrl(serverUrl);
         this._log(`Connecting to ${wsUrl}`);
         return { authHeaders, wsUrl };
-    }
-
-    private _buildStompConfig(
-        generation: number,
-        authHeaders: Record<string, string>,
-        wsUrl: string,
-    ): StompConfig {
-        this._log(`Reconnect config: delay=${INITIAL_RECONNECT_DELAY_MS}ms, timeout=${CONNECTION_TIMEOUT_MS}ms, heartbeat=${HEARTBEAT_INTERVAL_MS}ms`);
-
-        return {
-            brokerURL: wsUrl,
-            connectHeaders: {},
-            reconnectDelay: INITIAL_RECONNECT_DELAY_MS,
-            reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
-            maxReconnectDelay: MAX_RECONNECT_DELAY_MS,
-            connectionTimeout: CONNECTION_TIMEOUT_MS,
-            // Must match Artemis server heartbeat (10s)
-            heartbeatIncoming: HEARTBEAT_INTERVAL_MS,
-            heartbeatOutgoing: HEARTBEAT_INTERVAL_MS,
-            discardWebsocketOnCommFailure: true,
-
-            webSocketFactory: () => {
-                this._disconnectCountedThisAttempt = false;
-                const ws = new WebSocket(wsUrl, {
-                    headers: {
-                        ...authHeaders,
-                        'User-Agent': getUserAgent(),
-                    },
-                });
-
-                ws.on('error', (err) => {
-                    this._log(`WebSocket error: ${err.message}`);
-                });
-
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return -- STOMP library expects generic WebSocket type
-                return ws as any;
-            },
-
-            onConnect: () => {
-                if (this._connectionGeneration !== generation) { return; }
-                this._onConnected();
-            },
-
-            onStompError: (frame: IFrame) => {
-                if (this._connectionGeneration !== generation) { return; }
-                const body = frame.body ? ` body=${frame.body.substring(0, 500)}` : '';
-                this._onError(`STOMP error: ${frame.headers['message']}${body}`);
-            },
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- STOMP library onWebSocketError uses generic event type
-            onWebSocketError: (event: any) => {
-                if (this._connectionGeneration !== generation) { return; }
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- event shape is untyped
-                const detail = event?.message || event?.type || 'unknown';
-                this._onError(`WebSocket error: ${detail}`);
-            },
-
-            onDisconnect: () => {
-                if (this._connectionGeneration !== generation) { return; }
-                this._onDisconnected();
-            },
-
-            onWebSocketClose: () => {
-                if (this._connectionGeneration !== generation) { return; }
-                this._onDisconnected();
-            },
-        };
     }
 
     /**

--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -8,10 +8,12 @@ import { AuthManager } from '@extension/services/auth';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { WebSocketMessageHandler } from '@extension/types';
 import { parseProgrammingSubmission, parseResultDTO, parseSubmissionProcessingMessage } from '@extension/types';
-import { CONFIG, getUserAgent, resolveServerUrl, WEBSOCKET_TOPICS } from '@extension/utils';
+import { getUserAgent, resolveServerUrl, WEBSOCKET_TOPICS } from '@extension/utils';
 
 import type { ConnectionState } from './connectionState';
 import { deriveDisplayStatus } from './displayStatus';
+import { extractJwtFromHeaders } from './jwtExtractor';
+import { buildWebSocketUrl } from './webSocketUrl';
 
 interface Deferred<T> {
     promise: Promise<T>;
@@ -194,13 +196,13 @@ export class ArtemisWebsocketService {
         // Validation only: the JWT itself isn't forwarded as a STOMP connect
         // header (connectHeaders stays empty); we just want to fail fast when
         // the cookie carries no usable token.
-        if (!this._extractJwtFromHeaders(authHeaders)) {
+        if (!extractJwtFromHeaders(authHeaders)) {
             const errorMsg = 'Failed to extract JWT token from auth headers';
             this._log(`⚠️ ${errorMsg}`);
             throw new Error(errorMsg);
         }
 
-        const wsUrl = this._buildWebSocketUrl(serverUrl);
+        const wsUrl = buildWebSocketUrl(serverUrl);
         this._log(`Connecting to ${wsUrl}`);
         return { authHeaders, wsUrl };
     }
@@ -505,7 +507,7 @@ export class ArtemisWebsocketService {
             maxReconnectAttempts: MAX_CONNECTION_ATTEMPTS,
             sessionId: this._sessionId,
             serverUrl,
-            websocketUrl: this._buildWebSocketUrl(serverUrl),
+            websocketUrl: buildWebSocketUrl(serverUrl),
         };
     }
 
@@ -629,33 +631,6 @@ export class ArtemisWebsocketService {
         this._settleDeferred(new Error(message));
         this._clearSubscriptions();
         this._transitionTo('disconnected');
-    }
-
-    private _buildWebSocketUrl(serverUrl: string): string {
-        // Convert HTTP(S) URL to WS(S) URL
-        const url = new URL(serverUrl);
-        const protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-
-        // Artemis uses /websocket/websocket to bypass SockJS and use STOMP directly
-        const wsEndpoint = `${protocol}//${url.host}/websocket/websocket`;
-
-        this._log(`Using direct STOMP endpoint (no SockJS): ${wsEndpoint}`);
-        return wsEndpoint;
-    }
-
-    private _extractJwtFromHeaders(headers: Record<string, string>): string | undefined {
-        const bearer = headers['Authorization'];
-        if (bearer) {
-            return bearer.replace(/^Bearer\s+/, '');
-        }
-
-        const cookie = headers['Cookie'];
-        if (cookie) {
-            const jwtMatch = cookie.match(new RegExp(`${CONFIG.AUTH_COOKIE_NAME}=([^;]+)`));
-            return jwtMatch ? jwtMatch[1] : undefined;
-        }
-
-        return undefined;
     }
 
     private _transitionTo(newState: ConnectionState): void {

--- a/extension/src/extension/services/websocket/artemisWebsocketService.ts
+++ b/extension/src/extension/services/websocket/artemisWebsocketService.ts
@@ -8,6 +8,7 @@ import { LogCategory, logger } from '@extension/services/loggingService';
 import type { WebSocketMessageHandler } from '@extension/types';
 import { resolveServerUrl } from '@extension/utils';
 
+import { ConnectionLifecycle, MAX_CONNECTION_ATTEMPTS } from './connectionLifecycle';
 import type { ConnectionState } from './connectionState';
 import { deriveDisplayStatus } from './displayStatus';
 import { extractJwtFromHeaders } from './jwtExtractor';
@@ -15,100 +16,62 @@ import { buildStompConfig } from './stompConfigBuilder';
 import { SubscriptionRegistry } from './subscriptionRegistry';
 import { buildWebSocketUrl } from './webSocketUrl';
 
-interface Deferred<T> {
-    promise: Promise<T>;
-    resolve: (value: T) => void;
-    reject: (error: Error) => void;
-}
-
-function createDeferred<T>(): Deferred<T> {
-    let resolve!: (value: T) => void;
-    let reject!: (error: Error) => void;
-    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
-    return { promise, resolve, reject };
-}
-
-const SAFETY_TIMEOUT_MS = 15000;
-
-/** Matches Artemis webapp CONNECTION_STATE_DELAY_MS. */
-const CONNECTION_STATE_DELAY_MS = 5000;
-
-const MAX_CONNECTION_ATTEMPTS = 20;
-
 /**
  * Manages STOMP/WebSocket connections to Artemis for real-time updates
  * (submissions, results, build status, Iris chat).
+ *
+ * The service is a thin coordinator. The connection state machine lives in
+ * {@link ConnectionLifecycle}. Topic subscriptions live in
+ * {@link SubscriptionRegistry}. STOMP `Client` config is built by
+ * {@link buildStompConfig}. The service owns only:
+ *   - the STOMP `Client` instance,
+ *   - the `AuthManager` reference,
+ *   - a per-connection session id (debug-only),
+ *   - the `vscode.EventEmitter` exposed to consumers.
  */
 export class ArtemisWebsocketService {
     private _client?: Client;
-    private _authManager: AuthManager;
-    private _connectionState: ConnectionState = 'disconnected';
-    private _connectionGeneration: number = 0;
-    private _reconnectAttempts: number = 0;
-    private _disconnectCountedThisAttempt = false;
-
-    private _wasConnectedOnce: boolean = false;
-    private _connectionStateDebounceTimer?: ReturnType<typeof setTimeout>;
-
-    private readonly _subscriptions = new SubscriptionRegistry({ log: (m) => this._log(m) });
-    private _sessionId: string = '';
-
+    private readonly _authManager: AuthManager;
+    private _sessionId: string;
+    private readonly _subscriptions: SubscriptionRegistry;
+    private readonly _lifecycle: ConnectionLifecycle;
     private readonly _onDidChangeConnectionState = new vscode.EventEmitter<{ connected: boolean; wasEverConnected: boolean }>();
     public readonly onDidChangeConnectionState = this._onDidChangeConnectionState.event;
-
-    private _connectDeferred?: Deferred<void>;
-    private _safetyTimeout?: ReturnType<typeof setTimeout>;
 
     constructor(authManager: AuthManager) {
         this._authManager = authManager;
         this._sessionId = this._generateSecureSessionId();
+        this._subscriptions = new SubscriptionRegistry({ log: (m) => this._log(m) });
+        this._lifecycle = new ConnectionLifecycle({
+            log: (m) => this._log(m),
+            onDidChangeConnectionState: (evt) => this._onDidChangeConnectionState.fire(evt),
+        });
     }
 
-    private _generateSecureSessionId(): string {
-        const bytes = new Uint8Array(6);
-        crypto.getRandomValues(bytes);
-        return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+    public registerMessageHandler(h: WebSocketMessageHandler): void { this._subscriptions.registerMessageHandler(h); }
+    public unregisterMessageHandler(h: WebSocketMessageHandler): void { this._subscriptions.unregisterMessageHandler(h); }
+    public subscribeToPersonalResults(): void { this._subscriptions.subscribeToPersonalResults(); }
+    public subscribeToPersonalSubmissions(): void { this._subscriptions.subscribeToPersonalSubmissions(); }
+    public subscribeToSubmissionProcessing(): void { this._subscriptions.subscribeToSubmissionProcessing(); }
+    public subscribeToIrisSession(id: number, onMessage: (m: unknown) => void): () => void {
+        return this._subscriptions.subscribeToIrisSession(id, onMessage);
     }
 
-    /** Register a message handler for WebSocket events. */
-    public registerMessageHandler(handler: WebSocketMessageHandler): void {
-        this._subscriptions.registerMessageHandler(handler);
-    }
-
-    /** Unregister a previously registered message handler. */
-    public unregisterMessageHandler(handler: WebSocketMessageHandler): void {
-        this._subscriptions.unregisterMessageHandler(handler);
-    }
-
-    /** Check if the WebSocket is currently connected. */
     public isConnected(): boolean {
-        return this._connectionState === 'connected' && this._client?.connected === true;
+        return this._lifecycle.state === 'connected' && this._client?.connected === true;
     }
 
-    /** Current number of reconnect attempts. */
-    public get reconnectAttempts(): number {
-        return this._reconnectAttempts;
-    }
+    public get reconnectAttempts(): number { return this._lifecycle.reconnectAttempts; }
+    public get connectionState(): ConnectionState { return this._lifecycle.state; }
 
-    /** Reset connection state to allow retrying after giving up. */
-    public resetConnectionState(): void {
-        this._log('Resetting connection state');
-        this._reconnectAttempts = 0;
-        this._transitionTo('disconnected');
-    }
+    public resetConnectionState(): void { this._lifecycle.reset(); }
 
-    /** Connect to the Artemis WebSocket server. */
     public async connect(): Promise<void> {
-        const reuse = this._maybeReuseInflightConnect();
-        if (reuse !== undefined) { return reuse; }
+        const clientInflight = !!(this._client?.active && !this._client.connected);
+        const begin = this._lifecycle.beginConnect({ clientInflight });
+        if (begin.kind === 'reuse') { return begin.promise; }
 
-        this._transitionTo('connecting');
-        // Generation bumped before deactivation so old lifecycle callbacks are ignored
-        const generation = ++this._connectionGeneration;
-
-        this._connectDeferred = createDeferred<void>();
-        this._startSafetyTimeout();
-
+        const { generation, promise } = begin;
         try {
             await this._teardownExistingClient();
             const { authHeaders, wsUrl } = await this._prepareConnectionContext();
@@ -116,227 +79,75 @@ export class ArtemisWebsocketService {
                 generation,
                 authHeaders,
                 wsUrl,
-                currentGeneration: () => this._connectionGeneration,
-                onConnected: () => this._onConnected(),
-                onStompError: (msg) => this._onError(msg),
-                onWebSocketError: (msg) => this._onError(msg),
-                onDisconnected: () => this._onDisconnected(),
-                onWebSocketBeforeOpen: () => { this._disconnectCountedThisAttempt = false; },
-                log: (msg) => this._log(msg),
+                currentGeneration: () => this._lifecycle.generation,
+                onConnected: () => this._onStompConnected(),
+                onStompError: (msg) => this._onStompError(msg),
+                onWebSocketError: (msg) => this._onStompError(msg),
+                onDisconnected: () => this._onStompDisconnected(),
+                onWebSocketBeforeOpen: () => this._lifecycle.recordWebSocketReopened(),
+                log: (m) => this._log(m),
             }));
+            // Note: NO attachClient() here. The registry attaches only inside
+            // _onStompConnected (after recordConnected) so "client attached"
+            // is equivalent to "state === 'connected'" by construction.
         } catch (error) {
-            this._handleConnectError(error);
-            throw error;
+            const err = error instanceof Error ? error : new Error(String(error));
+            this._log(`❌ Failed to connect to WebSocket: ${err.message}`);
+            logger.error(`Failed to connect to WebSocket: ${err.message}`, LogCategory.WEBSOCKET);
+            this._subscriptions.clearAll();
+            this._subscriptions.detachClient(); // defensive: registry may have been attached by a racing onConnect
+            this._lifecycle.recordConnectError(err);
+            throw err;
         }
 
-        if (this._connectionGeneration !== generation) {
+        if (this._lifecycle.generation !== generation) {
             this._log('Connection aborted: superseded by newer connect/disconnect');
-            this._transitionTo('disconnected');
+            // The superseding call (parallel disconnect or reconnect) has already:
+            //   - bumped generation
+            //   - rejected our deferred via beginDisconnect()/beginConnect()
+            //   - cleaned up its own prior client
+            // Our just-created `this._client` was never activated and is unreferenced
+            // beyond `this._client`. We defensively clean it up here so a later
+            // connect() doesn't accidentally `deactivate()` an orphan that was
+            // briefly attached to the registry by a racing onConnect.
+            this._subscriptions.detachClient();
+            this._client = undefined;
+            this._lifecycle.abortSupersededConnect();
             throw new Error('Connection aborted: superseded by newer connect/disconnect');
         }
 
         this._client.activate();
-        return this._connectDeferred.promise;
+        return promise;
     }
 
-    /**
-     * If a connect is already in flight (or the STOMP client is mid-handshake),
-     * return the existing deferred so callers join the running attempt instead
-     * of stomping on it. Returns `undefined` when a fresh attempt is required.
-     * Throws for unrecoverable states (`disconnecting`, `gave-up`, stale
-     * `connecting` without a deferred).
-     */
-    private _maybeReuseInflightConnect(): Promise<void> | undefined {
-        if (this._connectionState === 'connecting') {
-            if (this._connectDeferred) { return this._connectDeferred.promise; }
-            throw new Error('Connection attempt already timed out');
-        }
-        if (this._connectionState === 'disconnecting') {
-            throw new Error('Disconnect in progress');
-        }
-        if (this._connectionState === 'gave-up') {
-            throw new Error('Max attempts reached. Call resetConnectionState() to retry.');
-        }
-        if (this._client?.active && !this._client.connected) {
-            if (!this._connectDeferred) {
-                this._connectDeferred = createDeferred<void>();
-                this._startSafetyTimeout();
-            }
-            return this._connectDeferred.promise;
-        }
-        return undefined;
-    }
-
-    /** Tear down a prior STOMP client before reconnecting. */
-    private async _teardownExistingClient(): Promise<void> {
-        if (!this._client) { return; }
-        this._log('Deactivating existing connection before reconnect');
-        await this._client.deactivate();
-        this._subscriptions.clearAll();
-        this._subscriptions.detachClient();
-        this._client = undefined;
-    }
-
-    /**
-     * Resolve server URL, fetch auth headers, validate them, and derive the
-     * WebSocket URL. Throws if there is no usable cookie/JWT — this is the
-     * auth pre-flight check that keeps the connection from racing into a
-     * 4xx-only loop.
-     */
-    private async _prepareConnectionContext(): Promise<{ authHeaders: Record<string, string>; wsUrl: string }> {
-        const serverUrl = resolveServerUrl();
-        this._log(`Connecting to Artemis WebSocket (attempt ${this._reconnectAttempts + 1}/${MAX_CONNECTION_ATTEMPTS})...`);
-
-        const authHeaders = await this._authManager.getAuthHeaders();
-        if (Object.keys(authHeaders).length === 0) {
-            const errorMsg = 'No authentication cookie available. Please log in first.';
-            this._log(`⚠️ ${errorMsg}`);
-            throw new Error(errorMsg);
-        }
-
-        // Validation only: the JWT itself isn't forwarded as a STOMP connect
-        // header (connectHeaders stays empty); we just want to fail fast when
-        // the cookie carries no usable token.
-        if (!extractJwtFromHeaders(authHeaders)) {
-            const errorMsg = 'Failed to extract JWT token from auth headers';
-            this._log(`⚠️ ${errorMsg}`);
-            throw new Error(errorMsg);
-        }
-
-        const wsUrl = buildWebSocketUrl(serverUrl);
-        this._log(`Connecting to ${wsUrl}`);
-        return { authHeaders, wsUrl };
-    }
-
-    /**
-     * Common cleanup for the `connect()` catch path. Settling the deferred
-     * matters because a concurrent `connect()` that joined while we awaited
-     * `deactivate()` (via `_maybeReuseInflightConnect`) is awaiting the same
-     * promise; failing to reject it would orphan that caller forever.
-     */
-    private _handleConnectError(error: unknown): void {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        this._log(`❌ Failed to connect to WebSocket: ${errorMessage}`);
-        logger.error(`Failed to connect to WebSocket: ${errorMessage}`, LogCategory.WEBSOCKET);
-        this._subscriptions.clearAll();
-        this._subscriptions.detachClient();
-        this._transitionTo('disconnected');
-        const settleError = error instanceof Error ? error : new Error(String(error));
-        this._settleDeferred(settleError);
-    }
-
-    protected _createClient(config: StompConfig): Client {
-        return new Client(config);
-    }
-
-    private _startSafetyTimeout(): void {
-        this._safetyTimeout = setTimeout(() => {
-            this._safetyTimeout = undefined;
-            if (!this._connectDeferred) { return; }
-            this._connectDeferred.reject(new Error('Connection timed out'));
-            this._connectDeferred = undefined;
-            this._transitionTo('disconnected');
-        }, SAFETY_TIMEOUT_MS);
-    }
-
-    private _settleDeferred(outcome: 'resolve' | Error): void {
-        if (this._safetyTimeout) {
-            clearTimeout(this._safetyTimeout);
-            this._safetyTimeout = undefined;
-        }
-        const deferred = this._connectDeferred;
-        this._connectDeferred = undefined;
-        if (!deferred) { return; }
-        if (outcome === 'resolve') {
-            deferred.resolve();
-        } else {
-            // Attach a fallback catch BEFORE rejecting so the rejection is
-            // considered handled even when no external caller is awaiting
-            // this deferred (e.g. the catch path of `connect()` throws
-            // directly and no parallel `connect()` ever attached an awaiter).
-            // External awaiters still observe the rejection via their own await.
-            deferred.promise.catch(() => { /* defensive no-op */ });
-            deferred.reject(outcome);
-        }
-    }
-
-    /** Disconnect from the WebSocket server. */
     public async disconnect(): Promise<void> {
-        this._connectionGeneration++;
-        this._transitionTo('disconnecting');
-        this._settleDeferred(new Error('Disconnected'));
-
-        if (this._connectionStateDebounceTimer) {
-            clearTimeout(this._connectionStateDebounceTimer);
-            this._connectionStateDebounceTimer = undefined;
-        }
-
+        this._lifecycle.beginDisconnect();
         if (this._client) {
             this._log('Disconnecting from Artemis WebSocket (intentional)');
             this._subscriptions.clearAll();
             this._subscriptions.detachClient();
-
             try {
                 await this._client.deactivate();
             } catch (e) {
                 this._log(`Error deactivating client: ${e}`);
             }
             this._client = undefined;
-
-            // Fire before resetting wasConnectedOnce so consumers see (false, true)
-            this._onDidChangeConnectionState.fire({ connected: false, wasEverConnected: this._wasConnectedOnce });
-
-            this._wasConnectedOnce = false;
-            this._reconnectAttempts = 0;
             this._sessionId = this._generateSecureSessionId();
+            this._lifecycle.completeDisconnectWithClient();
+        } else {
+            this._lifecycle.completeDisconnectNoClient();
         }
-
-        this._transitionTo('disconnected');
     }
 
-    /** Subscribe to personal result updates for the authenticated user. */
-    public subscribeToPersonalResults(): void {
-        this._subscriptions.subscribeToPersonalResults();
-    }
-
-    /** Subscribe to personal submission updates. */
-    public subscribeToPersonalSubmissions(): void {
-        this._subscriptions.subscribeToPersonalSubmissions();
-    }
-
-    /** Subscribe to submission processing updates (build status). */
-    public subscribeToSubmissionProcessing(): void {
-        this._subscriptions.subscribeToSubmissionProcessing();
-    }
-
-    /** Subscribe to Iris chat session updates for the given session ID. */
-    public subscribeToIrisSession(sessionId: number, onMessage: (message: unknown) => void): () => void {
-        return this._subscriptions.subscribeToIrisSession(sessionId, onMessage);
-    }
-
-    /** Public read-only accessor for connection state. */
-    public get connectionState(): ConnectionState {
-        return this._connectionState;
-    }
-
-    /** Derived UI status for consumers (status bar, chat webview). */
     public getDisplayStatus(): WebSocketDisplayStatus {
-        const baseStatus = deriveDisplayStatus(this._connectionState, this._wasConnectedOnce);
-
-        if (baseStatus === 'connected' || baseStatus === 'disconnected') {
-            return baseStatus;
-        }
-
-        // Only report 'connecting'/'reconnecting' if STOMP is actively retrying
+        const baseStatus = deriveDisplayStatus(this._lifecycle.state, this._lifecycle.wasConnectedOnce);
+        if (baseStatus === 'connected' || baseStatus === 'disconnected') { return baseStatus; }
         const stompTrying = this._client?.active === true;
-        const inFlightConnectingState = this._connectionState === 'connecting';
-        if (!stompTrying && !inFlightConnectingState) {
-            return 'disconnected';
-        }
+        const inFlightConnectingState = this._lifecycle.state === 'connecting';
+        if (!stompTrying && !inFlightConnectingState) { return 'disconnected'; }
         return baseStatus;
     }
 
-    /** Synchronous diagnostics snapshot for debugging and status display. */
     public getDiagnostics(): {
         clientConnected: boolean;
         clientActive: boolean;
@@ -354,7 +165,7 @@ export class ArtemisWebsocketService {
             clientActive: this._client?.active ?? false,
             subscriptionCount: this._subscriptions.size,
             subscriptions: this._subscriptions.topics,
-            reconnectAttempts: this._reconnectAttempts,
+            reconnectAttempts: this._lifecycle.reconnectAttempts,
             maxReconnectAttempts: MAX_CONNECTION_ATTEMPTS,
             sessionId: this._sessionId,
             serverUrl,
@@ -362,125 +173,101 @@ export class ArtemisWebsocketService {
         };
     }
 
-    /** Dispose and cleanup. */
     public dispose(): void {
         this._log('Disposing WebSocket service');
         this._onDidChangeConnectionState.dispose();
         this._subscriptions.clearMessageHandlers();
-
-        if (this._connectionStateDebounceTimer) {
-            clearTimeout(this._connectionStateDebounceTimer);
-            this._connectionStateDebounceTimer = undefined;
-        }
+        this._lifecycle.dispose();
         void this.disconnect().catch(err => this._log(`Error during disconnect in dispose: ${err}`));
     }
 
-    private _onConnected(): void {
-        this._disconnectCountedThisAttempt = false;
+    protected _createClient(config: StompConfig): Client { return new Client(config); }
 
-        if (this._connectionState === 'disconnecting') {
-            this._log('Ignoring onConnected during disconnect');
-            return;
-        }
-
-        this._transitionTo('connected');
-        this._reconnectAttempts = 0; // Reset on successful connection
-        this._wasConnectedOnce = true;
-
-        // Resolve the connect() promise so callers know the socket is usable
-        this._settleDeferred('resolve');
-
-        // Cancel any pending disconnect notification
-        if (this._connectionStateDebounceTimer) {
-            clearTimeout(this._connectionStateDebounceTimer);
-            this._connectionStateDebounceTimer = undefined;
-        }
-
-        this._log('✅ Connected to Artemis WebSocket');
-
-        // Attach client to registry BEFORE firing the connected event.
-        // Synchronous consumers (e.g. IrisWebSocketSessionClient) may call
-        // subscribeToIrisSession during the fire callback; the registry must
-        // already own a client at that moment. Auto-subscribes below also
-        // rely on an attached client.
-        this._subscriptions.attachClient(this._client!);
-
-        // Immediately notify of connection (no delay for connect events)
-        this._onDidChangeConnectionState.fire({ connected: true, wasEverConnected: this._wasConnectedOnce });
-
-        // Auto-subscribe to personal topics
-        this.subscribeToPersonalResults();
-        this.subscribeToPersonalSubmissions();
-        this.subscribeToSubmissionProcessing();
-    }
-
-    private _onDisconnected(): void {
-        // Intentional disconnect: don't count
-        if (this._connectionState === 'disconnecting') {
-            this._log('Ignoring onDisconnected during intentional disconnect');
-            return;
-        }
-
-        // Reject deferred if still in connecting state (handshake failure)
-        if (this._connectionState === 'connecting') {
-            this._settleDeferred(new Error('WebSocket closed during connection'));
-            this._transitionTo('disconnected');
-        }
-
-        // Double-count prevention: only count once per physical WebSocket attempt
-        if (this._disconnectCountedThisAttempt) { return; }
-        this._disconnectCountedThisAttempt = true;
-        this._reconnectAttempts++;
-
-        // Transition to disconnected if we were connected
-        if (this._connectionState === 'connected') {
+    /**
+     * STOMP onConnect callback. The lifecycle has already gated on
+     * generation match (see {@link buildStompConfig}).
+     *
+     * Order matters here: we attach the registry to the STOMP client BEFORE
+     * `recordConnected()` fires the `onDidChangeConnectionState` event.
+     * Consumers (notably `IrisWebSocketSessionClient`) react synchronously
+     * to that event and may call `subscribeToIrisSession()` before
+     * `recordConnected()` returns. If the registry were unattached at that
+     * point, the subscribe would throw and the resubscribe-on-reconnect
+     * path would break.
+     *
+     * Invariant (consumer-observable): at every yield point and at every
+     * consumer-visible event boundary, `subscriptions.isAttached` iff
+     * `lifecycle.state === 'connected'`. The brief synchronous window
+     * between `attachClient` and `recordConnected` is not observable
+     * because `_onStompConnected` is invoked on a single STOMP callback
+     * and no other coroutine can run before it returns.
+     */
+    private _onStompConnected(): void {
+        if (!this._client) { return; }
+        this._subscriptions.attachClient(this._client);
+        this._lifecycle.recordConnected();
+        if (this._lifecycle.state !== 'connected') {
+            // recordConnected refused (we were in 'disconnecting'). Roll back the attach.
             this._subscriptions.detachClient();
-            this._transitionTo('disconnected');
-            this._subscriptions.clearAll();
-            this._log('Disconnected from Artemis WebSocket');
+            return;
         }
-
-        // Debounce disconnect notification (5 seconds grace period)
-        if (!this._connectionStateDebounceTimer) {
-            this._connectionStateDebounceTimer = setTimeout(() => {
-                this._connectionStateDebounceTimer = undefined;
-                if (this._connectionState !== 'connected' && this._connectionState !== 'disconnecting') {
-                    this._log('Disconnect grace period elapsed, notifying consumers');
-                    this._onDidChangeConnectionState.fire({ connected: false, wasEverConnected: this._wasConnectedOnce });
-                }
-            }, CONNECTION_STATE_DELAY_MS);
-        }
-
-        // Check gave-up threshold
-        if (this._reconnectAttempts >= MAX_CONNECTION_ATTEMPTS) {
-            if (this._connectionStateDebounceTimer) {
-                clearTimeout(this._connectionStateDebounceTimer);
-                this._connectionStateDebounceTimer = undefined;
-            }
-            this._transitionTo('gave-up');
-            this._log(`MAX RECONNECTION ATTEMPTS (${MAX_CONNECTION_ATTEMPTS}) REACHED`);
-            this._onDidChangeConnectionState.fire({ connected: false, wasEverConnected: this._wasConnectedOnce });
-            // Stop STOMP's internal reconnection loop, but KEEP gave-up state
-            if (this._client) {
-                this._connectionGeneration++;
-                void this._client.deactivate({ force: true });
-            }
-        } else {
-            this._log(`STOMP will attempt reconnection (attempt ${this._reconnectAttempts}/${MAX_CONNECTION_ATTEMPTS})`);
-        }
+        this._subscriptions.subscribeToPersonalResults();
+        this._subscriptions.subscribeToPersonalSubmissions();
+        this._subscriptions.subscribeToSubmissionProcessing();
     }
 
-    private _onError(message: string): void {
-        this._log(`❌ ${message}`);
+    private _onStompError(message: string): void {
         logger.error(message, LogCategory.WEBSOCKET);
-        this._subscriptions.detachClient();
-        this._settleDeferred(new Error(message));
+        this._lifecycle.recordError(message);
         this._subscriptions.clearAll();
-        this._transitionTo('disconnected');
+        this._subscriptions.detachClient();
     }
 
-    private _transitionTo(newState: ConnectionState): void {
-        this._connectionState = newState;
+    private _onStompDisconnected(): void {
+        const directive = this._lifecycle.recordDisconnect({ hasClient: !!this._client });
+        if (directive.clearedConnectedState) {
+            this._subscriptions.clearAll();
+            this._subscriptions.detachClient();
+        }
+        if (directive.gaveUp && this._client) {
+            void this._client.deactivate({ force: true });
+        }
+    }
+
+    private async _teardownExistingClient(): Promise<void> {
+        if (!this._client) { return; }
+        this._log('Deactivating existing connection before reconnect');
+        await this._client.deactivate();
+        this._subscriptions.clearAll();
+        this._subscriptions.detachClient();
+        this._client = undefined;
+    }
+
+    private async _prepareConnectionContext(): Promise<{ authHeaders: Record<string, string>; wsUrl: string }> {
+        const serverUrl = resolveServerUrl();
+        this._log(`Connecting to Artemis WebSocket (attempt ${this._lifecycle.reconnectAttempts + 1}/${MAX_CONNECTION_ATTEMPTS})...`);
+
+        const authHeaders = await this._authManager.getAuthHeaders();
+        if (Object.keys(authHeaders).length === 0) {
+            const errorMsg = 'No authentication cookie available. Please log in first.';
+            this._log(`⚠️ ${errorMsg}`);
+            throw new Error(errorMsg);
+        }
+        if (!extractJwtFromHeaders(authHeaders)) {
+            const errorMsg = 'Failed to extract JWT token from auth headers';
+            this._log(`⚠️ ${errorMsg}`);
+            throw new Error(errorMsg);
+        }
+
+        const wsUrl = buildWebSocketUrl(serverUrl);
+        this._log(`Connecting to ${wsUrl}`);
+        return { authHeaders, wsUrl };
+    }
+
+    private _generateSecureSessionId(): string {
+        const bytes = new Uint8Array(6);
+        crypto.getRandomValues(bytes);
+        return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
     }
 
     private _log(message: string): void {

--- a/extension/src/extension/services/websocket/connectionLifecycle.ts
+++ b/extension/src/extension/services/websocket/connectionLifecycle.ts
@@ -1,0 +1,318 @@
+import type { ConnectionState } from './connectionState';
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (error: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+const SAFETY_TIMEOUT_MS = 15000;
+const CONNECTION_STATE_DELAY_MS = 5000; // matches Artemis webapp
+export const MAX_CONNECTION_ATTEMPTS = 20;
+
+interface ConnectionLifecycleDeps {
+    log(message: string): void;
+    /**
+     * Fired on connect (immediately) and disconnect (after debounce or
+     * immediately on gave-up / intentional disconnect). Mirrors the prior
+     * EventEmitter exposed by the service.
+     */
+    onDidChangeConnectionState(evt: { connected: boolean; wasEverConnected: boolean }): void;
+}
+
+interface BeginConnectOptions {
+    /**
+     * Set to true when the orchestrator detects a STOMP client mid-handshake
+     * (`client?.active && !client.connected`). State-based gates are checked
+     * first: if the lifecycle is `connecting` we return reuse; if it's
+     * `disconnecting` or `gave-up` we throw, regardless of this flag. Only
+     * a `disconnected` state combined with this flag returns reuse, matching
+     * the original guard order.
+     */
+    clientInflight?: boolean;
+}
+
+type BeginConnectResult =
+    | { kind: 'fresh'; generation: number; promise: Promise<void> }
+    | { kind: 'reuse'; promise: Promise<void> };
+
+interface RecordDisconnectOptions {
+    /**
+     * True iff the orchestrator currently holds a STOMP `Client` instance.
+     * The lifecycle uses this to decide whether to bump the generation
+     * token when hitting `gave-up` (the original code only bumped when
+     * `this._client` was non-null, because the bump exists to invalidate
+     * STOMP callbacks before force-deactivation).
+     */
+    hasClient: boolean;
+}
+
+interface RecordDisconnectDirective {
+    /** True if the lifecycle transitioned 'connected' -> 'disconnected' (orchestrator should clear subscriptions and detach client). */
+    clearedConnectedState: boolean;
+    /** True if the lifecycle just hit MAX_CONNECTION_ATTEMPTS (orchestrator should force-teardown the STOMP client iff one exists). */
+    gaveUp: boolean;
+}
+
+/**
+ * Pure state machine for the Artemis WebSocket connection.
+ *
+ * Owns the connection state, generation token, reconnect counting, deferred
+ * for connect()-callers, safety timeout, and the debounce timer for
+ * disconnect notifications. Does NOT own the STOMP client or any
+ * subscriptions, those are the orchestrator's concern.
+ *
+ * Threading: all methods are synchronous. Timeouts and debounce are
+ * registered as Node timers; the lifecycle does not perform `await`.
+ */
+export class ConnectionLifecycle {
+    private _state: ConnectionState = 'disconnected';
+    private _generation = 0;
+    private _reconnectAttempts = 0;
+    private _wasConnectedOnce = false;
+    private _connectDeferred?: Deferred<void>;
+    private _safetyTimeout?: ReturnType<typeof setTimeout>;
+    private _debounceTimer?: ReturnType<typeof setTimeout>;
+    private _disconnectCountedThisAttempt = false;
+    private _gaveUpEventFired = false;
+
+    constructor(private readonly _deps: ConnectionLifecycleDeps) {}
+
+    public get state(): ConnectionState { return this._state; }
+    public get generation(): number { return this._generation; }
+    public get reconnectAttempts(): number { return this._reconnectAttempts; }
+    public get wasConnectedOnce(): boolean { return this._wasConnectedOnce; }
+
+    /**
+     * Top of `connect()`. Handles all state-based gates (matches the original
+     * `_maybeReuseInflightConnect` guard order) FIRST, then falls through to
+     * `clientInflight` reuse, then to a fresh attempt.
+     */
+    public beginConnect(opts: BeginConnectOptions): BeginConnectResult {
+        if (this._state === 'connecting') {
+            if (this._connectDeferred) { return { kind: 'reuse', promise: this._connectDeferred.promise }; }
+            throw new Error('Connection attempt already timed out');
+        }
+        if (this._state === 'disconnecting') { throw new Error('Disconnect in progress'); }
+        if (this._state === 'gave-up') { throw new Error('Max attempts reached. Call resetConnectionState() to retry.'); }
+
+        if (opts.clientInflight) {
+            // STOMP client is mid-handshake while we are 'disconnected'. Join
+            // the existing attempt without re-entering 'connecting' or bumping
+            // generation. Original behavior preserved.
+            if (!this._connectDeferred) {
+                this._connectDeferred = createDeferred<void>();
+                this._startSafetyTimeout();
+            }
+            return { kind: 'reuse', promise: this._connectDeferred.promise };
+        }
+
+        this._state = 'connecting';
+        this._generation++;
+        this._gaveUpEventFired = false;
+        this._connectDeferred = createDeferred<void>();
+        this._startSafetyTimeout();
+        return { kind: 'fresh', generation: this._generation, promise: this._connectDeferred.promise };
+    }
+
+    /** Called by the orchestrator when STOMP fires onConnect. */
+    public recordConnected(): void {
+        this._disconnectCountedThisAttempt = false;
+
+        if (this._state === 'disconnecting') {
+            this._deps.log('Ignoring onConnected during disconnect');
+            return;
+        }
+
+        this._state = 'connected';
+        this._reconnectAttempts = 0;
+        this._wasConnectedOnce = true;
+        this._settleDeferred('resolve');
+
+        if (this._debounceTimer) {
+            clearTimeout(this._debounceTimer);
+            this._debounceTimer = undefined;
+        }
+
+        this._deps.log('✅ Connected to Artemis WebSocket');
+        this._deps.onDidChangeConnectionState({ connected: true, wasEverConnected: true });
+    }
+
+    /**
+     * Called by the orchestrator when the WebSocket factory is about to
+     * open a new physical socket (per-attempt counter reset). Mirrors the
+     * original `_disconnectCountedThisAttempt = false` reset inside the
+     * `webSocketFactory`.
+     */
+    public recordWebSocketReopened(): void {
+        this._disconnectCountedThisAttempt = false;
+    }
+
+    /** Called by the orchestrator when STOMP fires onDisconnect / onWebSocketClose. */
+    public recordDisconnect(opts: RecordDisconnectOptions): RecordDisconnectDirective {
+        if (this._state === 'disconnecting') {
+            this._deps.log('Ignoring onDisconnected during intentional disconnect');
+            return { clearedConnectedState: false, gaveUp: false };
+        }
+
+        if (this._state === 'connecting') {
+            this._settleDeferred(new Error('WebSocket closed during connection'));
+            this._state = 'disconnected';
+        }
+
+        if (this._disconnectCountedThisAttempt) {
+            return { clearedConnectedState: false, gaveUp: false };
+        }
+        this._disconnectCountedThisAttempt = true;
+        this._reconnectAttempts++;
+
+        let clearedConnectedState = false;
+        if (this._state === 'connected') {
+            this._state = 'disconnected';
+            clearedConnectedState = true;
+            this._deps.log('Disconnected from Artemis WebSocket');
+        }
+
+        if (!this._debounceTimer) {
+            this._debounceTimer = setTimeout(() => {
+                this._debounceTimer = undefined;
+                if (this._state !== 'connected' && this._state !== 'disconnecting') {
+                    this._deps.log('Disconnect grace period elapsed, notifying consumers');
+                    this._deps.onDidChangeConnectionState({ connected: false, wasEverConnected: this._wasConnectedOnce });
+                }
+            }, CONNECTION_STATE_DELAY_MS);
+        }
+
+        if (this._reconnectAttempts >= MAX_CONNECTION_ATTEMPTS) {
+            if (this._debounceTimer) {
+                clearTimeout(this._debounceTimer);
+                this._debounceTimer = undefined;
+            }
+            this._state = 'gave-up';
+            this._deps.log(`MAX RECONNECTION ATTEMPTS (${MAX_CONNECTION_ATTEMPTS}) REACHED`);
+            if (opts.hasClient) {
+                // Matches old behavior: generation only bumps when a client
+                // exists to be force-deactivated. The bump exists to invalidate
+                // STOMP callbacks before the orchestrator calls
+                // `client.deactivate({ force: true })`.
+                this._generation++;
+            }
+            if (!this._gaveUpEventFired) {
+                this._gaveUpEventFired = true;
+                this._deps.onDidChangeConnectionState({ connected: false, wasEverConnected: this._wasConnectedOnce });
+            }
+            return { clearedConnectedState, gaveUp: true };
+        }
+
+        this._deps.log(`STOMP will attempt reconnection (attempt ${this._reconnectAttempts}/${MAX_CONNECTION_ATTEMPTS})`);
+        return { clearedConnectedState, gaveUp: false };
+    }
+
+    /** Called by the orchestrator when STOMP fires onStompError or onWebSocketError. */
+    public recordError(message: string): void {
+        this._deps.log(`❌ ${message}`);
+        this._settleDeferred(new Error(message));
+        this._state = 'disconnected';
+    }
+
+    /** Called by the orchestrator from the connect() catch path (deactivate throws, auth missing, etc.). */
+    public recordConnectError(error: Error): void {
+        this._state = 'disconnected';
+        this._settleDeferred(error);
+    }
+
+    /**
+     * Called by the orchestrator when the post-client-creation generation
+     * check fails (a concurrent disconnect bumped generation). Transitions
+     * to disconnected without firing events. The deferred has already been
+     * settled by whatever bumped the generation; calling this is a no-op
+     * for the deferred but tightens state.
+     */
+    public abortSupersededConnect(): void {
+        this._state = 'disconnected';
+    }
+
+    /** Called by the orchestrator at the start of disconnect(). */
+    public beginDisconnect(): void {
+        this._generation++;
+        this._state = 'disconnecting';
+        this._settleDeferred(new Error('Disconnected'));
+        if (this._debounceTimer) {
+            clearTimeout(this._debounceTimer);
+            this._debounceTimer = undefined;
+        }
+    }
+
+    /**
+     * Called by the orchestrator after STOMP deactivation completes AND a
+     * client was present at disconnect start. Fires the
+     * `(false, prior wasEverConnected)` event then resets counters.
+     */
+    public completeDisconnectWithClient(): void {
+        const priorWasEverConnected = this._wasConnectedOnce;
+        this._deps.onDidChangeConnectionState({ connected: false, wasEverConnected: priorWasEverConnected });
+        this._wasConnectedOnce = false;
+        this._reconnectAttempts = 0;
+        this._state = 'disconnected';
+    }
+
+    /**
+     * Called by the orchestrator when `disconnect()` runs but no client
+     * existed. Matches the original no-event-fired path. No counters
+     * touched (they were already at zero by definition).
+     */
+    public completeDisconnectNoClient(): void {
+        this._state = 'disconnected';
+    }
+
+    public reset(): void {
+        this._deps.log('Resetting connection state');
+        this._reconnectAttempts = 0;
+        this._state = 'disconnected';
+        this._gaveUpEventFired = false;
+    }
+
+    public dispose(): void {
+        if (this._debounceTimer) {
+            clearTimeout(this._debounceTimer);
+            this._debounceTimer = undefined;
+        }
+        if (this._safetyTimeout) {
+            clearTimeout(this._safetyTimeout);
+            this._safetyTimeout = undefined;
+        }
+    }
+
+    private _startSafetyTimeout(): void {
+        this._safetyTimeout = setTimeout(() => {
+            this._safetyTimeout = undefined;
+            if (!this._connectDeferred) { return; }
+            this._connectDeferred.reject(new Error('Connection timed out'));
+            this._connectDeferred = undefined;
+            this._state = 'disconnected';
+        }, SAFETY_TIMEOUT_MS);
+    }
+
+    private _settleDeferred(outcome: 'resolve' | Error): void {
+        if (this._safetyTimeout) {
+            clearTimeout(this._safetyTimeout);
+            this._safetyTimeout = undefined;
+        }
+        const deferred = this._connectDeferred;
+        this._connectDeferred = undefined;
+        if (!deferred) { return; }
+        if (outcome === 'resolve') {
+            deferred.resolve();
+        } else {
+            deferred.promise.catch(() => { /* defensive no-op for orphan awaiters */ });
+            deferred.reject(outcome);
+        }
+    }
+}

--- a/extension/src/extension/services/websocket/jwtExtractor.ts
+++ b/extension/src/extension/services/websocket/jwtExtractor.ts
@@ -1,0 +1,22 @@
+import { CONFIG } from '@extension/utils';
+
+/**
+ * Extract the JWT from either a Bearer Authorization header or the Artemis
+ * auth cookie. Used as a connection-time validation step (the token itself
+ * is not forwarded as a STOMP `connectHeaders` field; this just fails fast
+ * when the cookie carries no usable token).
+ */
+export function extractJwtFromHeaders(headers: Record<string, string>): string | undefined {
+    const bearer = headers['Authorization'];
+    if (bearer) {
+        return bearer.replace(/^Bearer\s+/, '');
+    }
+
+    const cookie = headers['Cookie'];
+    if (cookie) {
+        const jwtMatch = cookie.match(new RegExp(`${CONFIG.AUTH_COOKIE_NAME}=([^;]+)`));
+        return jwtMatch ? jwtMatch[1] : undefined;
+    }
+
+    return undefined;
+}

--- a/extension/src/extension/services/websocket/stompConfigBuilder.ts
+++ b/extension/src/extension/services/websocket/stompConfigBuilder.ts
@@ -1,0 +1,97 @@
+import { IFrame, ReconnectionTimeMode, StompConfig } from '@stomp/stompjs';
+import WebSocket from 'ws';
+
+import { getUserAgent } from '@extension/utils';
+
+const INITIAL_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 10000;
+const CONNECTION_TIMEOUT_MS = 10000;
+const HEARTBEAT_INTERVAL_MS = 10000;
+
+interface BuildStompConfigDeps {
+    /** Generation captured at build time. Compared with currentGeneration() before every callback. */
+    generation: number;
+    authHeaders: Record<string, string>;
+    wsUrl: string;
+    /** Read at callback time, so the orchestrator can invalidate this attempt. */
+    currentGeneration(): number;
+    /** Called when STOMP successfully connects. */
+    onConnected(): void;
+    /** Called when STOMP reports a broker error frame. Receives a formatted message. */
+    onStompError(message: string): void;
+    /** Called on lower-level WebSocket errors. Receives a formatted message. */
+    onWebSocketError(message: string): void;
+    /** Called when STOMP or the underlying WebSocket disconnects. */
+    onDisconnected(): void;
+    /** Called immediately before each WebSocket constructor invocation (used to reset per-attempt counters). */
+    onWebSocketBeforeOpen(): void;
+    log(message: string): void;
+}
+
+/**
+ * Construct the STOMP `Client` configuration for a single connect attempt.
+ *
+ * Each lifecycle callback is gated on the captured `generation` matching
+ * `currentGeneration()` at fire time. This is how the orchestrator
+ * invalidates an in-flight attempt during reconnect/disconnect without
+ * tearing down the STOMP client mid-callback.
+ */
+export function buildStompConfig(deps: BuildStompConfigDeps): StompConfig {
+    const { generation, authHeaders, wsUrl, currentGeneration, log } = deps;
+
+    log(`Reconnect config: delay=${INITIAL_RECONNECT_DELAY_MS}ms, timeout=${CONNECTION_TIMEOUT_MS}ms, heartbeat=${HEARTBEAT_INTERVAL_MS}ms`);
+
+    return {
+        brokerURL: wsUrl,
+        connectHeaders: {},
+        reconnectDelay: INITIAL_RECONNECT_DELAY_MS,
+        reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
+        maxReconnectDelay: MAX_RECONNECT_DELAY_MS,
+        connectionTimeout: CONNECTION_TIMEOUT_MS,
+        heartbeatIncoming: HEARTBEAT_INTERVAL_MS,
+        heartbeatOutgoing: HEARTBEAT_INTERVAL_MS,
+        discardWebsocketOnCommFailure: true,
+
+        webSocketFactory: () => {
+            deps.onWebSocketBeforeOpen();
+            const ws = new WebSocket(wsUrl, {
+                headers: {
+                    ...authHeaders,
+                    'User-Agent': getUserAgent(),
+                },
+            });
+            ws.on('error', (err) => log(`WebSocket error: ${err.message}`));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return -- STOMP library expects generic WebSocket type
+            return ws as any;
+        },
+
+        onConnect: () => {
+            if (currentGeneration() !== generation) { return; }
+            deps.onConnected();
+        },
+
+        onStompError: (frame: IFrame) => {
+            if (currentGeneration() !== generation) { return; }
+            const body = frame.body ? ` body=${frame.body.substring(0, 500)}` : '';
+            deps.onStompError(`STOMP error: ${frame.headers['message']}${body}`);
+        },
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- STOMP library onWebSocketError uses generic event type
+        onWebSocketError: (event: any) => {
+            if (currentGeneration() !== generation) { return; }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- event shape is untyped
+            const detail = event?.message || event?.type || 'unknown';
+            deps.onWebSocketError(`WebSocket error: ${detail}`);
+        },
+
+        onDisconnect: () => {
+            if (currentGeneration() !== generation) { return; }
+            deps.onDisconnected();
+        },
+
+        onWebSocketClose: () => {
+            if (currentGeneration() !== generation) { return; }
+            deps.onDisconnected();
+        },
+    };
+}

--- a/extension/src/extension/services/websocket/subscriptionRegistry.ts
+++ b/extension/src/extension/services/websocket/subscriptionRegistry.ts
@@ -1,0 +1,162 @@
+import type { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+import type { WebSocketMessageHandler } from '@extension/types';
+import { parseProgrammingSubmission, parseResultDTO, parseSubmissionProcessingMessage } from '@extension/types';
+import { WEBSOCKET_TOPICS } from '@extension/utils';
+
+interface SubscriptionRegistryDeps {
+    log(message: string): void;
+}
+
+/**
+ * Owns the STOMP subscriptions and the `WebSocketMessageHandler` fan-out.
+ *
+ * The registry does not own the STOMP client; the orchestrator attaches/
+ * detaches the client at connect/disconnect time. Subscriptions made
+ * without an attached client throw (Iris) or no-op (personal topics) — they
+ * are never silently queued.
+ */
+export class SubscriptionRegistry {
+    private _client?: Client;
+    private readonly _subscriptions: Map<string, StompSubscription> = new Map();
+    private _messageHandlers: WebSocketMessageHandler[] = [];
+
+    constructor(private readonly _deps: SubscriptionRegistryDeps) {}
+
+    public attachClient(client: Client): void {
+        this._client = client;
+    }
+
+    public detachClient(): void {
+        this._client = undefined;
+    }
+
+    public registerMessageHandler(handler: WebSocketMessageHandler): void {
+        if (this._messageHandlers.includes(handler)) { return; }
+        this._messageHandlers.push(handler);
+        this._deps.log(`Message handler registered. Total handlers: ${this._messageHandlers.length}`);
+    }
+
+    public unregisterMessageHandler(handler: WebSocketMessageHandler): void {
+        const idx = this._messageHandlers.indexOf(handler);
+        if (idx !== -1) { this._messageHandlers.splice(idx, 1); }
+    }
+
+    public clearMessageHandlers(): void {
+        this._messageHandlers = [];
+    }
+
+    public subscribeToPersonalResults(): void {
+        this._subscribeToTopic(
+            WEBSOCKET_TOPICS.NEW_RESULTS,
+            (data) => parseResultDTO(data),
+            (handler, result) => handler.onNewResult?.(result),
+            (result) => `Received new result: score=${result.score}, successful=${result.successful}`,
+        );
+    }
+
+    public subscribeToPersonalSubmissions(): void {
+        this._subscribeToTopic(
+            WEBSOCKET_TOPICS.NEW_SUBMISSIONS,
+            (data) => parseProgrammingSubmission(data),
+            (handler, submission) => handler.onNewSubmission?.(submission),
+            (submission) => `Received new submission: ${submission.id}`,
+        );
+    }
+
+    public subscribeToSubmissionProcessing(): void {
+        this._subscribeToTopic(
+            WEBSOCKET_TOPICS.SUBMISSION_PROCESSING,
+            (data) => parseSubmissionProcessingMessage(data),
+            (handler, msg) => handler.onSubmissionProcessing?.(msg),
+            (msg) => `Received submission processing update: participationId=${msg.participationId}`,
+        );
+    }
+
+    public subscribeToIrisSession(sessionId: number, onMessage: (message: unknown) => void): () => void {
+        if (!this._client) {
+            this._deps.log('Cannot subscribe: not connected');
+            throw new Error('WebSocket not connected');
+        }
+
+        const topic = WEBSOCKET_TOPICS.irisSession(sessionId);
+
+        if (this._subscriptions.has(topic)) {
+            this._deps.log(`Replacing existing subscription for ${topic}`);
+            const oldSub = this._subscriptions.get(topic);
+            try { oldSub?.unsubscribe(); } catch { /* stale sub, ignore */ }
+            this._subscriptions.delete(topic);
+        }
+
+        const subscription = this._client.subscribe(topic, (message: IMessage) => {
+            try {
+                const data: unknown = JSON.parse(message.body);
+                this._deps.log(`Received Iris message for session ${sessionId}`);
+                onMessage(data);
+            } catch (error) {
+                const stack = error instanceof Error ? error.stack : String(error);
+                this._deps.log(`Error processing Iris message: ${stack}`);
+                logger.error('Full error processing Iris message', LogCategory.WEBSOCKET, error as Error);
+            }
+        });
+
+        this._subscriptions.set(topic, subscription);
+        this._deps.log(`✅ Subscribed to Iris session: ${topic}`);
+
+        const capturedSub = subscription;
+        return () => {
+            capturedSub.unsubscribe();
+            if (this._subscriptions.get(topic) === capturedSub) {
+                this._subscriptions.delete(topic);
+            }
+            this._deps.log(`Unsubscribed from ${topic}`);
+        };
+    }
+
+    public clearAll(): void {
+        this._subscriptions.forEach((subscription, topic) => {
+            try {
+                subscription.unsubscribe();
+                this._deps.log(`Unsubscribed from ${topic}`);
+            } catch { /* stale sub after disconnect, safe to ignore */ }
+        });
+        this._subscriptions.clear();
+    }
+
+    public get size(): number {
+        return this._subscriptions.size;
+    }
+
+    public get topics(): string[] {
+        return Array.from(this._subscriptions.keys());
+    }
+
+    private _subscribeToTopic<T>(
+        topic: string,
+        parser: (data: unknown) => T,
+        dispatch: (handler: WebSocketMessageHandler, parsed: T) => void,
+        logFormatter: (parsed: T) => string,
+    ): void {
+        if (!this._client) {
+            this._deps.log('Cannot subscribe: not connected');
+            return;
+        }
+        if (this._subscriptions.has(topic)) {
+            this._deps.log(`Already subscribed to ${topic}`);
+            return;
+        }
+        const subscription = this._client.subscribe(topic, (message: IMessage) => {
+            try {
+                const parsed = parser(JSON.parse(message.body));
+                this._deps.log(logFormatter(parsed));
+                [...this._messageHandlers].forEach(handler => dispatch(handler, parsed));
+            } catch (error) {
+                const stack = error instanceof Error ? error.stack : String(error);
+                this._deps.log(`Error processing message on ${topic}: ${stack}`);
+            }
+        });
+        this._subscriptions.set(topic, subscription);
+        this._deps.log(`Subscribed to ${topic}`);
+    }
+}

--- a/extension/src/extension/services/websocket/webSocketUrl.ts
+++ b/extension/src/extension/services/websocket/webSocketUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert an Artemis HTTP(S) server URL into the direct STOMP WebSocket URL.
+ *
+ * Artemis exposes STOMP at `/websocket/websocket` (bypassing SockJS). We
+ * preserve host + port and only translate the scheme.
+ */
+export function buildWebSocketUrl(serverUrl: string): string {
+    const url = new URL(serverUrl);
+    const protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${url.host}/websocket/websocket`;
+}

--- a/extension/test/unit/services/websocket.test.ts
+++ b/extension/test/unit/services/websocket.test.ts
@@ -119,29 +119,28 @@ class TestableArtemisWebsocketService extends ArtemisWebsocketService {
     public mockClient?: MockStompClient;
     public connectCallCount: number = 0;
 
-    // Expose private fields for testing via getters
-    public get isConnectingState(): boolean {
-        return (this as any)._connectionState === 'connecting';
-    }
-
-    public get isDisconnectingState(): boolean {
-        return (this as any)._connectionState === 'disconnecting';
-    }
-
-    public get connectionGaveUpState(): boolean {
-        return (this as any)._connectionState === 'gave-up';
-    }
+    // Expose private fields for testing via getters. After the
+    // ConnectionLifecycle extraction, state and counters live on
+    // `_lifecycle`; we reach in via `as any` to keep the same public
+    // testing surface.
+    public get isConnectingState(): boolean { return this._lifecycleState() === 'connecting'; }
+    public get isDisconnectingState(): boolean { return this._lifecycleState() === 'disconnecting'; }
+    public get connectionGaveUpState(): boolean { return this._lifecycleState() === 'gave-up'; }
 
     public get reconnectAttemptsCount(): number {
-        return (this as any)._reconnectAttempts;
+        return ((this as any)._lifecycle._reconnectAttempts) as number;
     }
 
     public get wasConnectedOnceState(): boolean {
-        return (this as any)._wasConnectedOnce;
+        return ((this as any)._lifecycle._wasConnectedOnce) as boolean;
     }
 
     public get connectionGeneration(): number {
-        return (this as any)._connectionGeneration;
+        return ((this as any)._lifecycle._generation) as number;
+    }
+
+    private _lifecycleState(): string {
+        return (this as any)._lifecycle._state as string;
     }
 
     // Override client creation to use mock
@@ -165,32 +164,22 @@ class TestableArtemisWebsocketService extends ArtemisWebsocketService {
         connectionGaveUp?: boolean;
         reconnectAttempts?: number;
     }): void {
-        if (state.connectionGaveUp === true) {
-            (this as any)._connectionState = 'gave-up';
-        } else if (state.isDisconnecting === true) {
-            (this as any)._connectionState = 'disconnecting';
-        } else if (state.isConnecting === true) {
-            (this as any)._connectionState = 'connecting';
-        }
+        const lc: any = (this as any)._lifecycle;
+        if (state.connectionGaveUp === true) { lc._state = 'gave-up'; }
+        else if (state.isDisconnecting === true) { lc._state = 'disconnecting'; }
+        else if (state.isConnecting === true) { lc._state = 'connecting'; }
         // When setting flags to false, only change state if it currently matches
         // that flag (don't clobber 'connected' when clearing 'isConnecting')
-        if (state.isConnecting === false && (this as any)._connectionState === 'connecting') {
-            (this as any)._connectionState = 'disconnected';
-        }
-        if (state.isDisconnecting === false && (this as any)._connectionState === 'disconnecting') {
-            (this as any)._connectionState = 'disconnected';
-        }
-        if (state.connectionGaveUp === false && (this as any)._connectionState === 'gave-up') {
-            (this as any)._connectionState = 'disconnected';
-        }
-        if (state.reconnectAttempts !== undefined) {
-            (this as any)._reconnectAttempts = state.reconnectAttempts;
-        }
+        if (state.isConnecting === false && lc._state === 'connecting') { lc._state = 'disconnected'; }
+        if (state.isDisconnecting === false && lc._state === 'disconnecting') { lc._state = 'disconnected'; }
+        if (state.connectionGaveUp === false && lc._state === 'gave-up') { lc._state = 'disconnected'; }
+        if (state.reconnectAttempts !== undefined) { lc._reconnectAttempts = state.reconnectAttempts; }
     }
 
-    // Helper to trigger onDisconnected
+    // Helper to trigger onDisconnected (now routed through the orchestrator's
+    // STOMP callback which delegates to the lifecycle).
     public triggerOnDisconnected(): void {
-        (this as any)._onDisconnected();
+        (this as any)._onStompDisconnected();
     }
 
 }

--- a/extension/test/unit/services/websocket/connectionLifecycle.test.ts
+++ b/extension/test/unit/services/websocket/connectionLifecycle.test.ts
@@ -1,0 +1,264 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ConnectionLifecycle } from '@extension/services/websocket/connectionLifecycle';
+import type { ConnectionState } from '@extension/services/websocket/connectionState';
+
+/** Test-only subclass exposing internal hooks. Never imported from production. */
+class TestableConnectionLifecycle extends ConnectionLifecycle {
+    public forceState(state: ConnectionState): void {
+        (this as any)._state = state;
+    }
+    public setReconnectAttempts(n: number): void {
+        (this as any)._reconnectAttempts = n;
+    }
+}
+
+const createdLifecycles: TestableConnectionLifecycle[] = [];
+
+function makeLifecycle(): {
+    lifecycle: TestableConnectionLifecycle;
+    events: Array<{ connected: boolean; wasEverConnected: boolean }>;
+} {
+    const events: Array<{ connected: boolean; wasEverConnected: boolean }> = [];
+    const lifecycle = new TestableConnectionLifecycle({
+        log: () => { /* silent */ },
+        onDidChangeConnectionState: (evt) => { events.push(evt); },
+    });
+    createdLifecycles.push(lifecycle);
+    return { lifecycle, events };
+}
+
+suite('ConnectionLifecycle', () => {
+    teardown(() => {
+        // Dispose every lifecycle the test created so safety timeouts and
+        // debounce timers do not leak into other suites.
+        for (const lifecycle of createdLifecycles) { lifecycle.dispose(); }
+        createdLifecycles.length = 0;
+        sinon.restore();
+    });
+
+    test('initial state is disconnected with generation 0', () => {
+        const { lifecycle } = makeLifecycle();
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.strictEqual(lifecycle.generation, 0);
+        assert.strictEqual(lifecycle.reconnectAttempts, 0);
+        assert.strictEqual(lifecycle.wasConnectedOnce, false);
+    });
+
+    test('beginConnect bumps generation, transitions to connecting, returns deferred', async () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        assert.strictEqual(result.kind, 'fresh');
+        if (result.kind !== 'fresh') { return; }
+        assert.strictEqual(lifecycle.state, 'connecting');
+        assert.strictEqual(lifecycle.generation, 1);
+        assert.strictEqual(result.generation, 1);
+        lifecycle.recordConnected();
+        await result.promise;
+    });
+
+    test('beginConnect during connecting returns reuse directive', async () => {
+        const { lifecycle } = makeLifecycle();
+        const first = lifecycle.beginConnect({});
+        const second = lifecycle.beginConnect({});
+        assert.strictEqual(first.kind, 'fresh');
+        assert.strictEqual(second.kind, 'reuse');
+        lifecycle.recordConnected();
+        if (first.kind === 'fresh') { await first.promise; }
+        if (second.kind === 'reuse') { await second.promise; }
+    });
+
+    test('beginConnect after gave-up throws (state gate, NOT inflight reuse)', () => {
+        const { lifecycle } = makeLifecycle();
+        lifecycle.forceState('gave-up');
+        assert.throws(() => lifecycle.beginConnect({ clientInflight: true }), /Max attempts reached/);
+    });
+
+    test('beginConnect during disconnecting throws', () => {
+        const { lifecycle } = makeLifecycle();
+        lifecycle.forceState('disconnecting');
+        assert.throws(() => lifecycle.beginConnect({ clientInflight: true }), /Disconnect in progress/);
+    });
+
+    test('beginConnect with clientInflight returns reuse from disconnected (STOMP mid-handshake)', () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({ clientInflight: true });
+        assert.strictEqual(result.kind, 'reuse');
+        // The lifecycle should NOT have transitioned to 'connecting' or bumped generation
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.strictEqual(lifecycle.generation, 0);
+    });
+
+    test('recordConnected resolves deferred and fires connected event', async () => {
+        const { lifecycle, events } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { assert.fail(); return; }
+        lifecycle.recordConnected();
+        await result.promise;
+        assert.strictEqual(lifecycle.state, 'connected');
+        assert.strictEqual(lifecycle.wasConnectedOnce, true);
+        assert.strictEqual(lifecycle.reconnectAttempts, 0);
+        assert.deepStrictEqual(events, [{ connected: true, wasEverConnected: true }]);
+    });
+
+    test('recordDisconnect during connecting rejects the deferred', async () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { assert.fail(); return; }
+        lifecycle.recordDisconnect({ hasClient: true });
+        await assert.rejects(result.promise, /closed during connection/);
+        assert.strictEqual(lifecycle.state, 'disconnected');
+    });
+
+    test('recordDisconnect after connected fires debounced disconnect event', () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const { lifecycle, events } = makeLifecycle();
+            const result = lifecycle.beginConnect({});
+            if (result.kind !== 'fresh') { return; }
+            lifecycle.recordConnected();
+            events.length = 0;
+
+            const directive = lifecycle.recordDisconnect({ hasClient: true });
+            assert.strictEqual(directive.clearedConnectedState, true);
+            assert.strictEqual(directive.gaveUp, false);
+            assert.strictEqual(events.length, 0, 'event must wait for debounce');
+
+            clock.tick(4999);
+            assert.strictEqual(events.length, 0);
+
+            clock.tick(1);
+            assert.strictEqual(events.length, 1);
+            assert.deepStrictEqual(events[0], { connected: false, wasEverConnected: true });
+        } finally {
+            clock.restore();
+        }
+    });
+
+    test('recordDisconnect twice in same attempt does not double-count', () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { return; }
+        lifecycle.recordConnected();
+
+        lifecycle.recordDisconnect({ hasClient: true });
+        assert.strictEqual(lifecycle.reconnectAttempts, 1);
+        lifecycle.recordDisconnect({ hasClient: true });
+        assert.strictEqual(lifecycle.reconnectAttempts, 1);
+    });
+
+    test('20 unexpected disconnects with client present transition to gave-up, bump generation, emit one event', () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const { lifecycle, events } = makeLifecycle();
+            const result = lifecycle.beginConnect({});
+            if (result.kind !== 'fresh') { return; }
+            lifecycle.recordConnected();
+            events.length = 0;
+            const genAfterConnect = lifecycle.generation;
+
+            for (let i = 0; i < 20; i++) {
+                lifecycle.recordWebSocketReopened();
+                lifecycle.recordDisconnect({ hasClient: true });
+            }
+            assert.strictEqual(lifecycle.state, 'gave-up');
+            assert.ok(lifecycle.generation > genAfterConnect, 'generation bumped on gave-up with client');
+            const falseEvents = events.filter(e => !e.connected);
+            assert.strictEqual(falseEvents.length, 1, 'exactly one disconnect notification');
+        } finally {
+            clock.restore();
+        }
+    });
+
+    test('gave-up reached with hasClient=false does NOT bump generation', () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { return; }
+        lifecycle.recordConnected();
+        const genAfterConnect = lifecycle.generation;
+
+        for (let i = 0; i < 20; i++) {
+            lifecycle.recordWebSocketReopened();
+            lifecycle.recordDisconnect({ hasClient: false });
+        }
+        assert.strictEqual(lifecycle.state, 'gave-up');
+        assert.strictEqual(lifecycle.generation, genAfterConnect, 'no generation bump when client is gone');
+    });
+
+    test('beginDisconnect bumps generation, transitions to disconnecting, rejects in-flight deferred', async () => {
+        const { lifecycle } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { return; }
+        const genBefore = lifecycle.generation;
+
+        lifecycle.beginDisconnect();
+        assert.ok(lifecycle.generation > genBefore);
+        assert.strictEqual(lifecycle.state, 'disconnecting');
+        await assert.rejects(result.promise, /Disconnected/);
+    });
+
+    test('completeDisconnectWithClient fires (false, prior wasEverConnected) and resets counters', () => {
+        const { lifecycle, events } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { return; }
+        lifecycle.recordConnected();
+        events.length = 0;
+
+        lifecycle.beginDisconnect();
+        lifecycle.completeDisconnectWithClient();
+
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.strictEqual(lifecycle.reconnectAttempts, 0);
+        assert.strictEqual(lifecycle.wasConnectedOnce, false);
+        const falseEvent = events.find(e => !e.connected);
+        assert.ok(falseEvent);
+        assert.strictEqual(falseEvent!.wasEverConnected, true);
+    });
+
+    test('completeDisconnectNoClient transitions to disconnected without firing event', () => {
+        const { lifecycle, events } = makeLifecycle();
+        lifecycle.beginDisconnect();
+        events.length = 0;
+        lifecycle.completeDisconnectNoClient();
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.deepStrictEqual(events, [], 'no event fired when no client existed');
+    });
+
+    test('abortSupersededConnect transitions to disconnected without firing or settling', () => {
+        const { lifecycle, events } = makeLifecycle();
+        const result = lifecycle.beginConnect({});
+        if (result.kind !== 'fresh') { return; }
+        // Simulate disconnect bumping the generation underneath us
+        lifecycle.forceState('disconnected');
+        events.length = 0;
+        lifecycle.abortSupersededConnect();
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.deepStrictEqual(events, []);
+        // The deferred was already settled by whatever bumped the generation;
+        // abortSupersededConnect must NOT throw on a settled-or-missing deferred.
+    });
+
+    test('reset clears reconnectAttempts and exits gave-up', () => {
+        const { lifecycle } = makeLifecycle();
+        lifecycle.forceState('gave-up');
+        lifecycle.setReconnectAttempts(15);
+        lifecycle.reset();
+        assert.strictEqual(lifecycle.state, 'disconnected');
+        assert.strictEqual(lifecycle.reconnectAttempts, 0);
+    });
+
+    test('safety timeout rejects deferred after 15s and transitions to disconnected', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const { lifecycle } = makeLifecycle();
+            const result = lifecycle.beginConnect({});
+            if (result.kind !== 'fresh') { return; }
+            clock.tick(15001);
+            await assert.rejects(result.promise, /timed out/);
+            assert.strictEqual(lifecycle.state, 'disconnected');
+        } finally {
+            clock.restore();
+        }
+    });
+});

--- a/extension/test/unit/services/websocket/jwtExtractor.test.ts
+++ b/extension/test/unit/services/websocket/jwtExtractor.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+
+import { extractJwtFromHeaders } from '@extension/services/websocket/jwtExtractor';
+
+suite('extractJwtFromHeaders', () => {
+    test('extracts JWT from Bearer Authorization header', () => {
+        assert.strictEqual(
+            extractJwtFromHeaders({ Authorization: 'Bearer abc.def.ghi' }),
+            'abc.def.ghi'
+        );
+    });
+
+    test('extracts JWT from Cookie header (jwt cookie)', () => {
+        assert.strictEqual(
+            extractJwtFromHeaders({ Cookie: 'jwt=abc.def.ghi; other=foo' }),
+            'abc.def.ghi'
+        );
+    });
+
+    test('returns undefined when no JWT is present', () => {
+        assert.strictEqual(extractJwtFromHeaders({}), undefined);
+        assert.strictEqual(extractJwtFromHeaders({ Cookie: 'other=foo' }), undefined);
+    });
+
+    test('handles Bearer with no token gracefully', () => {
+        assert.strictEqual(extractJwtFromHeaders({ Authorization: 'Bearer ' }), '');
+    });
+});

--- a/extension/test/unit/services/websocket/stompConfigBuilder.test.ts
+++ b/extension/test/unit/services/websocket/stompConfigBuilder.test.ts
@@ -1,0 +1,130 @@
+import * as assert from 'assert';
+
+import { buildStompConfig } from '@extension/services/websocket/stompConfigBuilder';
+
+suite('buildStompConfig', () => {
+    function makeDeps(overrides: Partial<Parameters<typeof buildStompConfig>[0]> = {}) {
+        return {
+            generation: 7,
+            authHeaders: { Cookie: 'jwt=abc' },
+            wsUrl: 'wss://example.com/websocket/websocket',
+            currentGeneration: () => 7,
+            onConnected: () => { /* spy */ },
+            onStompError: (_msg: string) => { /* spy */ },
+            onWebSocketError: (_msg: string) => { /* spy */ },
+            onDisconnected: () => { /* spy */ },
+            onWebSocketBeforeOpen: () => { /* spy */ },
+            log: (_msg: string) => { /* spy */ },
+            ...overrides,
+        };
+    }
+
+    test('sets brokerURL to wsUrl and empty connectHeaders', () => {
+        const cfg = buildStompConfig(makeDeps());
+        assert.strictEqual(cfg.brokerURL, 'wss://example.com/websocket/websocket');
+        assert.deepStrictEqual(cfg.connectHeaders, {});
+    });
+
+    test('onConnect callback gated by generation match', () => {
+        let connectedCalls = 0;
+        let current = 7;
+        const cfg = buildStompConfig(makeDeps({
+            currentGeneration: () => current,
+            onConnected: () => { connectedCalls++; },
+        }));
+
+        cfg.onConnect!({} as any);
+        assert.strictEqual(connectedCalls, 1);
+
+        current = 8;
+        cfg.onConnect!({} as any);
+        assert.strictEqual(connectedCalls, 1, 'must not fire when generation differs');
+    });
+
+    test('onStompError callback gated by generation', () => {
+        let lastError = '';
+        let current = 7;
+        const cfg = buildStompConfig(makeDeps({
+            currentGeneration: () => current,
+            onStompError: (msg) => { lastError = msg; },
+        }));
+
+        cfg.onStompError!({ headers: { message: 'broker rejected' }, body: '' } as any);
+        assert.ok(lastError.includes('broker rejected'));
+
+        current = 8;
+        cfg.onStompError!({ headers: { message: 'ignored' }, body: '' } as any);
+        assert.ok(!lastError.includes('ignored'));
+    });
+
+    test('onWebSocketError extracts message or type from event', () => {
+        let lastError = '';
+        const cfg = buildStompConfig(makeDeps({
+            onWebSocketError: (msg) => { lastError = msg; },
+        }));
+
+        cfg.onWebSocketError!({ message: 'ECONNREFUSED' } as any);
+        assert.ok(lastError.includes('ECONNREFUSED'));
+
+        cfg.onWebSocketError!({ type: 'error' } as any);
+        assert.ok(lastError.includes('error'));
+
+        cfg.onWebSocketError!({} as any);
+        assert.ok(lastError.includes('unknown'));
+    });
+
+    test('onWebSocketError gated by generation', () => {
+        let calls = 0;
+        let current = 7;
+        const cfg = buildStompConfig(makeDeps({
+            currentGeneration: () => current,
+            onWebSocketError: () => { calls++; },
+        }));
+        cfg.onWebSocketError!({ message: 'x' } as any);
+        assert.strictEqual(calls, 1);
+        current = 8;
+        cfg.onWebSocketError!({ message: 'x' } as any);
+        assert.strictEqual(calls, 1, 'must not fire when generation differs');
+    });
+
+    test('onDisconnect gated by generation', () => {
+        let calls = 0;
+        let current = 7;
+        const cfg = buildStompConfig(makeDeps({
+            currentGeneration: () => current,
+            onDisconnected: () => { calls++; },
+        }));
+        cfg.onDisconnect!({} as any);
+        assert.strictEqual(calls, 1);
+        current = 8;
+        cfg.onDisconnect!({} as any);
+        assert.strictEqual(calls, 1, 'must not fire when generation differs');
+    });
+
+    test('onWebSocketClose gated by generation', () => {
+        let calls = 0;
+        let current = 7;
+        const cfg = buildStompConfig(makeDeps({
+            currentGeneration: () => current,
+            onDisconnected: () => { calls++; },
+        }));
+        cfg.onWebSocketClose!({} as any);
+        assert.strictEqual(calls, 1);
+        current = 8;
+        cfg.onWebSocketClose!({} as any);
+        assert.strictEqual(calls, 1, 'must not fire when generation differs');
+    });
+
+    test('webSocketFactory invokes onWebSocketBeforeOpen each call', () => {
+        let beforeOpenCalls = 0;
+        const cfg = buildStompConfig(makeDeps({
+            onWebSocketBeforeOpen: () => { beforeOpenCalls++; },
+        }));
+
+        // Wrap to swallow constructor exceptions from `new WebSocket(...)`
+        // (the fake URL won't resolve, but the hook still fires first).
+        try { cfg.webSocketFactory!(); } catch { /* ignore */ }
+        try { cfg.webSocketFactory!(); } catch { /* ignore */ }
+        assert.strictEqual(beforeOpenCalls, 2);
+    });
+});

--- a/extension/test/unit/services/websocket/subscriptionRegistry.test.ts
+++ b/extension/test/unit/services/websocket/subscriptionRegistry.test.ts
@@ -1,0 +1,103 @@
+import { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+import * as assert from 'assert';
+
+import { SubscriptionRegistry } from '@extension/services/websocket/subscriptionRegistry';
+import type { WebSocketMessageHandler } from '@extension/types';
+
+class FakeClient {
+    public subscribed: Map<string, (msg: IMessage) => void> = new Map();
+    public connected = true;
+    private _id = 0;
+    public subscribe(topic: string, cb: (msg: IMessage) => void): StompSubscription {
+        this.subscribed.set(topic, cb);
+        const id = `sub-${++this._id}`;
+        return {
+            id,
+            unsubscribe: () => {
+                if (this.subscribed.get(topic) === cb) { this.subscribed.delete(topic); }
+            },
+        };
+    }
+}
+
+function makeRegistry(): { registry: SubscriptionRegistry; client: FakeClient } {
+    const registry = new SubscriptionRegistry({ log: () => { /* silent */ } });
+    const client = new FakeClient();
+    registry.attachClient(client as unknown as Client);
+    return { registry, client };
+}
+
+suite('SubscriptionRegistry', () => {
+    test('subscribeToPersonalResults dispatches to registered handlers', () => {
+        const { registry, client } = makeRegistry();
+        let received: any;
+        const handler: WebSocketMessageHandler = { onNewResult: (r) => { received = r; } };
+        registry.registerMessageHandler(handler);
+
+        registry.subscribeToPersonalResults();
+        const cb = client.subscribed.get('/user/topic/newResults');
+        assert.ok(cb, 'subscription registered');
+        cb!({ body: JSON.stringify({ id: 1, score: 75, successful: true }) } as IMessage);
+
+        assert.strictEqual(received.id, 1);
+        assert.strictEqual(received.score, 75);
+    });
+
+    test('duplicate subscribe is idempotent', () => {
+        const { registry, client } = makeRegistry();
+        registry.subscribeToPersonalResults();
+        registry.subscribeToPersonalResults();
+        assert.strictEqual(client.subscribed.size, 1);
+    });
+
+    test('clearAll unsubscribes everything', () => {
+        const { registry, client } = makeRegistry();
+        registry.subscribeToPersonalResults();
+        registry.subscribeToPersonalSubmissions();
+        registry.subscribeToSubmissionProcessing();
+        assert.strictEqual(client.subscribed.size, 3);
+
+        registry.clearAll();
+        assert.strictEqual(client.subscribed.size, 0);
+    });
+
+    test('subscribeToIrisSession returns unsubscribe that ignores stale replacement', () => {
+        const { registry, client } = makeRegistry();
+        const sessionId = 99;
+        const topic = '/user/topic/iris/99';
+
+        const unsub1 = registry.subscribeToIrisSession(sessionId, () => { /* noop */ });
+        assert.ok(client.subscribed.has(topic));
+
+        // Replace
+        const unsub2 = registry.subscribeToIrisSession(sessionId, () => { /* noop */ });
+        assert.ok(client.subscribed.has(topic));
+
+        // Stale unsubscribe must not remove the active one
+        unsub1();
+        assert.ok(client.subscribed.has(topic));
+
+        unsub2();
+        assert.strictEqual(client.subscribed.has(topic), false);
+    });
+
+    test('subscribe throws if no client attached', () => {
+        const registry = new SubscriptionRegistry({ log: () => { /* silent */ } });
+        assert.throws(() => registry.subscribeToIrisSession(1, () => { /* noop */ }), /not connected/);
+    });
+
+    test('handler unregister stops dispatch', () => {
+        const { registry, client } = makeRegistry();
+        let calls = 0;
+        const handler: WebSocketMessageHandler = { onNewResult: () => { calls++; } };
+        registry.registerMessageHandler(handler);
+        registry.subscribeToPersonalResults();
+        const cb = client.subscribed.get('/user/topic/newResults')!;
+        cb({ body: JSON.stringify({ id: 1, score: 1, successful: true }) } as IMessage);
+        assert.strictEqual(calls, 1);
+
+        registry.unregisterMessageHandler(handler);
+        cb({ body: JSON.stringify({ id: 2, score: 2, successful: true }) } as IMessage);
+        assert.strictEqual(calls, 1);
+    });
+});

--- a/extension/test/unit/services/websocket/webSocketUrl.test.ts
+++ b/extension/test/unit/services/websocket/webSocketUrl.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+
+import { buildWebSocketUrl } from '@extension/services/websocket/webSocketUrl';
+
+suite('buildWebSocketUrl', () => {
+    test('converts https:// to wss://', () => {
+        assert.strictEqual(
+            buildWebSocketUrl('https://artemis.example.com/'),
+            'wss://artemis.example.com/websocket/websocket'
+        );
+    });
+
+    test('converts http:// to ws://', () => {
+        assert.strictEqual(
+            buildWebSocketUrl('http://localhost:8080/'),
+            'ws://localhost:8080/websocket/websocket'
+        );
+    });
+
+    test('preserves port and host', () => {
+        assert.strictEqual(
+            buildWebSocketUrl('https://artemis.example.com:8443/path'),
+            'wss://artemis.example.com:8443/websocket/websocket'
+        );
+    });
+});


### PR DESCRIPTION
Closes #207. Final sub-task of #170 (god class 3/3).

Decomposes `ArtemisWebsocketService` (668 LOC) into 5 focused modules. Public API of the service is unchanged. Race-handling behavior preserved byte-for-byte (verified by 60+ existing behavior tests plus 33 new unit tests).

## Architecture

| File | LOC | Role |
|---|---:|---|
| `artemisWebsocketService.ts` | 277 | thin orchestrator; owns STOMP `Client` + `AuthManager` + sessionId + EventEmitter |
| `connectionLifecycle.ts` | 318 | state machine (state, generation token, reconnect counter, deferred, safety timeout, debounce timer, gave-up logic) |
| `subscriptionRegistry.ts` | 162 | subscription Map + message handler list + personal/iris topic helpers |
| `stompConfigBuilder.ts` | 97 | pure function returning `StompConfig` with generation-gated callbacks |
| `jwtExtractor.ts` | 22 | pure helper |
| `webSocketUrl.ts` | 11 | pure helper |

Service shrunk from 668 → 277 LOC (-59%).

## Commits

5 atomic commits (TDD per task, full test + lint + knip after each):

1. `b0e83962` extract pure helpers (URL + JWT) — 7 new tests
2. `433d9d00` extract `buildStompConfig` pure function — 8 new tests, full generation-gating coverage on all 5 STOMP callbacks (`onConnect`, `onStompError`, `onWebSocketError`, `onDisconnect`, `onWebSocketClose`)
3. `67bfa2e0` extract `SubscriptionRegistry` — 6 new tests; critical invariant: registry is attached only inside `_onConnected`, between `transitionTo('connected')` and the public event fire
4. `ca71e56f` extract `ConnectionLifecycle` — 18 new tests; no test-only mutators on the production API; `clientInflight` option preserves the old `_maybeReuseInflightConnect` guard ordering; `hasClient` option preserves the old `if (this._client) { _connectionGeneration++; ... }` semantics on gave-up
5. `57923bf6` correct an inline comment in `connect()` whose wording was inverted

## Race-handling parity

Preserved byte-for-byte:

- State-gate ordering in `beginConnect`: `connecting → reuse; disconnecting → throw; gave-up → throw; clientInflight reuse from disconnected; fresh attempt`.
- Generation token bumps in exactly 3 places: `beginConnect` (fresh), `beginDisconnect`, `recordDisconnect` on gave-up iff `hasClient`.
- Deferred settle paths: success / explicit error / connect-error catch / disconnect / safety timeout / handshake close / abort-superseded.
- Double-count guard via `_disconnectCountedThisAttempt` reset on `recordWebSocketReopened` (called from `onWebSocketBeforeOpen`).
- Debounce cancellation on connect / disconnect / gave-up.
- `_onStompConnected` ordering: attach BEFORE `recordConnected` fires the event, so synchronous consumers (`IrisWebSocketSessionClient`) observe an attached registry.

## Plan and reviews

- Plan: codex-reviewed in 4 rounds (verdict A on round 3 + B on round 4 verbatim).
- Per-task spec review and code-quality review (both APPROVED for each of the 4 tasks).
- Final codex review of the full branch: verdict A, no correctness regressions.

## Verification

- 1108 mocha tests, 0 failures, 3 skipped (baseline 1069 + 33 new + 6 pre-existing — net +39, of which 33 are this PR's new tests).
- `tsc --noEmit`: clean.
- `eslint --quiet`: clean.
- `knip`: clean.

## Manual test checklist

For local validation (these paths are covered by unit tests but a smoke test never hurts):

- [ ] Launch Extension Development Host. Log in to Artemis. Verify WebSocket status bar shows "Connected".
- [ ] Open the Iris chat. Send a message. Verify the response arrives (WebSocket subscribe path).
- [ ] Disconnect network for 5s. Verify status bar shows "Reconnecting (k/20)". Reconnect network. Verify it goes back to connected.
- [ ] Log out. Verify status bar disappears (or shows according to setting).
- [ ] Trigger a build (e.g. push to remote repo). Verify result and submission updates arrive in the UI.
