### PR TITLE
ci: gate recording-viewer with lint, test, and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,60 @@ jobs:
       - run: npm run package
       - run: npx @vscode/vsce package --no-dependencies
 
+  viewer-lint:
+    name: Viewer lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: recording-viewer
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: recording-viewer/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+
+  viewer-test:
+    name: Viewer unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: recording-viewer
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: recording-viewer/package-lock.json
+      - run: npm ci
+      - run: npx vitest run
+
+  viewer-build:
+    name: Viewer build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: recording-viewer
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: recording-viewer/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
   ci-gate:
     name: CI gate
-    needs: [typecheck, lint, test, knip, build]
+    needs: [typecheck, lint, test, knip, build, viewer-lint, viewer-test, viewer-build]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     if: always()


### PR DESCRIPTION
## Problem

The `recording-viewer/` subproject has no CI coverage. Every job in
`.github/workflows/ci.yml` inherits the top-level `defaults.run.working-directory: extension`
and uses `cache-dependency-path: extension/package-lock.json`, so typecheck, lint, test, knip,
and build all run against `extension/` only. The viewer's ~30 test files, its lint, and its build
have never gated a PR, so a change that breaks viewer types, lint, tests, or the Vite bundle can
merge silently.

## Change

Add three jobs that run inside `recording-viewer/` and require them via the `CI gate` aggregator:

- **Viewer lint** — `npm run lint`
- **Viewer unit tests** — `npx vitest run`
- **Viewer build** — `npm run build` (= `tsc -b && vite build`)

The build job runs `tsc -b`, so type checking is covered there; a separate typecheck job would
only duplicate `npm ci` and `tsc -b` for marginal granularity, so it is intentionally omitted.

`dev` branch protection requires only the `CI gate` check, so adding these jobs to the
aggregator's `needs` makes them blocking automatically — no branch-protection change is needed.

## Verification

Locally from `recording-viewer/`:

- `npm run lint` — clean
- `npx vitest run` — 283 passed (run twice, non-flaky)
- `npm run build` — succeeds

Only `.github/workflows/ci.yml` is touched.
