### PR TITLE
feat(recording-viewer): raise live buffer to 50k + honest counter

### DIFF
--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -530,7 +530,8 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                     {isLiveSession && (
                         <LiveControlBar
                             connected={live.connected}
-                            eventsReceived={live.events.length}
+                            bufferSize={live.events.length}
+                            totalReceived={live.totalReceived}
                             latestEventTimestamp={live.latestEventTimestamp}
                             lastLabelToast={lastLabelToast}
                         />

--- a/recording-viewer/src/components/LiveControlBar.tsx
+++ b/recording-viewer/src/components/LiveControlBar.tsx
@@ -9,7 +9,11 @@ const CONTEXT_KEY_BY_VALUE: Record<string, string> = Object.fromEntries(
 
 interface Props {
     connected: boolean;
-    eventsReceived: number;
+    /** Number of events currently in the browser buffer (the sliding window). */
+    bufferSize: number;
+    /** Cumulative number of events received since this session connected.
+     *  When this exceeds bufferSize, the window has been trimming oldest events. */
+    totalReceived: number;
     latestEventTimestamp: number | null;
     lastLabelToast: AnnotationToast | null;
 }
@@ -28,7 +32,7 @@ function renderToast(toast: AnnotationToast): string {
 }
 
 export function LiveControlBar({
-    connected, eventsReceived, latestEventTimestamp, lastLabelToast,
+    connected, bufferSize, totalReceived, latestEventTimestamp, lastLabelToast,
 }: Props) {
     // Re-render every second so the "last event N s ago" updates live
     const [now, setNow] = useState(() => Date.now());
@@ -45,7 +49,11 @@ export function LiveControlBar({
             <div className="live-status">
                 <span className={`live-dot ${connected ? 'on' : 'off'}`} />
                 <strong>{connected ? 'LIVE' : 'Disconnected'}</strong>
-                <span className="live-counter">{eventsReceived} events</span>
+                <span className="live-counter">
+                    {bufferSize < totalReceived
+                        ? `${bufferSize.toLocaleString()} of ${totalReceived.toLocaleString()} events`
+                        : `${totalReceived.toLocaleString()} events`}
+                </span>
                 {ageMs !== null && (
                     <span className="live-age">last event {(ageMs / 1000).toFixed(1)}s ago</span>
                 )}

--- a/recording-viewer/src/hooks/useLiveSession.ts
+++ b/recording-viewer/src/hooks/useLiveSession.ts
@@ -6,14 +6,22 @@ export interface LiveSessionState {
     events: RecordedEvent[];
     latestEventTimestamp: number | null;
     error: string | null;
+    /** Cumulative count of unique events received from the server since
+     *  this session connected. Strictly monotonic — does not decrease when
+     *  the sliding window trims old events. */
+    totalReceived: number;
 }
 
-const INITIAL: LiveSessionState = { connected: false, events: [], latestEventTimestamp: null, error: null };
+const INITIAL: LiveSessionState = { connected: false, events: [], latestEventTimestamp: null, error: null, totalReceived: 0 };
 
 /** Maximum number of live events retained in browser memory. Older events
  * drop off the front as new ones arrive; the full archive remains
- * accessible via /api/recordings/:id/events after the session ends. */
-export const MAX_LIVE_EVENTS = 5000;
+ * accessible via /api/recordings/:id/events after the session ends.
+ *
+ * Sized to cover realistic study-session volumes (observed worst case so far:
+ * ~4k events). Bumping further is bounded less by RAM (~400 bytes/event) than
+ * by re-derivation cost in EventStream/TrackingTimeline on each RAF flush. */
+export const MAX_LIVE_EVENTS = 50_000;
 
 type ScheduleHandle = { cancel: () => void };
 
@@ -38,6 +46,7 @@ export function useLiveSession(sessionId: string | null, enabled: boolean): Live
         const eventsBuf: RecordedEvent[] = [];
         const pendingBuf: RecordedEvent[] = [];
         let maxLineNo = 0;
+        let totalReceived = 0;
         let sessionEndPending = false;
         let scheduled: ScheduleHandle | null = null;
 
@@ -78,6 +87,7 @@ export function useLiveSession(sessionId: string | null, enabled: boolean): Live
                 ...s,
                 events: snapshot,
                 latestEventTimestamp: last?.timestamp ?? s.latestEventTimestamp,
+                totalReceived,
                 connected: ended ? false : s.connected,
                 // Clear any stale "Disconnected, retrying..." error: if we're
                 // flushing real events, we obviously aren't disconnected.
@@ -109,6 +119,7 @@ export function useLiveSession(sessionId: string | null, enabled: boolean): Live
             try {
                 const parsed = JSON.parse(evt.data) as RecordedEvent;
                 pendingBuf.push(parsed);
+                totalReceived += 1;
                 const isSessionEnd = (parsed as { type?: string }).type === 'sessionEnd';
                 if (isSessionEnd) {
                     sessionEndPending = true;


### PR DESCRIPTION
## Summary

The live-session counter previously froze at \`5000\` once the sliding window filled — it displayed `live.events.length` (the buffer size, capped at 5000) rather than the cumulative number of events received. For live ground-truth annotation during long study sessions, this also meant older events silently scrolled out of the browser buffer, breaking scroll-back during the session.

Two changes:

1. **\`MAX_LIVE_EVENTS\`: 5_000 → 50_000.** Sized to cover realistic study-session volumes (worst observed on disk: ~4k events). RAM cost ~20 MB at the new cap; the real bound is re-derivation cost in \`EventStream\` / \`TrackingTimeline\` on each RAF flush — those still operate on the full retained array. 50k is a deliberate safety fuse, not a sliding window we expect to hit in practice.

2. **Honest counter.** \`LiveSessionState\` gains a strictly-monotonic \`totalReceived\` field that increments per successfully-parsed, deduped event. \`LiveControlBar\` props change from \`eventsReceived\` to \`(bufferSize, totalReceived)\`. Display:
   - Normal: \`12,345 events\`
   - Window trimming (buffer < total): \`50,000 of 73,210 events\`

## What changed
| File | Change |
|---|---|
| \`src/hooks/useLiveSession.ts\` | \`MAX_LIVE_EVENTS = 50_000\`, new \`totalReceived\` state field, increment after dedup + JSON.parse, sync into React state on each RAF flush |
| \`src/components/LiveControlBar.tsx\` | Props \`(bufferSize, totalReceived)\` instead of \`eventsReceived\`; conditional display when buffer < total |
| \`src/App.tsx\` | Pass \`bufferSize\` + \`totalReceived\` instead of \`eventsReceived\` |

## Discussion notes (from review)

- Pre-cap branch: events that arrive in a pathological initial-tail burst and get sliced out of \`pendingBuf\` before reaching the visible buffer still count toward \`totalReceived\`. Semantics is "events received from server", which is correct.
- Monotonicity is preserved across native EventSource reconnects: replayed messages with \`lastEventId <= maxLineNo\` return before the increment, so no double-counting.
- Pre-existing edge case unaffected by this change: a malformed SSE message with a finite \`lastEventId\` advances \`maxLineNo\` before \`JSON.parse\`, which could poison the dedupe state. Out of scope.

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 174/174 passing
- [x] \`npm run build\` — succeeds
- [ ] Manual: open a live session, verify the counter shows real cumulative count and grows past 5000 without sticking