### PR TITLE
feat: record explicit submission events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Iris Chat Connectivity Resilience**: Network drops and server errors now show a "temporarily unavailable" banner with a Retry button instead of the misleading "instructor disabled Iris" overlay, and the chat reloads automatically when the WebSocket reconnects.
 - **Recorder Gate**: the Record button now reads from the workspace-detected exercise instead of the Iris chat selection. Clicking Record before opening Iris no longer shows the misleading "Select an exercise context" warning.
 - **Debugger Recording**: The session recorder now captures debug session lifecycle and in-exercise breakpoint changes, visible in the recording timeline and live viewer.
+- **Submission Recording**: The session recorder now captures explicit submit actions (started, succeeded, or failed with a reason), visible in the recording timeline and live viewer and correlatable with the build result.
 
 ## [0.4.4] - 2026-05-10
 

--- a/extension/scripts/validate-recording.ts
+++ b/extension/scripts/validate-recording.ts
@@ -75,7 +75,7 @@ const KNOWN_EVENT_TYPES = new Set([
     // Terminal
     'terminalCommand', 'terminalOpenClose',
     // Build
-    'buildResult',
+    'buildResult', 'submission',
     // Config
     'configurationSnapshot', 'configurationChange',
     // Views

--- a/extension/src/extension/activation/sessionRecorderWiring.ts
+++ b/extension/src/extension/activation/sessionRecorderWiring.ts
@@ -146,6 +146,12 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
         sessionRecorder.recordTaskFeedbackClosed(payload);
     }));
 
+    // Submission tracking. Provider events flow from handleSubmitExercise ->
+    // ArtemisWebviewProvider.fireSubmission -> here.
+    disposables.push(artemisWebviewProvider.onDidSubmission(payload => {
+        sessionRecorder.recordSubmission(payload);
+    }));
+
     // ── Startup contributors ─────────────────────────────────────────
     // These run synchronously inside SessionRecorder._doStart, between the
     // initial-state events and the `startupPhaseComplete` marker. They

--- a/extension/src/extension/controller/commands/repositorySubmitCommands.ts
+++ b/extension/src/extension/controller/commands/repositorySubmitCommands.ts
@@ -4,6 +4,7 @@ import type { WebCmd, WebviewToExtensionMessage } from '@shared/messageContracts
 import { ExtensionMsg, getPayload, WebviewCmd } from '@shared/messageContracts';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
+import type { SubmissionFailureReason, SubmissionPayload } from '@extension/services/telemetry/recording/types';
 import * as workspaceServices from '@extension/services/workspace';
 import * as fileChecker from '@extension/services/workspace/workspaceFileChecker';
 import { extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
@@ -50,14 +51,31 @@ export class RepositorySubmitCommands {
     }
 
     private handleSubmitExercise = async (message: WebviewToExtensionMessage): Promise<void> => {
+        let participationId: number | undefined;
+        let failureReason: SubmissionFailureReason = 'other';
+        let resolvedCommitMessage: string | undefined;   // function-scoped: assigned inside withProgress, read at the succeeded emit
+        let succeededEmitted = false;
+        const fireSubmission = (payload: SubmissionPayload): void => {
+            this.context.providerRegistry.getArtemisWebviewProvider()?.fireSubmission(payload);
+        };
         try {
             const payload = getPayload<WebCmd<'submitExercise'>>(message);
+            // participationId is contractually required, but guard: a malformed/partial message must
+            // not produce a submission event with a missing participationId (the parser rejects that).
+            participationId = typeof payload.participationId === 'number' ? payload.participationId : undefined;
             const exerciseTitle = payload.exerciseTitle ?? 'Exercise';
             const commitMessage = payload.commitMessage;
+            const rawCommitMessage = commitMessage?.trim() || undefined;
+            if (participationId !== undefined) {
+                // fireSubmission is synchronous; the recorder's _record phase guard drops the event
+                // if no session is recording, so no session-state guard is needed at any call site.
+                fireSubmission({ status: 'started', participationId, commitMessage: rawCommitMessage });
+            }
+
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) {
-                vscode.window.showErrorMessage('Open the exercise repository in VS Code before submitting.');
-                return;
+                failureReason = 'no-workspace';
+                throw new Error('Open the exercise repository in VS Code before submitting.');
             }
 
             const cwd = workspaceFolder.uri.fsPath;
@@ -68,13 +86,13 @@ export class RepositorySubmitCommands {
             }, async progress => {
                 progress.report({ message: 'Preparing repository...' });
 
-                // Use unified workspace file checker (lightweight)
                 const result = await this.deps.checkWorkspaceFiles(workspaceFolder, {
                     includeContent: false,
                     applyFilters: false
                 });
 
                 if (!result.hasChanges) {
+                    failureReason = 'no-changes';
                     throw new Error('No local changes detected to submit.');
                 }
 
@@ -86,27 +104,41 @@ export class RepositorySubmitCommands {
                     VSCODE_CONFIG.DEFAULT_COMMIT_MESSAGE_KEY,
                     'Solution submission via Iris extension'
                 );
-                const messageText = (commitMessage && commitMessage.trim()) || configuredDefault;
+                resolvedCommitMessage = (commitMessage && commitMessage.trim()) || configuredDefault;
 
                 await this.ensureGitIdentityConfigured(cwd);
 
                 progress.report({ message: 'Committing changes...' });
-                await this.gitService.commit(messageText, { cwd });
+                await this.gitService.commit(resolvedCommitMessage, { cwd });
 
                 progress.report({ message: 'Syncing with remote...' });
                 try {
                     await this.gitService.pullWithRebase({ cwd });
                 } catch (pullError: unknown) {
-                    const errorMessage = pullError instanceof Error ? pullError.message : '';
-                    if (errorMessage && errorMessage.includes('CONFLICT')) {
+                    const pullMessage = pullError instanceof Error ? pullError.message : '';
+                    if (pullMessage && pullMessage.includes('CONFLICT')) {
+                        failureReason = 'merge-conflict';
                         throw new Error('Merge conflict detected. Please resolve conflicts manually using git and try again.');
                     }
-                    logger.warn('Pull failed, but continuing with push:', LogCategory.SUBMISSION, errorMessage);
+                    logger.warn('Pull failed, but continuing with push:', LogCategory.SUBMISSION, pullMessage);
                 }
 
                 progress.report({ message: 'Pushing to Artemis...' });
-                await this.gitService.push({ cwd });
+                try {
+                    await this.gitService.push({ cwd });
+                } catch (pushError: unknown) {
+                    failureReason = 'push-failed';
+                    throw pushError;
+                }
             });
+
+            // succeeded — the only success site. The post-success work below cannot throw into the
+            // outer catch (the websocket reconnect has its own inner try/catch), but succeededEmitted
+            // also hardens the "exactly one terminal per started" invariant against future edits.
+            if (participationId !== undefined) {
+                fireSubmission({ status: 'succeeded', participationId, commitMessage: resolvedCommitMessage });
+                succeededEmitted = true;
+            }
 
             vscode.window.showInformationMessage(`Successfully submitted "${exerciseTitle}".`);
 
@@ -127,11 +159,16 @@ export class RepositorySubmitCommands {
             logger.error('Submit exercise error:', LogCategory.SUBMISSION, error);
             const errorMessage = error instanceof Error ? error.message : 'Failed to submit exercise.';
 
-            // Don't show error notification if user is being directed to Git Credentials Helper
-            if (errorMessage !== GIT_IDENTITY_NOT_CONFIGURED) {
+            if (errorMessage === GIT_IDENTITY_NOT_CONFIGURED) {
+                // Sentinel constant (not free-text parsing): identity flow already navigated the user.
+                failureReason = 'git-identity-missing';
+            } else {
                 vscode.window.showErrorMessage(errorMessage);
             }
 
+            if (participationId !== undefined && !succeededEmitted) {
+                fireSubmission({ status: 'failed', participationId, failureReason });
+            }
         }
     };
 

--- a/extension/src/extension/controller/commands/repositorySubmitCommands.ts
+++ b/extension/src/extension/controller/commands/repositorySubmitCommands.ts
@@ -14,6 +14,22 @@ import type { CommandContext, CommandMap } from './types';
 const GIT_IDENTITY_NOT_CONFIGURED = 'GIT_IDENTITY_NOT_CONFIGURED';
 
 /**
+ * Maximum length of a commit message stored in the session recording. The full message is
+ * always used for the actual git commit; only the recorded copy is capped so a large pasted
+ * message cannot bloat events.jsonl, consistent with the truncation applied to file snapshots
+ * and terminal output elsewhere in the recorder.
+ */
+const MAX_RECORDED_COMMIT_MESSAGE_LENGTH = 512;
+
+/** Cap a commit message for the recording only — never the value committed to git. */
+function capRecordedCommitMessage(message: string | undefined): string | undefined {
+    if (message === undefined || message.length <= MAX_RECORDED_COMMIT_MESSAGE_LENGTH) {
+        return message;
+    }
+    return message.slice(0, MAX_RECORDED_COMMIT_MESSAGE_LENGTH);
+}
+
+/**
  * Helper functions injected via the constructor so tests can substitute
  * deterministic doubles. The defaults wire up to the production modules.
  *
@@ -65,7 +81,7 @@ export class RepositorySubmitCommands {
             participationId = typeof payload.participationId === 'number' ? payload.participationId : undefined;
             const exerciseTitle = payload.exerciseTitle ?? 'Exercise';
             const commitMessage = payload.commitMessage;
-            const rawCommitMessage = commitMessage?.trim() || undefined;
+            const rawCommitMessage = capRecordedCommitMessage(commitMessage?.trim() || undefined);
             if (participationId !== undefined) {
                 // fireSubmission is synchronous; the recorder's _record phase guard drops the event
                 // if no session is recording, so no session-state guard is needed at any call site.
@@ -136,7 +152,7 @@ export class RepositorySubmitCommands {
             // outer catch (the websocket reconnect has its own inner try/catch), but succeededEmitted
             // also hardens the "exactly one terminal per started" invariant against future edits.
             if (participationId !== undefined) {
-                fireSubmission({ status: 'succeeded', participationId, commitMessage: resolvedCommitMessage });
+                fireSubmission({ status: 'succeeded', participationId, commitMessage: capRecordedCommitMessage(resolvedCommitMessage) });
                 succeededEmitted = true;
             }
 

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -21,6 +21,7 @@ import { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
 import type { TelemetryManager } from '@extension/services/telemetry';
+import type { SubmissionPayload } from '@extension/services/telemetry/recording/types';
 import type { IProviderRegistry } from '@extension/services/ui';
 import {
     BuildDiagnosticsService,
@@ -93,11 +94,13 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     private readonly _onDidCloseTestResultsOverview = new vscode.EventEmitter<TestResultsOverviewClosedPayload>();
     private readonly _onDidOpenTaskFeedback = new vscode.EventEmitter<TaskFeedbackOpenedPayload>();
     private readonly _onDidCloseTaskFeedback = new vscode.EventEmitter<TaskFeedbackClosedPayload>();
+    private readonly _onDidSubmission = new vscode.EventEmitter<SubmissionPayload>();
 
     public readonly onDidOpenTestResultsOverview = this._onDidOpenTestResultsOverview.event;
     public readonly onDidCloseTestResultsOverview = this._onDidCloseTestResultsOverview.event;
     public readonly onDidOpenTaskFeedback = this._onDidOpenTaskFeedback.event;
     public readonly onDidCloseTaskFeedback = this._onDidCloseTaskFeedback.event;
+    public readonly onDidSubmission = this._onDidSubmission.event;
 
     // ── Constructor ────────────────────────────────────────────────────
     constructor(deps: ArtemisWebviewProviderDeps) {
@@ -244,6 +247,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             this._onDidCloseTestResultsOverview,
             this._onDidOpenTaskFeedback,
             this._onDidCloseTaskFeedback,
+            this._onDidSubmission,
         );
     }
 
@@ -390,6 +394,10 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
 
     public fireTaskFeedbackClosed(payload: TaskFeedbackClosedPayload): void {
         this._onDidCloseTaskFeedback.fire(payload);
+    }
+
+    public fireSubmission(payload: SubmissionPayload): void {
+        this._onDidSubmission.fire(payload);
     }
 
     // ── Public API: navigation delegation ──────────────────────────────

--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -48,6 +48,7 @@ import type {
     SessionMetadata,
     SessionStartEvent,
     StartupPhaseCompleteEvent,
+    SubmissionEvent,
     TaskFeedbackViewClosedEvent,
     TaskFeedbackViewEvent,
     TaskFeedbackViewOpenedEvent,
@@ -645,6 +646,27 @@ function parseBreakpointChange(d: Record<string, unknown>, timestamp: number): B
     return { type: 'breakpointChange', timestamp, action: d.action, breakpoints };
 }
 
+function parseSubmission(d: Record<string, unknown>, timestamp: number): SubmissionEvent | null {
+    if (!isOneOf(d.status, ['started', 'succeeded', 'failed'] as const)) { return null; }
+    if (!isFiniteNumber(d.participationId)) { return null; }
+    if (!isOptFiniteNumber(d.exerciseId)) { return null; }
+    if (!isOptString(d.commitMessage)) { return null; }
+    if (d.failureReason !== undefined
+        && !isOneOf(d.failureReason,
+            ['no-workspace', 'no-changes', 'git-identity-missing', 'merge-conflict', 'push-failed', 'other'] as const)) {
+        return null;
+    }
+    return stripUndefined({
+        type: 'submission' as const,
+        timestamp,
+        status: d.status,
+        participationId: d.participationId,
+        exerciseId: d.exerciseId as number | undefined,
+        commitMessage: d.commitMessage as string | undefined,
+        failureReason: d.failureReason as SubmissionEvent['failureReason'],
+    });
+}
+
 // ── Public dispatcher ─────────────────────────────────────────────────
 
 type EventParser = (d: Record<string, unknown>, timestamp: number) => RecordedEvent | null;
@@ -696,6 +718,7 @@ const EVENT_PARSERS = {
     taskFeedbackView: parseTaskFeedbackView,
     debugSession: parseDebugSession,
     breakpointChange: parseBreakpointChange,
+    submission: parseSubmission,
 } satisfies Record<RecordedEvent['type'], EventParser>;
 
 /**

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -42,7 +42,7 @@ import * as vscode from 'vscode';
 
 import type { ResultDTO, WebSocketMessageHandler } from '@extension/types';
 
-import type { RecordedEvent, SerializedErrorSnapshot } from './types';
+import type { RecordedEvent, SerializedErrorSnapshot, SubmissionPayload } from './types';
 
 /**
  * Distributive `Omit` over `RecordedEvent` — keeps each union variant intact
@@ -435,6 +435,21 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
             type: 'panelVisibility',
             panel,
             visible,
+        });
+    }
+
+    /**
+     * Record a submission lifecycle event (started/succeeded/failed). `exerciseId`
+     * is stamped from the active session, consistent with how buildResult is stamped.
+     */
+    recordSubmission(payload: SubmissionPayload): void {
+        this._record({
+            type: 'submission',
+            status: payload.status,
+            participationId: payload.participationId,
+            exerciseId: this._activeExerciseId,
+            commitMessage: payload.commitMessage,
+            failureReason: payload.failureReason,
         });
     }
 

--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -428,6 +428,40 @@ export interface BreakpointChangeEvent {
     }[];
 }
 
+// ── Submission events ─────────────────────────────────────────────────
+
+export type SubmissionFailureReason =
+    | 'no-workspace' | 'no-changes' | 'git-identity-missing'
+    | 'merge-conflict' | 'push-failed' | 'other';
+
+/**
+ * A student's Submit action. Recorded as a lifecycle (mirrors irisChatSendAttempt):
+ * `started` at the click instant, then `succeeded` after a successful push or
+ * `failed` with a categorised reason. Standalone but correlatable to the later
+ * `buildResult` by `participationId` + timestamp ordering (the server-assigned
+ * submissionId does not exist at submit time).
+ */
+export interface SubmissionEvent {
+    type: 'submission';
+    timestamp: number;
+    status: 'started' | 'succeeded' | 'failed';
+    /** Correlation key with buildResult. Required (submitExercise payload guarantees it). */
+    participationId: number;
+    /** Stamped by the recorder from the active session, consistent with buildResult. */
+    exerciseId?: number;
+    /** Raw intended text on `started`; resolved committed text on `succeeded`; omitted on `failed`. */
+    commitMessage?: string;
+    /** Present only on status === 'failed'. */
+    failureReason?: SubmissionFailureReason;
+}
+
+/**
+ * Data the submit command emits about a submission. The recorder stamps
+ * `timestamp` and `exerciseId`; everything else comes from the command.
+ * Pick keeps the field types a single source of truth with SubmissionEvent.
+ */
+export type SubmissionPayload = Pick<SubmissionEvent, 'status' | 'participationId' | 'commitMessage' | 'failureReason'>;
+
 // ── Discriminated union ───────────────────────────────────────────────
 
 export type RecordedEvent =
@@ -465,7 +499,8 @@ export type RecordedEvent =
     | TestResultsOverviewViewEvent
     | TaskFeedbackViewEvent
     | DebugSessionEvent
-    | BreakpointChangeEvent;
+    | BreakpointChangeEvent
+    | SubmissionEvent;
 
 // ── Session metadata ──────────────────────────────────────────────────
 

--- a/extension/src/extension/types/IArtemisWebviewProvider.ts
+++ b/extension/src/extension/types/IArtemisWebviewProvider.ts
@@ -7,6 +7,8 @@ import type {
     TestResultsOverviewOpenedPayload,
 } from '@shared/messageContracts/webviewCommands';
 
+import type { SubmissionPayload } from '@extension/services/telemetry/recording/types';
+
 /**
  * Minimal contract for the Artemis webview provider, exposing only what the
  * command-handler layer and sessionRecorderWiring need. Keeps the provider
@@ -17,9 +19,11 @@ export interface IArtemisWebviewProvider {
     fireTestResultsOverviewClosed(payload: TestResultsOverviewClosedPayload): void;
     fireTaskFeedbackOpened(payload: TaskFeedbackOpenedPayload): void;
     fireTaskFeedbackClosed(payload: TaskFeedbackClosedPayload): void;
+    fireSubmission(payload: SubmissionPayload): void;
 
     readonly onDidOpenTestResultsOverview: vscode.Event<TestResultsOverviewOpenedPayload>;
     readonly onDidCloseTestResultsOverview: vscode.Event<TestResultsOverviewClosedPayload>;
     readonly onDidOpenTaskFeedback: vscode.Event<TaskFeedbackOpenedPayload>;
     readonly onDidCloseTaskFeedback: vscode.Event<TaskFeedbackClosedPayload>;
+    readonly onDidSubmission: vscode.Event<SubmissionPayload>;
 }

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -36,6 +36,7 @@ import type {
     ConfigurationSnapshotEvent,
     InterventionEvent,
     RecordedEvent,
+    SubmissionPayload,
 } from '@extension/services/telemetry/recording/types';
 import { TelemetryManager } from '@extension/services/telemetry/telemetryManager';
 import type { InterventionDecision } from '@extension/services/telemetry/types';
@@ -95,6 +96,7 @@ function stubWebviewProvider(): ArtemisWebviewProvider {
     const onDidCloseOverview = new vscode.EventEmitter<TestResultsOverviewClosedPayload>();
     const onDidOpenTask = new vscode.EventEmitter<TaskFeedbackOpenedPayload>();
     const onDidCloseTask = new vscode.EventEmitter<TaskFeedbackClosedPayload>();
+    const onDidSubmission = new vscode.EventEmitter<SubmissionPayload>();
     return {
         getCurrentVisibility: () => false,
         onDidChangeViewNavigation: onDidChangeViewNavigation.event,
@@ -107,6 +109,8 @@ function stubWebviewProvider(): ArtemisWebviewProvider {
         fireTestResultsOverviewClosed: (p: TestResultsOverviewClosedPayload) => onDidCloseOverview.fire(p),
         fireTaskFeedbackOpened: (p: TaskFeedbackOpenedPayload) => onDidOpenTask.fire(p),
         fireTaskFeedbackClosed: (p: TaskFeedbackClosedPayload) => onDidCloseTask.fire(p),
+        onDidSubmission: onDidSubmission.event,
+        fireSubmission: (p: SubmissionPayload) => onDidSubmission.fire(p),
     } as unknown as ArtemisWebviewProvider;
 }
 
@@ -380,6 +384,19 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
             const payload: TaskFeedbackClosedPayload = { viewId: 'v', exerciseId: 1, taskName: 't', durationMs: 100, closeReason: 'button' };
             (harness.artemisWebviewProvider as unknown as { fireTaskFeedbackClosed: (p: TaskFeedbackClosedPayload) => void })
                 .fireTaskFeedbackClosed(payload);
+            sinon.assert.calledOnceWithExactly(recordStub, payload);
+        } finally {
+            await harness.dispose();
+        }
+    });
+
+    test('forwards onDidSubmission to the recorder', async () => {
+        const harness = await makeWiringHarness(sandbox, { enabled: true, showInterventions: true, developerMode: false });
+        try {
+            const recordStub = sandbox.stub(harness.recorder, 'recordSubmission');
+            const payload: SubmissionPayload = { status: 'started', participationId: 99, commitMessage: 'wip' };
+            (harness.artemisWebviewProvider as unknown as { fireSubmission: (p: SubmissionPayload) => void })
+                .fireSubmission(payload);
             sinon.assert.calledOnceWithExactly(recordStub, payload);
         } finally {
             await harness.dispose();

--- a/extension/test/unit/controller/repositorySubmitCommands.test.ts
+++ b/extension/test/unit/controller/repositorySubmitCommands.test.ts
@@ -59,17 +59,22 @@ suite('RepositorySubmitCommands', () => {
         sendMessage: sinon.SinonStub;
         showGitCredentials: sinon.SinonStub;
         recheckRepoStatus: sinon.SinonStub;
+        fireSubmission: sinon.SinonStub;
     } {
         const sendMessage = overrides.sendMessage ?? sandbox.stub();
         const recheckRepoStatus = overrides.recheckRepoStatus ?? sandbox.stub().resolves();
         const showGitCredentials = overrides.showGitCredentials ?? sandbox.stub();
+        const fireSubmission = sandbox.stub();
         const ctx = {
             actionHandler: { showGitCredentials },
             sendMessage,
             recheckRepoStatus,
             getWebsocketService: overrides.getWebsocketService,
+            providerRegistry: {
+                getArtemisWebviewProvider: () => ({ fireSubmission }),
+            },
         } as unknown as CommandContext;
-        return { ctx, sendMessage, showGitCredentials, recheckRepoStatus };
+        return { ctx, sendMessage, showGitCredentials, recheckRepoStatus, fireSubmission };
     }
 
     setup(() => {
@@ -423,5 +428,148 @@ suite('RepositorySubmitCommands', () => {
             name: '',
             email: '',
         });
+    });
+
+    test('happy path emits started then succeeded (exactly one terminal)', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'My change' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.deepStrictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.deepStrictEqual(fireSubmission.getCall(0).args[0].participationId, 42);
+        assert.deepStrictEqual(fireSubmission.getCall(1).args[0].status, 'succeeded');
+        assert.deepStrictEqual(fireSubmission.getCall(1).args[0].participationId, 42);
+    });
+
+    test('no-changes emits started then failed with reason no-changes', async () => {
+        checkWorkspaceFiles.resolves({ hasChanges: false, files: [] });
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Ex', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'no-changes');
+    });
+
+    test('merge-conflict emits failed with reason merge-conflict', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ pullWithRebase: sandbox.stub().rejects(new Error('CONFLICT (content): Merge conflict in foo.ts')) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'merge-conflict');
+    });
+
+    test('push failure emits failed with reason push-failed', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ push: sandbox.stub().rejects(new Error('fatal: push rejected')) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'push-failed');
+    });
+
+    test('git-identity-not-configured emits failed with reason git-identity-missing', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ getIdentity: sandbox.stub().resolves(undefined) });
+        showWarningMessage.resolves('Configure Git Identity' as never);
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'git-identity-missing');
+    });
+
+    test('no-workspace emits started then failed with reason no-workspace', async () => {
+        // The default setup stubs workspaceFolders to a present folder, so override it to undefined
+        // for this test. Mirror the existing "no workspace folder" abort test's sandbox-reset approach.
+        sandbox.restore();
+        sandbox = sinon.createSandbox();
+        showErrorMessage = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined as never);
+        showWarningMessage = sandbox.stub(vscode.window, 'showWarningMessage').resolves(undefined as never);
+        showInformationMessage = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined as never);
+        sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+        withProgress = sandbox.stub(vscode.window, 'withProgress');
+        checkWorkspaceFiles = sandbox.stub();
+
+        // buildContext() is called AFTER the fresh sandbox is set up so its fireSubmission stub
+        // belongs to the active sandbox and is the one the handler actually calls.
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Ex', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'no-workspace');
+    });
+
+    test('generic failure emits failed with reason other', async () => {
+        // Default setup (workspace present, hasChanges true). An early git step throws a generic
+        // error (non-conflict, non-sentinel) so the catch falls through to the default 'other'.
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ addAll: sandbox.stub().rejects(new Error('disk full')) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'other');
+    });
+
+    test('emits nothing when the payload has no participationId', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 0);
     });
 });

--- a/extension/test/unit/controller/repositorySubmitCommands.test.ts
+++ b/extension/test/unit/controller/repositorySubmitCommands.test.ts
@@ -445,6 +445,47 @@ suite('RepositorySubmitCommands', () => {
         assert.deepStrictEqual(fireSubmission.getCall(0).args[0].participationId, 42);
         assert.deepStrictEqual(fireSubmission.getCall(1).args[0].status, 'succeeded');
         assert.deepStrictEqual(fireSubmission.getCall(1).args[0].participationId, 42);
+        // commitMessage is the field that distinguishes the lifecycle states (raw on started,
+        // resolved on succeeded); here both carry the provided text verbatim.
+        assert.strictEqual(fireSubmission.getCall(0).args[0].commitMessage, 'My change');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].commitMessage, 'My change');
+    });
+
+    test('blank commitMessage: started carries undefined, succeeded carries the configured default', async () => {
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: '' },
+        } as never);
+
+        assert.strictEqual(fireSubmission.callCount, 2);
+        // Raw (started) text is blank -> undefined; resolved (succeeded) falls back to the configured default.
+        // This is the only case where the raw and resolved values diverge.
+        assert.strictEqual(fireSubmission.getCall(0).args[0].commitMessage, undefined);
+        assert.strictEqual(fireSubmission.getCall(1).args[0].commitMessage, 'Solution submission via Iris extension');
+    });
+
+    test('recorded commitMessage is capped to 512 chars without truncating the real git commit', async () => {
+        const longMessage = 'a'.repeat(1000);
+        const { ctx, fireSubmission } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: longMessage },
+        } as never);
+
+        // The actual git commit must receive the FULL message — the cap is recording-only.
+        sinon.assert.calledOnceWithExactly(stubs.commit, longMessage, { cwd: '/ws' });
+
+        // Both recorded events carry the capped (512-char) copy.
+        assert.strictEqual(fireSubmission.getCall(0).args[0].commitMessage.length, 512);
+        assert.strictEqual(fireSubmission.getCall(1).args[0].commitMessage.length, 512);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].commitMessage, longMessage.slice(0, 512));
     });
 
     test('no-changes emits started then failed with reason no-changes', async () => {

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -660,4 +660,12 @@ suite('parseRecordedEvent — submission', () => {
     test('rejects an unknown failureReason', () => {
         assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'failed', participationId: 1, failureReason: 'nope' }), null);
     });
+
+    test('rejects a non-numeric exerciseId', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'started', participationId: 1, exerciseId: '7' }), null);
+    });
+
+    test('rejects a non-string commitMessage', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'started', participationId: 1, commitMessage: 123 }), null);
+    });
 });

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -615,3 +615,49 @@ suite('parseRecordedEvent — debug/breakpoint per-variant rejection', () => {
         );
     });
 });
+
+suite('parseRecordedEvent — submission', () => {
+    test('round-trips a started submission', () => {
+        const ev = { type: 'submission', timestamp: 100, status: 'started', participationId: 42, commitMessage: 'wip' };
+        assert.deepStrictEqual(parseRecordedEvent(ev), ev);
+    });
+
+    test('round-trips a succeeded submission with exerciseId', () => {
+        const ev = { type: 'submission', timestamp: 200, status: 'succeeded', participationId: 42, exerciseId: 7, commitMessage: 'final' };
+        assert.deepStrictEqual(parseRecordedEvent(ev), ev);
+    });
+
+    test('round-trips a failed submission with a failureReason', () => {
+        const ev = { type: 'submission', timestamp: 300, status: 'failed', participationId: 42, failureReason: 'merge-conflict' };
+        assert.deepStrictEqual(parseRecordedEvent(ev), ev);
+    });
+
+    test('omits absent optional fields (no undefined keys)', () => {
+        const ev = { type: 'submission', timestamp: 400, status: 'started', participationId: 1 };
+        const parsed = parseRecordedEvent(ev);
+        assert.deepStrictEqual(parsed, ev);
+        assert.ok(parsed && parsed.type === 'submission', 'should parse as a submission event');
+        assert.ok(parsed && !('exerciseId' in parsed));
+        assert.ok(parsed && !('failureReason' in parsed));
+    });
+
+    test('rejects missing status', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, participationId: 1 }), null);
+    });
+
+    test('rejects an unknown status', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'queued', participationId: 1 }), null);
+    });
+
+    test('rejects missing participationId', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'started' }), null);
+    });
+
+    test('rejects a non-numeric participationId', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'started', participationId: '1' }), null);
+    });
+
+    test('rejects an unknown failureReason', () => {
+        assert.strictEqual(parseRecordedEvent({ type: 'submission', timestamp: 1, status: 'failed', participationId: 1, failureReason: 'nope' }), null);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
@@ -24,6 +24,7 @@ import type {
     ConfigurationSnapshotEvent,
     InterventionEvent,
     RecordedEvent,
+    SubmissionEvent,
 } from '@extension/services/telemetry/recording/types';
 
 /**
@@ -665,6 +666,40 @@ suite('SessionRecorder (Block AB+E)', () => {
         const panelEvents = events.filter(e => e.type === 'panelVisibility');
         assert.strictEqual(panelEvents.length, 0,
             'panelVisibility before startSession must not be recorded');
+    });
+
+    // ── Test: recordSubmission stamps exerciseId and respects recording phase ──
+
+    test('recordSubmission stamps exerciseId from the active session and records the payload', async () => {
+        recorder.enable();
+        await recorder.startSession(7);
+        recorder.recordSubmission({ status: 'started', participationId: 42, commitMessage: 'wip' });
+        await recorder.endSession();
+
+        const events = collectWrittenEvents(fs);
+        const submission = events.find((e): e is SubmissionEvent => e.type === 'submission');
+        assert.ok(submission, 'expected a submission event');
+        assert.strictEqual(submission!.status, 'started');
+        assert.strictEqual(submission!.participationId, 42);
+        assert.strictEqual(submission!.exerciseId, 7);
+        assert.strictEqual(submission!.commitMessage, 'wip');
+    });
+
+    test('recordSubmission is dropped when not recording', async () => {
+        // Recorder is enabled but no session has started, so the phase is not
+        // 'recording' and _record must short-circuit. Mirroring the
+        // recordPanelVisibility no-op test, we prove nothing was written by
+        // inspecting the actual event stream, not just the trivial eventCount.
+        recorder.enable();
+
+        recorder.recordSubmission({ status: 'failed', participationId: 1, failureReason: 'push-failed' });
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const events = collectWrittenEvents(fs);
+        assert.strictEqual(events.filter(e => e.type === 'submission').length, 0,
+            'submission before startSession must not be recorded');
+        assert.strictEqual(recorder.eventCount, 0);
     });
 
     // ── Block J: Per-URI debounce tests ───────────────────────────────────

--- a/recording-viewer/src/components/EventStream.tsx
+++ b/recording-viewer/src/components/EventStream.tsx
@@ -290,6 +290,14 @@ export function EventDetail({ event }: { event: RecordedEvent }) {
                 </span>
             );
         }
+        case 'submission':
+            return (
+                <span className="event-detail">
+                    SUBMIT {event.status.toUpperCase()} | participation {event.participationId}
+                    {event.commitMessage && ` | "${event.commitMessage.length > 60 ? event.commitMessage.slice(0, 60) + '...' : event.commitMessage}"`}
+                    {event.failureReason && <span className="event-error"> — {event.failureReason}</span>}
+                </span>
+            );
         default:
             return null;
     }

--- a/recording-viewer/src/components/TrackingTimeline.tsx
+++ b/recording-viewer/src/components/TrackingTimeline.tsx
@@ -142,6 +142,8 @@ export function eventSummary(event: RecordedEvent, sessionStartTime: number): Re
             const where = first ? formatBreakpointLocation(first.uri, first.line) : '';
             return <><span className="tt-time">{time}</span> {event.action} | {event.breakpoints.length} bp{event.breakpoints.length === 1 ? '' : 's'}{where ? ` | ${where}` : ''}</>;
         }
+        case 'submission':
+            return <><span className="tt-time">{time}</span> SUBMIT {event.status.toUpperCase()} | participation {event.participationId}{event.failureReason ? ` — ${event.failureReason}` : ''}</>;
         default:
             return <span className="tt-time">{time}</span>;
     }

--- a/recording-viewer/src/constants.ts
+++ b/recording-viewer/src/constants.ts
@@ -36,12 +36,13 @@ export const MARKER_COLORS: Record<EventType, string> = {
     textDocumentClose: '#93c5fd',
     debugSession: '#f59e0b',
     breakpointChange: '#ef4444',
+    submission: '#10b981',
 };
 
 export const ALL_EVENT_TYPES = [
     'sessionStart', 'sessionEnd', 'consentChange', 'startupPhaseComplete',
     'configurationSnapshot', 'configurationChange',
-    'eqSnapshot', 'eqEngineState', 'intervention', 'buildResult',
+    'eqSnapshot', 'eqEngineState', 'intervention', 'buildResult', 'submission',
     'textChange', 'save',
     'diagnostics',
     'fileSwitch',

--- a/recording-viewer/src/generated/recordingTypes.ts
+++ b/recording-viewer/src/generated/recordingTypes.ts
@@ -423,6 +423,40 @@ export interface BreakpointChangeEvent {
     }[];
 }
 
+// ── Submission events ─────────────────────────────────────────────────
+
+export type SubmissionFailureReason =
+    | 'no-workspace' | 'no-changes' | 'git-identity-missing'
+    | 'merge-conflict' | 'push-failed' | 'other';
+
+/**
+ * A student's Submit action. Recorded as a lifecycle (mirrors irisChatSendAttempt):
+ * `started` at the click instant, then `succeeded` after a successful push or
+ * `failed` with a categorised reason. Standalone but correlatable to the later
+ * `buildResult` by `participationId` + timestamp ordering (the server-assigned
+ * submissionId does not exist at submit time).
+ */
+export interface SubmissionEvent {
+    type: 'submission';
+    timestamp: number;
+    status: 'started' | 'succeeded' | 'failed';
+    /** Correlation key with buildResult. Required (submitExercise payload guarantees it). */
+    participationId: number;
+    /** Stamped by the recorder from the active session, consistent with buildResult. */
+    exerciseId?: number;
+    /** Raw intended text on `started`; resolved committed text on `succeeded`; omitted on `failed`. */
+    commitMessage?: string;
+    /** Present only on status === 'failed'. */
+    failureReason?: SubmissionFailureReason;
+}
+
+/**
+ * Data the submit command emits about a submission. The recorder stamps
+ * `timestamp` and `exerciseId`; everything else comes from the command.
+ * Pick keeps the field types a single source of truth with SubmissionEvent.
+ */
+export type SubmissionPayload = Pick<SubmissionEvent, 'status' | 'participationId' | 'commitMessage' | 'failureReason'>;
+
 // ── Discriminated union ───────────────────────────────────────────────
 
 export type RecordedEvent =
@@ -460,7 +494,8 @@ export type RecordedEvent =
     | TestResultsOverviewViewEvent
     | TaskFeedbackViewEvent
     | DebugSessionEvent
-    | BreakpointChangeEvent;
+    | BreakpointChangeEvent
+    | SubmissionEvent;
 
 // ── Session metadata ──────────────────────────────────────────────────
 

--- a/recording-viewer/test/submissionRendering.test.tsx
+++ b/recording-viewer/test/submissionRendering.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import type { RecordedEvent } from '../src/types';
+import { eventSummary } from '../src/components/TrackingTimeline';
+import { EventDetail } from '../src/components/EventStream';
+
+const started: RecordedEvent = { type: 'submission', timestamp: 1000, status: 'started', participationId: 42, commitMessage: 'wip' };
+const succeeded: RecordedEvent = { type: 'submission', timestamp: 2000, status: 'succeeded', participationId: 42, exerciseId: 7, commitMessage: 'final' };
+const failed: RecordedEvent = { type: 'submission', timestamp: 3000, status: 'failed', participationId: 42, failureReason: 'merge-conflict' };
+
+describe('submission event rendering', () => {
+    it('eventSummary renders the status', () => {
+        expect(render(<>{eventSummary(started, 0)}</>).container.textContent).toContain('SUBMIT');
+        expect(render(<>{eventSummary(succeeded, 0)}</>).container.textContent).toContain('SUCCEEDED');
+    });
+
+    it('eventSummary renders the failure reason', () => {
+        expect(render(<>{eventSummary(failed, 0)}</>).container.textContent).toContain('merge-conflict');
+    });
+
+    it('EventDetail renders the status and participation', () => {
+        const text = render(<EventDetail event={succeeded} />).container.textContent ?? '';
+        expect(text).toContain('SUCCEEDED');
+        expect(text).toContain('42');
+    });
+
+    it('EventDetail renders the failure reason', () => {
+        expect((render(<EventDetail event={failed} />).container.textContent ?? '')).toContain('merge-conflict');
+    });
+});


### PR DESCRIPTION
## Summary

Records an explicit `submission` event when a student presses Submit, so the submit action is visible in the session recording at the moment it happens, separate from the `buildResult` that arrives over the websocket seconds later.

Closes #234.

## Motivation

The recorder previously captured only the build result; the submit action itself was invisible. A failed submit (no local changes, merge conflict, push failure, missing git identity) produces no `buildResult` at all, so it was completely untracked even though it is a useful signal.

## Approach

A `submission` event with a `started` then `succeeded`/`failed` lifecycle (mirrors the existing `irisChatSendAttempt` idiom):

- Fired from `handleSubmitExercise` via the existing decoupled path (command, `ArtemisWebviewProvider.fireSubmission`, `sessionRecorderWiring`, `SessionRecorder.recordSubmission`), the same pattern used for test-results tracking.
- `handleSubmitExercise` is restructured into a single-failure-funnel so every emitted `started` is followed by exactly one terminal event (`succeeded` XOR `failed`), with a categorised `failureReason` (`no-workspace`, `no-changes`, `git-identity-missing`, `merge-conflict`, `push-failed`, `other`).
- Standalone but correlatable: the event carries `participationId` (and a recorder-stamped `exerciseId`), the same fields `buildResult` carries, so analysis can pair "pressed submit" with "got result" by `participationId` and timestamp ordering. The server-assigned `submissionId` does not exist at submit time, so no hard link is possible or needed.
- Validated in `parseRecordedData.ts` through the compile-checked `EVENT_PARSERS` table, and rendered in the recording-viewer timeline and event stream.

## Testing

- Parser: round-trip plus rejection unit tests.
- Recorder: `recordSubmission` stamps `exerciseId` from the active session, and is dropped when not recording.
- Command: the started/succeeded/failed emit sequence and all six failure reasons, exactly one terminal per started, nothing emitted without a `participationId`, and all pre-existing submit tests preserved.
- Wiring: `onDidSubmission` forwards to `recordSubmission`.
- Viewer: render tests for both switch consumers.
- Full extension unit suite green (1227 tests), full viewer suite green.

Purely additive, no migration needed.
