### PR TITLE
feat(problem-statement): reload PS on WebSocket newResult

### DIFF
--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -13,6 +13,7 @@ import { AppStateManager } from '@extension/controller/appStateManager';
 import { fetchAndEnrichExerciseDetails } from '@extension/controller/exerciseDataLoader';
 import { getViewHtml } from '@extension/controller/viewRouter';
 import { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
+import type { ResultDTO } from '@extension/domain';
 import { AuthFlowHandler, AuthManager } from '@extension/services/auth';
 import { type CourseAccessScope, CourseAccessStorageService } from '@extension/services/courseAccessStorageService';
 import type { CourseDataCache } from '@extension/services/courseDataCache';
@@ -37,6 +38,7 @@ import { CONFIG, resolveServerUrl } from '@extension/utils';
 
 import type { ArtemisWebviewProviderDeps } from './artemisWebviewProviderDeps';
 import { BaseWebviewProvider } from './baseWebviewProvider';
+import { shouldRefreshPSForResult } from './problemStatementRefreshDecision';
 import { WebviewNavigationFacade } from './webviewNavigationFacade';
 import { WebviewSSRCoordinator } from './webviewSSRCoordinator';
 
@@ -157,6 +159,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             appStateManager: this._appStateManager,
             renderService: this._renderService,
             postMessage: (msg) => this._postMessageSafe(msg),
+            fetchExerciseDetails: (exerciseId) => fetchAndEnrichExerciseDetails(this._artemisApi, exerciseId),
         });
         this._disposables.push(this._ssrCoordinator);
 
@@ -203,10 +206,13 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             this._courseAccessStorage,
         );
 
-        // 11. Submission WS handler — fans build results into diagnostics.
+        // 11. Submission WS handler — fans build results into diagnostics
+        //     and, for results on the currently-rendered participation, triggers
+        //     a re-fetch + PS re-render so test-case checkmarks stay current.
         this._submissionWsHandler = new SubmissionWebSocketHandler(
             (msg) => this._postMessageSafe(msg),
             (result) => this._buildDiagnosticsService.handleBuildResult(result),
+            (result) => this._onResultForPSRefresh(result),
         );
 
         // 12. Auth flow handler — callbacks route through the navigation facade.
@@ -315,7 +321,12 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
                             try {
                                 freshData = await fetchAndEnrichExerciseDetails(this._artemisApi, exerciseId);
                             } catch { /* fall through to sendInitData with cached data */ }
-                            if (freshData) {
+                            // Guard: a concurrent refresh (e.g. WS newResult-driven) may
+                            // have advanced state during the await. Apply only if we are
+                            // still on the same exercise.
+                            if (freshData
+                                && this._appStateManager.currentState === 'exercise-detail'
+                                && this._appStateManager.currentExerciseData?.exercise?.id === exerciseId) {
                                 this._appStateManager.showExerciseDetail(freshData);
                             }
                         }
@@ -417,6 +428,19 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             serverUrl,
             principal: { id: info.user?.id, login: info.username || info.user?.login },
         };
+    }
+
+    /**
+     * Called for every WebSocket newResult event. Delegates the decision
+     * to {@link shouldRefreshPSForResult} (kept pure for unit testing) and
+     * forwards to the SSR coordinator when a refresh is warranted.
+     */
+    private _onResultForPSRefresh(result: ResultDTO): void {
+        const exercise = this._appStateManager.currentExerciseData?.exercise;
+        if (!shouldRefreshPSForResult(this._appStateManager.currentState, exercise, result)) { return; }
+        const exerciseId = exercise?.id;
+        if (exerciseId === undefined) { return; }
+        this._ssrCoordinator.refreshFromServer({ exerciseId });
     }
 
 }

--- a/extension/src/extension/provider/problemStatementRefreshDecision.ts
+++ b/extension/src/extension/provider/problemStatementRefreshDecision.ts
@@ -1,0 +1,40 @@
+import type { ResultDTO } from '@extension/domain';
+
+/** Minimal exercise shape for the participation-id check. */
+interface ExerciseLike {
+    readonly studentParticipations?: ReadonlyArray<{ readonly id?: number }>;
+}
+
+/**
+ * Decide whether a WebSocket `newResult` event should trigger a
+ * server-driven problem-statement refresh.
+ *
+ * Pure function so we can unit-test the filter in isolation from
+ * {@link ArtemisWebviewProvider}.
+ *
+ * Rules:
+ *   - Must be on the exercise-detail view.
+ *   - The current exercise must be known (have an id).
+ *   - The result must carry a finite, defined participation id.
+ *   - That participation id must match the participation the SSR
+ *     coordinator currently renders (today: `studentParticipations[0]`).
+ *     When the coordinator's selection logic is generalized in a
+ *     follow-up (graded/practice repo aware), this comparison must be
+ *     revisited so other-participation results trigger refreshes too.
+ */
+export function shouldRefreshPSForResult(
+    currentState: string,
+    exercise: ExerciseLike | undefined,
+    result: Pick<ResultDTO, 'participation'>,
+): boolean {
+    if (currentState !== 'exercise-detail') { return false; }
+    if (!exercise) { return false; }
+
+    const resultPid = result.participation?.id;
+    if (resultPid === undefined || !Number.isFinite(resultPid)) { return false; }
+
+    const renderedPid = exercise.studentParticipations?.[0]?.id;
+    if (renderedPid === undefined) { return false; }
+
+    return resultPid === renderedPid;
+}

--- a/extension/src/extension/provider/webviewSSRCoordinator.ts
+++ b/extension/src/extension/provider/webviewSSRCoordinator.ts
@@ -6,11 +6,17 @@ import { ExtensionMsg } from '@shared/messageContracts';
 import type { AppStateManager } from '@extension/controller/appStateManager';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
+import type { ExerciseDetailsResponse } from '@extension/types';
 
 export interface WebviewSSRCoordinatorDeps {
     appStateManager: AppStateManager;
     renderService: ProblemStatementRenderService;
     postMessage: (msg: ExtensionToWebviewMessage) => void;
+    fetchExerciseDetails: (exerciseId: number) => Promise<ExerciseDetailsResponse>;
+}
+
+interface RefreshOpts {
+    exerciseId: number;
 }
 
 /**
@@ -18,9 +24,18 @@ export interface WebviewSSRCoordinatorDeps {
  * exercise-detail view. Owns the theme-change listener that invalidates the
  * render cache and schedules a fresh render whenever the active color theme
  * changes (because darkMode is part of the render request).
+ *
+ * Also coordinates server-driven refreshes (e.g. WebSocket newResult events)
+ * via {@link refreshFromServer}: re-fetches enriched exercise details,
+ * updates the extension-side app state, and re-renders the PS. Concurrent
+ * refresh requests are coalesced last-wins so only one fetch is in flight
+ * at a time with at most one pending behind it.
  */
 export class WebviewSSRCoordinator implements vscode.Disposable {
     private readonly _themeListener: vscode.Disposable;
+    private _refreshing = false;
+    private _refreshPending: RefreshOpts | undefined;
+    private _disposed = false;
 
     constructor(private readonly deps: WebviewSSRCoordinatorDeps) {
         this._themeListener = vscode.window.onDidChangeActiveColorTheme(() => {
@@ -31,6 +46,7 @@ export class WebviewSSRCoordinator implements vscode.Disposable {
     }
 
     public async scheduleRender(): Promise<void> {
+        if (this._disposed) { return; }
         // SSR is for the exercise detail view only.
         if (this.deps.appStateManager.currentState !== 'exercise-detail') { return; }
 
@@ -49,7 +65,9 @@ export class WebviewSSRCoordinator implements vscode.Disposable {
         try {
             const rendered = await this.deps.renderService.render(exercise, { participation });
 
-            // Guard: verify same exercise is still active after await
+            // Guard: dispose may have happened during the render await; also
+            // verify same exercise is still active.
+            if (this._disposed) { return; }
             const current = this.deps.appStateManager.currentExerciseData;
             if (current?.exercise?.id !== exerciseId) { return; }
 
@@ -70,7 +88,82 @@ export class WebviewSSRCoordinator implements vscode.Disposable {
         }
     }
 
+    /**
+     * Re-fetch enriched exercise details from the server, push them into
+     * app state, and trigger a fresh SSR render.
+     *
+     * Concurrency: at most one fetch is in flight. A second call while one
+     * is in flight stores the latest opts as pending and runs after the
+     * current completes (last-wins). Multiple results arriving rapidly
+     * therefore collapse to at most one extra refresh.
+     *
+     * No `sendInitData()` is performed here on purpose: the webview's store
+     * already patches `newResult` payloads incrementally, and the SSR
+     * re-render arrives via the `ProblemStatementRendered` message. Sending
+     * a full init would clear the cached server render (because
+     * `showExerciseDetail` resets `serverRenderedProblemStatement` to null)
+     * and produce a brief blank/markdown-fallback render until the new
+     * SSR returns.
+     */
+    public refreshFromServer(opts: RefreshOpts): void {
+        if (this._disposed) { return; }
+        if (this._refreshing) {
+            this._refreshPending = opts;
+            return;
+        }
+        void this._runRefreshLoop(opts);
+    }
+
+    private async _runRefreshLoop(initial: RefreshOpts): Promise<void> {
+        this._refreshing = true;
+        try {
+            let next: RefreshOpts | undefined = initial;
+            while (next) {
+                this._refreshPending = undefined;
+                try {
+                    await this._refreshOnce(next);
+                } catch (err) {
+                    // `_refreshOnce` already swallows fetch errors. This catch
+                    // is belt-and-suspenders against an unexpected throw
+                    // (e.g. a future invariant breach in `showExerciseDetail`)
+                    // permanently stalling the loop and dropping the pending
+                    // refresh.
+                    logger.warn(`[SSR] Refresh iteration threw: ${err}`, LogCategory.GENERAL);
+                }
+                next = this._refreshPending;
+            }
+        } finally {
+            this._refreshing = false;
+        }
+    }
+
+    private async _refreshOnce({ exerciseId }: RefreshOpts): Promise<void> {
+        if (this._disposed) { return; }
+        if (this.deps.appStateManager.currentState !== 'exercise-detail') { return; }
+        const current = this.deps.appStateManager.currentExerciseData;
+        if (current?.exercise?.id !== exerciseId) { return; }
+
+        let fresh: ExerciseDetailsResponse;
+        try {
+            fresh = await this.deps.fetchExerciseDetails(exerciseId);
+        } catch (err) {
+            logger.info(`[SSR] Refresh fetch failed for exercise ${exerciseId}: ${err}`, LogCategory.GENERAL);
+            return;
+        }
+
+        // Re-check guards: state, exerciseId, and disposed may all have
+        // changed during the await.
+        if (this._disposed) { return; }
+        if (this.deps.appStateManager.currentState !== 'exercise-detail') { return; }
+        const curAfter = this.deps.appStateManager.currentExerciseData;
+        if (curAfter?.exercise?.id !== exerciseId) { return; }
+
+        this.deps.appStateManager.showExerciseDetail(fresh);
+        await this.scheduleRender();
+    }
+
     public dispose(): void {
+        this._disposed = true;
         this._themeListener.dispose();
     }
 }

--- a/extension/src/extension/services/ui/submissionWebSocketHandler.ts
+++ b/extension/src/extension/services/ui/submissionWebSocketHandler.ts
@@ -14,6 +14,7 @@ export class SubmissionWebSocketHandler {
     constructor(
         private readonly _postMessage: (msg: ExtensionToWebviewMessage) => void,
         private readonly _onBuildResult?: (result: ResultDTO) => void,
+        private readonly _onResultReceived?: (result: ResultDTO) => void,
     ) {}
 
     public createHandler(): WSHandler {
@@ -51,6 +52,7 @@ export class SubmissionWebSocketHandler {
             data: summary,
         });
         this._onBuildResult?.(result);
+        this._onResultReceived?.(result);
     }
 
     public handleNewSubmission(submission: ProgrammingSubmission): void {

--- a/extension/test/unit/provider/problemStatementRefreshDecision.test.ts
+++ b/extension/test/unit/provider/problemStatementRefreshDecision.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+
+import type { ResultDTO } from '@extension/domain';
+import { shouldRefreshPSForResult } from '@extension/provider/problemStatementRefreshDecision';
+
+function makeExercise(participationIds: number[]): { studentParticipations: Array<{ id: number }> } {
+    return { studentParticipations: participationIds.map(id => ({ id })) };
+}
+
+function makeResult(pid: number | undefined | null): Pick<ResultDTO, 'participation'> {
+    return { participation: pid === undefined ? undefined : { id: pid as number } };
+}
+
+suite('shouldRefreshPSForResult', () => {
+    test('returns false when not on exercise-detail', () => {
+        assert.strictEqual(
+            shouldRefreshPSForResult('dashboard', makeExercise([7]), makeResult(7)),
+            false,
+        );
+    });
+
+    test('returns false when exercise is undefined', () => {
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', undefined, makeResult(7)),
+            false,
+        );
+    });
+
+    test('returns false when result has no participation id', () => {
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', makeExercise([7]), makeResult(undefined)),
+            false,
+        );
+    });
+
+    test('returns false when participation id is not finite', () => {
+        const result = { participation: { id: Number.NaN as unknown as number } };
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', makeExercise([7]), result),
+            false,
+        );
+    });
+
+    test('returns false when rendered exercise has no participations', () => {
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', makeExercise([]), makeResult(7)),
+            false,
+        );
+    });
+
+    test('returns false when result belongs to a different participation than the rendered one', () => {
+        // Coordinator currently renders studentParticipations[0]; a result for
+        // a non-[0] participation must not trigger a refresh.
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', makeExercise([7, 99]), makeResult(99)),
+            false,
+        );
+    });
+
+    test('returns true when participation id matches the rendered one', () => {
+        assert.strictEqual(
+            shouldRefreshPSForResult('exercise-detail', makeExercise([7]), makeResult(7)),
+            true,
+        );
+    });
+});

--- a/extension/test/unit/provider/webviewSSRCoordinator.test.ts
+++ b/extension/test/unit/provider/webviewSSRCoordinator.test.ts
@@ -27,12 +27,14 @@ suite('WebviewSSRCoordinator', () => {
             currentState: string;
             currentExerciseData: ExerciseDetailsResponse | undefined;
             serverRenderedProblemStatement: { html: string } | null;
+            showExerciseDetail: sinon.SinonStub;
         };
         renderService: {
             render: sinon.SinonStub;
             invalidateAll: sinon.SinonStub;
         };
         postMessage: sinon.SinonStub;
+        fetchExerciseDetails: sinon.SinonStub;
     }
 
     function buildDeps(overrides: Partial<DepStubs> = {}): {
@@ -44,18 +46,21 @@ suite('WebviewSSRCoordinator', () => {
                 currentState: 'login',
                 currentExerciseData: undefined,
                 serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
             },
             renderService: overrides.renderService ?? {
                 render: sandbox.stub().resolves(undefined),
                 invalidateAll: sandbox.stub(),
             },
             postMessage: overrides.postMessage ?? sandbox.stub(),
+            fetchExerciseDetails: overrides.fetchExerciseDetails ?? sandbox.stub().resolves(undefined),
         };
 
         const deps = {
             appStateManager: stubs.appStateManager,
             renderService: stubs.renderService,
             postMessage: stubs.postMessage,
+            fetchExerciseDetails: stubs.fetchExerciseDetails,
         } as unknown as WebviewSSRCoordinatorDeps;
 
         return { deps, stubs };
@@ -100,6 +105,7 @@ suite('WebviewSSRCoordinator', () => {
                 currentState: 'login',
                 currentExerciseData: undefined,
                 serverRenderedProblemStatement: { html: '<p>cached</p>' },
+                showExerciseDetail: sandbox.stub(),
             },
         });
         new WebviewSSRCoordinator(deps);
@@ -127,6 +133,7 @@ suite('WebviewSSRCoordinator', () => {
                 currentState: 'dashboard',
                 currentExerciseData: undefined,
                 serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
             },
         });
         const coordinator = new WebviewSSRCoordinator(deps);
@@ -143,6 +150,7 @@ suite('WebviewSSRCoordinator', () => {
                 currentState: 'exercise-detail',
                 currentExerciseData: undefined,
                 serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
             },
         });
         const coordinator = new WebviewSSRCoordinator(deps);
@@ -167,6 +175,7 @@ suite('WebviewSSRCoordinator', () => {
             currentState: 'exercise-detail',
             currentExerciseData: exerciseData,
             serverRenderedProblemStatement: null as { html: string } | null,
+            showExerciseDetail: sandbox.stub(),
         };
         const { deps, stubs } = buildDeps({
             appStateManager,
@@ -195,5 +204,356 @@ suite('WebviewSSRCoordinator', () => {
         coordinator.dispose();
 
         sinon.assert.calledOnce(themeDisposable.dispose);
+    });
+
+    // ── refreshFromServer ────────────────────────────────────────────
+
+    function makeDeferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+        let resolveFn!: (v: T) => void;
+        let rejectFn!: (e: unknown) => void;
+        const promise = new Promise<T>((res, rej) => { resolveFn = res; rejectFn = rej; });
+        return { promise, resolve: resolveFn, reject: rejectFn };
+    }
+
+    function flushMicrotasks(): Promise<void> {
+        return new Promise(resolve => setImmediate(resolve));
+    }
+
+    function makeExerciseData(id: number): ExerciseDetailsResponse {
+        return {
+            exercise: {
+                id,
+                problemStatement: '# stmt',
+                studentParticipations: [{ id: id * 10 }],
+            },
+        } as unknown as ExerciseDetailsResponse;
+    }
+
+    test('refreshFromServer is a no-op when not on exercise-detail', async () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'dashboard',
+                currentExerciseData: makeExerciseData(42),
+                serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(stubs.fetchExerciseDetails);
+        sinon.assert.notCalled(stubs.appStateManager.showExerciseDetail);
+    });
+
+    test('refreshFromServer is a no-op when exerciseId no longer matches current', async () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: makeExerciseData(99),
+                serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(stubs.fetchExerciseDetails);
+        sinon.assert.notCalled(stubs.appStateManager.showExerciseDetail);
+    });
+
+    test('refreshFromServer happy path: fetches, updates app state, schedules render', async () => {
+        const exerciseData = makeExerciseData(42);
+        const freshData = makeExerciseData(42);
+        const fetchStub = sandbox.stub().resolves(freshData);
+        const showExerciseStub = sandbox.stub();
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: exerciseData,
+                serverRenderedProblemStatement: null,
+                showExerciseDetail: showExerciseStub,
+            },
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        sinon.assert.calledOnceWithExactly(stubs.fetchExerciseDetails, 42);
+        sinon.assert.calledOnceWithExactly(showExerciseStub, freshData);
+        sinon.assert.calledOnce(scheduleSpy);
+    });
+
+    test('refreshFromServer coalesces two rapid calls into sequential (not parallel) fetches', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetch1 = makeDeferred<ExerciseDetailsResponse>();
+        const fetch2 = makeDeferred<ExerciseDetailsResponse>();
+        const fetchStub = sandbox.stub();
+        fetchStub.onCall(0).returns(fetch1.promise);
+        fetchStub.onCall(1).returns(fetch2.promise);
+
+        const appState = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps } = buildDeps({
+            appStateManager: appState,
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        // Two rapid calls
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        // Only the first fetch should have started; the second is pending.
+        sinon.assert.calledOnce(fetchStub);
+
+        // Resolve the first; the second must start only now.
+        fetch1.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+        await flushMicrotasks();
+        sinon.assert.calledTwice(fetchStub);
+
+        // Resolve the second so the test finishes cleanly.
+        fetch2.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+    });
+
+    test('refreshFromServer coalesces three rapid calls into two total fetches (last-wins, pending slot of 1)', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetch1 = makeDeferred<ExerciseDetailsResponse>();
+        const fetch2 = makeDeferred<ExerciseDetailsResponse>();
+        const fetchStub = sandbox.stub();
+        fetchStub.onCall(0).returns(fetch1.promise);
+        fetchStub.onCall(1).returns(fetch2.promise);
+
+        const { deps } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: exerciseData,
+                serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
+            },
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+        sinon.assert.calledOnce(fetchStub);
+
+        fetch1.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+        await flushMicrotasks();
+        sinon.assert.calledTwice(fetchStub);
+
+        fetch2.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+        sinon.assert.calledTwice(fetchStub);
+    });
+
+    test('refreshFromServer skips post-fetch mutation when state changed during await', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetch1 = makeDeferred<ExerciseDetailsResponse>();
+        const fetchStub = sandbox.stub().returns(fetch1.promise);
+
+        const appState = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps } = buildDeps({
+            appStateManager: appState,
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+        sinon.assert.calledOnce(fetchStub);
+
+        // Navigate away mid-fetch.
+        appState.currentState = 'course-detail';
+
+        fetch1.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(appState.showExerciseDetail);
+        sinon.assert.notCalled(scheduleSpy);
+    });
+
+    test('refreshFromServer skips post-fetch mutation when exerciseId changed during await', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetch1 = makeDeferred<ExerciseDetailsResponse>();
+        const fetchStub = sandbox.stub().returns(fetch1.promise);
+
+        const appState = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps } = buildDeps({
+            appStateManager: appState,
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        // Switch to a different exercise while fetch is in flight.
+        appState.currentExerciseData = makeExerciseData(99);
+
+        fetch1.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(appState.showExerciseDetail);
+        sinon.assert.notCalled(scheduleSpy);
+    });
+
+    test('refreshFromServer skips post-fetch mutation when disposed during await', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetch1 = makeDeferred<ExerciseDetailsResponse>();
+        const fetchStub = sandbox.stub().returns(fetch1.promise);
+
+        const appState = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps } = buildDeps({
+            appStateManager: appState,
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        coordinator.dispose();
+
+        fetch1.resolve(makeExerciseData(42));
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(appState.showExerciseDetail);
+        sinon.assert.notCalled(scheduleSpy);
+    });
+
+    test('scheduleRender skips mutation/post when disposed during the render await', async () => {
+        const exercise = {
+            id: 42,
+            problemStatement: '# Hello',
+            studentParticipations: [{ id: 7 }],
+        };
+        const exerciseData = { exercise } as unknown as ExerciseDetailsResponse;
+        const renderDeferred = makeDeferred<{ html: string; contentHash: string }>();
+
+        const renderStub = sandbox.stub().returns(renderDeferred.promise);
+        const appStateManager = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null as { html: string } | null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps, stubs } = buildDeps({
+            appStateManager,
+            renderService: {
+                render: renderStub,
+                invalidateAll: sandbox.stub(),
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+
+        const renderPromise = coordinator.scheduleRender();
+        await flushMicrotasks();
+        sinon.assert.calledOnce(renderStub);
+
+        // Dispose mid-render.
+        coordinator.dispose();
+
+        // Render returns after dispose; coordinator must not mutate state or post.
+        renderDeferred.resolve({ html: '<p>Hello</p>', contentHash: 'abcdef1234567890' });
+        await renderPromise;
+
+        sinon.assert.match(stubs.appStateManager.serverRenderedProblemStatement, null);
+        sinon.assert.notCalled(stubs.postMessage);
+    });
+
+    test('refreshFromServer after dispose() is an immediate no-op', async () => {
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: makeExerciseData(42),
+                serverRenderedProblemStatement: null,
+                showExerciseDetail: sandbox.stub(),
+            },
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        coordinator.dispose();
+
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(stubs.fetchExerciseDetails);
+    });
+
+    test('refreshFromServer swallows fetch errors and stays usable for subsequent refreshes', async () => {
+        const exerciseData = makeExerciseData(42);
+        const fetchStub = sandbox.stub();
+        fetchStub.onCall(0).rejects(new Error('network down'));
+        fetchStub.onCall(1).resolves(makeExerciseData(42));
+
+        const appState = {
+            currentState: 'exercise-detail',
+            currentExerciseData: exerciseData,
+            serverRenderedProblemStatement: null,
+            showExerciseDetail: sandbox.stub(),
+        };
+        const { deps } = buildDeps({
+            appStateManager: appState,
+            fetchExerciseDetails: fetchStub,
+        });
+        const coordinator = new WebviewSSRCoordinator(deps);
+        const scheduleSpy = sandbox.stub(coordinator, 'scheduleRender').resolves();
+
+        // First refresh fails — must NOT throw out of refreshFromServer (it returns void anyway,
+        // but the internal loop must not leave _refreshing in an inconsistent state).
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        sinon.assert.notCalled(appState.showExerciseDetail);
+
+        // Second refresh after the failure must succeed.
+        coordinator.refreshFromServer({ exerciseId: 42 });
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        sinon.assert.calledTwice(fetchStub);
+        sinon.assert.calledOnce(appState.showExerciseDetail);
+        sinon.assert.calledOnce(scheduleSpy);
     });
 });

--- a/extension/test/unit/services/submissionWebSocketHandler.test.ts
+++ b/extension/test/unit/services/submissionWebSocketHandler.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ExtensionMsg } from '@shared/messageContracts';
+
+import type { ResultDTO } from '@extension/domain';
+import { SubmissionWebSocketHandler } from '@extension/services/ui/submissionWebSocketHandler';
+
+function makeResult(): ResultDTO {
+    return {
+        id: 1,
+        completionDate: new Date().toISOString(),
+        successful: true,
+        score: 100,
+        testCaseCount: 5,
+        passedTestCaseCount: 5,
+        codeIssueCount: 0,
+        feedbacks: [],
+        participation: { id: 42 },
+        submission: { buildFailed: false },
+    } as unknown as ResultDTO;
+}
+
+suite('SubmissionWebSocketHandler', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => { sandbox = sinon.createSandbox(); });
+    teardown(() => { sandbox.restore(); });
+
+    test('handleNewResult posts a WebsocketUpdate message of type newResult', () => {
+        const postMessage = sandbox.stub();
+        const handler = new SubmissionWebSocketHandler(postMessage);
+
+        handler.handleNewResult(makeResult());
+
+        sinon.assert.calledOnce(postMessage);
+        sinon.assert.calledWith(
+            postMessage,
+            sinon.match({ type: ExtensionMsg.WebsocketUpdate, updateType: 'newResult' }),
+        );
+    });
+
+    test('handleNewResult calls _onBuildResult with the result', () => {
+        const postMessage = sandbox.stub();
+        const onBuildResult = sandbox.stub();
+        const handler = new SubmissionWebSocketHandler(postMessage, onBuildResult);
+        const r = makeResult();
+
+        handler.handleNewResult(r);
+
+        sinon.assert.calledOnceWithExactly(onBuildResult, r);
+    });
+
+    test('handleNewResult calls _onResultReceived with the result', () => {
+        const postMessage = sandbox.stub();
+        const onBuildResult = sandbox.stub();
+        const onResultReceived = sandbox.stub();
+        const handler = new SubmissionWebSocketHandler(postMessage, onBuildResult, onResultReceived);
+        const r = makeResult();
+
+        handler.handleNewResult(r);
+
+        sinon.assert.calledOnceWithExactly(onResultReceived, r);
+    });
+
+    test('handleNewResult invokes callbacks in order: postMessage, _onBuildResult, _onResultReceived', () => {
+        const order: string[] = [];
+        const postMessage = sandbox.stub().callsFake(() => { order.push('post'); });
+        const onBuildResult = sandbox.stub().callsFake(() => { order.push('build'); });
+        const onResultReceived = sandbox.stub().callsFake(() => { order.push('refresh'); });
+        const handler = new SubmissionWebSocketHandler(postMessage, onBuildResult, onResultReceived);
+
+        handler.handleNewResult(makeResult());
+
+        assert.deepStrictEqual(order, ['post', 'build', 'refresh']);
+    });
+
+    test('handleNewResult tolerates missing optional callbacks', () => {
+        const postMessage = sandbox.stub();
+        const handler = new SubmissionWebSocketHandler(postMessage);
+
+        // Must not throw.
+        handler.handleNewResult(makeResult());
+
+        sinon.assert.calledOnce(postMessage);
+    });
+});


### PR DESCRIPTION
## Summary

When a WebSocket `newResult` arrives for the currently rendered participation, re-fetch enriched exercise details and re-render the problem statement so test-case checkmarks reflect the new result without requiring panel-toggle or re-navigation.

## What changed

- **`SubmissionWebSocketHandler`** gains an optional 3rd constructor callback `_onResultReceived`, fired after `_onBuildResult` in `handleNewResult`.
- **`WebviewSSRCoordinator`** gains:
  - `fetchExerciseDetails` dep (injected loader, no whole-API coupling).
  - `refreshFromServer({ exerciseId })`: at most one fetch in flight + one pending behind it (last-wins coalescing). State / exerciseId / disposed guards before mutating. Each loop iteration is try/catched so an unexpected throw cannot strand a pending refresh.
  - `scheduleRender()` is now disposal-aware (guard at entry and after the render await).
  - `dispose()` sets `_disposed = true`.
  - **No `sendInitData()`** in the refresh path on purpose: `showExerciseDetail` clears the cached SSR HTML, so a full init would briefly blank the PS until the new SSR returns. The webview store already patches `newResult` incrementally; the SSR re-render arrives via `ProblemStatementRendered`.
- **`problemStatementRefreshDecision.ts`** (new): pure `shouldRefreshPSForResult(...)` so the filter is unit-testable in isolation. Today it narrows to results for `studentParticipations[0]?.id` because the coordinator currently renders that participation. When the coordinator's selection logic is generalized (graded/practice repo aware), the filter must be revisited.
- **`ArtemisWebviewProvider`**: wires the new callback, passes the fetch loader to the coordinator, and adds a post-fetch state+exerciseId guard to the existing visibility-change refresh so a slower visibility fetch cannot overwrite fresher result-driven data.

## Out of scope (follow-up)

The coordinator still selects `studentParticipations[0]` for SSR while the webview picks by `repoStatus.isPracticeRepo`. Pre-existing mismatch; not amplified by this PR but worth its own issue.

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run test:unit` — 2363/2363 passing
  - 12 new tests on `WebviewSSRCoordinator` (coalesce sequential not parallel, last-wins pending slot of 1, state/exerciseId/disposed guards both during fetch and during render, fetch-error swallow + recovery)
  - 7 new tests on `shouldRefreshPSForResult` (filter correctness incl. NaN, missing participation, non-rendered participation)
  - 5 new tests on `SubmissionWebSocketHandler` (callback order: postMessage → onBuildResult → onResultReceived; tolerant of missing optional callbacks)
- [ ] Manual smoke: submit code in an exercise, observe PS checkmarks update without re-navigating.