### PR TITLE
ci(release): simplify branch selection + harden release edge cases

### DIFF
--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -115,16 +115,41 @@ jobs:
             exit 1
           fi
 
-      - name: Verify CHANGELOG entry exists
+      - name: Extract and validate changelog notes
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          marker="## [$INPUT_VERSION]"
-          if ! grep -qF "$marker" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no entry for version $INPUT_VERSION (expected line containing '$marker')."
+          # Exactly one matching section header (prefix match, same as the extraction
+          # below; catches duplicate '## [version]' sections).
+          header_count=$(awk -v ver="$INPUT_VERSION" 'index($0, "## [" ver "]") == 1 { c++ } END { print c+0 }' CHANGELOG.md)
+          if [[ "$header_count" -ne 1 ]]; then
+            echo "::error::CHANGELOG.md must have exactly one '## [$INPUT_VERSION]' section header (found $header_count)."
             exit 1
           fi
+          # Extract the section body once here; release reuses these exact bytes via
+          # the release-notes artifact (validated == published).
+          awk -v ver="$INPUT_VERSION" '
+            index($0, "## [" ver "]") == 1 { matching=1; next }
+            matching && /^## \[/ { exit }
+            matching { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          # Reject empty or whitespace-only sections (header present, no real content).
+          if ! grep -q '[^[:space:]]' /tmp/release-notes.md; then
+            echo "::error::CHANGELOG.md section for $INPUT_VERSION is empty (header present but no content below it)."
+            exit 1
+          fi
+          echo "Notes preview:"
+          head -20 /tmp/release-notes.md
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: release-notes
+          path: /tmp/release-notes.md
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
 
       - name: Verify tag does not already exist
         env:
@@ -241,6 +266,7 @@ jobs:
           path: extension/${{ steps.vsix.outputs.name }}
           retention-days: 30
           if-no-files-found: error
+          overwrite: true
 
       - name: Upload Open VSX VSIX
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -249,6 +275,7 @@ jobs:
           path: extension/${{ steps.openvsx.outputs.name }}
           retention-days: 30
           if-no-files-found: error
+          overwrite: true
 
       - name: Generate artifact attestation
         if: ${{ !inputs.dry_run }}
@@ -311,7 +338,7 @@ jobs:
               curl -fsSL -o /tmp/remote.vsix "$remote_url"
               remote_sha256=$(sha256sum /tmp/remote.vsix | cut -d' ' -f1)
               if [[ "$LOCAL_SHA256" != "$remote_sha256" ]]; then
-                echo "::error::Open VSX has $INPUT_VERSION but with sha256=$remote_sha256, CI-built is $LOCAL_SHA256. Cannot rerun safely; investigate manually."
+                echo "::error::Open VSX already has $INPUT_VERSION with sha256=$remote_sha256, but the CI-built VSIX is $LOCAL_SHA256. If this is recovery after a partial failure, use 'Re-run failed jobs' on the ORIGINAL run (it reuses the already-built artifact, so the checksum matches) instead of a new dispatch (which rebuilds and may differ). Investigate manually only if the mismatch persists."
                 exit 1
               fi
               echo "::warning::Version already published with matching checksum. Skipping ovsx publish (treating as retry)."
@@ -362,16 +389,37 @@ jobs:
           "$RUNNER_TEMP/vsce-cli/node_modules/.bin/vsce" --version
 
       # --skip-duplicate: vsce exits 0 if the version already exists on
-      # Marketplace, making retries idempotent without a separate pre-check.
-      # Drops the brittle 'vsce show' parsing (network/auth/schema errors
-      # could otherwise be misclassified as "version missing" -> publish).
+      # Marketplace, making retries idempotent without a separate PRE-check.
+      # A 'vsce show' pre-check was deliberately dropped (network/auth/schema
+      # errors could be misclassified as "version missing" -> publish). We instead
+      # verify existence AFTER publishing, which is fail-closed-safe.
       - name: Publish to VS Marketplace (idempotent via --skip-duplicate)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           VSIX_FILE: ${{ needs.build.outputs.marketplace-vsix-name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          vsce publish --skip-duplicate --no-dependencies --packagePath "$VSIX_FILE"
+          vsce publish --skip-duplicate --no-dependencies --packagePath "$VSIX_FILE" 2>&1 | tee /tmp/vsce_out.txt
+          if grep -qiE 'already (exists|published)|skipping' /tmp/vsce_out.txt; then
+            echo "::warning::Marketplace already had $INPUT_VERSION; --skip-duplicate skipped the upload (treated as a retry). Note: Marketplace has no byte-level parity check here (unlike Open VSX), so existing content is not re-verified byte-for-byte."
+          fi
+          # Post-publish existence verification (fail-closed). Marketplace indexing can
+          # lag a few seconds after publish, so retry briefly before failing. A genuine
+          # failure here is safe to re-run: --skip-duplicate skips the upload and this
+          # check passes once the version is indexed.
+          ok=false
+          for i in 1 2 3 4 5; do
+            if vsce show aet-tum.iris-thaumantias --json | jq -e --arg v "$INPUT_VERSION" 'any(.versions[]?; .version == $v)' >/dev/null; then
+              ok=true; break
+            fi
+            echo "Version $INPUT_VERSION not visible on Marketplace yet (attempt $i/5); retrying..."
+            sleep 15
+          done
+          if [[ "$ok" != "true" ]]; then
+            echo "::error::Marketplace does not report version $INPUT_VERSION after publish (checked 5x). If this is indexing lag, use 'Re-run failed jobs'."
+            exit 1
+          fi
 
   release:
     name: Tag + GitHub Release
@@ -406,24 +454,12 @@ jobs:
           name: vsix-openvsx
           path: ./
 
-      - name: Extract changelog section for this version (awk, literal match)
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          awk -v ver="$INPUT_VERSION" '
-            index($0, "## [" ver "]") == 1 { matching=1; next }
-            matching && /^## \[/ { exit }
-            matching { print }
-          ' CHANGELOG.md > /tmp/release-notes.md
-          if [[ ! -s /tmp/release-notes.md ]]; then
-            echo "::error::Empty changelog notes extracted for $INPUT_VERSION."
-            exit 1
-          fi
-          echo "Notes preview:"
-          head -20 /tmp/release-notes.md
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: release-notes
+          path: ./
 
-      - name: Create tag and GitHub Release with VSIX asset
+      - name: Create or converge GitHub Release (idempotent)
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_VERSION: ${{ inputs.version }}
@@ -432,8 +468,37 @@ jobs:
           OPENVSX_VSIX_FILE: ${{ needs.build.outputs.openvsx-vsix-name }}
         run: |
           set -euo pipefail
-          gh release create "$INPUT_VERSION" \
-            --target "$SHA" \
-            --title "$INPUT_VERSION" \
-            --notes-file /tmp/release-notes.md \
-            "$VSIX_FILE" "$OPENVSX_VSIX_FILE"
+          TAG="$INPUT_VERSION"
+          notes="./release-notes.md"
+          assets=("$VSIX_FILE" "$OPENVSX_VSIX_FILE")
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # Recovery path: reached only via "Re-run failed jobs" (a fresh dispatch is
+            # blocked earlier by the tag-not-exist check). Converge WITHOUT --clobber so
+            # an already-good asset is never deleted by a retry that might then fail.
+            echo "::warning::Release $TAG already exists; converging idempotently (no --clobber)."
+            gh release edit "$TAG" --title "$TAG" --notes-file "$notes"
+            existing=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+            for a in "${assets[@]}"; do
+              base=$(basename "$a")
+              if grep -qxF "$base" <<<"$existing"; then
+                echo "Asset $base already attached; leaving as-is."
+              else
+                gh release upload "$TAG" "$a"
+              fi
+            done
+          else
+            gh release create "$TAG" \
+              --target "$SHA" \
+              --title "$TAG" \
+              --notes-file "$notes" \
+              "${assets[@]}"
+          fi
+          # Fail-closed: both expected assets must be present on the release.
+          final=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          for a in "${assets[@]}"; do
+            base=$(basename "$a")
+            grep -qxF "$base" <<<"$final" || {
+              echo "::error::Asset $base missing from release $TAG after publish."
+              exit 1
+            }
+          done

--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -1,20 +1,15 @@
 name: Release to Open VSX and VS Marketplace
 
 on:
+  # The branch to release from is the one chosen in the "Use workflow from"
+  # dropdown (github.ref); the prepare job enforces it is main or dev. There is no
+  # separate "source branch" input - one selector decides both the workflow and the code.
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to release (semver, e.g., 0.4.4). Must match extension/package.json version.'
         required: true
         type: string
-      ref:
-        description: 'Source branch to release from. Default "main" (released code). Pick "dev" only for ad-hoc / hotfix releases of pre-merge work.'
-        required: true
-        default: 'main'
-        type: choice
-        options:
-          - main
-          - dev
       dry_run:
         description: 'Dry run: build + validate, skip publish/tag/release'
         required: true
@@ -53,10 +48,23 @@ jobs:
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
     steps:
+      # Checks out the branch picked in "Use workflow from" (github.ref) - the single
+      # selector that decides both which workflow runs and which code gets released.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: refs/heads/${{ inputs.ref }}
           fetch-depth: 0
+
+      - name: Validate release branch (main or dev only)
+        # Compare the full github.ref so a TAG named main/dev (refs/tags/...) is also
+        # rejected - only the refs/heads/{main,dev} branches may be released.
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF" != "refs/heads/main" && "$REF" != "refs/heads/dev" ]]; then
+            echo "::error::Releases must run from branch 'main' or 'dev' (got ref '$REF' in 'Use workflow from'; tags are not allowed). Default to main; pick dev only for ad-hoc / hotfix releases of pre-merge work."
+            exit 1
+          fi
 
       - name: Validate version is strict semver
         env:
@@ -80,11 +88,13 @@ jobs:
             exit 1
           fi
 
-      - name: Verify extension/ directory exists on ref
+      - name: Verify extension/ directory exists on the selected branch
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [[ ! -d extension ]]; then
-            echo "::error::extension/ directory missing on ref '${{ inputs.ref }}'. Did you point to a pre-rename commit on main? Release blocked until dev->main merge brings the rename to main."
+            echo "::error::extension/ directory missing on '$REF_NAME'. Did you point to a pre-rename commit on main? Release blocked until dev->main merge brings the rename to main."
             exit 1
           fi
 

--- a/extension/scripts/package-openvsx.js
+++ b/extension/scripts/package-openvsx.js
@@ -31,5 +31,12 @@ run(`node scripts/generate-clean-manifest.js ${path.join(staging, 'package.json'
 const pkg = JSON.parse(fs.readFileSync(path.join(staging, 'package.json'), 'utf8'));
 const vsixName = `${pkg.name}-${pkg.version}-openvsx.vsix`;
 const vsixOut = path.join(root, vsixName);
-run(`npx --yes @vscode/vsce@3.9.1 package --no-dependencies --out ${vsixOut}`, { cwd: staging });
+// Prefer the pinned vsce already on PATH (the release workflow installs it under
+// RUNNER_TEMP) for deterministic, supply-chain-controlled packaging; fall back to a
+// pinned npx for local runs where vsce is not on PATH.
+const hasVsce = (() => {
+    try { execSync('vsce --version', { stdio: 'ignore' }); return true; } catch { return false; }
+})();
+const vsceCmd = hasVsce ? 'vsce' : 'npx --yes @vscode/vsce@3.9.1';
+run(`${vsceCmd} package --no-dependencies --out ${vsixOut}`, { cwd: staging });
 console.log(`[package-openvsx] wrote ${vsixOut}`);


### PR DESCRIPTION
## What

Two related changes to the manual release workflow (`release-openvsx.yml`), plus a packaging-script tweak.

### Simplify branch selection
- Drop the redundant `ref` choice input. The branch to release from is now solely the one picked in "Use workflow from" (`github.ref`), so there is no way to mismatch the workflow branch and the packaged code.
- A guard rejects anything but `refs/heads/main` or `refs/heads/dev` (tags included).

### Harden release edge cases
- **Idempotent GitHub Release:** create-or-converge without `--clobber`, with a fail-closed post-check that both VSIX assets are attached. Recovers a partial `gh release create` (tag created, asset upload failed) via "Re-run failed jobs" without deleting an already-good asset.
- **Changelog notes single-sourced:** extracted and validated in `prepare` (reject empty/whitespace-only sections and duplicate `## [version]` headers), uploaded as an artifact, reused verbatim in `release`. Previously an empty section was only caught after publishing.
- **Marketplace post-publish existence check:** after `vsce publish --skip-duplicate`, verify the version is reported by the Marketplace (retries for indexing lag, fail-closed), plus an observable warning when a duplicate is skipped.
- **`overwrite: true`** on all artifact uploads (safe for "Re-run all jobs").
- **`package-openvsx.js`** prefers the pinned `vsce` already on `PATH` over a fresh `npx` (determinism / supply chain), with an `npx` fallback for local runs.
- Open VSX checksum-mismatch error now points to "Re-run failed jobs".

## Test plan
- YAML parse + `node --check` pass; normal CI green.
- Validate end-to-end with a **`dry_run`** dispatch from `dev` (builds both VSIX + `verify-clean-bundle`, no publish/tag).