### PR TITLE
fix(viewer): handle write-stream errors in video upload

### DIFF
--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -903,12 +903,32 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
             let headerValidated = false;
             let rejected = false;
             let requestEnded = false;
+            let settled = false;
 
             const cleanup = () => {
                 ws.destroy();
                 try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
                 uploadInProgress.delete(sessionId);
             };
+
+            // Send exactly one response for this upload. Guards every exit path
+            // (reject, success, stream error) against a double-send.
+            const respond = (status: number, payload: unknown) => {
+                if (settled) return;
+                settled = true;
+                sendJson(res, status, payload);
+            };
+
+            // The write stream does async I/O, so an error (its lazy fd open
+            // losing a race with a concurrent directory removal — e.g. a test's
+            // afterEach cleanup — or a disk failure) must be handled. Left
+            // unhandled it crashes the process. Tear down and, if nothing has
+            // responded yet, fail the upload.
+            ws.on('error', () => {
+                rejected = true;
+                cleanup();
+                respond(500, { error: 'Video upload failed' });
+            });
 
             req.on('data', (chunk: Buffer) => {
                 if (rejected) return;
@@ -928,7 +948,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
                     if (!valid) {
                         rejected = true;
                         cleanup();
-                        sendJson(res, 400, { error: `Invalid ${ext.toUpperCase()} file (bad magic bytes)` });
+                        respond(400, { error: `Invalid ${ext.toUpperCase()} file (bad magic bytes)` });
                         return;
                     }
                     // Write accumulated header buffer
@@ -970,11 +990,11 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
                         }
 
                         uploadInProgress.delete(sessionId);
-                        sendJson(res, 200, { ok: true, videoExtension: ext });
+                        respond(200, { ok: true, videoExtension: ext });
                     } catch (err) {
                         try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
                         uploadInProgress.delete(sessionId);
-                        sendJson(res, 500, { error: String(err) });
+                        respond(500, { error: String(err) });
                     }
                 });
             });
@@ -982,6 +1002,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
             req.on('error', () => {
                 if (rejected) return;
                 rejected = true;
+                settled = true; // client gone; suppress any late error response
                 cleanup();
             });
 
@@ -990,6 +1011,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
                 if (rejected || requestEnded) return;
                 // Request closed before 'end' fired — this is a genuine abort
                 rejected = true;
+                settled = true; // genuine abort; suppress any late error response
                 cleanup();
             });
 


### PR DESCRIPTION
## Problem

The video-upload handler (`PUT /api/recordings/:id/video`) streams the request body to a temp
file via `fs.createWriteStream(tmpPath)` but never attached an `'error'` listener to that stream.

The write stream's fd `open` is asynchronous. On the magic-bytes reject path the handler calls
`ws.destroy()`, but the still-pending `open` can fail *after* the response was already sent. This
shows up most reliably in tests: `afterEach` runs `fs.rmSync(tmpDir)` before the open completes, so
the open fails with `ENOENT` against the now-deleted directory. With no `'error'` listener, that
becomes an **unhandled error** that fails the entire `vitest run` even though all 283 tests pass.
It is also a latent process-crash risk in production (disk full, permissions, etc.).

This surfaced once the new viewer CI gate started running the server tests; locally it is timing-
dependent and rarely reproduces, but it broke CI intermittently.

## Fix

- Attach `ws.on('error')`: tear down and, if nothing has responded yet, return `500`.
- Route all three exit points (reject `400`, success `200`, catch `500`) through a single-response
  `respond()` guard, so a late stream error can never double-send.
- Set `rejected` on stream error so subsequent `data`/`end` events stop writing to the destroyed
  stream.
- Mark the abort paths `settled` so a later stream error cannot reply to a client that already
  disconnected (preserves the prior "abort sends no response" behaviour).

## Verification

- Reproduced **deterministically** in a standalone harness of the exact pattern: the old code
  produced an unhandled `ENOENT` on 400/400 iterations; with the `'error'` listener, 0/400.
- From `recording-viewer/`: `npm run lint` clean, `npx vitest run` 283 passed, `npm run build`
  succeeds. Only `server/recordingsApi.ts` changes.
