### PR TITLE
feat(recording-viewer): add "Reading test results" context marker

### DIFF
--- a/recording-viewer/README.md
+++ b/recording-viewer/README.md
@@ -39,7 +39,7 @@ Active sessions show a red **LIVE** badge.
 ### Hotkeys (when viewing a live session)
 
 - `1`-`5`: Struggle level (confident, light, medium, high, blocked)
-- `q`/`w`/`e`/`r`/`t`/`i`: Context marker (idle, trial-error, reading, off-task, using-ai, iris-moment)
+- `q`/`w`/`e`/`r`/`t`/`i`/`u`: Context marker (idle, trial-error, reading, off-task, using-ai, iris-moment, reading-test-results)
 - The reaction-delay slider (0-1000ms) tunes the offset added to the last
   observed event timestamp before the annotation is stamped (default 300ms).
 

--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -596,7 +596,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
         // accepted in the body for backwards compatibility but ignored.
         const VALID_LABELS = new Set([
             'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
-            'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment',
+            'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment', 'reading-test-results',
         ]);
 
         const annotPostMatch = urlPath.match(/^\/api\/recordings\/([^/]+)\/annotations$/);

--- a/recording-viewer/src/hooks/useLiveHotkeys.ts
+++ b/recording-viewer/src/hooks/useLiveHotkeys.ts
@@ -5,7 +5,7 @@ const STRUGGLE_KEYS: Record<string, StruggleLevel> = {
     '1': 'confident', '2': 'light-struggle', '3': 'medium-struggle', '4': 'high-struggle', '5': 'blocked',
 };
 export const CONTEXT_KEYS: Record<string, ContextMarker> = {
-    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai', 'i': 'iris-moment',
+    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai', 'i': 'iris-moment', 'u': 'reading-test-results',
 };
 
 export interface LiveHotkeyHandlers {

--- a/recording-viewer/src/types.ts
+++ b/recording-viewer/src/types.ts
@@ -13,7 +13,7 @@ export interface VideoSyncConfig {
 }
 
 export type StruggleLevel = 'confident' | 'light-struggle' | 'medium-struggle' | 'high-struggle' | 'blocked';
-export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai' | 'iris-moment';
+export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai' | 'iris-moment' | 'reading-test-results';
 export type AnnotationLabel = StruggleLevel | ContextMarker;
 
 export const STRUGGLE_LABELS: { value: StruggleLevel; label: string; color: string }[] = [
@@ -31,6 +31,7 @@ export const CONTEXT_LABELS: { value: ContextMarker; label: string; color: strin
     { value: 'off-task', label: 'Off-task', color: '#fb7185' },
     { value: 'using-ai', label: 'Using AI', color: '#2dd4bf' },
     { value: 'iris-moment', label: 'Iris Moment', color: '#818cf8' },
+    { value: 'reading-test-results', label: 'Reading test results', color: '#f59e0b' },
 ];
 
 export const ALL_LABELS = [...STRUGGLE_LABELS, ...CONTEXT_LABELS];

--- a/recording-viewer/test/liveHotkeys.test.ts
+++ b/recording-viewer/test/liveHotkeys.test.ts
@@ -138,6 +138,7 @@ describe('handleLiveHotkey — label hotkeys still work', () => {
         ['r', 'off-task'],
         ['t', 'using-ai'],
         ['i', 'iris-moment'],
+        ['u', 'reading-test-results'],
     ] as Array<[string, AnnotationLabel]>)('"%s" → onLabel("%s")', (key, expected) => {
         const h = makeHandlers();
         handleLiveHotkey(makeEvent({ key }), h);

--- a/recording-viewer/test/server/recordingsApi.annotations.test.ts
+++ b/recording-viewer/test/server/recordingsApi.annotations.test.ts
@@ -87,6 +87,17 @@ describe('POST /api/recordings/:id/annotations', () => {
         expect(stored[0].label).toBe('iris-moment');
     });
 
+    it('accepts reading-test-results label', async () => {
+        const api = createRecordingsApi(cfg());
+        const handle = makeRes();
+        await invoke(api, makeReq('POST', '/api/recordings/sess-1/annotations',
+            JSON.stringify({ label: 'reading-test-results', text: '' })),
+            handle);
+        expect(handle.captured.status).toBe(200);
+        const stored = JSON.parse(fs.readFileSync(path.join(tmpDir, 'sess-1/annotations.json'), 'utf-8'));
+        expect(stored[0].label).toBe('reading-test-results');
+    });
+
     it('rejects unknown label values', async () => {
         const api = createRecordingsApi(cfg());
         const handle = makeRes();


### PR DESCRIPTION
## Summary
- Adds a 7th `ContextMarker` value `reading-test-results` (display "Reading test results", amber `#f59e0b`) so annotators can distinguish "student is reading test output" from the broader `reading` marker (task descriptions, docs).
- Hotkey: `u` (sits next to `i` for `iris-moment` in the live-session hotkey row).
- Same pattern as the just-merged "Iris Moment" marker (#225). `LiveControlBar`'s reverse-map keeps the legend in sync automatically — no UI plumbing needed.

## What changed
| File | Change |
|---|---|
| `src/types.ts` | `ContextMarker` union + new `CONTEXT_LABELS` entry |
| `src/hooks/useLiveHotkeys.ts` | `'u' → 'reading-test-results'` in `CONTEXT_KEYS` |
| `server/recordingsApi.ts` | `reading-test-results` added to `VALID_LABELS` |
| `test/liveHotkeys.test.ts` | New `['u', 'reading-test-results']` case |
| `test/server/recordingsApi.annotations.test.ts` | New "accepts reading-test-results label" test |
| `README.md` | Hotkey docs updated |

## Known caveats
- Amber `#f59e0b` sits visually between `medium-struggle` (#fbbf24) and `high-struggle` (#f97316) on the timeline. Acceptable for now per annotator preference; can be swapped if it pollutes analysis.
- "Reading test results" is a longer label than the other context buttons — may wrap on very narrow layouts.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 174/174 passing
- [x] `npm run build` — succeeds
- [ ] Manual: press `u` in a live session, verify amber "Reading test results" marker on the timeline and `u=Reading test results` in the legend