### PR TITLE
fix(recorder): decouple Record button from Iris chat context (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Iris Chat**: Updated to the unified Iris API in Artemis 9.2+ so chat keeps working after the upstream session-endpoint consolidation.
 - **Iris Chat New Conversation**: Fixed "New Conversation" silently jumping back to the workspace exercise instead of starting a new session in the currently selected context.
 - **Iris Chat Connectivity Resilience**: Network drops and server errors now show a "temporarily unavailable" banner with a Retry button instead of the misleading "instructor disabled Iris" overlay, and the chat reloads automatically when the WebSocket reconnects.
+- **Recorder Gate**: the Record button now reads from the workspace-detected exercise instead of the Iris chat selection. Clicking Record before opening Iris no longer shows the misleading "Select an exercise context" warning.
 
 ## [0.4.4] - 2026-05-10
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -16,6 +16,10 @@ import { createProviderRegistry } from '@extension/services/ui';
 import { ArtemisWebsocketService, WebSocketStatusBarService } from '@extension/services/websocket';
 import { NoAiDetectionService } from '@extension/services/workspace';
 import {
+    buildChatProviderSink,
+    wireWorkspaceDetection,
+} from '@extension/services/workspace/wireWorkspaceDetection';
+import {
     authenticateFromEnvironment,
     autoCloneIfNeeded,
     detectPlatformCapabilities,
@@ -150,6 +154,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	providerRegistry.setChatWebviewProvider(chatWebviewProvider);
 	providerRegistry.setArtemisWebviewProvider(artemisWebviewProvider);
+
+	context.subscriptions.push(wireWorkspaceDetection({
+		api: artemisApiService,
+		registry: exerciseRegistry,
+		courseDataCache,
+		sink: buildChatProviderSink(chatWebviewProvider),
+	}));
+
 	context.subscriptions.push(telemetryManager);
 	context.subscriptions.push(artemisWebsocketService);
 	context.subscriptions.push(websocketStatusBarService);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -227,7 +227,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const { sessionRecorder, disposable: recorderDisposable } = wireSessionRecorder({
 		context, consentService, artemisWebsocketService,
 		telemetryManager, artemisWebviewProvider, chatWebviewProvider,
-		capabilities, exerciseRegistry,
+		capabilities, exerciseRegistry, contextStore,
 	});
 	activeSessionRecorder = sessionRecorder;
 	context.subscriptions.push(recorderDisposable);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -8,6 +8,7 @@ import { AuthManager } from '@extension/services/auth';
 import { ConsentService } from '@extension/services/auth';
 import { CourseDataCache } from '@extension/services/courseDataCache';
 import { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import { ContextStore } from '@extension/services/iris/context/contextStore';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { SessionRecorder } from '@extension/services/telemetry';
 import { TelemetryManager } from '@extension/services/telemetry';
@@ -132,9 +133,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerWebviewViewProvider(ArtemisWebviewProvider.viewType, artemisWebviewProvider)
 	);
 
+	const contextStore = new ContextStore(context);
+	context.subscriptions.push(contextStore);
+
 	const chatWebviewProvider = new ChatWebviewProvider(
 		context.extensionUri, context, artemisApiService, artemisWebsocketService,
 		noAiDetectionService, exerciseRegistry, courseDataCache, telemetryManager,
+		contextStore,
 	);
 	chatWebviewProvider.onDidChangeExerciseContext(({ exerciseId, exerciseRoot }) => {
 		telemetryManager.startExerciseSession(exerciseId, exerciseRoot);

--- a/extension/src/extension/activation/sessionRecorderWiring.ts
+++ b/extension/src/extension/activation/sessionRecorderWiring.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/provider';
 import type { ConsentService } from '@extension/services/auth';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import type { ContextStore } from '@extension/services/iris/context/contextStore';
 import type { SessionRecorder, TelemetryManager } from '@extension/services/telemetry';
 import {
     RecordingStatusBarService as RecordingStatusBarServiceImpl,
@@ -22,6 +23,7 @@ interface RecorderWiringDeps {
     chatWebviewProvider: ChatWebviewProvider;
     capabilities?: PlatformCapabilities;
     exerciseRegistry?: ExerciseRegistry;
+    contextStore: ContextStore;
 }
 
 interface RecorderWiringResult {
@@ -33,7 +35,7 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
     const {
         context, consentService, artemisWebsocketService,
         telemetryManager, artemisWebviewProvider, chatWebviewProvider,
-        capabilities, exerciseRegistry,
+        capabilities, exerciseRegistry, contextStore,
     } = deps;
 
     const sessionRecorder = new SessionRecorderImpl(context.globalStorageUri, capabilities, exerciseRegistry);
@@ -238,7 +240,7 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
     // Recording status bar button
     const recordingStatusBar = new RecordingStatusBarServiceImpl(
         sessionRecorder,
-        () => chatWebviewProvider.getSelectedExerciseId(),
+        () => contextStore.getWorkspaceExerciseId(),
     );
     disposables.push(recordingStatusBar);
 

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -23,7 +23,6 @@ import { type StruggleContext, TelemetryManager } from '@extension/services/tele
 import { getReactWebviewHtml } from '@extension/services/ui';
 import { ArtemisWebsocketService } from '@extension/services/websocket';
 import {
-    detectAndRegisterWorkspaceExercise,
     FileMonitorService,
     getEntryExercises,
     NoAiDetectionService,
@@ -345,13 +344,6 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         });
         this._viewDisposables.push(visibilityListener);
 
-        const workspaceListener = vscode.workspace.onDidChangeWorkspaceFolders(() => {
-            void this._detectWorkspaceExercise().catch((err: unknown) => {
-                logger.error('Failed to detect workspace exercise after folder change', LogCategory.IRIS_CHAT, err);
-            });
-        });
-        this._viewDisposables.push(workspaceListener);
-
         const configListener = vscode.workspace.onDidChangeConfiguration(event => {
             if (event.affectsConfiguration('artemis.developerMode')) {
                 this.refreshTheme();
@@ -378,7 +370,6 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
 
     private async _sendInitData(): Promise<void> {
         this._viewStatePresenter.postSnapshot();
-        await this._detectWorkspaceExercise();
         await this._populateAvailableContexts();
         void this._loadIrisMessagesIfNeeded().catch((err: unknown) => {
             logger.error('Failed to load Iris messages during init', LogCategory.IRIS_CHAT, err);
@@ -785,18 +776,6 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         } catch (error) {
             logger.debug('Failed to populate available contexts', LogCategory.IRIS_CHAT, error);
         }
-    }
-
-    private async _detectWorkspaceExercise(): Promise<void> {
-        await detectAndRegisterWorkspaceExercise(
-            this._artemisApiService,
-            {
-                registerExercise: (input) => this._chatContextManager.registerExerciseAndAutoSelect(input),
-                clearStaleWorkspaceContext: () => this._chatContextManager.clearStaleWorkspaceContext(),
-            },
-            this._exerciseRegistry,
-            this._courseDataCache,
-        );
     }
 
     private _handleContextSelection(contextType: ChatContextType, itemId: number, itemName: string, itemShortName?: string): void {

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -115,13 +115,14 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     // ── Constructor ────────────────────────────────────────────────────
     constructor(
         private readonly _extensionUri: vscode.Uri,
-        private readonly _extensionContext: vscode.ExtensionContext,
+        _extensionContext: vscode.ExtensionContext,
         private readonly _artemisApiService: ArtemisApiService | undefined,
         private readonly _websocketService: ArtemisWebsocketService | undefined,
         noAiDetectionService: NoAiDetectionService,
         private readonly _exerciseRegistry: ExerciseRegistry,
-        private readonly _courseDataCache?: CourseDataCache,
-        private readonly _telemetryManager?: TelemetryManager,
+        private readonly _courseDataCache: CourseDataCache | undefined,
+        private readonly _telemetryManager: TelemetryManager | undefined,
+        contextStore: ContextStore,
     ) {
         super(LogCategory.IRIS_CHAT);
         this._disposables.push(this._onDidChangeExerciseContext);
@@ -129,8 +130,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         this._disposables.push(this._onDidAttemptIrisChatSend);
         this._disposables.push(this._onDidProvideIrisChatFeedback);
         this._disposables.push(this._onDidChangePanelVisibility);
-        this._contextStore = new ContextStore(this._extensionContext);
-        this._disposables.push(this._contextStore);
+        this._contextStore = contextStore;
         this._disposables.push(
             this._contextStore.onDidChangeActiveContext(({ current, previous }) => {
                 if (current?.type === 'exercise') {
@@ -466,6 +466,29 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
 
     public getSelectedExerciseId(): number | undefined {
         return this._chatContextManager.getSelectedExerciseId();
+    }
+
+    // ── Workspace detection sink ──────────────────────────────────────
+    // Called by wireWorkspaceDetection at activation. The provider implements
+    // the sink because it owns the ChatContextManager + presenter that need
+    // to be refreshed when the workspace exercise changes.
+
+    public registerWorkspaceExercise(input: {
+        id: number;
+        title: string;
+        shortName?: string;
+        courseId?: number;
+        repositoryUri?: string;
+        source: 'workspace-detected';
+        isWorkspace: true;
+    }): void {
+        this._chatContextManager.registerExerciseAndAutoSelect(input);
+    }
+
+    public clearWorkspaceExercise(): void {
+        this._chatContextManager.clearStaleWorkspaceContext();
+        this._contextStore.clearWorkspaceFlag();
+        this._viewStatePresenter.postSnapshot();
     }
 
     public setCourseContext(

--- a/extension/src/extension/services/iris/context/contextStore.ts
+++ b/extension/src/extension/services/iris/context/contextStore.ts
@@ -80,6 +80,20 @@ export class ContextStore {
         return this._repository.getWorkspaceExercise();
     }
 
+    public getWorkspaceExerciseId(): number | undefined {
+        return this._repository.getWorkspaceExercise()?.id;
+    }
+
+    /**
+     * Clears the `isWorkspace` flag on all tracked exercises. Silent: does NOT fire
+     * `onDidChangeActiveContext`. Callers that need a UI refresh must post a snapshot
+     * themselves — see `ChatWebviewProvider.clearWorkspaceExercise`.
+     */
+    public clearWorkspaceFlag(): void {
+        this._repository.clearAllWorkspaceFlags();
+        this._persistence.save(this.state);
+    }
+
     public registerExercise(input: ExerciseInput): ContextSnapshot {
         this._repository.upsertExercise(input);
         this._repository.trimExerciseHistory();

--- a/extension/src/extension/services/iris/context/trackedItemRepository.ts
+++ b/extension/src/extension/services/iris/context/trackedItemRepository.ts
@@ -86,6 +86,13 @@ export class TrackedItemRepository {
         return this._getState().exercises.find(ex => ex.isWorkspace);
     }
 
+    public clearAllWorkspaceFlags(): void {
+        const state = this._getState();
+        state.exercises = state.exercises.map(ex =>
+            ex.isWorkspace ? { ...ex, isWorkspace: false } : ex,
+        );
+    }
+
     public upsertCourse(input: CourseInput): TrackedCourse {
         const state = this._getState();
         const existing = state.courses.find(c => c.id === input.id);

--- a/extension/src/extension/services/telemetry/recording/recordingStatusBar.ts
+++ b/extension/src/extension/services/telemetry/recording/recordingStatusBar.ts
@@ -80,7 +80,7 @@ export class RecordingStatusBarService implements vscode.Disposable {
 
         const exerciseId = this._getExerciseId();
         if (exerciseId === undefined) {
-            vscode.window.showWarningMessage('Select an exercise context before starting a recording.');
+            vscode.window.showWarningMessage('No Artemis exercise detected for the current workspace.');
             return;
         }
 

--- a/extension/src/extension/services/workspace/index.ts
+++ b/extension/src/extension/services/workspace/index.ts
@@ -3,7 +3,6 @@ export { GitService } from './gitService';
 export { NoAiDetectionService } from './noAiDetectionService';
 export {
     collectExerciseSources,
-    detectAndRegisterWorkspaceExercise,
     type DetectedExercise,
     findExerciseByRepositoryUrl,
     findWorkspaceCourseInArchive,

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -65,3 +65,19 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
         },
     };
 }
+
+/**
+ * Build a WorkspaceDetectionSink that routes register/clear calls through a
+ * ChatWebviewProvider (or any object with the same two methods). Extracted so
+ * the sink construction is unit-testable and so `extension.ts` does not contain
+ * untestable inline closures.
+ */
+export function buildChatProviderSink(provider: {
+    registerWorkspaceExercise: WorkspaceDetectionSink['registerWorkspaceExercise'];
+    clearWorkspaceExercise: WorkspaceDetectionSink['clearWorkspaceExercise'];
+}): WorkspaceDetectionSink {
+    return {
+        registerWorkspaceExercise: (input) => provider.registerWorkspaceExercise(input),
+        clearWorkspaceExercise: () => provider.clearWorkspaceExercise(),
+    };
+}

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -38,7 +38,10 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
                 if (token !== generation) return;
                 deps.sink.registerWorkspaceExercise(input);
             },
-            clearStaleWorkspaceContext: () => deps.sink.clearWorkspaceExercise(),
+            clearStaleWorkspaceContext: () => {
+                if (token !== generation) return;
+                deps.sink.clearWorkspaceExercise();
+            },
         };
         await detectAndRegisterWorkspaceExercise(
             deps.api, callbacks, deps.registry, deps.courseDataCache,

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+
+import type { ArtemisApiService } from '@extension/api';
+import type { CourseDataCache } from '@extension/services/courseDataCache';
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+
+import { detectAndRegisterWorkspaceExercise } from './workspaceDetectionService';
+
+export interface WorkspaceRegisterInput {
+    id: number;
+    title: string;
+    shortName?: string;
+    courseId?: number;
+    repositoryUri?: string;
+    source: 'workspace-detected';
+    isWorkspace: true;
+}
+
+export interface WorkspaceDetectionSink {
+    registerWorkspaceExercise(input: WorkspaceRegisterInput): void;
+    clearWorkspaceExercise(): void;
+}
+
+export interface WorkspaceDetectionDeps {
+    api: ArtemisApiService | undefined;
+    registry: ExerciseRegistry;
+    courseDataCache: CourseDataCache;
+    sink: WorkspaceDetectionSink;
+}
+
+export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Disposable {
+    const runDetection = async (): Promise<void> => {
+        const callbacks = {
+            registerExercise: (input: WorkspaceRegisterInput) => deps.sink.registerWorkspaceExercise(input),
+            clearStaleWorkspaceContext: () => deps.sink.clearWorkspaceExercise(),
+        };
+        await detectAndRegisterWorkspaceExercise(
+            deps.api, callbacks, deps.registry, deps.courseDataCache,
+        );
+    };
+
+    void runDetection();
+    return { dispose: () => undefined };
+}

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -40,5 +40,11 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
     };
 
     void runDetection();
-    return { dispose: () => undefined };
+    const folderSub = vscode.workspace.onDidChangeWorkspaceFolders(() => void runDetection());
+
+    return {
+        dispose: () => {
+            folderSub.dispose();
+        },
+    };
 }

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -21,7 +21,7 @@ export interface WorkspaceDetectionSink {
     clearWorkspaceExercise(): void;
 }
 
-export interface WorkspaceDetectionDeps {
+interface WorkspaceDetectionDeps {
     api: ArtemisApiService | undefined;
     registry: ExerciseRegistry;
     courseDataCache: CourseDataCache;

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -30,16 +30,21 @@ export interface WorkspaceDetectionDeps {
 
 export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Disposable {
     let generation = 0;
+    let disposed = false;
 
     const runDetection = async (): Promise<void> => {
         const token = ++generation;
         const callbacks = {
             registerExercise: (input: WorkspaceRegisterInput) => {
-                if (token !== generation) return;
+                if (disposed || token !== generation) {
+                    return;
+                }
                 deps.sink.registerWorkspaceExercise(input);
             },
             clearStaleWorkspaceContext: () => {
-                if (token !== generation) return;
+                if (disposed || token !== generation) {
+                    return;
+                }
                 deps.sink.clearWorkspaceExercise();
             },
         };
@@ -54,6 +59,7 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
 
     return {
         dispose: () => {
+            disposed = true;
             folderSub.dispose();
             coursesSub.dispose();
         },

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -41,10 +41,12 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
 
     void runDetection();
     const folderSub = vscode.workspace.onDidChangeWorkspaceFolders(() => void runDetection());
+    const coursesSub = deps.courseDataCache.onCoursesLoaded(() => void runDetection());
 
     return {
         dispose: () => {
             folderSub.dispose();
+            coursesSub.dispose();
         },
     };
 }

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -29,9 +29,15 @@ export interface WorkspaceDetectionDeps {
 }
 
 export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Disposable {
+    let generation = 0;
+
     const runDetection = async (): Promise<void> => {
+        const token = ++generation;
         const callbacks = {
-            registerExercise: (input: WorkspaceRegisterInput) => deps.sink.registerWorkspaceExercise(input),
+            registerExercise: (input: WorkspaceRegisterInput) => {
+                if (token !== generation) return;
+                deps.sink.registerWorkspaceExercise(input);
+            },
             clearStaleWorkspaceContext: () => deps.sink.clearWorkspaceExercise(),
         };
         await detectAndRegisterWorkspaceExercise(

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -28,6 +28,7 @@ import type {
 import { wireSessionRecorder } from '@extension/activation/sessionRecorderWiring';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/provider';
 import type { ConsentService } from '@extension/services/auth';
+import type { ContextStore } from '@extension/services/iris/context/contextStore';
 import { SessionRecorder } from '@extension/services/telemetry/recording/sessionRecorder';
 import type {
     ConfigurationChangeEvent,
@@ -108,21 +109,26 @@ function stubWebviewProvider(): ArtemisWebviewProvider {
     } as unknown as ArtemisWebviewProvider;
 }
 
-function stubChatProvider(): ChatWebviewProvider {
+type ChatProviderStub = ChatWebviewProvider & { _selectedExerciseIdSpy: sinon.SinonSpy };
+
+function stubChatProvider(): ChatProviderStub {
     const onDidSendIrisChatMessage = new vscode.EventEmitter<string>();
     const onDidAttemptIrisChatSend = new vscode.EventEmitter<{ content: string; status: 'pending' | 'sent' | 'failed'; errorMessage?: string }>();
     const onDidProvideIrisChatFeedback = new vscode.EventEmitter<{ messageId: string; helpful: boolean }>();
     const onDidChangePanelVisibility = new vscode.EventEmitter<boolean>();
     const onDidReceiveIrisChatMessage = new vscode.EventEmitter<{ content: string; messageId?: string; sessionId?: string; sentAt?: number }>();
-    return {
+    const _selectedExerciseIdSpy = sinon.spy(() => 42);
+    const chat = {
         getCurrentVisibility: () => false,
-        getSelectedExerciseId: () => 42,
+        getSelectedExerciseId: _selectedExerciseIdSpy,
         onDidSendIrisChatMessage: onDidSendIrisChatMessage.event,
         onDidAttemptIrisChatSend: onDidAttemptIrisChatSend.event,
         onDidProvideIrisChatFeedback: onDidProvideIrisChatFeedback.event,
         onDidChangePanelVisibility: onDidChangePanelVisibility.event,
         websocketMessageHandler: { onDidReceiveIrisChatMessage: onDidReceiveIrisChatMessage.event },
-    } as unknown as ChatWebviewProvider;
+        _selectedExerciseIdSpy,
+    };
+    return chat as unknown as ChatProviderStub;
 }
 
 /** Read every events.jsonl file produced under tmpDir/recordings/<sessionId>/ and return the parsed events. */
@@ -154,9 +160,11 @@ interface WiringHarness {
     telemetryManager: TelemetryManager;
     recorder: SessionRecorder;
     artemisWebviewProvider: ArtemisWebviewProvider;
+    chatProvider: ChatProviderStub;
     tmpDir: string;
     configState: MutableConfigState;
     capturedConfigListener: () => ((e: vscode.ConfigurationChangeEvent) => void) | undefined;
+    clickRecord: () => Promise<void>;
     dispose: () => Promise<void>;
 }
 
@@ -169,6 +177,7 @@ interface WiringHarness {
 async function makeWiringHarness(
     sandbox: sinon.SinonSandbox,
     initial: MutableConfigState,
+    contextStore: ContextStore = { getWorkspaceExerciseId: () => 42 } as unknown as ContextStore,
 ): Promise<WiringHarness> {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wiring-test-'));
     const configState: MutableConfigState = { ...initial };
@@ -184,9 +193,16 @@ async function makeWiringHarness(
     // The extension under test is already activated by the test runner and has
     // registered `artemis.toggleRecording`. Stub registerCommand so the wiring's
     // RecordingStatusBarService does not collide with that pre-existing
-    // registration. Same story for createStatusBarItem (avoid duplicating the
-    // real status bar item).
-    sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+    // registration. Capture the handler so tests can invoke the Record click
+    // directly without hitting the live extension's already-registered command.
+    // Same story for createStatusBarItem (avoid duplicating the real status bar item).
+    let capturedRecordHandler: (() => Promise<void>) | undefined;
+    sandbox.stub(vscode.commands, 'registerCommand').callsFake((id: string, handler: () => Promise<void>) => {
+        if (id === 'artemis.toggleRecording') {
+            capturedRecordHandler = handler;
+        }
+        return new vscode.Disposable(() => { /* noop */ });
+    });
     sandbox.stub(vscode.window, 'createStatusBarItem').returns({
         text: '', tooltip: undefined, backgroundColor: undefined, command: undefined,
         show: sandbox.stub(), hide: sandbox.stub(), dispose: sandbox.stub(),
@@ -196,24 +212,33 @@ async function makeWiringHarness(
     const telemetryManager = new TelemetryManager();
     const ctx = { globalStorageUri: vscode.Uri.file(tmpDir), subscriptions: [] } as unknown as vscode.ExtensionContext;
     const artemisProvider = stubWebviewProvider();
+    const chatProvider = stubChatProvider();
     const wiring = wireSessionRecorder({
         context: ctx,
         consentService: stubConsent(true),
         artemisWebsocketService: stubWebsocket(sandbox),
         telemetryManager,
         artemisWebviewProvider: artemisProvider,
-        chatWebviewProvider: stubChatProvider(),
+        chatWebviewProvider: chatProvider,
         capabilities: undefined,
         exerciseRegistry: undefined,
+        contextStore,
     });
 
     return {
         telemetryManager,
         recorder: wiring.sessionRecorder,
         artemisWebviewProvider: artemisProvider,
+        chatProvider,
         tmpDir,
         configState,
         capturedConfigListener: () => captured,
+        clickRecord: async () => {
+            if (!capturedRecordHandler) {
+                throw new Error('Record-toggle handler was not registered');
+            }
+            await capturedRecordHandler();
+        },
         dispose: async () => {
             wiring.disposable.dispose();
             try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
@@ -350,6 +375,24 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
             const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
             assert.ok(change, 'configurationChange missing');
             assert.deepStrictEqual(change!.changes, { showInterventions: false });
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('recorder gate reads from contextStore.getWorkspaceExerciseId; chat getter is unused', async () => {
+        const workspaceGetter = sinon.spy(() => 99);
+        const contextStore = { getWorkspaceExerciseId: workspaceGetter } as unknown as ContextStore;
+        const initial: MutableConfigState = {
+            enabled: true,
+            showInterventions: true,
+            developerMode: false,
+        };
+        const harness = await makeWiringHarness(sandbox, initial, contextStore);
+        try {
+            await harness.clickRecord();
+            assert.strictEqual(workspaceGetter.callCount, 1, 'workspace getter should be called once per click');
+            assert.ok(!harness.chatProvider._selectedExerciseIdSpy.called, 'chat getter must NOT be called by the wiring');
         } finally {
             await harness.dispose();
         }

--- a/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
@@ -1,6 +1,6 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as vscode from 'vscode';
 
 import { ChatWebviewProvider } from '@extension/provider/chatWebviewProvider';
 import { ContextStore } from '@extension/services/iris/context/contextStore';

--- a/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 import { ChatWebviewProvider } from '@extension/provider/chatWebviewProvider';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
+import * as detectionModule from '@extension/services/workspace/workspaceDetectionService';
 import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
 
 function buildProvider(): { provider: ChatWebviewProvider; sandbox: sinon.SinonSandbox; mockContext: MockExtensionContext } {
@@ -74,5 +75,66 @@ suite('ChatWebviewProvider workspace sink', () => {
         assert.ok(c.calledOnce, 'postSnapshot should fire');
         assert.ok(a.calledBefore(b), 'clearStale must run before clearFlag');
         assert.ok(b.calledBefore(c), 'clearFlag must run before postSnapshot');
+    });
+});
+
+suite('ChatWebviewProvider stops detecting workspace', () => {
+    let sandbox: sinon.SinonSandbox;
+    let detectStub: sinon.SinonStub;
+    let onDidChangeFoldersStub: sinon.SinonStub;
+    let provider: ChatWebviewProvider;
+
+    setup(() => {
+        const built = buildProvider();
+        provider = built.provider;
+        sandbox = built.sandbox;
+        detectStub = sandbox.stub(detectionModule, 'detectAndRegisterWorkspaceExercise').resolves();
+        onDidChangeFoldersStub = sandbox.stub(vscode.workspace, 'onDidChangeWorkspaceFolders').returns({ dispose: () => undefined });
+    });
+
+    teardown(() => {
+        provider.dispose();
+        sandbox.restore();
+    });
+
+    function makeWebviewStub(): vscode.WebviewView {
+        const webview = {
+            options: {} as vscode.WebviewOptions,
+            html: '',
+            onDidReceiveMessage: () => ({ dispose: () => undefined }),
+            asWebviewUri: (u: vscode.Uri) => u,
+            cspSource: 'https://example',
+        } as unknown as vscode.Webview;
+        return {
+            webview,
+            onDidDispose: () => ({ dispose: () => undefined }),
+            onDidChangeVisibility: () => ({ dispose: () => undefined }),
+            visible: false,
+            show: () => undefined,
+            title: '',
+            description: '',
+            badge: undefined,
+            viewType: 'irisChat',
+        } as unknown as vscode.WebviewView;
+    }
+
+    test('resolveWebviewView does NOT register onDidChangeWorkspaceFolders', () => {
+        provider.resolveWebviewView(makeWebviewStub(), {} as never, {} as never);
+        assert.ok(!onDidChangeFoldersStub.called, 'resolveWebviewView must not subscribe to workspace folder changes');
+    });
+
+    test('the provider never calls detectAndRegisterWorkspaceExercise (resolveWebviewView path)', async () => {
+        provider.resolveWebviewView(makeWebviewStub(), {} as never, {} as never);
+        await Promise.resolve();
+        await Promise.resolve();
+        assert.strictEqual(detectStub.callCount, 0, 'resolveWebviewView path must not detect workspace');
+    });
+
+    test('_sendInitData does not invoke workspace detection', async () => {
+        // _sendInitData is private but is the path that previously called detection.
+        // Cast through unknown to invoke it directly — this is a regression guard,
+        // documenting that the detection call has been deleted from that codepath.
+        await (provider as unknown as { _sendInitData: () => Promise<void> })._sendInitData();
+        assert.strictEqual(detectStub.callCount, 0, '_sendInitData must not detect workspace');
     });
 });

--- a/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderWorkspaceSink.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { ChatWebviewProvider } from '@extension/provider/chatWebviewProvider';
+import { ContextStore } from '@extension/services/iris/context/contextStore';
+import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
+
+function buildProvider(): { provider: ChatWebviewProvider; sandbox: sinon.SinonSandbox; mockContext: MockExtensionContext } {
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(vscode.commands, 'registerCommand').returns({ dispose: () => undefined });
+    const mockContext = new MockExtensionContext();
+    const noAi = {
+        isNoAiEnabled: false,
+        onNoAiStatusChanged: new vscode.EventEmitter<boolean>().event,
+    };
+    const registry = { getAllExercises: () => [] };
+    const courseDataCache = {
+        onCoursesLoaded: new vscode.EventEmitter<unknown>().event,
+        fetch: async () => undefined,
+    };
+    const contextStore = new ContextStore(mockContext);
+    const provider = new ChatWebviewProvider(
+        vscode.Uri.file('/tmp'),
+        mockContext as unknown as vscode.ExtensionContext,
+        undefined,
+        undefined,
+        noAi as never,
+        registry as never,
+        courseDataCache as never,
+        undefined,
+        contextStore,
+    );
+    return { provider, sandbox, mockContext };
+}
+
+suite('ChatWebviewProvider workspace sink', () => {
+    let provider: ChatWebviewProvider;
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        const built = buildProvider();
+        provider = built.provider;
+        sandbox = built.sandbox;
+    });
+
+    teardown(() => {
+        provider.dispose();
+        sandbox.restore();
+    });
+
+    test('registerWorkspaceExercise delegates to chatContextManager.registerExerciseAndAutoSelect', () => {
+        const ccm = (provider as unknown as { _chatContextManager: { registerExerciseAndAutoSelect: sinon.SinonStub } })._chatContextManager;
+        const spy = sandbox.stub(ccm, 'registerExerciseAndAutoSelect');
+        const input = { id: 1, title: 'X', source: 'workspace-detected' as const, isWorkspace: true as const };
+        provider.registerWorkspaceExercise(input);
+        assert.ok(spy.calledOnceWith(input));
+    });
+
+    test('clearWorkspaceExercise calls clearStaleWorkspaceContext, clearWorkspaceFlag, postSnapshot in order', () => {
+        const internals = provider as unknown as {
+            _chatContextManager: { clearStaleWorkspaceContext: sinon.SinonStub };
+            _contextStore: { clearWorkspaceFlag: sinon.SinonStub };
+            _viewStatePresenter: { postSnapshot: sinon.SinonStub };
+        };
+        const a = sandbox.stub(internals._chatContextManager, 'clearStaleWorkspaceContext');
+        const b = sandbox.stub(internals._contextStore, 'clearWorkspaceFlag');
+        const c = sandbox.stub(internals._viewStatePresenter, 'postSnapshot');
+
+        provider.clearWorkspaceExercise();
+
+        assert.ok(a.calledOnce, 'clearStaleWorkspaceContext should fire');
+        assert.ok(b.calledOnce, 'clearWorkspaceFlag should fire');
+        assert.ok(c.calledOnce, 'postSnapshot should fire');
+        assert.ok(a.calledBefore(b), 'clearStale must run before clearFlag');
+        assert.ok(b.calledBefore(c), 'clearFlag must run before postSnapshot');
+    });
+});

--- a/extension/test/unit/provider/contextStore.test.ts
+++ b/extension/test/unit/provider/contextStore.test.ts
@@ -609,3 +609,37 @@ suite('ContextStore Test Suite', () => {
         assert.strictEqual(after.courses.length, 0);
     });
 });
+
+suite('ContextStore workspace accessors', () => {
+    let store: ContextStore;
+
+    setup(() => {
+        store = new ContextStore(new MockExtensionContext());
+    });
+
+    test('getWorkspaceExerciseId returns the id of the flagged exercise', () => {
+        store.registerExercise({ id: 7, title: 'Ws', isWorkspace: true });
+        assert.strictEqual(store.getWorkspaceExerciseId(), 7);
+    });
+
+    test('getWorkspaceExerciseId returns undefined when no exercise is flagged', () => {
+        store.registerExercise({ id: 8, title: 'NotWs' });
+        assert.strictEqual(store.getWorkspaceExerciseId(), undefined);
+    });
+
+    test('clearWorkspaceFlag clears the flag', () => {
+        store.registerExercise({ id: 9, title: 'Ws', isWorkspace: true });
+        assert.ok(store.getWorkspaceExercise(), 'precondition');
+        store.clearWorkspaceFlag();
+        assert.strictEqual(store.getWorkspaceExercise(), undefined);
+    });
+
+    test('clearWorkspaceFlag does NOT fire onDidChangeActiveContext (silent by design)', () => {
+        store.registerExercise({ id: 10, title: 'Ws', isWorkspace: true });
+        const calls: unknown[] = [];
+        const sub = store.onDidChangeActiveContext(ev => calls.push(ev));
+        store.clearWorkspaceFlag();
+        sub.dispose();
+        assert.strictEqual(calls.length, 0);
+    });
+});

--- a/extension/test/unit/services/iris/context/trackedItemRepository.test.ts
+++ b/extension/test/unit/services/iris/context/trackedItemRepository.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+
+import type { StoredState } from '@extension/services/iris/context/contextStateTypes';
+import { TrackedItemRepository } from '@extension/services/iris/context/trackedItemRepository';
+
+function makeState(): StoredState {
+    return {
+        version: 2,
+        exercises: [],
+        courses: [],
+        sessions: {},
+        activeContext: null,
+        activeSessionId: null,
+    };
+}
+
+suite('TrackedItemRepository workspace-flag clear', () => {
+    test('clearAllWorkspaceFlags sets isWorkspace=false on every flagged exercise', () => {
+        const state = makeState();
+        const repo = new TrackedItemRepository(() => state, {
+            exerciseArchiveLimit: 20,
+            courseArchiveLimit: 20,
+        });
+        // Upsert A as workspace, then forcibly flag B too — simulating a corrupted
+        // multi-flag state that the production code's single-writer invariant
+        // normally prevents but that clearAllWorkspaceFlags must still handle.
+        repo.upsertExercise({ id: 1, title: 'Alpha', isWorkspace: true });
+        repo.upsertExercise({ id: 2, title: 'Beta' });
+        state.exercises = state.exercises.map(ex => ({ ...ex, isWorkspace: true }));
+
+        repo.clearAllWorkspaceFlags();
+
+        for (const ex of state.exercises) {
+            assert.strictEqual(ex.isWorkspace, false, `exercise ${ex.id} still flagged`);
+        }
+    });
+
+    test('clearAllWorkspaceFlags is a no-op on an empty repository', () => {
+        const state = makeState();
+        const repo = new TrackedItemRepository(() => state, {
+            exerciseArchiveLimit: 20,
+            courseArchiveLimit: 20,
+        });
+        repo.clearAllWorkspaceFlags();
+        assert.deepStrictEqual(state.exercises, []);
+    });
+
+    test('clearAllWorkspaceFlags makes getWorkspaceExercise return undefined', () => {
+        const state = makeState();
+        const repo = new TrackedItemRepository(() => state, {
+            exerciseArchiveLimit: 20,
+            courseArchiveLimit: 20,
+        });
+        repo.upsertExercise({ id: 1, title: 'Alpha', isWorkspace: true });
+        assert.ok(repo.getWorkspaceExercise(), 'precondition: workspace exercise should exist');
+        repo.clearAllWorkspaceFlags();
+        assert.strictEqual(repo.getWorkspaceExercise(), undefined);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/recordingStatusBar.test.ts
+++ b/extension/test/unit/services/telemetry/recording/recordingStatusBar.test.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { RecordingStatusBarService } from '@extension/services/telemetry/recording/recordingStatusBar';
+import type { SessionRecorder } from '@extension/services/telemetry/recording/sessionRecorder';
+
+function makeRecorderStub(): SessionRecorder {
+    const emitter = new vscode.EventEmitter<{ isEnabled: boolean; isRecording: boolean }>();
+    return {
+        isEnabled: true,
+        isRecording: false,
+        onDidChangeState: emitter.event,
+        startSession: sinon.stub().resolves(),
+        endSession: sinon.stub().resolves(),
+    } as unknown as SessionRecorder;
+}
+
+suite('RecordingStatusBarService gate', () => {
+    let sandbox: sinon.SinonSandbox;
+    let recorder: SessionRecorder;
+    let warnStub: sinon.SinonStub;
+    let bar: RecordingStatusBarService;
+    let capturedHandler: (() => Promise<void>) | undefined;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(vscode.window, 'createStatusBarItem').returns({
+            dispose: () => undefined, show: () => undefined, hide: () => undefined,
+            text: '', backgroundColor: undefined, tooltip: '', command: '',
+        } as unknown as vscode.StatusBarItem);
+        capturedHandler = undefined;
+        sandbox.stub(vscode.commands, 'registerCommand').callsFake((id: string, handler: () => Promise<void>) => {
+            if (id === RecordingStatusBarService.COMMAND_ID) {
+                capturedHandler = handler;
+            }
+            return { dispose: () => undefined };
+        });
+        warnStub = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined as never);
+        recorder = makeRecorderStub();
+    });
+
+    teardown(() => {
+        bar?.dispose();
+        sandbox.restore();
+    });
+
+    async function click(): Promise<void> {
+        assert.ok(capturedHandler, 'command handler was not captured by the stub');
+        await capturedHandler();
+    }
+
+    test('starts a session when the getter returns a number', async () => {
+        bar = new RecordingStatusBarService(recorder, () => 42);
+        await click();
+        const startStub = recorder.startSession as sinon.SinonStub;
+        assert.ok(startStub.calledOnce);
+        assert.strictEqual(startStub.firstCall.args[0], 42);
+        assert.ok(!warnStub.called);
+    });
+
+    test('shows the new warning text when the getter returns undefined', async () => {
+        bar = new RecordingStatusBarService(recorder, () => undefined);
+        await click();
+        assert.ok((recorder.startSession as sinon.SinonStub).notCalled);
+        assert.ok(warnStub.calledOnceWith('No Artemis exercise detected for the current workspace.'));
+    });
+
+    test('the getter is invoked exactly once per Record click', async () => {
+        const getter = sandbox.stub().returns(7);
+        bar = new RecordingStatusBarService(recorder, getter);
+        await click();
+        assert.strictEqual(getter.callCount, 1);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/recordingStatusBar.test.ts
+++ b/extension/test/unit/services/telemetry/recording/recordingStatusBar.test.ts
@@ -1,6 +1,6 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as vscode from 'vscode';
 
 import { RecordingStatusBarService } from '@extension/services/telemetry/recording/recordingStatusBar';
 import type { SessionRecorder } from '@extension/services/telemetry/recording/sessionRecorder';

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -55,4 +55,15 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(detectStub.callCount, 1);
         disposable.dispose();
     });
+
+    test('onDidChangeWorkspaceFolders event triggers re-detection', async () => {
+        const sink = makeSinkSpy();
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        detectStub.resetHistory();
+        folderEmitter.fire({ added: [], removed: [] });
+        await Promise.resolve();
+        assert.strictEqual(detectStub.callCount, 1);
+        disposable.dispose();
+    });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -77,4 +77,40 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(detectStub.callCount, 1);
         disposable.dispose();
     });
+
+    test('generation guard: stale registerExercise from older detection is a no-op', async () => {
+        const sink = makeSinkSpy();
+        let resolveA!: () => void;
+        let resolveB!: () => void;
+        const capturedCallbacks: Array<{
+            registerExercise: (input: WorkspaceRegisterInput) => void;
+            clearStaleWorkspaceContext: () => void;
+        }> = [];
+        detectStub.callsFake(async (_api: unknown, cb: typeof capturedCallbacks[number]) => {
+            capturedCallbacks.push(cb);
+            if (capturedCallbacks.length === 1) await new Promise<void>(r => { resolveA = r; });
+            else await new Promise<void>(r => { resolveB = r; });
+        });
+
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();          // schedule detection A
+        folderEmitter.fire({ added: [], removed: [] });
+        await Promise.resolve();          // schedule detection B (A still pending)
+
+        // A finishes late; its callback must be a no-op.
+        capturedCallbacks[0].registerExercise({
+            id: 1, title: 'Stale', source: 'workspace-detected', isWorkspace: true,
+        });
+        // B finishes normally.
+        capturedCallbacks[1].registerExercise({
+            id: 2, title: 'Fresh', source: 'workspace-detected', isWorkspace: true,
+        });
+
+        resolveA(); resolveB();
+        await Promise.resolve();
+
+        assert.strictEqual(sink._register.callCount, 1, 'only fresh detection should reach sink');
+        assert.strictEqual(sink._register.firstCall.args[0].id, 2);
+        disposable.dispose();
+    });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -113,4 +113,33 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(sink._register.firstCall.args[0].id, 2);
         disposable.dispose();
     });
+
+    test('generation guard: stale clearWorkspaceExercise from older detection is a no-op', async () => {
+        const sink = makeSinkSpy();
+        let resolveA!: () => void;
+        let resolveB!: () => void;
+        const capturedCallbacks: Array<{
+            registerExercise: (input: WorkspaceRegisterInput) => void;
+            clearStaleWorkspaceContext: () => void;
+        }> = [];
+        detectStub.callsFake(async (_api: unknown, cb: typeof capturedCallbacks[number]) => {
+            capturedCallbacks.push(cb);
+            if (capturedCallbacks.length === 1) await new Promise<void>(r => { resolveA = r; });
+            else await new Promise<void>(r => { resolveB = r; });
+        });
+
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        folderEmitter.fire({ added: [], removed: [] });
+        await Promise.resolve();
+
+        capturedCallbacks[0].clearStaleWorkspaceContext();   // stale, must be no-op
+        capturedCallbacks[1].clearStaleWorkspaceContext();   // fresh
+
+        resolveA(); resolveB();
+        await Promise.resolve();
+
+        assert.strictEqual(sink._clear.callCount, 1, 'only fresh detection should reach sink');
+        disposable.dispose();
+    });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import type { CourseDataCache } from '@extension/services/courseDataCache';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import {
+    buildChatProviderSink,
     wireWorkspaceDetection,
     type WorkspaceDetectionSink,
     type WorkspaceRegisterInput,
@@ -190,5 +191,28 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(sink._clear.callCount, 1);
         assert.strictEqual(sink._register.callCount, 0);
         disposable.dispose();
+    });
+});
+
+suite('buildChatProviderSink', () => {
+    test('registerWorkspaceExercise delegates to the provider method', () => {
+        const provider = {
+            registerWorkspaceExercise: sinon.spy(),
+            clearWorkspaceExercise: sinon.spy(),
+        };
+        const sink = buildChatProviderSink(provider);
+        const input = { id: 1, title: 'X', source: 'workspace-detected' as const, isWorkspace: true as const };
+        sink.registerWorkspaceExercise(input);
+        assert.ok((provider.registerWorkspaceExercise as sinon.SinonSpy).calledOnceWith(input));
+    });
+
+    test('clearWorkspaceExercise delegates to the provider method', () => {
+        const provider = {
+            registerWorkspaceExercise: sinon.spy(),
+            clearWorkspaceExercise: sinon.spy(),
+        };
+        const sink = buildChatProviderSink(provider);
+        sink.clearWorkspaceExercise();
+        assert.ok((provider.clearWorkspaceExercise as sinon.SinonSpy).calledOnce);
     });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -142,4 +142,53 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(sink._clear.callCount, 1, 'only fresh detection should reach sink');
         disposable.dispose();
     });
+
+    test('dispose guard: callbacks after dispose are no-ops', async () => {
+        const sink = makeSinkSpy();
+        let resolve!: () => void;
+        let captured!: {
+            registerExercise: (input: WorkspaceRegisterInput) => void;
+            clearStaleWorkspaceContext: () => void;
+        };
+        detectStub.callsFake(async (_api: unknown, cb: typeof captured) => {
+            captured = cb;
+            await new Promise<void>(r => { resolve = r; });
+        });
+
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();          // detection in flight
+        disposable.dispose();
+
+        captured.registerExercise({ id: 1, title: 'X', source: 'workspace-detected', isWorkspace: true });
+        captured.clearStaleWorkspaceContext();
+        resolve();
+        await Promise.resolve();
+
+        assert.strictEqual(sink._register.callCount, 0);
+        assert.strictEqual(sink._clear.callCount, 0);
+    });
+
+    test('dispose unsubscribes both event listeners: later folder/courses events do not re-trigger detection', async () => {
+        const sink = makeSinkSpy();
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        disposable.dispose();
+        detectStub.resetHistory();
+        folderEmitter.fire({ added: [], removed: [] });
+        coursesEmitter.fire(undefined);
+        await Promise.resolve();
+        assert.strictEqual(detectStub.callCount, 0);
+    });
+
+    test('no-match path invokes sink.clearWorkspaceExercise exactly once per detection', async () => {
+        const sink = makeSinkSpy();
+        detectStub.callsFake(async (_api: unknown, cb: { clearStaleWorkspaceContext: () => void }) => {
+            cb.clearStaleWorkspaceContext();
+        });
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        assert.strictEqual(sink._clear.callCount, 1);
+        assert.strictEqual(sink._register.callCount, 0);
+        disposable.dispose();
+    });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import type { CourseDataCache } from '@extension/services/courseDataCache';
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import {
+    wireWorkspaceDetection,
+    type WorkspaceDetectionSink,
+    type WorkspaceRegisterInput,
+} from '@extension/services/workspace/wireWorkspaceDetection';
+import * as detectionModule from '@extension/services/workspace/workspaceDetectionService';
+
+function makeSinkSpy(): WorkspaceDetectionSink & {
+    _register: sinon.SinonSpy<[WorkspaceRegisterInput], void>;
+    _clear: sinon.SinonSpy<[], void>;
+} {
+    const _register = sinon.spy<(input: WorkspaceRegisterInput) => void>(() => undefined);
+    const _clear = sinon.spy<() => void>(() => undefined);
+    return {
+        registerWorkspaceExercise: _register,
+        clearWorkspaceExercise: _clear,
+        _register, _clear,
+    };
+}
+
+suite('wireWorkspaceDetection', () => {
+    let sandbox: sinon.SinonSandbox;
+    let detectStub: sinon.SinonStub;
+    let folderEmitter: vscode.EventEmitter<vscode.WorkspaceFoldersChangeEvent>;
+    let coursesEmitter: vscode.EventEmitter<unknown>;
+    let courseDataCache: CourseDataCache;
+    let registry: ExerciseRegistry;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        detectStub = sandbox.stub(detectionModule, 'detectAndRegisterWorkspaceExercise').resolves();
+        folderEmitter = new vscode.EventEmitter<vscode.WorkspaceFoldersChangeEvent>();
+        coursesEmitter = new vscode.EventEmitter<unknown>();
+        sandbox.stub(vscode.workspace, 'onDidChangeWorkspaceFolders').callsFake(listener => folderEmitter.event(listener));
+        courseDataCache = { onCoursesLoaded: coursesEmitter.event } as unknown as CourseDataCache;
+        registry = {} as ExerciseRegistry;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+        folderEmitter.dispose();
+        coursesEmitter.dispose();
+    });
+
+    test('initial detection runs once at wiring time', async () => {
+        const sink = makeSinkSpy();
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        assert.strictEqual(detectStub.callCount, 1);
+        disposable.dispose();
+    });
+});

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -1,6 +1,6 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as vscode from 'vscode';
 
 import type { CourseDataCache } from '@extension/services/courseDataCache';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
@@ -89,8 +89,8 @@ suite('wireWorkspaceDetection', () => {
         }> = [];
         detectStub.callsFake(async (_api: unknown, cb: typeof capturedCallbacks[number]) => {
             capturedCallbacks.push(cb);
-            if (capturedCallbacks.length === 1) await new Promise<void>(r => { resolveA = r; });
-            else await new Promise<void>(r => { resolveB = r; });
+            if (capturedCallbacks.length === 1) {await new Promise<void>(r => { resolveA = r; });}
+            else {await new Promise<void>(r => { resolveB = r; });}
         });
 
         const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
@@ -125,8 +125,8 @@ suite('wireWorkspaceDetection', () => {
         }> = [];
         detectStub.callsFake(async (_api: unknown, cb: typeof capturedCallbacks[number]) => {
             capturedCallbacks.push(cb);
-            if (capturedCallbacks.length === 1) await new Promise<void>(r => { resolveA = r; });
-            else await new Promise<void>(r => { resolveB = r; });
+            if (capturedCallbacks.length === 1) {await new Promise<void>(r => { resolveA = r; });}
+            else {await new Promise<void>(r => { resolveB = r; });}
         });
 
         const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -66,4 +66,15 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(detectStub.callCount, 1);
         disposable.dispose();
     });
+
+    test('courseDataCache.onCoursesLoaded event triggers re-detection', async () => {
+        const sink = makeSinkSpy();
+        const disposable = wireWorkspaceDetection({ api: undefined, registry, courseDataCache, sink });
+        await Promise.resolve();
+        detectStub.resetHistory();
+        coursesEmitter.fire(undefined);
+        await Promise.resolve();
+        assert.strictEqual(detectStub.callCount, 1);
+        disposable.dispose();
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #213. The Record button on the status bar no longer rejects with `Select an exercise context before starting a recording.` when an exercise is clearly active in the Artemis side panel. Root cause: the gate was reading from the Iris chat ContextStore, which is only populated when the chat view is opened.

- Workspace exercise detection now runs at extension activation, not when the Iris chat view opens. Subscribes to `vscode.workspace.onDidChangeWorkspaceFolders` and `CourseDataCache.onCoursesLoaded` independently of chat lifecycle.
- Recorder gate reads `contextStore.getWorkspaceExerciseId()` (workspace-derived). Iris chat's context selector still exists for chat reasoning but no longer drives the Recorder.
- Warning text is now `No Artemis exercise detected for the current workspace.` — accurate whether no exercise is open or detection is still in flight.
- Stale `isWorkspace` flag in the repository is now cleared on no-match, fixing a latent bug where switching from an Artemis workspace to a non-Artemis one would leave the previous exercise as the active workspace target.

## What changed

**New helper `wireWorkspaceDetection`** (`extension/src/extension/services/workspace/wireWorkspaceDetection.ts`). Free function with closure-local generation counter + `disposed` flag. Token-guarded callbacks ensure stale detections from rapid folder switches cannot mutate state, and any in-flight detection that resumes after dispose is a no-op. Pairs with a small `WorkspaceDetectionSink` interface so the helper depends on a contract, not on `ChatContextManager`.

**Sink construction extracted to `buildChatProviderSink(provider)`** for direct unit-testing of the closure that connects activation-level detection to the chat provider's sink methods. extension.ts wires the sink with one line and the helper is added to `context.subscriptions`.

**`ChatWebviewProvider` ownership move.** `ContextStore` is now constructed in `extension.ts activate()` and passed to the provider. The provider exposes two new methods: `registerWorkspaceExercise(input)` and `clearWorkspaceExercise()`. The latter calls `clearStaleWorkspaceContext` → `clearWorkspaceFlag` → `postSnapshot` in that order so the Iris UI stays consistent (sorting, diagnostics, switch-to-workspace target all see the cleared state).

**ChatWebviewProvider stops detecting.** `_detectWorkspaceExercise`, its call in `_sendInitData`, and the `onDidChangeWorkspaceFolders` listener inside `resolveWebviewView` are all removed. Workspace detection is now strictly activation-owned.

**`ContextStore` additions.** `getWorkspaceExerciseId(): number | undefined` is a thin convenience that returns the id of the currently-flagged workspace exercise. `clearWorkspaceFlag()` clears the `isWorkspace` flag on every tracked exercise — silent by design (does not fire `onDidChangeActiveContext`); the caller (the chat provider sink) is responsible for the snapshot refresh.

**`TrackedItemRepository.clearAllWorkspaceFlags()`** added as the storage-layer primitive `ContextStore.clearWorkspaceFlag` delegates to.

**`wireSessionRecorder` rewiring.** `RecorderWiringDeps` now requires a `contextStore`. The gate callback in `recordingStatusBar.ts` becomes `() => contextStore.getWorkspaceExerciseId()`. The chat provider's `getSelectedExerciseId` is no longer used by the recorder path.

## Decisions explained

The bug could have been fixed three different ways (per the issue's options A/B/C). After codex review of the design (six rounds), we picked the "shared ContextStore + activation-owned detection" path because it addresses the root cause (chat-lifecycle-bound detection) without introducing a new abstraction layer. The single source of truth stays in `ContextStore`; the only ownership change is moving its construction out of the chat provider.

The workspace detection is independent of the Iris chat reasoning context by design: the chat selector can legitimately point at a different exercise/course/lecture than the user's actual workspace ("ask Iris about Exercise B while editing Exercise A"). The Recorder, on the other hand, has no such use case — there is no meaningful scenario where you record activity on Exercise A but tag it as Exercise B.

## Test plan

Automated:
- [x] `npm run check-types` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 1159 tests, 0 failures
- [x] `npm run test:react` — 744 tests, 0 failures

New test suites:
- `TrackedItemRepository workspace-flag clear` — 3 tests
- `ContextStore workspace accessors` — 4 tests
- `wireWorkspaceDetection` — 8 tests (initial detection, both event triggers, both generation guards, dispose guard, listener unsubscribe, no-match exact-once)
- `buildChatProviderSink` — 2 tests
- `ChatWebviewProvider workspace sink` — 2 tests
- `ChatWebviewProvider stops detecting workspace` — 3 tests
- `RecordingStatusBarService gate` — 3 tests
- New test in existing `sessionRecorderWiring` suite — 1 test asserting workspace getter is used and chat getter is NOT called

Manual (Extension Development Host):
- [ ] Open a programming exercise in the Artemis side panel without clicking "Ask Iris", click Record → recording starts
- [ ] Close the workspace, open a non-Artemis folder, click Record → new warning text shown
- [ ] Switch from Artemis workspace A to non-Artemis → no stale exercise id from A (stale-flag fix verification)
- [ ] Iris chat selector still works; switching it mid-recording does not affect the active recording

## Out of scope (per spec)

- `SessionRecorder.startSession` signature
- Recording capture pipeline
- Multi-root workspace beyond `workspaceFolders[0]`
- Renaming/relocating `ContextStore` out of `services/iris/context/` (follow-up issue)