### PR TITLE
fix(viewer): harmonize event detail/tooltip drift (#243)

### DIFF
--- a/recording-viewer/src/utils/eventDisplay.tsx
+++ b/recording-viewer/src/utils/eventDisplay.tsx
@@ -117,8 +117,7 @@ export function eventDetail(event: RecordedEvent): React.ReactNode {
         case 'intervention':
             return (
                 <span className="event-detail">
-                    {event.action.toUpperCase()} | {event.level}
-                    {' '} EQ: <strong>{Math.round(event.eq * 100)}%</strong>
+                    {event.action.toUpperCase()} | {event.level} | EQ: <strong>{Math.round(event.eq * 100)}%</strong>
                     {event.triggerType && ` | ${event.triggerType}`}
                 </span>
             );
@@ -266,11 +265,11 @@ export function eventSummary(event: RecordedEvent, sessionStartTime: number): Re
         case 'fileSwitch':
             return <><span className="tt-time">{time}</span> {shortenUri(event.fromUri)} → {shortenUri(event.toUri)}</>;
         case 'buildResult':
-            return <><span className="tt-time">{time}</span> {event.buildFailed ? 'BUILD FAILED' : event.successful ? 'PASSED' : `${event.errorCount} error(s)`}</>;
+            return <><span className="tt-time">{time}</span> {event.buildFailed ? 'BUILD FAILED' : event.successful ? 'PASSED' : `${event.errorCount} error(s)`}{event.failedTests.length > 0 ? ` | ${event.failedTests.length} test(s) failed` : ''}</>;
         case 'eqSnapshot':
             return <><span className="tt-time">{time}</span> EQ: {Math.round(event.eq * 100)}% ({event.confidence})</>;
         case 'eqEngineState':
-            return <><span className="tt-time">{time}</span> EQ: {Math.round(event.currentEQ * 100)}% | {event.snapshots.length} snapshot(s)</>;
+            return <><span className="tt-time">{time}</span> EQ: {Math.round(event.currentEQ * 100)}% ({event.confidence}) | {event.snapshots.length} snapshot(s)</>;
         case 'sessionStart':
             return <><span className="tt-time">{time}</span> Exercise {event.exerciseId}{event.participantId ? ` | ${event.participantId}` : ''}</>;
         case 'sessionEnd':
@@ -286,11 +285,11 @@ export function eventSummary(event: RecordedEvent, sessionStartTime: number): Re
         case 'fileSnapshot':
             return <><span className="tt-time">{time}</span> {shortenUri(event.uri)}</>;
         case 'selectionChange':
-            return <><span className="tt-time">{time}</span> {shortenUri(event.uri)} | L{event.selections[0]?.startLine ?? 0}{event.kind ? ` (${event.kind})` : ''}</>;
+            return <><span className="tt-time">{time}</span> {shortenUri(event.uri)} | L{event.selections[0]?.startLine ?? 0}:{event.selections[0]?.startCharacter ?? 0}{event.kind ? ` (${event.kind})` : ''}</>;
         case 'visibleRangeChange':
             return <><span className="tt-time">{time}</span> {shortenUri(event.uri)} | L{event.visibleRanges[0]?.startLine ?? 0}-L{event.visibleRanges[0]?.endLine ?? 0}</>;
         case 'intervention':
-            return <><span className="tt-time">{time}</span> {event.action} | {event.level} | EQ: {Math.round(event.eq * 100)}%{event.triggerType ? ` | ${event.triggerType}` : ''}</>;
+            return <><span className="tt-time">{time}</span> {event.action.toUpperCase()} | {event.level} | EQ: {Math.round(event.eq * 100)}%{event.triggerType ? ` | ${event.triggerType}` : ''}</>;
         case 'viewNavigation':
             return <><span className="tt-time">{time}</span> {event.from} → {event.to}</>;
         case 'panelVisibility':
@@ -316,7 +315,7 @@ export function eventSummary(event: RecordedEvent, sessionStartTime: number): Re
             return <><span className="tt-time">{time}</span> {parts.join(' | ')}</>;
         }
         case 'terminalCommand':
-            return <><span className="tt-time">{time}</span> <code>{event.command.length > 40 ? event.command.slice(0, 40) + '...' : event.command}</code> exit: {event.exitCode ?? '?'}</>;
+            return <><span className="tt-time">{time}</span> <code>{event.command.length > 40 ? event.command.slice(0, 40) + '...' : event.command}</code> exit: {event.exitCode ?? '?'} ({Math.round(event.durationMs / 1000)}s){event.outputTruncated ? ' [truncated]' : ''}</>;
         case 'terminalOpenClose':
             return <><span className="tt-time">{time}</span> {event.action} | {event.terminalName}</>;
         case 'fileSnapshotError':
@@ -339,7 +338,7 @@ export function eventSummary(event: RecordedEvent, sessionStartTime: number): Re
             return <><span className="tt-time">{time}</span> {event.action} | {event.breakpoints.length} bp{event.breakpoints.length === 1 ? '' : 's'}{where ? ` | ${where}` : ''}</>;
         }
         case 'submission':
-            return <><span className="tt-time">{time}</span> SUBMIT {event.status.toUpperCase()} | participation {event.participationId}{event.failureReason ? ` — ${event.failureReason}` : ''}</>;
+            return <><span className="tt-time">{time}</span> SUBMIT {event.status.toUpperCase()} | participation {event.participationId}{event.commitMessage ? ` | "${event.commitMessage.length > 40 ? event.commitMessage.slice(0, 40) + '...' : event.commitMessage}"` : ''}{event.failureReason ? ` — ${event.failureReason}` : ''}</>;
         default:
             return <span className="tt-time">{time}</span>;
     }

--- a/recording-viewer/test/eventDisplayDrift.test.tsx
+++ b/recording-viewer/test/eventDisplayDrift.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import type { RecordedEvent } from '../src/types';
+import { eventSummary, eventDetail } from '../src/utils/eventDisplay';
+
+// #243: the event-stream detail row (eventDetail) and the timeline tooltip
+// (eventSummary) had drifted on a handful of fields. The differences below were
+// classified as accidental and harmonized so the tooltip surfaces the same
+// information as the detail row. Each test asserts both views surface the
+// harmonized field (and, where the field is conditional, that it's omitted when
+// it should be). This guards the specific fields fixed here against re-drift; it
+// is not a full-string equality check — the two views intentionally differ in
+// styling and verbosity.
+
+const detailText = (e: RecordedEvent) => render(<>{eventDetail(e)}</>).container.textContent ?? '';
+const summaryText = (e: RecordedEvent) => render(<>{eventSummary(e, 0)}</>).container.textContent ?? '';
+
+describe('eventDisplay drift harmonization (#243)', () => {
+    it('intervention: both views uppercase the action and separate level from EQ with a pipe', () => {
+        const e: RecordedEvent = {
+            type: 'intervention', timestamp: 1000, action: 'dismissed', level: 'notification',
+            shouldIntervene: true, eq: 0.42, confidence: 'sufficient', triggerType: 'idle',
+        };
+        for (const text of [detailText(e), summaryText(e)]) {
+            expect(text).toContain('DISMISSED');
+            expect(text).toContain('notification | EQ:');
+        }
+    });
+
+    it('eqEngineState: both views show the confidence', () => {
+        const e: RecordedEvent = {
+            type: 'eqEngineState', timestamp: 1000, snapshots: [], currentEQ: 0.5,
+            pairCount: 3, confidence: 'sufficient',
+        };
+        expect(detailText(e)).toContain('sufficient');
+        expect(summaryText(e)).toContain('sufficient');
+    });
+
+    it('buildResult: both views show the failed-test count', () => {
+        const e: RecordedEvent = {
+            type: 'buildResult', timestamp: 1000, successful: false, errorCount: 0,
+            failedTests: ['t1', 't2'], buildFailed: false,
+        };
+        expect(detailText(e)).toContain('2 test(s) failed');
+        expect(summaryText(e)).toContain('2 test(s) failed');
+    });
+
+    it('buildResult: neither view shows a failed-test count when there are none', () => {
+        const e: RecordedEvent = {
+            type: 'buildResult', timestamp: 1000, successful: true, errorCount: 0,
+            failedTests: [], buildFailed: false,
+        };
+        expect(detailText(e)).not.toContain('test(s) failed');
+        expect(summaryText(e)).not.toContain('test(s) failed');
+    });
+
+    it('terminalCommand: both views show duration and the truncated flag', () => {
+        const e: RecordedEvent = {
+            type: 'terminalCommand', timestamp: 1000, command: 'gradle test', exitCode: 1,
+            output: 'x', outputTruncated: true, cwd: '/w', terminalName: 'bash', durationMs: 3000,
+        };
+        for (const text of [detailText(e), summaryText(e)]) {
+            expect(text).toContain('(3s)');
+            expect(text).toContain('[truncated]');
+        }
+    });
+
+    it('terminalCommand: neither view shows the truncated flag when output is whole', () => {
+        const e: RecordedEvent = {
+            type: 'terminalCommand', timestamp: 1000, command: 'ls', exitCode: 0,
+            output: 'x', outputTruncated: false, cwd: '/w', terminalName: 'bash', durationMs: 1000,
+        };
+        expect(detailText(e)).not.toContain('[truncated]');
+        expect(summaryText(e)).not.toContain('[truncated]');
+    });
+
+    it('selectionChange: both views show line and column', () => {
+        const e: RecordedEvent = {
+            type: 'selectionChange', timestamp: 1000, uri: 'file:///w/Main.java',
+            selections: [{ startLine: 9, startCharacter: 4, endLine: 9, endCharacter: 10 }],
+            kind: 'mouse',
+        };
+        expect(detailText(e)).toContain('L9:4');
+        expect(summaryText(e)).toContain('L9:4');
+    });
+
+    it('submission: both views show the commit message', () => {
+        const e: RecordedEvent = {
+            type: 'submission', timestamp: 1000, status: 'started', participationId: 42,
+            commitMessage: 'fix off-by-one',
+        };
+        expect(detailText(e)).toContain('fix off-by-one');
+        expect(summaryText(e)).toContain('fix off-by-one');
+    });
+});


### PR DESCRIPTION
Closes #243.

## What

#242 split the per-event-type render switch into one module (`eventDisplay.tsx`) verbatim, preserving pre-existing inconsistencies between the detail row (`eventDetail`) and the timeline tooltip (`eventSummary`). This audits each event type and harmonizes the differences that were accidental drift rather than deliberate compact-vs-full design.

## Harmonized (tooltip now matches the detail row)

| Event | Was missing / different in the tooltip |
|-------|----------------------------------------|
| intervention | action not uppercased; detail used a space before EQ, tooltip a pipe → both now read "ACTION \| level \| EQ" |
| eqEngineState | confidence not shown (detail shows it; eqSnapshot shows it in both) |
| buildResult | "\| N test(s) failed" not shown on failures |
| terminalCommand | duration "(Xs)" and the "[truncated]" flag not shown |
| submission | commit message not shown (now shown, truncated to 40 chars; the detail row keeps 60) |
| selectionChange | column not shown (now "L&lt;line&gt;:&lt;col&gt;") |

## Kept intentional (styling / compactness, not drift)

Tooltip time prefix, rich styling vs plain text, the text-vs-counts split in textChange, "bp" vs "breakpoint(s)" wording, the shorter tooltip truncation lengths, and the eqEngineState field ordering.

## Tests

New `eventDisplayDrift.test.tsx` asserts both renderers surface each harmonized field, and omit the conditional ones (failedTests, [truncated]) when absent. Viewer gates green locally: vitest 291 passed, eslint clean, vite build ok.
