### PR TITLE
fix(iris-chat): distinguish unavailable from disabled, add retry path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Iris Context Dropdown**: Conversations sort newest-first, the dropdown panel now spans exactly down to the chat input (no input controls peek through), scroll shadows appear when lists overflow, and exercise rows align consistently whether or not a course tag is shown.
 - **Iris Chat**: Updated to the unified Iris API in Artemis 9.2+ so chat keeps working after the upstream session-endpoint consolidation.
 - **Iris Chat New Conversation**: Fixed "New Conversation" silently jumping back to the workspace exercise instead of starting a new session in the currently selected context.
+- **Iris Chat Connectivity Resilience**: Network drops and server errors now show a "temporarily unavailable" banner with a Retry button instead of the misleading "instructor disabled Iris" overlay, and the chat reloads automatically when the WebSocket reconnects.
 
 ## [0.4.4] - 2026-05-10
 

--- a/extension/src/extension/provider/chatReloadDecision.ts
+++ b/extension/src/extension/provider/chatReloadDecision.ts
@@ -1,0 +1,29 @@
+import type { LastAvailability } from '@extension/services/iris/chat/chatSessionService';
+import type { ActiveContext } from '@extension/types';
+
+/**
+ * Decide whether a websocket reconnect should trigger an auto-retry reload
+ * of the chat session. Pure function so we can unit-test the context-keyed
+ * gate in isolation from the rest of {@link ChatWebviewProvider}.
+ *
+ * Rules:
+ *   - Last classification must be `unavailable` (no point auto-retrying a
+ *     disabled/enabled state).
+ *   - The user must still be looking at the SAME context the classification
+ *     was recorded for. After a context switch, the previous context's
+ *     unavailable state is no longer relevant — the new context will get
+ *     its own classification.
+ *   - No active context = no retry.
+ */
+export function shouldAutoRetryReload(
+    lastAvailability: LastAvailability,
+    currentContext: ActiveContext | null,
+): boolean {
+    if (lastAvailability.kind !== 'unavailable') {
+        return false;
+    }
+    if (!currentContext) {
+        return false;
+    }
+    return lastAvailability.contextKey === `${currentContext.type}:${currentContext.id}`;
+}

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -33,6 +33,7 @@ import { ActiveContext, ChatContextType } from '@extension/types';
 import type { IChatWebviewProvider } from '@extension/types/IChatWebviewProvider';
 
 import { BaseWebviewProvider } from './baseWebviewProvider';
+import { shouldAutoRetryReload } from './chatReloadDecision';
 import { ChatViewStatePresenter } from './chatViewStatePresenter';
 
 interface ExerciseContextChangeEvent {
@@ -56,6 +57,23 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     private _chatContextManager: ChatContextManager;
     private _websocketMessageHandler: IrisWebSocketMessageHandler;
     private _noAiDetectionService: NoAiDetectionService;
+
+    /**
+     * Context-keyed single-flight guard for chat-session reloads. Auto-retry
+     * on websocket reconnect, manual Retry button, and any other future
+     * reload trigger latch onto the in-flight reload for the SAME context.
+     * A trigger for a different context (after the user switched) bypasses
+     * the join and starts a fresh reload — otherwise a hung reload (no fetch
+     * timeout) for context A would silently swallow retries for context B.
+     */
+    private _reloadInFlight: { promise: Promise<void>; contextKey: string } | null = null;
+
+    /**
+     * Debounce timer for the websocket-reconnect → reload trigger. Coalesces
+     * the rapid `connected: true` re-emits we sometimes see when a flap
+     * settles. The single-flight guard catches everything else.
+     */
+    private _reloadDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
     private readonly _onDidChangeExerciseContext = new vscode.EventEmitter<ExerciseContextChangeEvent>();
     public readonly onDidChangeExerciseContext = this._onDidChangeExerciseContext.event;
@@ -122,6 +140,16 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                         exerciseRoot: vscode.workspace.workspaceFolders?.[0]?.uri,
                     });
                 }
+                // Real context change (type/id differs from previous — the
+                // event fires only on actual changes). Drop any stale
+                // availability classification from the outgoing context so
+                // the reconnect hook does not auto-retry the new context
+                // against the old context's banner state, and hide any
+                // visible banner so the user starts the new context from a
+                // clean slate.
+                this._chatSessionService.resetAvailability();
+                this._postMessageSafe({ type: ExtensionMsg.HideDisabledState });
+                this._postMessageSafe({ type: ExtensionMsg.HideUnavailableState });
             })
         );
         this._viewStatePresenter = new ChatViewStatePresenter(this._contextStore, (msg) => this._postMessageSafe(msg));
@@ -173,6 +201,28 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             this._disposables.push(
                 this._irisSessionManager.onDidConnectionStateChange(() => this._websocketMessageHandler.publishCurrentStatus())
             );
+
+            // Auto-retry chat reload on websocket reconnect when the chat is
+            // currently in an `unavailable` state for the active context.
+            // The 500 ms debounce coalesces rapid flap re-emits; the
+            // single-flight reload guard catches concurrent reconnect +
+            // manual-Retry presses.
+            this._disposables.push(
+                this._websocketService.onDidChangeConnectionState(({ connected }) => {
+                    if (!connected) {
+                        return;
+                    }
+                    if (this._reloadDebounceTimer) {
+                        clearTimeout(this._reloadDebounceTimer);
+                    }
+                    this._reloadDebounceTimer = setTimeout(() => {
+                        this._reloadDebounceTimer = undefined;
+                        if (this._shouldAutoRetryReload()) {
+                            void this._reloadChatSession('websocket-reconnect');
+                        }
+                    }, 500);
+                })
+            );
         }
 
         this._disposables.push(
@@ -195,7 +245,68 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     // ── Lifecycle ──────────────────────────────────────────────────────
 
     public dispose(): void {
+        if (this._reloadDebounceTimer) {
+            clearTimeout(this._reloadDebounceTimer);
+            this._reloadDebounceTimer = undefined;
+        }
         this._drainDisposables();
+    }
+
+    // ── Reload helpers (auto-retry + manual Retry share this path) ─────
+
+    /**
+     * Decide whether a websocket reconnect should trigger an auto-retry of
+     * the chat-session reload. The pure decision logic lives in
+     * {@link shouldAutoRetryReload} so it can be unit-tested in isolation;
+     * this method just plumbs the current state in.
+     */
+    private _shouldAutoRetryReload(): boolean {
+        return shouldAutoRetryReload(
+            this._chatSessionService.lastAvailability,
+            this._contextStore.getActiveContext(),
+        );
+    }
+
+    /**
+     * Trigger a chat-session reload, deduplicating concurrent triggers for
+     * the same context (auto-retry on reconnect, manual Retry button,
+     * future webview commands). A trigger for a different context bypasses
+     * the join and starts a fresh reload — otherwise a hung reload for the
+     * previous context would block recovery of the current one.
+     */
+    private _reloadChatSession(reason: string): Promise<void> {
+        const current = this._contextStore.getActiveContext();
+        if (!current) {
+            return Promise.resolve();
+        }
+        const currentKey = `${current.type}:${current.id}`;
+        if (this._reloadInFlight && this._reloadInFlight.contextKey === currentKey) {
+            logger.info(`Reload (${reason}) joined existing in-flight reload for ${currentKey}`, LogCategory.IRIS_CHAT);
+            return this._reloadInFlight.promise;
+        }
+        if (this._reloadInFlight) {
+            logger.info(`Reload (${reason}) for ${currentKey} starts fresh (in-flight is for ${this._reloadInFlight.contextKey})`, LogCategory.IRIS_CHAT);
+        } else {
+            logger.info(`Reload chat session (${reason})`, LogCategory.IRIS_CHAT);
+        }
+        const entry: { promise: Promise<void>; contextKey: string } = {
+            contextKey: currentKey,
+            promise: this._chatSessionService
+                .loadAllSessionsForContext()
+                .catch((err: unknown) => {
+                    logger.error(`Reload chat session (${reason}) threw`, LogCategory.IRIS_CHAT, err);
+                })
+                .finally(() => {
+                    // Only clear if WE are still the registered in-flight.
+                    // A later context-switch + new reload may have replaced
+                    // us; in that case the new entry owns the slot.
+                    if (this._reloadInFlight === entry) {
+                        this._reloadInFlight = null;
+                    }
+                }),
+        };
+        this._reloadInFlight = entry;
+        return entry.promise;
     }
 
     public resolveWebviewView(
@@ -440,6 +551,12 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                         vscode.window.showErrorMessage('Failed to reconnect. Please try again.');
                     });
                     break;
+                case WebviewCmd.ReloadChatSession:
+                    // Manual Retry from the unavailable banner. Single-flight
+                    // is enforced inside _reloadChatSession so a button mash
+                    // or a concurrent reconnect can't kick off duplicates.
+                    void this._reloadChatSession('manual-retry');
+                    break;
                 case WebviewCmd.MessageFeedback: {
                     const { sessionId, messageId, feedback } = getPayload<WebCmd<'messageFeedback'>>(message);
                     void this._handleMessageFeedback({
@@ -508,7 +625,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
      * AddMessage handler already calls resetTransientChatUi.
      */
     private _handleRejectedSend(
-        result: { sent: false; reason: 'no-ai' | 'no-context' | 'iris-disabled'; contextLabel?: string },
+        result: { sent: false; reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable'; contextLabel?: string; capturedContext?: ActiveContext },
         localId: string | undefined,
         localSessionId: string | undefined,
     ): void {
@@ -524,11 +641,30 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                 // message communicates this fully.
                 break;
             case 'iris-disabled':
-                this._postMessageSafe({
-                    type: ExtensionMsg.ShowDisabledState,
-                    message: `Iris chat is not enabled for this ${result.contextLabel ?? 'context'}. Please contact your instructor.`
-                });
+            case 'iris-unavailable': {
+                // Persistent availability emit is gated on "captured context
+                // still matches the live active context". Without this gate,
+                // a slow checkAndLoadIrisSettings that returns after the
+                // user switched would mislabel the NEW context's banner
+                // state with the OLD context's classification (race surfaced
+                // by codex review). If they diverge, skip the banner — the
+                // SendRejected message-level signal is still delivered so
+                // the optimistic user message gets marked failed.
+                const live = this._contextStore.getActiveContext();
+                const captured = result.capturedContext;
+                if (!live || !captured || live.type !== captured.type || live.id !== captured.id) {
+                    break;
+                }
+                if (result.reason === 'iris-disabled') {
+                    this._chatSessionService.postAvailability({ kind: 'disabled' }, captured);
+                } else {
+                    this._chatSessionService.postAvailability(
+                        { kind: 'unavailable', reason: 'Send rejected: iris-unavailable' },
+                        captured,
+                    );
+                }
                 break;
+            }
         }
 
         if (localId && localSessionId) {
@@ -556,7 +692,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         });
     }
 
-    private _friendlyRejectionMessage(result: { reason: 'no-ai' | 'no-context' | 'iris-disabled'; contextLabel?: string }): string {
+    private _friendlyRejectionMessage(result: { reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable'; contextLabel?: string }): string {
         switch (result.reason) {
             case 'no-ai':
                 return 'Not sent because AI assistance is disabled for this workspace.';
@@ -564,6 +700,8 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                 return 'Please select a course or exercise context first.';
             case 'iris-disabled':
                 return `Iris chat is disabled for this ${result.contextLabel ?? 'context'}.`;
+            case 'iris-unavailable':
+                return 'Iris is temporarily unavailable. Try again in a moment.';
         }
     }
 

--- a/extension/src/extension/services/iris/chat/chatMessageService.ts
+++ b/extension/src/extension/services/iris/chat/chatMessageService.ts
@@ -20,7 +20,20 @@ interface SendMessageInput {
 
 type SendMessageResult =
     | { sent: true }
-    | { sent: false; reason: 'no-ai' | 'no-context' | 'iris-disabled'; contextLabel?: string };
+    | {
+        sent: false;
+        reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable';
+        contextLabel?: string;
+        /**
+         * Context that was active when sendMessage started. Needed so the
+         * caller can decide whether to surface a persistent availability
+         * banner: if the user has since switched contexts, posting an
+         * availability for the new context based on the old context's
+         * settings-check result would be wrong (issue surfaced by codex
+         * review of the connectivity-resilience PR).
+         */
+        capturedContext?: ActiveContext;
+    };
 
 export class ChatMessageService {
     constructor(
@@ -42,10 +55,21 @@ export class ChatMessageService {
             return { sent: false, reason: 'no-context' };
         }
 
-        const isEnabled = await this._chatSessionService.checkAndLoadIrisSettings(activeContext);
-        if (!isEnabled) {
+        const availability = await this._chatSessionService.checkAndLoadIrisSettings(activeContext);
+        if (availability.kind !== 'enabled') {
+            // Distinguishing disabled from unavailable lets the webview's
+            // Retry-button affordance stay active for unavailable (a network
+            // blip might have cleared) while remaining disabled for the
+            // intentionally-off case.
             const contextLabel = activeContext.type === 'course' ? 'course' : 'exercise';
-            return { sent: false, reason: 'iris-disabled', contextLabel };
+            const reason: 'iris-disabled' | 'iris-unavailable' =
+                availability.kind === 'disabled' ? 'iris-disabled' : 'iris-unavailable';
+            // capturedContext is the context the settings check was actually
+            // run against. The provider compares it to the live active
+            // context before posting availability so a slow check that
+            // returns after the user switched does not pollute the new
+            // context's banner state.
+            return { sent: false, reason, contextLabel, capturedContext: activeContext };
         }
 
         await this._sendToIris(input.text, activeContext, input.struggleContext);

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -1,5 +1,6 @@
 import { ExtensionMsg } from '@shared/messageContracts';
 
+import { MalformedResponseError } from '@extension/domain/errors';
 import { resolveCourseIdFromContext } from '@extension/services/iris/context/courseIdResolver';
 import type { IrisServiceDeps } from '@extension/services/iris/context/sessionSyncUtils';
 import { fetchSessionsWithMessages, importSessionsToStore } from '@extension/services/iris/context/sessionSyncUtils';
@@ -8,6 +9,42 @@ import { LogCategory, logger } from '@extension/services/loggingService';
 import { ActiveContext, ApiError, type IrisChatMessage, type IrisSettingsResponse } from '@extension/types';
 
 import { extractIrisMessageContent } from './messageUtils';
+
+/**
+ * Three-way availability classification for the Iris chat. The distinction
+ * matters in the UI: `disabled` shows the persistent "instructor disabled
+ * Iris" overlay, while `unavailable` shows a transient "temporarily
+ * unavailable, retry" banner. Conflating the two misleads students into
+ * thinking their course turned Iris off whenever the network blips.
+ */
+export type IrisAvailability =
+    | { kind: 'enabled' }
+    | { kind: 'disabled' }
+    | { kind: 'unavailable'; reason: string };
+
+/**
+ * Tracked availability state with the context the classification belongs to.
+ * Auto-retry-on-reconnect uses this to only fire if the user is still looking
+ * at the same context (e.g. exercise 42) that originally classified as
+ * unavailable — a stale classification for a previous context must not
+ * trigger a reload of the current one.
+ */
+export type LastAvailability =
+    | { kind: 'unknown'; contextKey?: undefined }
+    | { kind: IrisAvailability['kind']; contextKey: string };
+
+const UNAVAILABLE_USER_MESSAGE = 'Iris is temporarily unavailable. Retry to reload.';
+
+function contextKeyOf(context: ActiveContext | null): string | undefined {
+    return context ? `${context.type}:${context.id}` : undefined;
+}
+
+function describeError(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message || error.name;
+    }
+    return String(error);
+}
 
 /**
  * Orchestrates Iris chat session lifecycle (create, load, switch).
@@ -19,6 +56,7 @@ import { extractIrisMessageContent } from './messageUtils';
  */
 export class IrisChatSessionService {
     private _contextLoadToken = 0;
+    private _lastAvailability: LastAvailability = { kind: 'unknown' };
 
     constructor(
         private readonly deps: IrisServiceDeps,
@@ -41,65 +79,157 @@ export class IrisChatSessionService {
         return !!current && current.type === expected.type && current.id === expected.id;
     }
 
-    public async checkAndLoadIrisSettings(context: ActiveContext): Promise<boolean> {
+    /**
+     * Most recent availability classification, paired with the context it
+     * belongs to. Consumed by the reconnect hook in
+     * {@link ChatWebviewProvider} to decide whether to fire an auto-retry.
+     */
+    public get lastAvailability(): LastAvailability {
+        return this._lastAvailability;
+    }
+
+    /**
+     * Clear the tracked availability state. Called on context changes so a
+     * stale `unavailable` from a previous exercise cannot trigger a reload
+     * of the new one. Does not emit any UI messages — the caller is
+     * responsible for hiding banners for the outgoing context.
+     */
+    public resetAvailability(): void {
+        this._lastAvailability = { kind: 'unknown' };
+    }
+
+    /**
+     * Public wrapper around the centralized availability emission. Used by
+     * paths outside the chat-session loader that still need to surface an
+     * availability state — e.g. {@link ChatMessageService.sendMessage} when
+     * it gets an `unavailable` from `checkAndLoadIrisSettings`. Funneling
+     * through here ensures `lastAvailability` is updated so the websocket
+     * reconnect hook can auto-retry the reload afterwards.
+     */
+    public postAvailability(availability: IrisAvailability, context: ActiveContext | null): void {
+        this._postAvailability(availability, context);
+    }
+
+    public async checkAndLoadIrisSettings(context: ActiveContext): Promise<IrisAvailability> {
         if (!this.deps.artemisApiService) {
             logger.warn('Artemis API service not available', LogCategory.IRIS_CHAT);
-            return false;
+            return { kind: 'unavailable', reason: 'Artemis API service not initialized' };
         }
 
+        logger.info(`Checking Iris settings for ${context.type}: ${context.title}`, LogCategory.IRIS_CHAT);
+
+        // Step 1: Profile probe. A 403 here is NOT a disable signal — that
+        // would mean "user not allowed to read the server profile", which
+        // is an infrastructure / auth issue. Profile-fetch failures
+        // therefore funnel through the same `unavailable` path as any
+        // other infra error.
+        let profileInfo;
         try {
-            logger.info(`Checking Iris settings for ${context.type}: ${context.title}`, LogCategory.IRIS_CHAT);
-
-            // Step 1: Check if Iris is globally enabled (server profile)
-            const profileInfo = await this.deps.artemisApiService.getProfileInfo();
-            if (!this.deps.artemisApiService.isIrisProfileActive(profileInfo)) {
-                logger.info('Iris profile not active on server (global check failed)', LogCategory.IRIS_CHAT);
-                return false;
-            }
-
-            // Step 2: Fetch course-level settings based on context type
-            let settings: IrisSettingsResponse;
-            if (context.type === 'course') {
-                settings = await this.deps.artemisApiService.getIrisCourseChatSettings(context.id);
-            } else if (context.type === 'exercise') {
-                const courseId = await this.resolveCourseIdForExercise(context);
-                if (!courseId) {
-                    logger.warn('Unable to resolve course for exercise context; cannot check Iris settings', LogCategory.IRIS_CHAT);
-                    return false;
-                }
-                settings = await this.deps.artemisApiService.getIrisCourseChatSettings(courseId);
-            } else {
-                logger.warn(`Unsupported context type for Iris: ${context.type}`, LogCategory.IRIS_CHAT);
-                return false;
-            }
-
-            // Check if Iris chat is enabled
-            const chatSettings = settings?.settings;
-
-            if (!chatSettings?.enabled) {
-                logger.info('Iris chat is disabled in settings', LogCategory.IRIS_CHAT);
-                return false;
-            }
-
-            logger.info('Iris chat is enabled, settings loaded:', LogCategory.IRIS_CHAT, {
-                enabled: chatSettings.enabled,
-                rateLimit: settings?.effectiveRateLimit?.requests,
-                rateLimitTimeframeHours: settings?.effectiveRateLimit?.timeframeHours
-            });
-
-            return true;
+            profileInfo = await this.deps.artemisApiService.getProfileInfo();
         } catch (error: unknown) {
-            logger.error('Error checking Iris settings:', LogCategory.IRIS_CHAT, error);
+            logger.error('Profile info fetch failed for Iris check:', LogCategory.IRIS_CHAT, error);
+            return { kind: 'unavailable', reason: `Profile probe failed: ${describeError(error)}` };
+        }
+        if (!this.deps.artemisApiService.isIrisProfileActive(profileInfo)) {
+            logger.info('Iris profile not active on server (global check failed)', LogCategory.IRIS_CHAT);
+            return { kind: 'disabled' };
+        }
 
-            // If it's a 403, Iris is probably disabled - return false to show disabled overlay
-            if ((error instanceof ApiError && error.status === 403) || (error instanceof Error && error.message?.includes('403'))) {
-                logger.info('Iris is not available (403 error)', LogCategory.IRIS_CHAT);
-                return false;
+        // Step 2: Resolve courseId for an exercise context. Failures here
+        // are transient (registry not populated yet, exercise-details
+        // endpoint dropped) — never a disable signal.
+        let courseId: number;
+        if (context.type === 'course') {
+            courseId = context.id;
+        } else if (context.type === 'exercise') {
+            let resolvedCourseId: number | undefined;
+            try {
+                resolvedCourseId = await this.resolveCourseIdForExercise(context);
+            } catch (error: unknown) {
+                logger.error('Course resolution failed for exercise context:', LogCategory.IRIS_CHAT, error);
+                return { kind: 'unavailable', reason: `Could not resolve course: ${describeError(error)}` };
             }
+            if (!resolvedCourseId) {
+                logger.warn('Unable to resolve course for exercise context; cannot check Iris settings', LogCategory.IRIS_CHAT);
+                return { kind: 'unavailable', reason: 'Could not resolve course for this exercise' };
+            }
+            courseId = resolvedCourseId;
+        } else {
+            logger.warn(`Unsupported context type for Iris: ${context.type}`, LogCategory.IRIS_CHAT);
+            return { kind: 'disabled' };
+        }
 
-            // For other errors, log but still return false to show disabled state
-            logger.info(`Could not load Iris settings: ${error instanceof Error ? error.message : String(error)}`, LogCategory.IRIS_CHAT);
-            return false;
+        // Step 3: Iris settings call — this is the ONLY endpoint where a
+        // 403 has a "disabled" semantic (course-level forbidden = Iris
+        // chat off for this user). All other status codes (incl. 401,
+        // 4xx, 5xx) plus network/timeout/malformed map to unavailable
+        // through the shared classifier.
+        let settings: IrisSettingsResponse;
+        try {
+            settings = await this.deps.artemisApiService.getIrisCourseChatSettings(courseId);
+        } catch (error: unknown) {
+            logger.error('Iris settings fetch failed:', LogCategory.IRIS_CHAT, error);
+            return classifyAvailabilityFromError(error);
+        }
+
+        // Distinguish "enabled is explicitly false" from "enabled field is
+        // missing / non-boolean". The latter signals a malformed response,
+        // which is a transport-layer issue, not an intentional disable.
+        const chatSettings = settings?.settings;
+        if (!chatSettings || typeof chatSettings.enabled !== 'boolean') {
+            logger.warn('Iris settings response is missing or malformed', LogCategory.IRIS_CHAT, { settings });
+            return { kind: 'unavailable', reason: 'Malformed Iris settings response' };
+        }
+        if (chatSettings.enabled === false) {
+            logger.info('Iris chat is disabled in settings', LogCategory.IRIS_CHAT);
+            return { kind: 'disabled' };
+        }
+
+        logger.info('Iris chat is enabled, settings loaded:', LogCategory.IRIS_CHAT, {
+            enabled: chatSettings.enabled,
+            rateLimit: settings?.effectiveRateLimit?.requests,
+            rateLimitTimeframeHours: settings?.effectiveRateLimit?.timeframeHours
+        });
+
+        return { kind: 'enabled' };
+    }
+
+    /**
+     * Single emission point for availability state. Every availability
+     * transition flows through here, which keeps the "always clear the
+     * opposite banner" invariant in one place and lets us record
+     * `lastAvailability` alongside the UI signal. Callers that bypass this
+     * helper will silently break banner consistency, so all other availability
+     * emission must be funneled through {@link postAvailability} (the public
+     * wrapper exposed for the send-path) or this private method directly.
+     */
+    private _postAvailability(availability: IrisAvailability, context: ActiveContext | null): void {
+        const key = contextKeyOf(context);
+        this._lastAvailability = key
+            ? { kind: availability.kind, contextKey: key }
+            : { kind: 'unknown' };
+
+        switch (availability.kind) {
+            case 'enabled':
+                this.deps.postMessage({ type: ExtensionMsg.HideDisabledState });
+                this.deps.postMessage({ type: ExtensionMsg.HideUnavailableState });
+                break;
+            case 'disabled': {
+                const label = context?.type === 'course' ? 'course' : 'exercise';
+                this.deps.postMessage({
+                    type: ExtensionMsg.ShowDisabledState,
+                    message: `Iris chat is not enabled for this ${label}. Please contact your instructor.`,
+                });
+                this.deps.postMessage({ type: ExtensionMsg.HideUnavailableState });
+                break;
+            }
+            case 'unavailable':
+                this.deps.postMessage({
+                    type: ExtensionMsg.ShowUnavailableState,
+                    message: UNAVAILABLE_USER_MESSAGE,
+                });
+                this.deps.postMessage({ type: ExtensionMsg.HideDisabledState });
+                break;
         }
     }
 
@@ -115,11 +245,16 @@ export class IrisChatSessionService {
         logger.info('Starting loadAllSessionsForContext', LogCategory.SESSION);
         logger.info('Active context:', LogCategory.SESSION, activeContext);
 
-        if (!activeContext || !this.deps.artemisApiService) {
-            logger.info('Cannot load sessions: missing context or API service', LogCategory.SESSION, {
-                hasContext: !!activeContext,
-                hasApiService: !!this.deps.artemisApiService
-            });
+        if (!activeContext) {
+            logger.info('Cannot load sessions: missing context', LogCategory.SESSION);
+            return;
+        }
+        if (!this.deps.artemisApiService) {
+            logger.warn('Cannot load sessions: API service not initialized', LogCategory.SESSION);
+            this._postAvailability(
+                { kind: 'unavailable', reason: 'Artemis API service not initialized' },
+                activeContext,
+            );
             return;
         }
 
@@ -133,31 +268,29 @@ export class IrisChatSessionService {
             logger.info(`Loading all Iris sessions for ${activeContext.type}: ${activeContext.title} (ID: ${activeContext.id})`, LogCategory.SESSION);
 
             // Step 0: Check if Iris is enabled for this context
-            const isEnabled = await this.checkAndLoadIrisSettings(activeContext);
+            const availability = await this.checkAndLoadIrisSettings(activeContext);
 
             if (!this.isCurrentContext(targetContext, loadToken)) {
                 logger.info('Context changed while checking Iris settings, aborting load', LogCategory.IRIS_CHAT);
                 return;
             }
 
-            if (!isEnabled) {
-                logger.info('Iris is disabled, not loading sessions', LogCategory.IRIS_CHAT);
-                // Clear any existing sessions and show disabled overlay
-                this.deps.postMessage({
-                    type: ExtensionMsg.ClearChatMessages
-                });
-                const contextLabel = activeContext.type === 'course' ? 'course' : 'exercise';
-                this.deps.postMessage({
-                    type: ExtensionMsg.ShowDisabledState,
-                    message: `Iris chat is not enabled for this ${contextLabel}. Please contact your instructor.`
-                });
+            if (availability.kind !== 'enabled') {
+                logger.info(`Iris is ${availability.kind}, not loading sessions`, LogCategory.IRIS_CHAT);
+                // Clear any stale messages, then announce availability. The
+                // banner is the terminal state for both disabled and
+                // unavailable; the view stops the loader on either flag.
+                // We intentionally do NOT post LoadMessagesError here:
+                // availability failures are not history-load failures, and
+                // emitting it would surface the misleading central error UI
+                // in addition to the banner.
+                this.deps.postMessage({ type: ExtensionMsg.ClearChatMessages });
+                this._postAvailability(availability, activeContext);
                 return;
             }
 
-            // Hide disabled overlay if it was previously shown
-            this.deps.postMessage({
-                type: ExtensionMsg.HideDisabledState
-            });
+            // Enabled: clear any prior availability banners.
+            this._postAvailability(availability, activeContext);
 
             const count = await this._fetchImportAndActivate(targetContext, loadToken);
             if (count === -1) { return; } // context changed
@@ -184,13 +317,18 @@ export class IrisChatSessionService {
             logger.error('Error loading sessions for context:', LogCategory.SESSION, error);
 
             if (!this.isCurrentContext(targetContext, loadToken)) {
-                logger.info('Context changed during error handling, skipping fallback session creation', LogCategory.IRIS_CHAT);
+                logger.info('Context changed during error handling, skipping availability emit', LogCategory.IRIS_CHAT);
                 return;
             }
 
-            // Fall back to creating a new session
-            this.createNewSession();
-            this.deps.postSnapshot();
+            // Any caught error here means the server-side load failed (or the
+            // settings/session listing call threw). Classify and surface as
+            // unavailable. The previous behavior — falling back to
+            // createNewSession() — silently masked transient server errors as
+            // "no sessions on server", which then made every reload create
+            // additional orphan local sessions. The right recovery is the
+            // Retry button (manual or websocket-reconnect-driven).
+            this._postAvailability(classifyAvailabilityFromError(error), targetContext);
         }
     }
 
@@ -357,12 +495,23 @@ export class IrisChatSessionService {
                 })
                 .catch((err: unknown) => {
                     logger.error('Error creating new Iris session:', LogCategory.IRIS_CHAT, err);
-                    if (isStillNewSession()) {
-                        this.deps.postMessage({
-                            type: ExtensionMsg.LoadMessagesError,
-                            localSessionId: newLocalSessionId,
-                        });
+                    if (!isStillNewSession()) {
+                        return;
                     }
+                    // Reuse the same availability classifier as
+                    // loadAllSessionsForContext so a network drop during the
+                    // server round-trip surfaces the unavailable banner
+                    // instead of leaving the spinner up indefinitely. The
+                    // LoadMessagesError signal is kept for true "history
+                    // failed to load" cases — but the classifier-driven
+                    // availability state is the primary outcome here, so the
+                    // view's loader stops via the banner.
+                    const availability = classifyAvailabilityFromError(err);
+                    this._postAvailability(availability, activeContext);
+                    this.deps.postMessage({
+                        type: ExtensionMsg.LoadMessagesError,
+                        localSessionId: newLocalSessionId,
+                    });
                 });
         }
     }
@@ -510,4 +659,34 @@ export class IrisChatSessionService {
         this.deps.postSnapshot();
         this.deps.postMessage({ type: ExtensionMsg.ClearChatMessages });
     }
+}
+
+/**
+ * Maps a raw error (from `fetch`, `ApiError`, schema validation, etc.) to an
+ * {@link IrisAvailability}. Exported privately to the file so both
+ * `checkAndLoadIrisSettings` and the outer `loadAllSessionsForContext` /
+ * `createNewSession` catch-blocks share one classification policy.
+ *
+ * Rules:
+ *   - `ApiError(403)`   → disabled (course-level forbidden = disabled for this user)
+ *   - any other `ApiError` (401/404/4xx/5xx)         → unavailable
+ *   - `MalformedResponseError` (subclass of ApiError) → unavailable
+ *   - any other Error / network / `TypeError`        → unavailable
+ *
+ * No string-matching on `error.message.includes('403')` — the historical
+ * fallback was inherited code with no good reason to keep it and could
+ * misclassify unrelated errors whose message happened to contain '403'.
+ */
+function classifyAvailabilityFromError(error: unknown): IrisAvailability {
+    if (error instanceof MalformedResponseError) {
+        return { kind: 'unavailable', reason: `Malformed response: ${error.message}` };
+    }
+    if (error instanceof ApiError) {
+        if (error.status === 403) {
+            return { kind: 'disabled' };
+        }
+        return { kind: 'unavailable', reason: `Server returned ${error.status}` };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: 'unavailable', reason: message || 'Unknown error' };
 }

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -63,6 +63,8 @@ export const ExtensionMsg = {
     UpdateWebSocketStatus: 'updateWebSocketStatus',
     ShowDisabledState: 'showDisabledState',
     HideDisabledState: 'hideDisabledState',
+    ShowUnavailableState: 'showUnavailableState',
+    HideUnavailableState: 'hideUnavailableState',
     UpdateNoAiStatus: 'updateNoAiStatus',
     UpdateIrisStages: 'updateIrisStages',
     SendRejected: 'sendRejected',
@@ -221,6 +223,8 @@ interface ExtensionMsgPayloads {
     updateWebSocketStatus: { status: WebSocketDisplayStatus };
     showDisabledState: { message: string };
     hideDisabledState: undefined;
+    showUnavailableState: { message: string };
+    hideUnavailableState: undefined;
     updateNoAiStatus: {
         isNoAiDetected: boolean;
         noAiFilePath?: string;
@@ -238,7 +242,7 @@ interface ExtensionMsgPayloads {
     sendRejected: {
         localId: string;
         localSessionId: string;
-        reason: 'no-ai' | 'no-context' | 'iris-disabled';
+        reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable';
         errorMessage: string;
     };
 

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -84,6 +84,7 @@ export const WebviewCmd = {
     SwitchToWorkspaceContext: 'switchToWorkspaceContext',
     ResetChatSessions: 'resetChatSessions',
     ReconnectWebSocket: 'reconnectWebSocket',
+    ReloadChatSession: 'reloadChatSession',
     MessageFeedback: 'messageFeedback',
     OpenFile: 'openFile',
     OpenDiagnostics: 'openDiagnostics',
@@ -175,6 +176,7 @@ interface WebviewCmdPayloads {
     switchToWorkspaceContext: undefined;
     resetChatSessions: undefined;
     reconnectWebSocket: undefined;
+    reloadChatSession: undefined;
     messageFeedback: { sessionId: number; messageId: number; feedback: 'positive' | 'negative' };
     openFile: { filePath: string };
     openDiagnostics: undefined;

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -60,6 +60,13 @@ interface ChatState {
     isLoading: boolean;
     webSocketStatus: ChatWebSocketStatus;
     disabledMessage: string | null;   // Non-null = Iris disabled (reason as string)
+    /**
+     * Non-null = Iris is currently unreachable due to a transient infrastructure
+     * failure (network, 5xx, timeout). Distinct from `disabledMessage`, which
+     * means Iris is intentionally off for this context. Mutually exclusive: a
+     * Set on one always clears the other.
+     */
+    unavailableMessage: string | null;
     isNoAiDetected: boolean;
     referencedFiles: ReferencedFilesData | null;
     showDiagnostics: boolean;
@@ -97,6 +104,7 @@ interface ChatState {
     setLoading: (loading: boolean) => void;
     setWebSocketStatus: (status: ChatWebSocketStatus) => void;
     setDisabledMessage: (message: string | null) => void;
+    setUnavailableMessage: (message: string | null) => void;
     setNoAiDetected: (detected: boolean) => void;
     setReferencedFiles: (data: ReferencedFilesData | null) => void;
     setShowDiagnostics: (show: boolean) => void;
@@ -123,6 +131,7 @@ export const useChatStore = create<ChatState>()(
             isLoading: false,
             webSocketStatus: 'unknown',
             disabledMessage: null,
+            unavailableMessage: null,
             isNoAiDetected: false,
             referencedFiles: null,
             showDiagnostics: false,
@@ -233,7 +242,29 @@ export const useChatStore = create<ChatState>()(
             },
 
             setDisabledMessage: (message) => {
-                set({ disabledMessage: message }, false, 'setDisabledMessage');
+                // Setting a real disabled reason clears any transient
+                // unavailable banner — disabled is a strictly more specific
+                // signal. Clearing (null) leaves unavailable untouched.
+                set(
+                    message === null
+                        ? { disabledMessage: null }
+                        : { disabledMessage: message, unavailableMessage: null },
+                    false,
+                    'setDisabledMessage',
+                );
+            },
+
+            setUnavailableMessage: (message) => {
+                // Symmetric to setDisabledMessage: setting a real unavailable
+                // reason clears any stale disabled banner (defensive — the
+                // extension-side helper normally enforces this already).
+                set(
+                    message === null
+                        ? { unavailableMessage: null }
+                        : { unavailableMessage: message, disabledMessage: null },
+                    false,
+                    'setUnavailableMessage',
+                );
             },
 
             setNoAiDetected: (detected) => {

--- a/extension/src/webview/views/IrisChat/IrisChatView.module.css
+++ b/extension/src/webview/views/IrisChat/IrisChatView.module.css
@@ -152,6 +152,36 @@
     background: var(--vscode-button-hoverBackground);
 }
 
+.unavailableBanner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: var(--vscode-inputValidation-warningBackground);
+    color: var(--vscode-inputValidation-warningForeground);
+    border-bottom: 1px solid var(--vscode-inputValidation-warningBorder);
+    flex-shrink: 0;
+}
+
+.unavailableBanner > span {
+    flex: 1;
+}
+
+.retryButton {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: none;
+    padding: 4px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: background-color 0.15s;
+}
+
+.retryButton:hover {
+    background: var(--vscode-button-hoverBackground);
+}
+
 /* Messages Section */
 .messagesSection {
     flex: 1;

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -27,7 +27,8 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         setIrisState, setShowDiagnostics, addMessage,
         applyLoadedMessages, setMessageLoadError,
         clearMessages, setReferencedFiles, setWebSocketStatus,
-        setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi,
+        setDisabledMessage, setUnavailableMessage, setNoAiDetected,
+        setIrisStages, resetTransientChatUi,
         markMessageFailed,
     } = store;
     const [sideMenuOpen, setSideMenuOpen] = useState(false);
@@ -174,6 +175,15 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 setDisabledMessage(null);
                 break;
 
+            case ExtensionMsg.ShowUnavailableState: {
+                setUnavailableMessage(msg.message);
+                break;
+            }
+
+            case ExtensionMsg.HideUnavailableState:
+                setUnavailableMessage(null);
+                break;
+
             case ExtensionMsg.UpdateNoAiStatus: {
                 setNoAiDetected(msg.isNoAiDetected);
                 break;
@@ -205,7 +215,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 break;
             }
         }
-    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setNoAiDetected, setIrisStages, resetTransientChatUi, markMessageFailed]);
+    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, setIrisStages, resetTransientChatUi, markMessageFailed]);
 
     const handleSendMessage = (text: string) => {
         const localId = crypto.randomUUID();
@@ -298,6 +308,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         postCommand(vscodeApi, 'reconnectWebSocket');
     };
 
+    const handleRetryChatLoad = () => {
+        postCommand(vscodeApi, 'reloadChatSession');
+    };
+
     // Check if chat is disabled
     const isChatDisabled = store.disabledMessage !== null || store.isNoAiDetected;
 
@@ -306,12 +320,19 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // has plausibly cleared since the original send. Computed inline per
     // render because the message list is short and `messages.map` already
     // walks it; rebuilding a Map would be wasted work.
-    const isRetryDisabled = (msg: { errorReason?: 'no-ai' | 'no-context' | 'iris-disabled' }) => {
+    const isRetryDisabled = (msg: { errorReason?: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable' }) => {
         switch (msg.errorReason) {
             case 'iris-disabled':
                 // Persistent until the user navigates away from the
                 // disabled exercise; the banner already states this.
                 return true;
+            case 'iris-unavailable':
+                // Disabled while the unavailable banner is shown — the
+                // banner's own Retry button is the right affordance to
+                // reload the chat. Once that succeeds (banner clears), the
+                // inline Retry on the failed message becomes active again
+                // so the user can resend their original text.
+                return store.unavailableMessage !== null;
             case 'no-ai':
                 return store.isNoAiDetected;
             case 'no-context':
@@ -321,7 +342,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         }
     };
 
-    // Determine disabled reason text
+    // Disabled banner = strictly off (instructor disabled, .noai). The
+    // unavailable banner (yellow, retry-able) is rendered separately below.
+    // When both states are non-null, the disabled banner wins — it carries
+    // strictly more information.
     let disabledBannerText: string | null = null;
     if (store.disabledMessage) {
         disabledBannerText = store.disabledMessage;
@@ -329,10 +353,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         disabledBannerText = 'AI assistance is disabled. A .noai file was detected in your workspace.';
     }
 
+    const showUnavailableBanner = store.unavailableMessage !== null && store.disabledMessage === null;
+
     // Compute disabled placeholder for input. Order matters: real
-    // unavailability ('no context', '.noai', explicit disabled) wins over
-    // the transient 'loading' state — we only fall through to 'Loading…'
-    // when the chat is otherwise usable but still waiting for hydration.
+    // unavailability ('no context', '.noai', explicit disabled, transient
+    // unavailable) wins over the 'loading' state — we only fall through to
+    // 'Loading…' when the chat is otherwise usable but still waiting for
+    // hydration.
     let disabledPlaceholder: string | undefined;
     if (store.context === null) {
         disabledPlaceholder = 'Select a course or exercise to start chatting';
@@ -340,6 +367,8 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         disabledPlaceholder = 'AI assistance is disabled (.noai detected)';
     } else if (store.disabledMessage) {
         disabledPlaceholder = 'Iris chat is not available for this exercise';
+    } else if (showUnavailableBanner) {
+        disabledPlaceholder = 'Iris is temporarily unavailable. Retry to reload.';
     }
 
     // Derive active stage: first stage that is not DONE or SKIPPED.
@@ -369,7 +398,16 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         && store.messageLoad !== null
         && store.messageLoad.localSessionId === store.activeSessionId
         && store.messageLoad.status === 'error';
-    const messagesLoading = !messagesHydrated && !messagesErrored;
+    // Availability failures (disabled / temporarily unavailable) are NOT
+    // "history failed to load" — gate the loader on them so the spinner
+    // does not spin forever next to a banner that already states the
+    // problem. Fixes the #219 stuck-loader symptom.
+    const isChatUnavailable = store.unavailableMessage !== null;
+    const messagesLoading =
+        !messagesHydrated
+        && !messagesErrored
+        && !store.disabledMessage
+        && !isChatUnavailable;
 
     const irisLogoUri = document.getElementById('root')?.dataset.irisLogoUri;
 
@@ -473,13 +511,34 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 </div>
             )}
 
+            {/* Iris-availability transient banner: chat-reload couldn't reach
+                Iris (network/5xx/timeout). The Retry button triggers
+                ReloadChatSession on the extension side, which is also fired
+                automatically on websocket reconnect — so the user has both
+                a manual and an automatic path back to a working chat. */}
+            {showUnavailableBanner && (
+                <div className={styles.unavailableBanner} role="alert">
+                    <Info size={16} />
+                    <span>{store.unavailableMessage}</span>
+                    <button
+                        className={styles.retryButton}
+                        onClick={handleRetryChatLoad}
+                    >
+                        Retry
+                    </button>
+                </div>
+            )}
+
             {/* WebSocket status banner: shown when the connection is in a
                 terminal state the user must act on (retries exhausted, or
                 client torn down without a pending retry). Transient states
                 ('connecting', 'reconnecting') and the pre-init 'unknown'
                 state suppress the banner — the status bar already surfaces
-                that detail. */}
-            {store.webSocketStatus === 'disconnected' && !isChatDisabled && (
+                that detail. Also suppressed when the unavailable banner is
+                shown: its Retry button is the right affordance and surfacing
+                a second Reconnect button would give the user two competing
+                recovery paths for the same underlying problem. */}
+            {store.webSocketStatus === 'disconnected' && !isChatDisabled && !showUnavailableBanner && (
                 <div className={styles.websocketBanner}>
                     <span>WebSocket disconnected</span>
                     <button
@@ -492,12 +551,18 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             )}
 
             {/* Message list with context-switch animation and hydration loader.
-                Hierarchy: error UI > loader (context-switch animation OR
-                pending hydration) > populated/welcome list. */}
+                Hierarchy: availability banner state (disabled/unavailable
+                already render their own banner above and gate everything
+                else) > error UI > loader (context-switch animation OR
+                pending hydration) > populated/welcome list.
+                When disabled or unavailable is set, the central "Failed to
+                load chat history" UI is suppressed — the banner above is the
+                authoritative error surface. */}
             <div className={clsx(styles.messagesSection, {
                 [styles.contextSwitching]: contextSwitching
             })}>
-                {messagesErrored ? (
+                {(store.disabledMessage || store.unavailableMessage) ? null
+                : messagesErrored ? (
                     <div className={styles.loadingState}>
                         <div className={styles.loadError} role="alert">
                             Failed to load chat history. Try selecting the
@@ -550,6 +615,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     disabled={
                         isChatDisabled
                         || store.context === null
+                        || isChatUnavailable
                         || messagesLoading
                         || store.streaming.isStreaming
                     }

--- a/extension/src/webview/views/IrisChat/types.ts
+++ b/extension/src/webview/views/IrisChat/types.ts
@@ -17,7 +17,7 @@ export interface ChatMessage {
      * meaningful right now (e.g. `iris-disabled` is persistent; `no-ai`
      * stays non-retryable as long as `.noai` is still detected).
      */
-    errorReason?: 'no-ai' | 'no-context' | 'iris-disabled';
+    errorReason?: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable';
 }
 
 // Chat session summary (from extension)

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -43,6 +43,7 @@ describe('useChatStore', () => {
 		expect(result.current.isLoading).toBe(false);
 		expect(result.current.webSocketStatus).toBe('unknown');
 		expect(result.current.disabledMessage).toBeNull();
+		expect(result.current.unavailableMessage).toBeNull();
 		expect(result.current.isNoAiDetected).toBe(false);
 		expect(result.current.referencedFiles).toBeNull();
 		expect(result.current.showDiagnostics).toBe(false);
@@ -214,6 +215,86 @@ describe('useChatStore', () => {
 			result.current.setDisabledMessage(null);
 		});
 
+		expect(result.current.disabledMessage).toBeNull();
+	});
+
+	it('setUnavailableMessage sets transient unavailability reason', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setUnavailableMessage('Iris is temporarily unavailable. Retry to reload.');
+		});
+
+		expect(result.current.unavailableMessage).toBe('Iris is temporarily unavailable. Retry to reload.');
+	});
+
+	it('setUnavailableMessage can be cleared with null', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setUnavailableMessage('Unavailable reason');
+		});
+
+		act(() => {
+			result.current.setUnavailableMessage(null);
+		});
+
+		expect(result.current.unavailableMessage).toBeNull();
+	});
+
+	it('setUnavailableMessage clears any existing disabledMessage', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setDisabledMessage('Disabled reason');
+		});
+		act(() => {
+			result.current.setUnavailableMessage('Unavailable reason');
+		});
+
+		expect(result.current.unavailableMessage).toBe('Unavailable reason');
+		expect(result.current.disabledMessage).toBeNull();
+	});
+
+	it('setDisabledMessage clears any existing unavailableMessage', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setUnavailableMessage('Unavailable reason');
+		});
+		act(() => {
+			result.current.setDisabledMessage('Disabled reason');
+		});
+
+		expect(result.current.disabledMessage).toBe('Disabled reason');
+		expect(result.current.unavailableMessage).toBeNull();
+	});
+
+	it('setUnavailableMessage(null) does NOT clear an existing disabledMessage', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setDisabledMessage('Disabled reason');
+		});
+		act(() => {
+			result.current.setUnavailableMessage(null);
+		});
+
+		expect(result.current.disabledMessage).toBe('Disabled reason');
+		expect(result.current.unavailableMessage).toBeNull();
+	});
+
+	it('setDisabledMessage(null) does NOT clear an existing unavailableMessage', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			result.current.setUnavailableMessage('Unavailable reason');
+		});
+		act(() => {
+			result.current.setDisabledMessage(null);
+		});
+
+		expect(result.current.unavailableMessage).toBe('Unavailable reason');
 		expect(result.current.disabledMessage).toBeNull();
 	});
 

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -62,6 +62,7 @@ describe('IrisChatView', () => {
 			isLoading: false,
 			webSocketStatus: 'connected',
 			disabledMessage: null,
+			unavailableMessage: null,
 			isNoAiDetected: false,
 			referencedFiles: null,
 			showDiagnostics: false,
@@ -226,6 +227,170 @@ describe('IrisChatView', () => {
 		const mockApi = createMockVsCodeApi();
 		render(<IrisChatView vscodeApi={mockApi} />);
 		expect(screen.getByText('WebSocket disconnected')).toBeInTheDocument();
+	});
+
+	describe('Iris unavailable banner', () => {
+		it('renders the unavailable banner with a Retry button when unavailableMessage is set', () => {
+			useChatStore.setState({
+				unavailableMessage: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			expect(screen.getByText('Iris is temporarily unavailable. Retry to reload.')).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+		});
+
+		it('posts reloadChatSession when the unavailable Retry button is clicked', async () => {
+			useChatStore.setState({
+				unavailableMessage: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+			expect(mockApi.postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'command',
+					command: 'reloadChatSession',
+				})
+			);
+		});
+
+		it('does NOT render the loader when unavailableMessage is set even if an active session is awaiting hydration', () => {
+			useChatStore.setState({
+				context: {
+					type: 'exercise',
+					id: 1,
+					title: 'Test Exercise',
+					shortName: 'TE',
+					courseId: 10,
+					locked: false,
+					source: 'user-selected',
+				},
+				activeSessionId: 'local-A',
+				sessions: [{
+					id: 'local-A',
+					artemisSessionId: 42,
+					preview: '',
+					title: '',
+					messageCount: 0,
+					createdAt: 0,
+					lastActivity: 0,
+				}],
+				unavailableMessage: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// The previous bug (#219) left the loader spinning forever when
+			// the chat became unavailable. The banner is the terminal state
+			// — no spinner should coexist with it.
+			expect(screen.queryByText(/Loading conversation/i)).not.toBeInTheDocument();
+		});
+
+		it('does NOT render the loader when disabledMessage is set (parallel fix to the spinning-forever bug)', () => {
+			useChatStore.setState({
+				context: {
+					type: 'exercise',
+					id: 1,
+					title: 'Test Exercise',
+					shortName: 'TE',
+					courseId: 10,
+					locked: false,
+					source: 'user-selected',
+				},
+				activeSessionId: 'local-A',
+				sessions: [{
+					id: 'local-A',
+					artemisSessionId: 42,
+					preview: '',
+					title: '',
+					messageCount: 0,
+					createdAt: 0,
+					lastActivity: 0,
+				}],
+				disabledMessage: 'Iris chat is not enabled for this exercise. Please contact your instructor.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			expect(screen.queryByText(/Loading conversation/i)).not.toBeInTheDocument();
+		});
+
+		it('suppresses the websocket-disconnected banner when the unavailable banner is active (avoid duplicate Retry affordances)', () => {
+			useChatStore.setState({
+				webSocketStatus: 'disconnected',
+				unavailableMessage: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// The unavailable banner already has the Retry action — surfacing
+			// the websocket banner alongside would give the user two
+			// competing recovery affordances for the same underlying problem.
+			expect(screen.queryByText('WebSocket disconnected')).not.toBeInTheDocument();
+		});
+
+		it('lets the disabled banner win when both fields are non-null (defensive — extension never emits both)', () => {
+			useChatStore.setState({
+				disabledMessage: 'Iris chat is not enabled for this exercise.',
+				unavailableMessage: 'Iris is temporarily unavailable.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// Disabled is the more specific signal, so it wins. The store
+			// cross-clears in normal flow, so this state shouldn't arise —
+			// but if it ever does, the user must not be told two
+			// contradictory things at once.
+			expect(screen.getByText('Iris chat is not enabled for this exercise.')).toBeInTheDocument();
+			expect(screen.queryByText('Iris is temporarily unavailable.')).not.toBeInTheDocument();
+		});
+
+		it('disables the chat input with an unavailable-specific placeholder', () => {
+			useChatStore.setState({
+				context: {
+					type: 'exercise',
+					id: 1,
+					title: 'Test Exercise',
+					shortName: 'TE',
+					courseId: 10,
+					locked: false,
+					source: 'user-selected',
+				},
+				...HYDRATED,
+				unavailableMessage: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const input = screen.getByPlaceholderText(/temporarily unavailable/i);
+			expect(input).toBeDisabled();
+		});
+	});
+
+	describe('ShowUnavailableState / HideUnavailableState message handling', () => {
+		it('sets unavailableMessage on ShowUnavailableState and clears it on HideUnavailableState', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'showUnavailableState',
+				message: 'Iris is temporarily unavailable. Retry to reload.',
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText('Iris is temporarily unavailable. Retry to reload.')).toBeInTheDocument();
+			});
+
+			dispatchExtensionMessage({ type: 'hideUnavailableState' });
+
+			await waitFor(() => {
+				expect(screen.queryByText('Iris is temporarily unavailable. Retry to reload.')).not.toBeInTheDocument();
+			});
+		});
 	});
 
 	describe('Message hydration loader', () => {

--- a/extension/test/unit/provider/chatReloadDecision.test.ts
+++ b/extension/test/unit/provider/chatReloadDecision.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+
+import { shouldAutoRetryReload } from '@extension/provider/chatReloadDecision';
+import type { LastAvailability } from '@extension/services/iris/chat/chatSessionService';
+import type { ActiveContext } from '@extension/types';
+
+const exerciseA: ActiveContext = {
+    type: 'exercise',
+    id: 1,
+    title: 'Exercise A',
+    source: 'user-selected',
+    locked: false,
+    selectedAt: Date.now(),
+};
+
+const exerciseB: ActiveContext = {
+    type: 'exercise',
+    id: 2,
+    title: 'Exercise B',
+    source: 'user-selected',
+    locked: false,
+    selectedAt: Date.now(),
+};
+
+const courseA: ActiveContext = {
+    type: 'course',
+    id: 1,
+    title: 'Course A',
+    source: 'user-selected',
+    locked: false,
+    selectedAt: Date.now(),
+};
+
+suite('shouldAutoRetryReload', () => {
+    test('returns true when unavailable matches the current context', () => {
+        const last: LastAvailability = { kind: 'unavailable', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, exerciseA), true);
+    });
+
+    test('returns false when unavailable was recorded for a different context (id)', () => {
+        // Auto-retry must not fire for context A's stale classification
+        // after the user has switched to context B — otherwise reconnect
+        // would pull A's sessions into B's view.
+        const last: LastAvailability = { kind: 'unavailable', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, exerciseB), false);
+    });
+
+    test('returns false when unavailable was recorded for a different context (type)', () => {
+        // exercise:1 vs course:1 share an id but are different contexts.
+        const last: LastAvailability = { kind: 'unavailable', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, courseA), false);
+    });
+
+    test('returns false for disabled state — no point auto-retrying a known disable', () => {
+        const last: LastAvailability = { kind: 'disabled', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, exerciseA), false);
+    });
+
+    test('returns false for enabled state — nothing to retry', () => {
+        const last: LastAvailability = { kind: 'enabled', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, exerciseA), false);
+    });
+
+    test('returns false for unknown state — pre-classification or after reset', () => {
+        const last: LastAvailability = { kind: 'unknown' };
+        assert.strictEqual(shouldAutoRetryReload(last, exerciseA), false);
+    });
+
+    test('returns false when no active context exists', () => {
+        // Edge case: reconnect fires while no context is selected.
+        const last: LastAvailability = { kind: 'unavailable', contextKey: 'exercise:1' };
+        assert.strictEqual(shouldAutoRetryReload(last, null), false);
+    });
+});

--- a/extension/test/unit/services/chatMessageService.test.ts
+++ b/extension/test/unit/services/chatMessageService.test.ts
@@ -81,7 +81,7 @@ suite('ChatMessageService', () => {
         mockChatSessionService = sinon.createStubInstance(IrisChatSessionService);
         mockChatSessionService.initializeIrisSessionAndLoadMessages.resolves();
         // Stub Iris settings check to return enabled by default
-        mockChatSessionService.checkAndLoadIrisSettings.resolves(true);
+        mockChatSessionService.checkAndLoadIrisSettings.resolves({ kind: 'enabled' });
         postSnapshotSpy = sinon.spy();
 
         mockSessionManager = { currentSessionId: 42 };
@@ -128,13 +128,38 @@ suite('ChatMessageService', () => {
         });
 
         test('should return iris-disabled when Iris is not enabled', async () => {
-            mockChatSessionService.checkAndLoadIrisSettings.resolves(false);
+            mockChatSessionService.checkAndLoadIrisSettings.resolves({ kind: 'disabled' });
             createService();
             const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
             assert.ok(!result.sent);
             if (!result.sent) {
                 assert.strictEqual(result.reason, 'iris-disabled');
                 assert.strictEqual(result.contextLabel, 'exercise');
+                // capturedContext is the contract the provider uses to detect
+                // a stale send-rejection after a mid-flight context switch;
+                // pin it here so the contract cannot regress silently.
+                assert.ok(result.capturedContext, 'capturedContext must be threaded through');
+                assert.strictEqual(result.capturedContext.id, activeContext.id);
+                assert.strictEqual(result.capturedContext.type, activeContext.type);
+            }
+        });
+
+        test('returns iris-unavailable when settings check classifies as unavailable', async () => {
+            mockChatSessionService.checkAndLoadIrisSettings.resolves({
+                kind: 'unavailable',
+                reason: 'Server returned 500',
+            });
+            createService();
+            const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
+            assert.ok(!result.sent);
+            if (!result.sent) {
+                assert.strictEqual(result.reason, 'iris-unavailable');
+                assert.strictEqual(result.contextLabel, 'exercise');
+                // Same contract as iris-disabled: the captured context flows
+                // through so the provider can drop stale rejections.
+                assert.ok(result.capturedContext, 'capturedContext must be threaded through');
+                assert.strictEqual(result.capturedContext.id, activeContext.id);
+                assert.strictEqual(result.capturedContext.type, activeContext.type);
             }
         });
 

--- a/extension/test/unit/services/chatSessionService.test.ts
+++ b/extension/test/unit/services/chatSessionService.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 
 import { ArtemisApiService } from '@extension/api';
+import { ApiError, MalformedResponseError } from '@extension/domain/errors';
 import { IrisChatSessionService } from '@extension/services/iris/chat/chatSessionService';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
 import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
@@ -140,7 +141,16 @@ suite('IrisChatSessionService Test Suite', () => {
     });
 
     suite('Iris Settings Check', () => {
-        test('should return false when API service is not available', async () => {
+        const courseContext: ActiveContext = {
+            type: 'course',
+            id: 101,
+            title: 'Test Course',
+            source: 'user-selected',
+            locked: false,
+            selectedAt: Date.now()
+        };
+
+        test('classifies as unavailable when API service is not available', async () => {
             const serviceWithoutApi = new IrisChatSessionService(
                 {
                     contextStore,
@@ -151,59 +161,48 @@ suite('IrisChatSessionService Test Suite', () => {
                 () => mockIrisWebSocketSessionClient as any,
             );
 
-            const context: ActiveContext = {
-                type: 'course',
-                id: 101,
-                title: 'Test Course',
-                source: 'user-selected',
-                locked: false,
-                selectedAt: Date.now()
-            };
-
-            const result = await serviceWithoutApi.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+            const result = await serviceWithoutApi.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
         });
 
-        test('should check Iris settings for course context', async () => {
-            const context: ActiveContext = {
-                type: 'course',
-                id: 101,
-                title: 'Test Course',
-                source: 'user-selected',
-                locked: false,
-                selectedAt: Date.now()
-            };
-
+        test('classifies as enabled for course context when settings.enabled is true', async () => {
             mockApiService.getIrisCourseChatSettings.resolves({
                 settings: { enabled: true },
                 effectiveRateLimit: { requests: 10, timeframeHours: 1 }
             });
 
-            const result = await chatSessionService.checkAndLoadIrisSettings(context);
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
 
-            assert.strictEqual(result, true);
+            assert.strictEqual(result.kind, 'enabled');
             assert.ok(mockApiService.getIrisCourseChatSettings.calledOnceWith(101));
         });
 
-        test('should return false when Iris is disabled', async () => {
-            const context: ActiveContext = {
-                type: 'course',
-                id: 101,
-                title: 'Test Course',
-                source: 'user-selected',
-                locked: false,
-                selectedAt: Date.now()
-            };
-
+        test('classifies as disabled when settings.enabled is false', async () => {
             mockApiService.getIrisCourseChatSettings.resolves({
                 settings: { enabled: false }
             });
 
-            const result = await chatSessionService.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'disabled');
         });
 
-        test('should check Iris settings for exercise context with courseId', async () => {
+        test('classifies as unavailable when settings.settings is missing entirely', async () => {
+            mockApiService.getIrisCourseChatSettings.resolves({} as any);
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies as unavailable when settings.settings.enabled is not a boolean', async () => {
+            mockApiService.getIrisCourseChatSettings.resolves({
+                settings: {} as any
+            });
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies as enabled for exercise context with courseId', async () => {
             const context: ActiveContext = {
                 type: 'exercise',
                 id: 123,
@@ -220,11 +219,11 @@ suite('IrisChatSessionService Test Suite', () => {
 
             const result = await chatSessionService.checkAndLoadIrisSettings(context);
 
-            assert.strictEqual(result, true);
+            assert.strictEqual(result.kind, 'enabled');
             assert.ok(mockApiService.getIrisCourseChatSettings.calledOnceWith(101));
         });
 
-        test('should resolve courseId from tracked exercise', async () => {
+        test('resolves courseId from tracked exercise', async () => {
             const context: ActiveContext = {
                 type: 'exercise',
                 id: 123,
@@ -246,11 +245,11 @@ suite('IrisChatSessionService Test Suite', () => {
 
             const result = await chatSessionService.checkAndLoadIrisSettings(context);
 
-            assert.strictEqual(result, true);
+            assert.strictEqual(result.kind, 'enabled');
             assert.ok(mockApiService.getIrisCourseChatSettings.calledWith(101));
         });
 
-        test('should resolve courseId from exercise details API', async () => {
+        test('resolves courseId from exercise details API', async () => {
             const context: ActiveContext = {
                 type: 'exercise',
                 id: 123,
@@ -274,12 +273,12 @@ suite('IrisChatSessionService Test Suite', () => {
 
             const result = await chatSessionService.checkAndLoadIrisSettings(context);
 
-            assert.strictEqual(result, true);
+            assert.strictEqual(result.kind, 'enabled');
             assert.ok(mockApiService.getExerciseDetails.calledOnceWith(123));
             assert.ok(mockApiService.getIrisCourseChatSettings.calledWith(101));
         });
 
-        test('should return false when courseId cannot be resolved for exercise', async () => {
+        test('classifies as unavailable when courseId cannot be resolved for exercise', async () => {
             const context: ActiveContext = {
                 type: 'exercise',
                 id: 123,
@@ -294,10 +293,10 @@ suite('IrisChatSessionService Test Suite', () => {
             });
 
             const result = await chatSessionService.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+            assert.strictEqual(result.kind, 'unavailable');
         });
 
-        test('should return false for unsupported context type', async () => {
+        test('classifies as disabled for unsupported context type', async () => {
             const context: ActiveContext = {
                 type: 'lecture' as any,
                 id: 999,
@@ -308,41 +307,146 @@ suite('IrisChatSessionService Test Suite', () => {
             };
 
             const result = await chatSessionService.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+            assert.strictEqual(result.kind, 'disabled');
         });
 
-        test('should return false on 403 error', async () => {
-            const context: ActiveContext = {
-                type: 'course',
-                id: 101,
-                title: 'Test Course',
+        test('classifies ApiError(403) as disabled', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Forbidden', 403));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'disabled');
+        });
+
+        test('classifies ApiError(401) as unavailable (auth handler is firing)', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Auth expired', 401));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies ApiError(404) as unavailable', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Not found', 404));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies ApiError(500) as unavailable', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Server error', 500));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies MalformedResponseError as unavailable', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(
+                new MalformedResponseError('Schema mismatch', 200, 'bad shape')
+            );
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies a plain network error as unavailable', async () => {
+            mockApiService.getIrisCourseChatSettings.rejects(new TypeError('Failed to fetch'));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies getProfileInfo failure as unavailable', async () => {
+            mockApiService.getProfileInfo.rejects(new TypeError('Failed to fetch'));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies as disabled when iris profile is not active on server', async () => {
+            mockApiService.isIrisProfileActive.returns(false);
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'disabled');
+        });
+
+        test('classifies ApiError(403) from getProfileInfo as unavailable, not disabled', async () => {
+            // 403 only means "Iris is off for this course/exercise" when it
+            // comes from the iris-settings endpoint. A 403 from the profile
+            // probe (or any other endpoint in the flow) is an
+            // infrastructure / auth issue and must NOT be misclassified as
+            // disabled — otherwise a transient permissions hiccup would
+            // surface the "instructor disabled Iris" overlay.
+            mockApiService.getProfileInfo.rejects(new ApiError('Forbidden', 403));
+
+            const result = await chatSessionService.checkAndLoadIrisSettings(courseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+
+        test('classifies ApiError(403) from getExerciseDetails (during course resolution) as unavailable', async () => {
+            // Same origin-sensitivity concern as the profile probe: a 403
+            // from the exercise-details endpoint while resolving the course
+            // ID is an auth / permissions issue, not an Iris-disabled
+            // signal. The user must see the unavailable banner, not the
+            // disabled overlay.
+            const exerciseContext: ActiveContext = {
+                type: 'exercise',
+                id: 123,
+                title: 'Test Exercise',
                 source: 'user-selected',
                 locked: false,
                 selectedAt: Date.now()
             };
+            mockApiService.getExerciseDetails.rejects(new ApiError('Forbidden', 403));
 
-            const error: any = new Error('Forbidden');
-            error.status = 403;
-            mockApiService.getIrisCourseChatSettings.rejects(error);
+            const result = await chatSessionService.checkAndLoadIrisSettings(exerciseContext);
+            assert.strictEqual(result.kind, 'unavailable');
+        });
+    });
 
-            const result = await chatSessionService.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+    suite('Availability state tracking', () => {
+        const courseContext: ActiveContext = {
+            type: 'course',
+            id: 101,
+            title: 'Test Course',
+            source: 'user-selected',
+            locked: false,
+            selectedAt: Date.now()
+        };
+
+        test('lastAvailability starts as unknown', () => {
+            assert.strictEqual(chatSessionService.lastAvailability.kind, 'unknown');
         });
 
-        test('should return false on other errors', async () => {
-            const context: ActiveContext = {
-                type: 'course',
-                id: 101,
-                title: 'Test Course',
-                source: 'user-selected',
-                locked: false,
-                selectedAt: Date.now()
-            };
+        test('lastAvailability reflects the last classification after loadAllSessionsForContext', async () => {
+            contextStore.setActiveContext(courseContext);
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Server error', 500));
 
-            mockApiService.getIrisCourseChatSettings.rejects(new Error('Network error'));
+            await chatSessionService.loadAllSessionsForContext();
 
-            const result = await chatSessionService.checkAndLoadIrisSettings(context);
-            assert.strictEqual(result, false);
+            assert.strictEqual(chatSessionService.lastAvailability.kind, 'unavailable');
+            assert.strictEqual(chatSessionService.lastAvailability.contextKey, 'course:101');
+        });
+
+        test('lastAvailability tracks contextKey for disabled state', async () => {
+            contextStore.setActiveContext(courseContext);
+            mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: false } });
+
+            await chatSessionService.loadAllSessionsForContext();
+
+            assert.strictEqual(chatSessionService.lastAvailability.kind, 'disabled');
+            assert.strictEqual(chatSessionService.lastAvailability.contextKey, 'course:101');
+        });
+
+        test('resetAvailability sets state back to unknown', async () => {
+            contextStore.setActiveContext(courseContext);
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Server error', 500));
+            await chatSessionService.loadAllSessionsForContext();
+            assert.strictEqual(chatSessionService.lastAvailability.kind, 'unavailable');
+
+            chatSessionService.resetAvailability();
+
+            const reset = chatSessionService.lastAvailability;
+            assert.strictEqual(reset.kind, 'unknown');
+            assert.strictEqual(reset.contextKey, undefined);
         });
     });
 
@@ -353,7 +457,7 @@ suite('IrisChatSessionService Test Suite', () => {
             assert.ok(mockApiService.listChatSessionsForCourse.notCalled);
         });
 
-        test('should not load sessions when API service is not available', async () => {
+        test('classifies as unavailable and surfaces the banner when API service is missing', async () => {
             const serviceWithoutApi = new IrisChatSessionService(
                 {
                     contextStore,
@@ -377,10 +481,20 @@ suite('IrisChatSessionService Test Suite', () => {
 
             await serviceWithoutApi.loadAllSessionsForContext();
 
-            assert.ok(postMessageSpy.notCalled);
+            // The API service being absent during early activation is transient
+            // (the next reload after init completes will pick up the service).
+            // Showing the unavailable banner is the right UX, not silently
+            // doing nothing and leaving the loader spinning.
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'showUnavailableState' })
+            ), 'expected showUnavailableState when API service is unavailable');
+            // The listing API must never be hit when no service exists.
+            // (Trivially true because the service is undefined, but worth
+            // documenting alongside the banner expectation.)
+            assert.ok(!mockApiService.listChatSessionsForCourse.called);
         });
 
-        test('should show disabled state when Iris is not enabled', async () => {
+        test('emits ShowDisabledState + HideUnavailableState when Iris is disabled', async () => {
             const context: ActiveContext = {
                 type: 'course',
                 id: 101,
@@ -404,6 +518,73 @@ suite('IrisChatSessionService Test Suite', () => {
             assert.ok(postMessageSpy.calledWith(
                 sinon.match({ type: 'showDisabledState' })
             ));
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'hideUnavailableState' })
+            ));
+            // Disabled is an availability decision, NOT a history-load failure.
+            // The view gates its loader on disabledMessage / unavailableMessage
+            // directly; emitting loadMessagesError would surface the misleading
+            // central error UI in addition to the banner.
+            assert.ok(postMessageSpy.neverCalledWith(
+                sinon.match({ type: 'loadMessagesError' })
+            ));
+        });
+
+        test('emits ShowUnavailableState + HideDisabledState on transient infrastructure failure', async () => {
+            const context: ActiveContext = {
+                type: 'course',
+                id: 101,
+                title: 'Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now()
+            };
+            contextStore.setActiveContext(context);
+
+            mockApiService.getIrisCourseChatSettings.rejects(new ApiError('Server error', 500));
+
+            await chatSessionService.loadAllSessionsForContext();
+
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'showUnavailableState' })
+            ), 'expected showUnavailableState to be posted');
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'hideDisabledState' })
+            ), 'expected hideDisabledState to be posted alongside unavailable');
+            assert.ok(postMessageSpy.neverCalledWith(
+                sinon.match({ type: 'showDisabledState' })
+            ), 'transient failure must NOT show the disabled overlay');
+            assert.ok(postMessageSpy.neverCalledWith(
+                sinon.match({ type: 'loadMessagesError' })
+            ), 'transient failure must NOT post the central history-load error');
+        });
+
+        test('outer fetch failure classifies as unavailable and does NOT create a fallback session', async () => {
+            const context: ActiveContext = {
+                type: 'course',
+                id: 101,
+                title: 'Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now()
+            };
+            contextStore.setActiveContext(context);
+
+            // Settings succeed → enabled path; then listChatSessionsForCourse blows up.
+            mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
+            mockApiService.listChatSessionsForCourse.rejects(new ApiError('Server error', 500));
+
+            const sessionCountBefore = contextStore.snapshot().sessions.length;
+
+            await chatSessionService.loadAllSessionsForContext();
+
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'showUnavailableState' })
+            ), 'outer catch must classify the failure as unavailable');
+
+            const sessionCountAfter = contextStore.snapshot().sessions.length;
+            assert.strictEqual(sessionCountAfter, sessionCountBefore,
+                'no createNewSession() fallback may run when listing fails — the server still has the real sessions');
         });
 
         test('should load course sessions successfully', async () => {
@@ -600,7 +781,7 @@ suite('IrisChatSessionService Test Suite', () => {
             assert.ok(mockIrisWebSocketSessionClient.resetSession.notCalled);
         });
 
-        test('should handle errors and create fallback session', async () => {
+        test('outer load failure surfaces unavailable without creating a fallback session', async () => {
             const context: ActiveContext = {
                 type: 'course',
                 id: 101,
@@ -615,16 +796,27 @@ suite('IrisChatSessionService Test Suite', () => {
             mockApiService.getIrisCourseChatSettings.resolves({
                 settings: { enabled: true }
             });
-
+            // Listing throws AFTER the enabled classification — exercises the
+            // outer try/catch path.
             mockApiService.listChatSessionsForCourse.rejects(new Error('API Error'));
 
             mockIrisWebSocketSessionClient.createNewSession.resolves(42);
 
             await chatSessionService.loadAllSessionsForContext();
 
-            // Should create fallback session (via createNewSession -> resetSession)
-            assert.ok(mockIrisWebSocketSessionClient.resetSession.calledOnce);
-            assert.ok(onPostSnapshotSpy.called);
+            // The previous behavior silently created a local fallback session
+            // whenever any error escaped the outer try — masking transient
+            // server outages as "no server-side sessions" and accumulating
+            // orphan local sessions on each reload. The new contract is:
+            // outer failures classify as `unavailable` and surface the
+            // banner. Retry is the user's recovery path.
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'showUnavailableState' })
+            ), 'outer failure must classify as unavailable');
+            assert.ok(mockIrisWebSocketSessionClient.resetSession.notCalled,
+                'createNewSession must not run as a silent fallback');
+            assert.ok(mockIrisWebSocketSessionClient.createNewSession.notCalled,
+                'no new server session may be allocated by the failure path');
         });
 
         test('should clear existing sessions before loading fresh data', async () => {
@@ -678,7 +870,7 @@ suite('IrisChatSessionService Test Suite', () => {
             assert.ok(snapshotAfter.sessions.length <= 2, 'Should have cleared old sessions');
         });
 
-        test('should hide disabled state when Iris is enabled', async () => {
+        test('hides both disabled and unavailable banners when Iris is enabled', async () => {
             const context: ActiveContext = {
                 type: 'course',
                 id: 101,
@@ -701,7 +893,10 @@ suite('IrisChatSessionService Test Suite', () => {
 
             assert.ok(postMessageSpy.calledWith(
                 sinon.match({ type: 'hideDisabledState' })
-            ));
+            ), 'expected hideDisabledState on enabled path');
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'hideUnavailableState' })
+            ), 'expected hideUnavailableState on enabled path');
         });
 
         test('posts snapshot before LoadMessages so webview accepts the imported-session payload', async () => {
@@ -938,6 +1133,38 @@ suite('IrisChatSessionService Test Suite', () => {
             await new Promise(resolve => setTimeout(resolve, 10));
 
             assert.ok(mockIrisWebSocketSessionClient.createNewSession.calledOnce);
+        });
+
+        test('server-side failure during new-session round-trip surfaces unavailable banner', async () => {
+            // The previous behavior posted only LoadMessagesError on a
+            // createNewSession failure — the loader stopped via the
+            // messagesErrored UI but the user got no "Iris unavailable,
+            // retry?" affordance. The new contract: classify the error via
+            // the shared availability classifier and surface the unavailable
+            // banner alongside the LoadMessagesError, so reconnect-auto-retry
+            // can recover the session.
+            const context: ActiveContext = {
+                type: 'course',
+                id: 101,
+                title: 'Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now()
+            };
+            contextStore.setActiveContext(context);
+
+            mockIrisWebSocketSessionClient.createNewSession.rejects(new ApiError('Server error', 500));
+
+            chatSessionService.createNewSession();
+
+            // Let the .catch() fire.
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            assert.ok(postMessageSpy.calledWith(
+                sinon.match({ type: 'showUnavailableState' })
+            ), 'expected showUnavailableState after createNewSession 500');
+            assert.strictEqual(chatSessionService.lastAvailability.kind, 'unavailable',
+                'lastAvailability must reflect the failure so reconnect-auto-retry fires');
         });
 
         test('does not attach the new artemis id to a different session if the user switched mid-flight', async () => {


### PR DESCRIPTION
## Summary

Fixes #218 and #219 together — both are about Iris chat resilience when the network drops.

- Distinguish "Iris genuinely disabled" from "Iris temporarily unavailable" so a network blip no longer surfaces the "instructor disabled Iris" overlay.
- Add a Retry button on the new unavailable banner, plus auto-retry on websocket reconnect, so the chat actually recovers once connectivity returns instead of sitting on "Loading conversation…" forever.
- Stop the loader from spinning forever when the chat is in a known terminal state (disabled or unavailable) — the banner is the right surface for that, not the loader.

## What changed

**Classifier.** `checkAndLoadIrisSettings` now returns a discriminated union `{ kind: 'enabled' | 'disabled' | 'unavailable' }`. The Iris settings endpoint is the only place where 403 means "disabled" (course-level forbidden); 403 from any other endpoint in the flow (profile probe, exercise-details course resolution) classifies as unavailable. 401/404/4xx/5xx/network/timeout/malformed responses all map to unavailable.

**Centralized emission.** A single `_postAvailability` method on `IrisChatSessionService` is the only path that emits availability messages, tracks `lastAvailability` (paired with `contextKey`), and clears the opposite banner. A public `postAvailability` wrapper lets the send path use the same helper so a send-time `iris-unavailable` also updates `lastAvailability` and lets the reconnect hook auto-retry.

**Auto-retry on reconnect.** `ChatWebviewProvider` subscribes to `onDidChangeConnectionState`. On `connected: true`, after a 500 ms debounce, it triggers a reload — but only if `lastAvailability.kind === 'unavailable'` and `contextKey` matches the live active context (gated by the new pure `shouldAutoRetryReload` helper). Both the reconnect path and the manual Retry button share a context-keyed single-flight: same-context triggers join the in-flight promise; different-context triggers start fresh, so a hung reload for one context cannot block recovery of another.

**Context-change reset.** Hooked off `contextStore.onDidChangeActiveContext`, which fires only on real type/id changes. On every context switch the provider resets `lastAvailability` to `unknown` and hides both banners, so a stale classification from the previous context cannot drive retries or banner state for the new one.

**Captured-context race fix.** `SendMessageResult` now carries a `capturedContext`. If the user switches context while `checkAndLoadIrisSettings` is in flight on the send path, the late rejection no longer pollutes the new context's banner state — the persistent emit is skipped, but the message-level `SendRejected` still fires.

**Outer catch.** The old fallback that silently called `createNewSession()` whenever the outer `loadAllSessionsForContext` try threw is gone. Caught errors now run through the same classifier and surface the unavailable banner; the user's recovery path is the Retry button. The previous behavior masked transient server outages as "no sessions on server" and accumulated orphan local sessions on each reload.

**Loader gating.** The view's `messagesLoading` predicate now also returns false when `disabledMessage` or `unavailableMessage` is set; the message section suppresses both the central loader and the central "Failed to load chat history" error UI while a banner is shown. Input is gated on the unavailable state too, with an unavailable-specific placeholder.

**Banner precedence.** When both `disabledMessage` and `unavailableMessage` would be set (defensive — the helper enforces cross-clearing), `disabledMessage` wins. The existing websocket-disconnected banner is suppressed while the unavailable banner is shown so the user only sees one Retry affordance for the same underlying problem.

## Files

- `src/shared/messageContracts/extensionMessages.ts` + `webviewCommands.ts` — added `ShowUnavailableState`, `HideUnavailableState`, `ReloadChatSession`. Extended `sendRejected.reason` with `iris-unavailable`.
- `src/extension/services/iris/chat/chatSessionService.ts` — `IrisAvailability` union, `lastAvailability`, `resetAvailability`, `postAvailability`, the classifier, new behavior in `loadAllSessionsForContext` outer catch and `createNewSession` async catch.
- `src/extension/services/iris/chat/chatMessageService.ts` — consumes the new union; threads `capturedContext` through the rejection result.
- `src/extension/provider/chatWebviewProvider.ts` — reconnect → reload hook with debounce + context-keyed single-flight, context-change reset, `ReloadChatSession` command handler, captured-context-gated `_handleRejectedSend`.
- `src/extension/provider/chatReloadDecision.ts` — pure `shouldAutoRetryReload` helper, extracted for direct unit-testing of the gate logic.
- `src/webview/stores/useChatStore.ts` — `unavailableMessage` with cross-clearing setters.
- `src/webview/views/IrisChat/IrisChatView.tsx` + `.module.css` + `types.ts` — banner with Retry button, loader/input gating, banner precedence, websocket-banner suppression.
- Tests across all of the above plus a new `test/unit/provider/chatReloadDecision.test.ts`.

## Test plan

Automated:
- [x] `npm run check-types` clean
- [x] `npm run lint` clean
- [x] `npm run test:react` (744 tests) all pass
- [x] `npm run test:unit` (1133 tests, 3 new) all pass

Manual (in Extension Development Host):
- [ ] Network drop on Iris-enabled exercise then context switch → unavailable banner (not the "not enabled" overlay), loader stops
- [ ] Click Retry while still offline → still unavailable (no false success, no duplicate spinners — single-flight)
- [ ] Re-enable network and wait for websocket reconnect → banner auto-clears, sessions load
- [ ] Navigate to a genuinely-disabled course → disabled overlay shows (unchanged)
- [ ] Take the Artemis backend to 500 → unavailable, not disabled
- [ ] Switch to a different exercise while the unavailable banner is showing → banner clears immediately for the new context, no stale reload fires