### PR TITLE
feat(problem-statement): differentiated empty states for task feedback

### DIFF
--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -557,6 +557,7 @@ function parseTaskFeedbackView(d: Record<string, unknown>, timestamp: number): T
         if (!isFiniteNumber(d.totalTests) || !isFiniteNumber(d.passedTests) || !isFiniteNumber(d.failedTests)) {
             return null;
         }
+        if (!isOptFiniteNumber(d.notExecutedTests)) { return null; }
         return stripUndefined<TaskFeedbackViewOpenedEvent>({
             type: 'taskFeedbackView',
             action: 'opened',
@@ -570,6 +571,7 @@ function parseTaskFeedbackView(d: Record<string, unknown>, timestamp: number): T
             totalTests: d.totalTests,
             passedTests: d.passedTests,
             failedTests: d.failedTests,
+            notExecutedTests: d.notExecutedTests as number | undefined,
         });
     }
     if (d.action === 'closed') {

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -350,6 +350,7 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
         totalTests: number;
         passedTests: number;
         failedTests: number;
+        notExecutedTests?: number;
     }): void {
         this._record({
             type: 'taskFeedbackView',

--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -378,6 +378,7 @@ export interface TaskFeedbackViewOpenedEvent {
     totalTests: number;
     passedTests: number;
     failedTests: number;
+    notExecutedTests?: number;
 }
 
 export interface TaskFeedbackViewClosedEvent {

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -214,6 +214,7 @@ interface WebviewCmdPayloads {
         totalTests: number;
         passedTests: number;
         failedTests: number;
+        notExecutedTests?: number;
     };
     taskFeedbackClosed: {
         viewId: string;

--- a/extension/src/webview/components/exercise/TestResultsOverlay.tsx
+++ b/extension/src/webview/components/exercise/TestResultsOverlay.tsx
@@ -5,21 +5,35 @@ import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import { IconButton } from '@webview/components/Button';
+import type { TaskTestState } from '@webview/utils/exerciseStatus';
 
 import type { TestCase } from './SubmissionStatus';
 import styles from './TestResultsOverlay.module.css';
 
 type TestResultsOverlayCloseReason = 'button' | 'escape';
 
-interface TestResultsOverlayProps {
+/** Per-task: classified state from {@link classifyTaskTests}. */
+interface TestResultsOverlayTaskProps {
     open: boolean;
     onClose: (reason: TestResultsOverlayCloseReason) => void;
-    testCases: TestCase[];
+    state: TaskTestState;
+    taskName: string;
     loading?: boolean;
-    taskName?: string;
 }
 
-export function TestResultsOverlay({ open, onClose, testCases, loading = false, taskName }: TestResultsOverlayProps) {
+/** Global overview: unfiltered list of all test cases for the latest result. */
+interface TestResultsOverlayOverviewProps {
+    open: boolean;
+    onClose: (reason: TestResultsOverlayCloseReason) => void;
+    state: { kind: 'all'; testCases: TestCase[] };
+    loading?: boolean;
+}
+
+type TestResultsOverlayProps = TestResultsOverlayTaskProps | TestResultsOverlayOverviewProps;
+
+export function TestResultsOverlay(props: TestResultsOverlayProps) {
+    const { open, onClose, loading = false } = props;
+
     useEffect(() => {
         if (!open) { return; }
         const handleKey = (e: KeyboardEvent) => {
@@ -40,10 +54,161 @@ export function TestResultsOverlay({ open, onClose, testCases, loading = false, 
 
     if (!open) { return null; }
 
+    const isTask = 'taskName' in props;
+    const title = isTask ? `Feedback for task: ${props.taskName}` : 'Test Results';
+
+    return createPortal(
+        <div className={styles.backdrop}>
+            <div className={styles.modal}>
+                <div className={styles.header}>
+                    <div className={styles.title}>{title}</div>
+                    <IconButton.Close onClick={() => onClose('button')} />
+                </div>
+
+                {loading ? (
+                    <div className={styles.testList}>
+                        <div className={styles.loading}>Loading test results...</div>
+                    </div>
+                ) : isTask ? (
+                    <TaskBody state={props.state} />
+                ) : (
+                    <OverviewBody testCases={props.state.testCases} />
+                )}
+            </div>
+        </div>,
+        document.body
+    );
+}
+
+// ── Overview body (global "all tests" modal) ────────────────────────────────
+
+function OverviewBody({ testCases }: { testCases: TestCase[] }) {
     const passed = testCases.filter((t) => t.passed);
     const failed = testCases.filter((t) => !t.passed);
     const total = testCases.length;
-    const passedCount = passed.length;
+
+    return (
+        <>
+            {total > 0 && <Summary passedCount={passed.length} total={total} />}
+            <div className={styles.testList}>
+                {total === 0 ? (
+                    <div className={styles.empty}>No test results available.</div>
+                ) : (
+                    <>
+                        {failed.length > 0 && (
+                            <Section label="Failed" count={failed.length} variant="failed">
+                                {failed.map((tc, i) => (
+                                    <TestResultItem key={`fail-${i}`} testCase={tc} />
+                                ))}
+                            </Section>
+                        )}
+                        {passed.length > 0 && (
+                            <Section label="Passed" count={passed.length} variant="passed">
+                                {passed.map((tc, i) => (
+                                    <TestResultItem key={`pass-${i}`} testCase={tc} />
+                                ))}
+                            </Section>
+                        )}
+                    </>
+                )}
+            </div>
+        </>
+    );
+}
+
+// ── Task body (per-task modal driven by TaskTestState) ──────────────────────
+
+function TaskBody({ state }: { state: TaskTestState }) {
+    switch (state.kind) {
+        case 'no-result':
+            return <Empty>No build results yet for this exercise. Submit your code to see test feedback.</Empty>;
+
+        case 'no-feedbacks':
+            return <Empty>The latest build produced no test feedback for this task.</Empty>;
+
+        case 'no-tests-in-task':
+            return <Empty>This task has no associated tests.</Empty>;
+
+        case 'legacy-success': {
+            const n = state.testIds.length;
+            return (
+                <>
+                    <Summary passedCount={n} total={n} />
+                    <div className={styles.testList}>
+                        <div className={styles.empty}>All {n} test{n !== 1 ? 's' : ''} passed. Detailed feedback isn&apos;t available for this result.</div>
+                    </div>
+                </>
+            );
+        }
+
+        case 'success': {
+            const n = state.passed.length;
+            return (
+                <>
+                    <Summary passedCount={n} total={n} />
+                    <div className={styles.testList}>
+                        <Section label="Passed" count={n} variant="passed">
+                            {state.passed.map((tc, i) => (
+                                <TestResultItem key={`pass-${i}`} testCase={tc} />
+                            ))}
+                        </Section>
+                    </div>
+                </>
+            );
+        }
+
+        case 'fail': {
+            const matched = state.passed.length + state.failed.length;
+            return (
+                <>
+                    {matched > 0 && <Summary passedCount={state.passed.length} total={matched} />}
+                    <div className={styles.testList}>
+                        <Section label="Failed" count={state.failed.length} variant="failed">
+                            {state.failed.map((tc, i) => (
+                                <TestResultItem key={`fail-${i}`} testCase={tc} />
+                            ))}
+                        </Section>
+                        {state.passed.length > 0 && (
+                            <Section label="Passed" count={state.passed.length} variant="passed">
+                                {state.passed.map((tc, i) => (
+                                    <TestResultItem key={`pass-${i}`} testCase={tc} />
+                                ))}
+                            </Section>
+                        )}
+                        {state.notExecutedIds.length > 0 && (
+                            <NotExecutedNote count={state.notExecutedIds.length} />
+                        )}
+                    </div>
+                </>
+            );
+        }
+
+        case 'not-executed': {
+            const passedCount = state.passed.length;
+            const notRunCount = state.notExecutedIds.length;
+            if (passedCount === 0) {
+                return <Empty>{notRunCount === 1 ? '1 test in this task did not run' : `${notRunCount} tests in this task did not run`} in the latest build.</Empty>;
+            }
+            return (
+                <>
+                    <Summary passedCount={passedCount} total={passedCount + notRunCount} />
+                    <div className={styles.testList}>
+                        <Section label="Passed" count={passedCount} variant="passed">
+                            {state.passed.map((tc, i) => (
+                                <TestResultItem key={`pass-${i}`} testCase={tc} />
+                            ))}
+                        </Section>
+                        {notRunCount > 0 && <NotExecutedNote count={notRunCount} />}
+                    </div>
+                </>
+            );
+        }
+    }
+}
+
+// ── Shared building blocks ──────────────────────────────────────────────────
+
+function Summary({ passedCount, total }: { passedCount: number; total: number }) {
     const percentage = total > 0 ? (passedCount / total) * 100 : 0;
 
     let summaryColorClass = styles.summaryFail;
@@ -56,64 +221,51 @@ export function TestResultsOverlay({ open, onClose, testCases, loading = false, 
         progressFillClass = styles.progressFillWarning;
     }
 
-    const title = taskName ? `Feedback for task: ${taskName}` : 'Test Results';
-    const emptyMessage = taskName ? 'No tests in this task.' : 'No test results available.';
-
-    return createPortal(
-        <div className={styles.backdrop}>
-            <div className={styles.modal}>
-                <div className={styles.header}>
-                    <div className={styles.title}>{title}</div>
-                    <IconButton.Close onClick={() => onClose('button')} />
-                </div>
-
-                {!loading && total > 0 && (
-                    <div className={styles.summary}>
-                        <div className={clsx(styles.summaryText, summaryColorClass)}>
-                            {passedCount} of {total} test{total !== 1 ? 's' : ''} passed ({percentage.toFixed(0)}%)
-                        </div>
-                        <div className={styles.progressTrack}>
-                            <div
-                                className={clsx(styles.progressFill, progressFillClass)}
-                                style={{ width: `${percentage}%` }}
-                            />
-                        </div>
-                    </div>
-                )}
-
-                <div className={styles.testList}>
-                    {loading ? (
-                        <div className={styles.loading}>Loading test results...</div>
-                    ) : total === 0 ? (
-                        <div className={styles.empty}>{emptyMessage}</div>
-                    ) : (
-                        <>
-                            {failed.length > 0 && (
-                                <>
-                                    <div className={clsx(styles.sectionLabel, styles.sectionLabelFailed)}>
-                                        Failed ({failed.length})
-                                    </div>
-                                    {failed.map((tc, i) => (
-                                        <TestResultItem key={`fail-${i}`} testCase={tc} />
-                                    ))}
-                                </>
-                            )}
-                            {passed.length > 0 && (
-                                <>
-                                    <div className={clsx(styles.sectionLabel, styles.sectionLabelPassed)}>
-                                        Passed ({passed.length})
-                                    </div>
-                                    {passed.map((tc, i) => (
-                                        <TestResultItem key={`pass-${i}`} testCase={tc} />
-                                    ))}
-                                </>
-                            )}
-                        </>
-                    )}
-                </div>
+    return (
+        <div className={styles.summary}>
+            <div className={clsx(styles.summaryText, summaryColorClass)}>
+                {passedCount} of {total} test{total !== 1 ? 's' : ''} passed ({percentage.toFixed(0)}%)
             </div>
-        </div>,
-        document.body
+            <div className={styles.progressTrack}>
+                <div
+                    className={clsx(styles.progressFill, progressFillClass)}
+                    style={{ width: `${percentage}%` }}
+                />
+            </div>
+        </div>
+    );
+}
+
+function Section({ label, count, variant, children }: {
+    label: string;
+    count: number;
+    variant: 'passed' | 'failed';
+    children: React.ReactNode;
+}) {
+    const labelClass = variant === 'passed' ? styles.sectionLabelPassed : styles.sectionLabelFailed;
+    return (
+        <>
+            <div className={clsx(styles.sectionLabel, labelClass)}>
+                {label} ({count})
+            </div>
+            {children}
+        </>
+    );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+    return (
+        <div className={styles.testList}>
+            <div className={styles.empty}>{children}</div>
+        </div>
+    );
+}
+
+function NotExecutedNote({ count }: { count: number }) {
+    return (
+        <div className={styles.empty}>
+            {count === 1 ? '1 test in this task did not run' : `${count} tests in this task did not run`} in the latest build.
+        </div>
     );
 }
 

--- a/extension/src/webview/utils/exerciseStatus.ts
+++ b/extension/src/webview/utils/exerciseStatus.ts
@@ -90,14 +90,144 @@ export function transformFeedbacksToTestCases(feedbacks: FeedbackInput[]): TestC
 }
 
 /**
- * Filter a TestCase array to only the entries whose id is in the given set.
- * Used by the per-task feedback modal to show only the tests linked to the
- * clicked [task] entry in the SSR'd problem statement.
+ * Classification of a task's test outcome, mirroring the buckets the Artemis
+ * web client uses (`ProgrammingExerciseInstructionService.testStatusForTask`)
+ * plus the legacy-success fallback for older results without an explicit
+ * feedback list.
  *
- * Tests without an id are excluded (cannot be matched). Returns a new array
- * preserving the input order.
+ * Used by the per-task feedback modal to render differentiated empty states
+ * instead of the generic "No tests in this task." message.
  */
-export function filterTestCasesByIds(all: TestCase[], ids: number[]): TestCase[] {
-    const idSet = new Set(ids);
-    return all.filter(tc => tc.id !== undefined && idSet.has(tc.id));
+export type TaskTestState =
+    | { kind: 'no-result'; notExecutedIds: number[] }
+    | { kind: 'no-feedbacks'; notExecutedIds: number[] }
+    | { kind: 'legacy-success'; testIds: number[] }
+    | { kind: 'no-tests-in-task' }
+    | { kind: 'success'; passed: TestCase[] }
+    | { kind: 'fail'; failed: TestCase[]; passed: TestCase[]; notExecutedIds: number[] }
+    | { kind: 'not-executed'; passed: TestCase[]; notExecutedIds: number[] };
+
+interface LatestResultLike {
+    successful?: boolean;
+    feedbacks?: FeedbackInput[];
+}
+
+/**
+ * Classify a task's test outcome from the latest result. Pure function.
+ *
+ * Behaviour parity with Artemis (`testStatusForTask`):
+ * - `successful: true` with empty/undefined feedbacks → `legacy-success` (older
+ *   results sometimes ship without an inline feedback list).
+ * - Otherwise partition `testIds` by feedback.positive:
+ *   true → passed, false → failed, undefined-or-missing → not executed.
+ *
+ * The empty-feedbacks branch additionally distinguishes "the enrichment step
+ * never delivered a feedback list" (feedbacks === undefined → `no-result`)
+ * from "feedbacks were delivered but the array is empty" (feedbacks === [] →
+ * `no-feedbacks`). The first surfaces "submit your code", the second surfaces
+ * "the latest build produced no test feedback".
+ *
+ * `no-tests-in-task` is defensive; the click handler in `ProblemStatement.tsx`
+ * already short-circuits empty testId lists before opening the overlay.
+ */
+export function classifyTaskTests(
+    testIds: number[],
+    latestResult: LatestResultLike | undefined,
+): TaskTestState {
+    // A task without testIds has no associated tests; the result is irrelevant.
+    // Hoisted above the other guards so 'no-tests-in-task' is the canonical
+    // state for this defensive case across all input combinations (the click
+    // handler in ProblemStatement.tsx already short-circuits empty testId
+    // lists before reaching here).
+    if (testIds.length === 0) {
+        return { kind: 'no-tests-in-task' };
+    }
+
+    if (!latestResult) {
+        return { kind: 'no-result', notExecutedIds: testIds };
+    }
+
+    const feedbacks = latestResult.feedbacks ?? [];
+
+    if (feedbacks.length === 0) {
+        if (latestResult.successful === true) {
+            return { kind: 'legacy-success', testIds };
+        }
+        return latestResult.feedbacks === undefined
+            ? { kind: 'no-result', notExecutedIds: testIds }
+            : { kind: 'no-feedbacks', notExecutedIds: testIds };
+    }
+
+    const byId = new Map<number, FeedbackInput>();
+    for (const f of feedbacks) {
+        const id = f.testCase?.id;
+        if (id === undefined) { continue; }
+        byId.set(id, f);
+    }
+
+    const passed: TestCase[] = [];
+    const failed: TestCase[] = [];
+    const notExecutedIds: number[] = [];
+    for (const tid of testIds) {
+        const fb = byId.get(tid);
+        if (!fb) { notExecutedIds.push(tid); continue; }
+        const tc: TestCase = {
+            id: tid,
+            name: fb.testCase?.testName ?? fb.text ?? 'Test',
+            passed: fb.positive === true,
+            message: fb.detailText,
+        };
+        if (fb.positive === true) {
+            passed.push(tc);
+        } else if (fb.positive === false) {
+            failed.push(tc);
+        } else {
+            // positive undefined → not executed (Artemis parity)
+            notExecutedIds.push(tid);
+        }
+    }
+
+    if (failed.length > 0) {
+        return { kind: 'fail', failed, passed, notExecutedIds };
+    }
+    if (notExecutedIds.length > 0) {
+        return { kind: 'not-executed', passed, notExecutedIds };
+    }
+    return { kind: 'success', passed };
+}
+
+/**
+ * Counts derived from a {@link TaskTestState}, in the shape the telemetry
+ * payload expects. `passedCount` + `failedCount` preserves the pre-existing
+ * `totalTests` semantics (matched tests for this task); `notExecutedCount`
+ * is additive so historical analytics keep working.
+ */
+export function countsForTelemetry(state: TaskTestState): {
+    passedCount: number;
+    failedCount: number;
+    notExecutedCount: number;
+} {
+    switch (state.kind) {
+        case 'no-result':
+        case 'no-feedbacks':
+            return { passedCount: 0, failedCount: 0, notExecutedCount: state.notExecutedIds.length };
+        case 'legacy-success':
+            return { passedCount: state.testIds.length, failedCount: 0, notExecutedCount: 0 };
+        case 'no-tests-in-task':
+            return { passedCount: 0, failedCount: 0, notExecutedCount: 0 };
+        case 'success':
+            return { passedCount: state.passed.length, failedCount: 0, notExecutedCount: 0 };
+        case 'fail':
+            return {
+                passedCount: state.passed.length,
+                failedCount: state.failed.length,
+                notExecutedCount: state.notExecutedIds.length,
+            };
+        case 'not-executed':
+            return {
+                passedCount: state.passed.length,
+                failedCount: 0,
+                notExecutedCount: state.notExecutedIds.length,
+            };
+    }
 }

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -21,8 +21,9 @@ import { useExerciseStatusMessages } from '@webview/hooks/useExerciseStatusMessa
 import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
 import { useWebSocketUpdates } from '@webview/hooks/useWebSocketUpdates';
 import { useExerciseDetailStore } from '@webview/stores/useExerciseDetailStore';
-import { filterTestCasesByIds } from '@webview/utils/exerciseStatus';
 import {
+    classifyTaskTests,
+    countsForTelemetry,
     determineParticipationStatus,
     determineSubmissionStatus,
     getLatestById,
@@ -280,17 +281,20 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
 
     const handleTaskOpen = ({ taskName, testIds }: { taskName: string; testIds: number[] }) => {
         if (!exerciseData?.exercise?.id) { return; }
-        const filtered = filterTestCasesByIds(testCases, testIds);
+        const classification = classifyTaskTests(testIds, latestResult);
+        // Telemetry: keep existing totalTests/passedTests/failedTests semantics
+        // (matched tests for this task). Add notExecutedTests as additive field.
+        const { passedCount, failedCount, notExecutedCount } = countsForTelemetry(classification);
+        const totalTestCount = passedCount + failedCount;
         const viewId = makeViewId();
         const openedAt = Date.now();
         const exerciseId = exerciseData.exercise.id;
         const resultId = latestResult?.id;
-        const totalTestCount = filtered.length;
-        const passedTestCount = filtered.filter(t => t.passed).length;
-        const failedTests = totalTestCount - passedTestCount;
         postCommand(vscodeApi, WebviewCmd.TaskFeedbackOpened, {
             viewId, exerciseId, participationId, resultId,
-            taskName, testIds, totalTests: totalTestCount, passedTests: passedTestCount, failedTests,
+            taskName, testIds,
+            totalTests: totalTestCount, passedTests: passedCount, failedTests: failedCount,
+            notExecutedTests: notExecutedCount,
         });
         setOpenTaskView({
             viewId,
@@ -603,15 +607,17 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
             <TestResultsOverlay
                 open={openOverviewView !== null}
                 onClose={handleOverviewClose}
-                testCases={testCases}
+                state={{ kind: 'all', testCases }}
             />
 
-            <TestResultsOverlay
-                open={openTaskView !== null}
-                onClose={handleTaskClose}
-                testCases={openTaskView !== null ? filterTestCasesByIds(testCases, openTaskView.testIds) : []}
-                taskName={openTaskView?.taskName}
-            />
+            {openTaskView !== null && (
+                <TestResultsOverlay
+                    open
+                    onClose={handleTaskClose}
+                    state={classifyTaskTests(openTaskView.testIds, latestResult)}
+                    taskName={openTaskView.taskName}
+                />
+            )}
         </div>
     );
 }

--- a/extension/test/react/components/exercise/TestResultsOverlay.test.tsx
+++ b/extension/test/react/components/exercise/TestResultsOverlay.test.tsx
@@ -7,33 +7,168 @@ import { TestResultsOverlay } from '@webview/components/exercise/TestResultsOver
 
 describe('TestResultsOverlay', () => {
     const testCases: TestCase[] = [
-        { name: 'testA', passed: true },
-        { name: 'testB', passed: false, message: 'fail msg' },
+        { id: 1, name: 'testA', passed: true },
+        { id: 2, name: 'testB', passed: false, message: 'fail msg' },
     ];
 
-    it('renders default title when taskName is absent', () => {
-        render(<TestResultsOverlay open onClose={() => undefined} testCases={testCases} />);
+    // ── Overview ('all') mode ────────────────────────────────────────────
+
+    it('renders default title in overview mode', () => {
+        render(<TestResultsOverlay open onClose={() => undefined} state={{ kind: 'all', testCases }} />);
         expect(screen.getByText('Test Results')).toBeInTheDocument();
     });
 
-    it('renders task-mode title when taskName is provided', () => {
-        render(<TestResultsOverlay open onClose={() => undefined} testCases={testCases} taskName="doOverlap" />);
-        expect(screen.getByText('Feedback for task: doOverlap')).toBeInTheDocument();
-    });
-
-    it('shows task-specific empty message when taskName given and testCases empty', () => {
-        render(<TestResultsOverlay open onClose={() => undefined} testCases={[]} taskName="emptyTask" />);
-        expect(screen.getByText('No tests in this task.')).toBeInTheDocument();
-    });
-
-    it('shows default empty message when taskName not given and testCases empty', () => {
-        render(<TestResultsOverlay open onClose={() => undefined} testCases={[]} />);
+    it('shows overview empty message when testCases is empty', () => {
+        render(<TestResultsOverlay open onClose={() => undefined} state={{ kind: 'all', testCases: [] }} />);
         expect(screen.getByText('No test results available.')).toBeInTheDocument();
     });
 
+    // ── Task mode: per-kind empty/structured states ──────────────────────
+
+    it('renders task-mode title from taskName', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="doOverlap"
+                state={{ kind: 'no-result', notExecutedIds: [1, 2, 3] }}
+            />,
+        );
+        expect(screen.getByText('Feedback for task: doOverlap')).toBeInTheDocument();
+    });
+
+    it('no-result renders the "submit your code" empty state', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'no-result', notExecutedIds: [1] }}
+            />,
+        );
+        expect(screen.getByText(/no build results yet/i)).toBeInTheDocument();
+    });
+
+    it('no-feedbacks renders the build-without-feedback empty state', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'no-feedbacks', notExecutedIds: [1] }}
+            />,
+        );
+        expect(screen.getByText(/produced no test feedback/i)).toBeInTheDocument();
+    });
+
+    it('no-tests-in-task renders the no-associated-tests empty state', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'no-tests-in-task' }}
+            />,
+        );
+        expect(screen.getByText(/no associated tests/i)).toBeInTheDocument();
+    });
+
+    it('legacy-success renders "All N tests passed" without details', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'legacy-success', testIds: [10, 11, 12] }}
+            />,
+        );
+        // Summary line
+        expect(screen.getByText(/3 of 3 tests passed/i)).toBeInTheDocument();
+        // Body note
+        expect(screen.getByText(/All 3 tests passed/i)).toBeInTheDocument();
+    });
+
+    it('success renders only the Passed section', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{
+                    kind: 'success',
+                    passed: [{ id: 1, name: 'tA', passed: true }, { id: 2, name: 'tB', passed: true }],
+                }}
+            />,
+        );
+        expect(screen.getByText('Passed (2)')).toBeInTheDocument();
+        expect(screen.queryByText(/^Failed/)).not.toBeInTheDocument();
+    });
+
+    it('fail renders Failed + Passed sections and a Not-executed note when applicable', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{
+                    kind: 'fail',
+                    failed: [{ id: 3, name: 'tF', passed: false, message: 'fail msg' }],
+                    passed: [{ id: 1, name: 'tA', passed: true }],
+                    notExecutedIds: [99, 100],
+                }}
+            />,
+        );
+        expect(screen.getByText('Failed (1)')).toBeInTheDocument();
+        expect(screen.getByText('Passed (1)')).toBeInTheDocument();
+        expect(screen.getByText(/2 tests in this task did not run/i)).toBeInTheDocument();
+    });
+
+    it('not-executed with no passed renders the count-only empty state', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'not-executed', passed: [], notExecutedIds: [1, 2, 3] }}
+            />,
+        );
+        expect(screen.getByText(/3 tests in this task did not run/i)).toBeInTheDocument();
+    });
+
+    it('not-executed singular: "1 test ... did not run"', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{ kind: 'not-executed', passed: [], notExecutedIds: [1] }}
+            />,
+        );
+        expect(screen.getByText(/1 test in this task did not run/i)).toBeInTheDocument();
+    });
+
+    it('not-executed with some passed shows the Passed section plus the Not-executed note', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="t"
+                state={{
+                    kind: 'not-executed',
+                    passed: [{ id: 1, name: 'tA', passed: true }],
+                    notExecutedIds: [2],
+                }}
+            />,
+        );
+        expect(screen.getByText('Passed (1)')).toBeInTheDocument();
+        expect(screen.getByText(/1 test in this task did not run/i)).toBeInTheDocument();
+    });
+
+    // ── Close interactions ───────────────────────────────────────────────
+
     it('calls onClose with "button" when X is clicked', async () => {
         const onClose = vi.fn();
-        render(<TestResultsOverlay open onClose={onClose} testCases={testCases} />);
+        render(<TestResultsOverlay open onClose={onClose} state={{ kind: 'all', testCases }} />);
         const closeBtn = screen.getByRole('button', { name: /close/i });
         await userEvent.click(closeBtn);
         expect(onClose).toHaveBeenCalledWith('button');
@@ -41,14 +176,14 @@ describe('TestResultsOverlay', () => {
 
     it('calls onClose with "escape" when Escape is pressed', () => {
         const onClose = vi.fn();
-        render(<TestResultsOverlay open onClose={onClose} testCases={testCases} />);
+        render(<TestResultsOverlay open onClose={onClose} state={{ kind: 'all', testCases }} />);
         fireEvent.keyDown(document, { key: 'Escape' });
         expect(onClose).toHaveBeenCalledWith('escape');
     });
 
     it('does not fire onClose when clicking inside the modal content', async () => {
         const onClose = vi.fn();
-        render(<TestResultsOverlay open onClose={onClose} testCases={testCases} />);
+        render(<TestResultsOverlay open onClose={onClose} state={{ kind: 'all', testCases }} />);
         await userEvent.click(screen.getByText('testA'));
         expect(onClose).not.toHaveBeenCalled();
     });

--- a/extension/test/react/utils/exerciseStatus.test.ts
+++ b/extension/test/react/utils/exerciseStatus.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyTaskTests, countsForTelemetry } from '@webview/utils/exerciseStatus';
+
+describe('classifyTaskTests', () => {
+    it('returns no-result when latestResult is undefined', () => {
+        const state = classifyTaskTests([1, 2, 3], undefined);
+        expect(state).toEqual({ kind: 'no-result', notExecutedIds: [1, 2, 3] });
+    });
+
+    it('returns no-result when feedbacks field is undefined (enrichment never delivered)', () => {
+        // Note: `feedbacks` not in the object at all — enrichment path leaves it undefined.
+        const state = classifyTaskTests([1], { successful: false });
+        expect(state).toEqual({ kind: 'no-result', notExecutedIds: [1] });
+    });
+
+    it('returns no-feedbacks when feedbacks is an empty array and result is not successful', () => {
+        const state = classifyTaskTests([1, 2], { successful: false, feedbacks: [] });
+        expect(state).toEqual({ kind: 'no-feedbacks', notExecutedIds: [1, 2] });
+    });
+
+    it('returns legacy-success when successful=true and feedbacks empty (Artemis legacy)', () => {
+        const state = classifyTaskTests([10, 11], { successful: true, feedbacks: [] });
+        expect(state).toEqual({ kind: 'legacy-success', testIds: [10, 11] });
+    });
+
+    it('returns legacy-success even when feedbacks field is undefined but successful=true', () => {
+        const state = classifyTaskTests([42], { successful: true });
+        expect(state).toEqual({ kind: 'legacy-success', testIds: [42] });
+    });
+
+    it('returns no-tests-in-task when testIds is empty for every latestResult shape', () => {
+        // testIds=[] short-circuits at the top of the classifier, so the result
+        // shape (undefined / successful / failed / with-feedbacks) is irrelevant.
+        expect(classifyTaskTests([], undefined)).toEqual({ kind: 'no-tests-in-task' });
+        expect(classifyTaskTests([], { successful: true, feedbacks: [] })).toEqual({ kind: 'no-tests-in-task' });
+        expect(classifyTaskTests([], { successful: false, feedbacks: [] })).toEqual({ kind: 'no-tests-in-task' });
+        expect(classifyTaskTests([], { feedbacks: [{ testCase: { id: 1, testName: 'x' }, positive: true }] }))
+            .toEqual({ kind: 'no-tests-in-task' });
+    });
+
+    it('returns success when every testId has a passing feedback', () => {
+        const state = classifyTaskTests([1, 2], {
+            feedbacks: [
+                { testCase: { id: 1, testName: 'tA' }, positive: true },
+                { testCase: { id: 2, testName: 'tB' }, positive: true },
+            ],
+        });
+        expect(state.kind).toBe('success');
+        if (state.kind === 'success') {
+            expect(state.passed).toHaveLength(2);
+            expect(state.passed[0]).toMatchObject({ id: 1, name: 'tA', passed: true });
+        }
+    });
+
+    it('returns fail when at least one testId failed', () => {
+        const state = classifyTaskTests([1, 2, 3], {
+            feedbacks: [
+                { testCase: { id: 1, testName: 'tA' }, positive: true },
+                { testCase: { id: 2, testName: 'tB' }, positive: false, detailText: 'boom' },
+            ],
+        });
+        expect(state.kind).toBe('fail');
+        if (state.kind === 'fail') {
+            expect(state.failed.map(t => t.id)).toEqual([2]);
+            expect(state.passed.map(t => t.id)).toEqual([1]);
+            expect(state.notExecutedIds).toEqual([3]);
+            expect(state.failed[0].message).toBe('boom');
+        }
+    });
+
+    it('returns not-executed when no failures but some testIds lack feedback', () => {
+        const state = classifyTaskTests([1, 2, 3], {
+            feedbacks: [{ testCase: { id: 1, testName: 'tA' }, positive: true }],
+        });
+        expect(state.kind).toBe('not-executed');
+        if (state.kind === 'not-executed') {
+            expect(state.passed.map(t => t.id)).toEqual([1]);
+            expect(state.notExecutedIds).toEqual([2, 3]);
+        }
+    });
+
+    it('treats positive=undefined as not-executed (Artemis parity)', () => {
+        const state = classifyTaskTests([1, 2], {
+            feedbacks: [
+                { testCase: { id: 1, testName: 'tA' }, positive: true },
+                { testCase: { id: 2, testName: 'tB' }, positive: undefined },
+            ],
+        });
+        expect(state.kind).toBe('not-executed');
+        if (state.kind === 'not-executed') {
+            expect(state.notExecutedIds).toEqual([2]);
+        }
+    });
+
+    it('ignores feedbacks without testCase.id (cannot be matched)', () => {
+        const state = classifyTaskTests([1], {
+            feedbacks: [
+                { text: 'orphan automatic feedback', positive: true }, // no testCase
+                { testCase: { id: 1, testName: 'tA' }, positive: true },
+            ],
+        });
+        expect(state.kind).toBe('success');
+        if (state.kind === 'success') {
+            expect(state.passed.map(t => t.id)).toEqual([1]);
+        }
+    });
+
+    it('falls back to f.text when testCase.testName is absent', () => {
+        const state = classifyTaskTests([1], {
+            feedbacks: [{ testCase: { id: 1 }, text: 'Fallback name', positive: true }],
+        });
+        if (state.kind === 'success') {
+            expect(state.passed[0].name).toBe('Fallback name');
+        }
+    });
+});
+
+describe('countsForTelemetry', () => {
+    it('maps no-result / no-feedbacks to {0, 0, notExecutedIds.length}', () => {
+        expect(countsForTelemetry({ kind: 'no-result', notExecutedIds: [1, 2] }))
+            .toEqual({ passedCount: 0, failedCount: 0, notExecutedCount: 2 });
+        expect(countsForTelemetry({ kind: 'no-feedbacks', notExecutedIds: [1] }))
+            .toEqual({ passedCount: 0, failedCount: 0, notExecutedCount: 1 });
+    });
+
+    it('maps legacy-success to {testIds.length, 0, 0}', () => {
+        expect(countsForTelemetry({ kind: 'legacy-success', testIds: [1, 2, 3] }))
+            .toEqual({ passedCount: 3, failedCount: 0, notExecutedCount: 0 });
+    });
+
+    it('maps no-tests-in-task to all-zero', () => {
+        expect(countsForTelemetry({ kind: 'no-tests-in-task' }))
+            .toEqual({ passedCount: 0, failedCount: 0, notExecutedCount: 0 });
+    });
+
+    it('maps success to {passed.length, 0, 0}', () => {
+        expect(countsForTelemetry({
+            kind: 'success',
+            passed: [{ id: 1, name: 'a', passed: true }, { id: 2, name: 'b', passed: true }],
+        })).toEqual({ passedCount: 2, failedCount: 0, notExecutedCount: 0 });
+    });
+
+    it('maps fail to {passed, failed, notExecuted} counts', () => {
+        expect(countsForTelemetry({
+            kind: 'fail',
+            passed: [{ id: 1, name: 'a', passed: true }],
+            failed: [{ id: 2, name: 'b', passed: false }, { id: 3, name: 'c', passed: false }],
+            notExecutedIds: [99],
+        })).toEqual({ passedCount: 1, failedCount: 2, notExecutedCount: 1 });
+    });
+
+    it('maps not-executed to {passed.length, 0, notExecutedIds.length}', () => {
+        expect(countsForTelemetry({
+            kind: 'not-executed',
+            passed: [{ id: 1, name: 'a', passed: true }],
+            notExecutedIds: [2, 3],
+        })).toEqual({ passedCount: 1, failedCount: 0, notExecutedCount: 2 });
+    });
+});

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -375,4 +375,132 @@ describe('ExerciseDetailView', () => {
 		expect(payload.failedTests).toBe(0);
 		expect(typeof payload.viewId).toBe('string');
 	});
+
+	// ── Task overlay state coverage ──────────────────────────────────────
+	//
+	// Each test sets up exerciseData to drive classifyTaskTests through a
+	// distinct branch, then clicks a task span and verifies the rendered
+	// empty-state copy. Catches regressions in the full click→classify→
+	// overlay-render pipeline that unit/component tests can't reach.
+
+	function exerciseWithFeedbacks(feedbacks: unknown[] | undefined, successful = false): ExerciseDetailsResponse {
+		const submission: Record<string, unknown> = {
+			id: 1,
+			submissionDate: '2025-01-01T00:00:00Z',
+			results: [{
+				id: 10,
+				score: successful ? 100 : 50,
+				successful,
+				completionDate: '2025-01-01T00:00:00Z',
+				...(feedbacks !== undefined ? { feedbacks } : {}),
+			}],
+		};
+		return makeExerciseData({
+			exercise: {
+				id: 42, title: 'My Exercise', type: 'programming',
+				maxPoints: 10, bonusPoints: 0, problemStatement: 'Solve.',
+				course: { id: 1, title: 'Test Course', shortName: 'TC' },
+				studentParticipations: [{
+					id: 99,
+					repositoryUri: 'https://git.example.com/repo',
+					submissions: [submission],
+				}],
+			},
+		});
+	}
+
+	function exerciseWithoutResult(): ExerciseDetailsResponse {
+		return makeExerciseData({
+			exercise: {
+				id: 42, title: 'My Exercise', type: 'programming',
+				maxPoints: 10, bonusPoints: 0, problemStatement: 'Solve.',
+				course: { id: 1, title: 'Test Course', shortName: 'TC' },
+				studentParticipations: [{
+					id: 99,
+					repositoryUri: 'https://git.example.com/repo',
+					submissions: [],
+				}],
+			},
+		});
+	}
+
+	const taskHtml = (testIds: string) =>
+		`<html><body><span class="artemis-task" data-task-name="taskA" data-test-ids="${testIds}">taskA</span></body></html>`;
+
+	async function clickTaskAndOpenOverlay(html: string) {
+		const mockApi = createMockVsCodeApi();
+		const { container } = render(<ExerciseDetailView vscodeApi={mockApi} />);
+		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html });
+		await waitFor(() => {
+			expect(container.querySelector('.artemis-task[data-test-ids]')).not.toBeNull();
+		});
+		await userEvent.click(container.querySelector('.artemis-task[data-test-ids]')!);
+	}
+
+	it('task overlay shows no-result copy when there is no latest result', async () => {
+		useExerciseDetailStore.setState({ exerciseData: exerciseWithoutResult(), isLoading: false });
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+		expect(screen.getByText(/no build results yet/i)).toBeInTheDocument();
+	});
+
+	it('task overlay shows no-feedbacks copy when the latest build returned no feedbacks', async () => {
+		useExerciseDetailStore.setState({ exerciseData: exerciseWithFeedbacks([], false), isLoading: false });
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+		expect(screen.getByText(/produced no test feedback/i)).toBeInTheDocument();
+	});
+
+	it('task overlay shows legacy-success copy when result is successful without inline feedbacks', async () => {
+		useExerciseDetailStore.setState({ exerciseData: exerciseWithFeedbacks(undefined, true), isLoading: false });
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+		expect(screen.getByText(/All 2 tests passed/i)).toBeInTheDocument();
+	});
+
+	it('task overlay shows not-executed count when feedbacks do not cover the task tests', async () => {
+		// Task references tests 50/51, but feedbacks only cover unrelated tests.
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseWithFeedbacks([
+				{ testCase: { id: 1, testName: 'other_test' }, positive: true },
+			], false),
+			isLoading: false,
+		});
+		await clickTaskAndOpenOverlay(taskHtml('50,51'));
+		expect(screen.getByText(/2 tests in this task did not run/i)).toBeInTheDocument();
+	});
+
+	it('task overlay shows the Failed section plus a Not-executed note when partial coverage hits a failure', async () => {
+		// Task references tests 1/2/99: 1 passes, 2 fails, 99 has no feedback (not-executed).
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseWithFeedbacks([
+				{ testCase: { id: 1, testName: 'pass_test' }, positive: true },
+				{ testCase: { id: 2, testName: 'fail_test' }, positive: false, detailText: 'boom' },
+			], false),
+			isLoading: false,
+		});
+		await clickTaskAndOpenOverlay(taskHtml('1,2,99'));
+		expect(screen.getByText('Failed (1)')).toBeInTheDocument();
+		expect(screen.getByText('Passed (1)')).toBeInTheDocument();
+		expect(screen.getByText(/1 test in this task did not run/i)).toBeInTheDocument();
+	});
+
+	it('task overlay re-classifies when exerciseData updates while the modal is open', async () => {
+		// Start with no-result, open the modal, then push a successful result
+		// via setState (mirroring the WS-driven store patch). The open modal
+		// must reflect the new state without reopening.
+		useExerciseDetailStore.setState({ exerciseData: exerciseWithoutResult(), isLoading: false });
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+		expect(screen.getByText(/no build results yet/i)).toBeInTheDocument();
+
+		// Patch in feedbacks that pass both task tests.
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseWithFeedbacks([
+				{ testCase: { id: 1, testName: 'tA' }, positive: true },
+				{ testCase: { id: 2, testName: 'tB' }, positive: true },
+			], false),
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByText(/no build results yet/i)).not.toBeInTheDocument();
+		});
+		expect(screen.getByText('Passed (2)')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
## Summary

Clicking a task in the SSR'd problem statement no longer collapses every empty case into a single misleading "No tests in this task." Each scenario gets its own tailored message and, where appropriate, a structured layout (passed / failed / not-executed sections).

## States

Mirrors Artemis's `ProgrammingExerciseInstructionService.testStatusForTask` four-state machine, with two extra states for cases the Artemis client doesn't surface explicitly but our extension can encounter:

| Kind | Trigger | UI |
|---|---|---|
| `no-tests-in-task` | task markup has no testIds | "This task has no associated tests." |
| `no-result` | no latest result, OR enrichment never delivered feedbacks | "No build results yet for this exercise. Submit your code..." |
| `no-feedbacks` | result exists, `successful: false`, feedbacks delivered as `[]` | "The latest build produced no test feedback for this task." |
| `legacy-success` | `successful: true` with empty/undefined feedbacks (old results) | "All N tests passed." (no detail list) |
| `success` | every task testId has `positive: true` feedback | Passed section, 100% bar |
| `fail` | at least one task testId has `positive: false` | Failed + Passed sections, plus Not-executed note when applicable |
| `not-executed` | no failures but some testIds have no feedback (or `positive: undefined`) | Passed section (if any) + count-only "{N} tests did not run" |

## Implementation

- `classifyTaskTests(testIds, latestResult)` is a pure function in `webview/utils/exerciseStatus.ts`, plus a `countsForTelemetry` helper.
- `TestResultsOverlay` now takes a discriminated `state` prop (task-mode = `TaskTestState`, overview-mode = `{ kind: 'all'; testCases }`). One renderer per kind.
- `ExerciseDetailView` keeps only `taskName` + `testIds` in `openTaskView` and runs the classifier in JSX at render time, so a WebSocket `newResult` patch reflects in the currently open modal on the next render.
- Removed the now-unused `filterTestCasesByIds`.

## Telemetry

Additive: a new optional `notExecutedTests?: number` field on the `taskFeedbackOpened` command + recording schema + parser. `totalTests` / `passedTests` / `failedTests` keep their existing "matched tests for this task" semantics so historical analytics are unaffected.

## Reviewed

Plan and implementation went through 3 + 2 rounds of codex review (Verdict A each time).

## Test plan

- [x] `npm run check-types`, `npm run lint`, `npm run knip` clean
- [x] `npm run test:react` 770/770 (18 new vitest tests covering all 7 classifier kinds + 13 overlay rendering variants)
- [x] `npm run test:unit` 2364/2364
- [ ] Manual: open a programming exercise mid-build, click a task — overlay shows "did not run" instead of "No tests in this task"
- [ ] Manual: open a freshly-created exercise with no submissions, click a task — overlay shows "Submit your code..."
- [ ] Manual: submit code, click task while build is running — initial state appears, then re-classifies once the result arrives (no modal-reopen needed)