### PR TITLE
feat(recording-viewer): add "Iris Moment" context marker

### DIFF
--- a/recording-viewer/README.md
+++ b/recording-viewer/README.md
@@ -39,7 +39,7 @@ Active sessions show a red **LIVE** badge.
 ### Hotkeys (when viewing a live session)
 
 - `1`-`5`: Struggle level (confident, light, medium, high, blocked)
-- `q`-`t`: Context marker (idle, trial-error, reading, off-task, using-ai)
+- `q`/`w`/`e`/`r`/`t`/`i`: Context marker (idle, trial-error, reading, off-task, using-ai, iris-moment)
 - The reaction-delay slider (0-1000ms) tunes the offset added to the last
   observed event timestamp before the annotation is stamped (default 300ms).
 

--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -596,7 +596,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
         // accepted in the body for backwards compatibility but ignored.
         const VALID_LABELS = new Set([
             'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
-            'idle', 'trial-error', 'reading', 'off-task', 'using-ai',
+            'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment',
         ]);
 
         const annotPostMatch = urlPath.match(/^\/api\/recordings\/([^/]+)\/annotations$/);

--- a/recording-viewer/src/components/LiveControlBar.tsx
+++ b/recording-viewer/src/components/LiveControlBar.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { STRUGGLE_LABELS, CONTEXT_LABELS, ALL_LABELS } from '../types';
+import { CONTEXT_KEYS } from '../hooks/useLiveHotkeys';
 import type { AnnotationToast } from '../hooks/useAnnotationMutations';
+
+const CONTEXT_KEY_BY_VALUE: Record<string, string> = Object.fromEntries(
+    Object.entries(CONTEXT_KEYS).map(([key, value]) => [value, key]),
+);
 
 interface Props {
     connected: boolean;
@@ -51,8 +56,8 @@ export function LiveControlBar({
                     <span key={s.value} style={{ color: s.color }}>{i + 1}={s.label}</span>
                 ))}
                 <strong>Context:</strong>
-                {CONTEXT_LABELS.map((s, i) => (
-                    <span key={s.value} style={{ color: s.color }}>{'qwert'[i]}={s.label}</span>
+                {CONTEXT_LABELS.map(s => (
+                    <span key={s.value} style={{ color: s.color }}>{CONTEXT_KEY_BY_VALUE[s.value] ?? '?'}={s.label}</span>
                 ))}
             </div>
             {toastVisible && (

--- a/recording-viewer/src/hooks/useLiveHotkeys.ts
+++ b/recording-viewer/src/hooks/useLiveHotkeys.ts
@@ -4,8 +4,8 @@ import type { AnnotationLabel, StruggleLevel, ContextMarker } from '../types';
 const STRUGGLE_KEYS: Record<string, StruggleLevel> = {
     '1': 'confident', '2': 'light-struggle', '3': 'medium-struggle', '4': 'high-struggle', '5': 'blocked',
 };
-const CONTEXT_KEYS: Record<string, ContextMarker> = {
-    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai',
+export const CONTEXT_KEYS: Record<string, ContextMarker> = {
+    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai', 'i': 'iris-moment',
 };
 
 export interface LiveHotkeyHandlers {

--- a/recording-viewer/src/types.ts
+++ b/recording-viewer/src/types.ts
@@ -13,7 +13,7 @@ export interface VideoSyncConfig {
 }
 
 export type StruggleLevel = 'confident' | 'light-struggle' | 'medium-struggle' | 'high-struggle' | 'blocked';
-export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai';
+export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai' | 'iris-moment';
 export type AnnotationLabel = StruggleLevel | ContextMarker;
 
 export const STRUGGLE_LABELS: { value: StruggleLevel; label: string; color: string }[] = [
@@ -30,6 +30,7 @@ export const CONTEXT_LABELS: { value: ContextMarker; label: string; color: strin
     { value: 'reading', label: 'Reading', color: '#60a5fa' },
     { value: 'off-task', label: 'Off-task', color: '#fb7185' },
     { value: 'using-ai', label: 'Using AI', color: '#2dd4bf' },
+    { value: 'iris-moment', label: 'Iris Moment', color: '#818cf8' },
 ];
 
 export const ALL_LABELS = [...STRUGGLE_LABELS, ...CONTEXT_LABELS];

--- a/recording-viewer/test/liveHotkeys.test.ts
+++ b/recording-viewer/test/liveHotkeys.test.ts
@@ -137,6 +137,7 @@ describe('handleLiveHotkey — label hotkeys still work', () => {
         ['e', 'reading'],
         ['r', 'off-task'],
         ['t', 'using-ai'],
+        ['i', 'iris-moment'],
     ] as Array<[string, AnnotationLabel]>)('"%s" → onLabel("%s")', (key, expected) => {
         const h = makeHandlers();
         handleLiveHotkey(makeEvent({ key }), h);

--- a/recording-viewer/test/server/recordingsApi.annotations.test.ts
+++ b/recording-viewer/test/server/recordingsApi.annotations.test.ts
@@ -76,6 +76,17 @@ describe('POST /api/recordings/:id/annotations', () => {
         expect(stored[0].id).toBe('old');
     });
 
+    it('accepts iris-moment label', async () => {
+        const api = createRecordingsApi(cfg());
+        const handle = makeRes();
+        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
+            JSON.stringify({ label: 'iris-moment', text: '' })),
+            handle);
+        expect(handle.captured.status).toBe(200);
+        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
+        expect(stored[0].label).toBe('iris-moment');
+    });
+
     it('rejects unknown label values', async () => {
         const api = createRecordingsApi(cfg());
         const handle = makeRes();


### PR DESCRIPTION
## Summary
- Adds a new `ContextMarker` value `iris-moment` (display "Iris Moment", indigo `#818cf8`) so annotators can flag moments where they think the recorded student would benefit from Iris interaction. Behaves identically to existing markers like `reading` or `using-ai`.
- Hotkey: `i` (live-session label hotkeys ignore modifier chords + input fields, so no shortcut collisions).
- Drive-by cleanup: replace the positional `'qwert'[i]` lookup in `LiveControlBar` with a reverse-map derived from `CONTEXT_KEYS`, so the legend stays in sync when context hotkeys are non-contiguous.

## What changed
| File | Change |
|---|---|
| `src/types.ts` | `ContextMarker` union + new `CONTEXT_LABELS` entry |
| `src/hooks/useLiveHotkeys.ts` | `'i' → 'iris-moment'`; `CONTEXT_KEYS` now exported |
| `src/components/LiveControlBar.tsx` | Reverse-map lookup instead of `'qwert'[i]` |
| `server/recordingsApi.ts` | `iris-moment` added to `VALID_LABELS` |
| `test/liveHotkeys.test.ts` | New `['i', 'iris-moment']` case |
| `test/server/recordingsApi.annotations.test.ts` | New "accepts iris-moment label" test |
| `README.md` | Hotkey docs updated for the non-contiguous set |

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 172/172 passing (includes the two new tests)
- [x] `npm run build` — succeeds (no new bundle-size warnings introduced)
- [ ] Manual: run viewer, load a session, press `i`, verify indigo "Iris Moment" annotation lands on the timeline and the live-control-bar legend shows `i=Iris Moment`