### PR TITLE
fix(recording): single source of truth for known event types (#215)

### DIFF
--- a/extension/scripts/validate-recording.ts
+++ b/extension/scripts/validate-recording.ts
@@ -21,6 +21,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { KNOWN_EVENT_TYPES } from '@extension/services/telemetry/recording/parseRecordedData';
+
 // ──────────────────────────────────────────────────────────────────────
 // Types
 // ──────────────────────────────────────────────────────────────────────
@@ -55,42 +57,14 @@ interface RecordedEvent {
 }
 
 // ──────────────────────────────────────────────────────────────────────
-// Known event types (kept in sync with extension/src/.../recording/types.ts)
-// Unknown types produce warnings, not errors — lets the validator survive
-// additive schema changes gracefully.
-// ──────────────────────────────────────────────────────────────────────
-
-const KNOWN_EVENT_TYPES = new Set([
-    // Lifecycle
-    'sessionStart', 'sessionEnd', 'consentChange', 'startupPhaseComplete',
-    // Editor
-    'textChange', 'save', 'fileSwitch', 'diagnostics',
-    'selectionChange', 'visibleRangeChange',
-    'fileSnapshot', 'fileSnapshotError',
-    // Workspace
-    'fileCreate', 'fileDelete', 'fileRename',
-    'textDocumentOpen', 'textDocumentClose',
-    // Window / panels
-    'windowFocus', 'viewNavigation', 'panelVisibility',
-    // Terminal
-    'terminalCommand', 'terminalOpenClose',
-    // Build
-    'buildResult', 'submission',
-    // Config
-    'configurationSnapshot', 'configurationChange',
-    // Views
-    'testResultsOverviewView', 'taskFeedbackView',
-    // Debug
-    'debugSession', 'breakpointChange',
-    // Chat (Iris)
-    'irisChatMessage', 'irisChatSendAttempt', 'irisChatFeedback',
-    // Telemetry / struggle detection
-    'eqSnapshot', 'eqEngineState', 'intervention',
-]);
-
-// ──────────────────────────────────────────────────────────────────────
 // Core validator
 // ──────────────────────────────────────────────────────────────────────
+//
+// `KNOWN_EVENT_TYPES` is imported from the runtime parser (derived from its
+// EVENT_PARSERS dispatch table) so this script and `parseRecordedEvent` stay in
+// lock-step instead of maintaining two hand-synced lists that drift (see #215).
+// Unknown types produce warnings, not errors — lets the validator survive
+// additive schema changes gracefully.
 
 function validateRecording(dir: string): ValidationResult {
     const issues: ValidationIssue[] = [];

--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -14,7 +14,9 @@
  * the union has a dedicated validator, wired through the `EVENT_PARSERS` table.
  * That table is `satisfies Record<RecordedEvent['type'], EventParser>`, so
  * adding a new event variant to `recording/types.ts` without adding its parser
- * here fails to compile — schema drift cannot silently land.
+ * here fails to compile — schema drift cannot silently land. The same table's
+ * keys are re-exported as `KNOWN_EVENT_TYPES` so `scripts/validate-recording.ts`
+ * shares one list instead of maintaining its own (see #215).
  */
 
 import type {
@@ -720,6 +722,13 @@ const EVENT_PARSERS = {
     breakpointChange: parseBreakpointChange,
     submission: parseSubmission,
 } satisfies Record<RecordedEvent['type'], EventParser>;
+
+// Runtime mirror of the recordable event-type set, derived from the dispatch
+// table's keys so it cannot drift from the parser. Typed as
+// `ReadonlySet<string>` (not `ReadonlySet<RecordedEvent['type']>`) so consumers
+// like `scripts/validate-recording.ts` can call `.has(ev.type)` on an untrusted
+// string read off disk without a cast. See #215.
+export const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set(Object.keys(EVENT_PARSERS));
 
 /**
  * Parse one line of an `events.jsonl` recording. Returns `null` on any shape

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -19,7 +19,7 @@
 
 import * as assert from 'assert';
 
-import { parseRecordedEvent, parseSessionMetadata } from '@extension/services/telemetry/recording/parseRecordedData';
+import { KNOWN_EVENT_TYPES, parseRecordedEvent, parseSessionMetadata } from '@extension/services/telemetry/recording/parseRecordedData';
 import type { RecordedEvent, SessionMetadata } from '@extension/services/telemetry/recording/types';
 
 const ts = 1700000000000;
@@ -667,5 +667,39 @@ suite('parseRecordedEvent — submission', () => {
 
     test('rejects a non-string commitMessage', () => {
         assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'started', participationId: 1, commitMessage: 123 }), null);
+    });
+});
+
+// ── KNOWN_EVENT_TYPES drift regression (#215) ─────────────────────────
+//
+// `scripts/validate-recording.ts` used to keep its own hand-synced Set of
+// known event types, which drifted from the parser. KNOWN_EVENT_TYPES is now
+// derived from the EVENT_PARSERS dispatch table and shared with the validator,
+// so the two can no longer drift. These assertions guard that the shared set
+// still recognizes the event types that historically drifted (or were added
+// after the original drift), and excludes unknown / inherited-prototype keys.
+
+suite('KNOWN_EVENT_TYPES — drift regression for #215', () => {
+    test('contains the event types that historically drifted out of the validator', () => {
+        // The original #215 drift cases (missing from the validator's old Set)
+        // plus the debugger / submission types added afterwards in #233 / #236.
+        const mustContain = [
+            'configurationSnapshot',
+            'configurationChange',
+            'testResultsOverviewView',
+            'taskFeedbackView',
+            'debugSession',
+            'breakpointChange',
+            'submission',
+        ];
+        for (const t of mustContain) {
+            assert.ok(KNOWN_EVENT_TYPES.has(t), `KNOWN_EVENT_TYPES is missing '${t}'`);
+        }
+    });
+
+    test('excludes unknown and inherited-prototype keys', () => {
+        for (const t of ['', 'totallyMadeUp', 'toString', '__proto__', 'constructor']) {
+            assert.ok(!KNOWN_EVENT_TYPES.has(t), `KNOWN_EVENT_TYPES unexpectedly contains '${t}'`);
+        }
     });
 });


### PR DESCRIPTION
Closes #215.

## Summary

The runtime parser (`parseRecordedData.ts`) and the standalone validator (`scripts/validate-recording.ts`) each maintained their own list of recordable event types, kept in sync by hand. That manual sync is the drift risk #215 describes.

Since this PR was first opened, `dev` independently replaced the parser's `switch` with a typed `EVENT_PARSERS` dispatch table (`satisfies Record<RecordedEvent['type'], EventParser>`, added in #233), so the parser side is already self-checking at compile time. This branch was rebased onto that work: it keeps the table and closes the remaining gap, the validator's separate hand-synced Set.

## Change

- **`parseRecordedData.ts`** re-exports `KNOWN_EVENT_TYPES`, derived from the dispatch table's own keys (`new Set(Object.keys(EVENT_PARSERS))`). Typed `ReadonlySet<string>` so the validator can call `.has()` on an untrusted `type` string read off disk without a cast.
- **`validate-recording.ts`** imports that set via the `@extension` alias and deletes its own ~30-entry list. There is no longer a second list to drift.
- **Regression test** guards that the shared set still recognizes the event types that historically drifted (the original #215 cases plus the debugger / submission types added later) and excludes unknown / inherited-prototype keys.

## Verification

- `npm run check-types`, `npm run lint` clean.
- Unit suite: 1233 passing, 0 failing (incl. the new #215 regression suite).
- `npm run validate-recording` against a synthetic recording covering all previously-drifted types: 0 "unknown event type" warnings; a genuinely unknown type still warns.
