### PR TITLE
fix(telemetry): align EQ families, accurate blockedReason, live config

### DIFF
--- a/extension/src/extension/services/telemetry/decision/interventionDecisionEngine.ts
+++ b/extension/src/extension/services/telemetry/decision/interventionDecisionEngine.ts
@@ -1,7 +1,6 @@
 import { InterventionFilter } from '@extension/services/telemetry/interventionFilter';
 import {
     EQConfidence,
-    InterventionBlockedReason,
     InterventionDecision,
     InterventionState,
     RecommendedAction,
@@ -91,15 +90,12 @@ export class InterventionDecisionEngine {
             };
         }
 
-        // 3. Apply guardrails via InterventionFilter
-        const shouldIntervene = this._filter.shouldInterveneEQ(
+        // 3. Apply guardrails via InterventionFilter, which reports the exact
+        //    blocking reason (warmup / recent-progress / session-limit / last-dismissed).
+        const { ok: shouldIntervene, reason } = this._filter.shouldInterveneEQ(
             { level, eq },
             interventionState,
         );
-
-        const blockedReason: InterventionBlockedReason | undefined = shouldIntervene
-            ? undefined
-            : this._computeBlockedReason(level, eq, interventionState);
 
         return {
             rawWanted: true,
@@ -108,36 +104,8 @@ export class InterventionDecisionEngine {
             triggerType,
             eq,
             confidence,
-            blockedReason,
+            blockedReason: shouldIntervene ? undefined : reason,
         };
-    }
-
-    /**
-     * Compute the reason why the InterventionFilter blocked a decision that
-     * had `rawWanted=true`. Returns the first matching reason in priority order.
-     */
-    private _computeBlockedReason(
-        level: RecommendedAction,
-        eq: number,
-        state: InterventionState,
-    ): InterventionBlockedReason {
-        // Warmup check (exercise hasn't started or hasn't elapsed 5 min)
-        // We call shouldInterveneEQ on a minimal level to probe each gate
-        // individually. Since InterventionFilter is a black box here, we
-        // approximate by evaluating the same guardrails in the same order.
-        // Mirror the order in InterventionFilter.shouldInterveneEQ:
-
-        // Check session-limit (most common for notification/proactive)
-        const LIMIT = 3; // MAX_INTERVENTIONS_PER_SESSION
-        if (state.sessionInterventionCount >= LIMIT) {
-            if (level !== 'proactive' || eq < 0.85) {
-                return 'session-limit';
-            }
-        }
-
-        // Warmup: if the filter blocked and session count is fine, assume warmup
-        // (we can't directly inspect InterventionFilter's private start time)
-        return 'warmup';
     }
 
     /**

--- a/extension/src/extension/services/telemetry/eventPipeline/boundaryTriggerEmitter.ts
+++ b/extension/src/extension/services/telemetry/eventPipeline/boundaryTriggerEmitter.ts
@@ -97,7 +97,7 @@ export class BoundaryTriggerEmitter implements vscode.Disposable, SessionResetta
         }
 
         for (const change of event.contentChanges) {
-            if (isLikelyManualPaste(change)) {
+            if (isLikelyManualPaste(change, this._config.MULTILINE_PASTE_MIN_LINES)) {
                 if (!this._checkCooldown('multiline-paste')) {
                     return;
                 }

--- a/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
+++ b/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 
+import { buildErrorFamiliesFromFeedbacks } from '@extension/services/telemetry/metrics/buildErrorFamily';
 import { shouldDedupSnapshot } from '@extension/services/telemetry/metrics/snapshotDedup';
 import {
     BuildResultClassification,
     CompileEquivalentEvent,
     DEFAULT_EQ_CONFIG,
+    DEFAULT_TRIGGER_CONFIG,
     EQConfig,
     ErrorSnapshot,
     SessionResettable,
@@ -164,16 +166,9 @@ export class CompileEquivalentEmitter implements vscode.Disposable, SessionReset
         const classification = classifyBuildResult(result);
 
         if (classification === 'compiler-error') {
-            // Build failed → treat as having errors
-            const errorFamilies = new Set<string>();
-            // Use feedbacks to extract error families if available
-            if (result.feedbacks) {
-                for (const feedback of result.feedbacks) {
-                    if (feedback.positive === false && feedback.text) {
-                        errorFamilies.add(`build:${feedback.text.substring(0, 50)}`);
-                    }
-                }
-            }
+            // Build failed → treat as having errors. Families come from the shared
+            // builder so the live EQ matches the recorded/replayed families.
+            const errorFamilies = new Set<string>(buildErrorFamiliesFromFeedbacks(result.feedbacks));
             // At minimum, mark as having a build error
             if (errorFamilies.size === 0) {
                 errorFamilies.add('build:compiler-error');
@@ -272,9 +267,12 @@ function getErrorFamily(d: vscode.Diagnostic): string {
  *
  * From MVP Edge Case 3 (lines 739-758).
  */
-export function isLikelyManualPaste(change: vscode.TextDocumentContentChangeEvent): boolean {
+export function isLikelyManualPaste(
+    change: vscode.TextDocumentContentChangeEvent,
+    minLines: number = DEFAULT_TRIGGER_CONFIG.MULTILINE_PASTE_MIN_LINES,
+): boolean {
     const insertedLines = change.text.split('\n').length;
-    if (insertedLines < 2) {
+    if (insertedLines < minLines) {
         return false;
     }
 

--- a/extension/src/extension/services/telemetry/interventionFilter.ts
+++ b/extension/src/extension/services/telemetry/interventionFilter.ts
@@ -1,4 +1,4 @@
-import { InterventionState, RecommendedAction, SessionResettable, SessionStartContext } from './types';
+import { InterventionBlockedReason, InterventionState, RecommendedAction, SessionResettable, SessionStartContext } from './types';
 
 /**
  * Pedagogical guards for intervention decisions.
@@ -11,6 +11,8 @@ export class InterventionFilter implements SessionResettable {
     private static readonly MAX_INTERVENTIONS_PER_SESSION = 3;
     /** Grace period after progress (2 minutes) */
     private static readonly PROGRESS_GRACE_PERIOD_MS = 2 * 60 * 1000;
+    /** EQ at/above which a proactive intervention is allowed even past the session limit */
+    private static readonly SEVERE_EQ_PROACTIVE_OVERRIDE = 0.85;
 
     private _exerciseStartTime: number | undefined;
     private _lastProgressTime: number = 0;
@@ -67,33 +69,33 @@ export class InterventionFilter implements SessionResettable {
     public shouldInterveneEQ(
         decision: { level: RecommendedAction; eq: number },
         state: InterventionState,
-    ): boolean {
+    ): { ok: boolean; reason?: InterventionBlockedReason } {
         if (decision.level === 'none') {
-            return false;
+            return { ok: false };
         }
 
         if (!this._hasEnoughExerciseTime()) {
-            return false;
+            return { ok: false, reason: 'warmup' };
         }
 
         if (this._hasRecentProgress()) {
-            return false;
+            return { ok: false, reason: 'recent-progress' };
         }
 
         // Session intervention limit
         if (state.sessionInterventionCount >= InterventionFilter.MAX_INTERVENTIONS_PER_SESSION) {
-            // Allow proactive even after limit for severe EQ (>= 0.85)
-            if (decision.level !== 'proactive' || decision.eq < 0.85) {
-                return false;
+            // Allow proactive even after limit for severe EQ
+            if (decision.level !== 'proactive' || decision.eq < InterventionFilter.SEVERE_EQ_PROACTIVE_OVERRIDE) {
+                return { ok: false, reason: 'session-limit' };
             }
         }
 
         // Dismissed → only proactive allowed
         if (state.lastDismissed && decision.level !== 'proactive') {
-            return false;
+            return { ok: false, reason: 'last-dismissed' };
         }
 
-        return true;
+        return { ok: true };
     }
 
     /**

--- a/extension/src/extension/services/telemetry/metrics/buildErrorFamily.ts
+++ b/extension/src/extension/services/telemetry/metrics/buildErrorFamily.ts
@@ -1,0 +1,42 @@
+/**
+ * Single source of truth for build-error family keys derived from build-result feedbacks.
+ *
+ * Used by both the live EQ path (compileEquivalentEmitter) and the recording path
+ * (eventCollectors) so that replayed EQ matches live EQ. Keeping the truncation length
+ * in one place prevents the live/recording divergence that otherwise breaks replay fidelity.
+ */
+
+/**
+ * Max characters of feedback text used to distinguish build-error families.
+ * Longer keeps similar-but-distinct failures separate; shorter over-merges them.
+ * [Engineering choice] — 200 was chosen to avoid family-merging of similar errors.
+ */
+export const BUILD_ERROR_FAMILY_MAX_CHARS = 200;
+
+/** Minimal structural shape of an Artemis build-result feedback. */
+interface FeedbackLike {
+    readonly positive?: boolean;
+    readonly text?: string;
+}
+
+/**
+ * Build the ordered list of `build:<text>` family keys for the failed feedbacks.
+ *
+ * A feedback contributes a family iff it is explicitly failing (`positive === false`)
+ * and carries non-empty `text`. Returns families only — the `build:compiler-error`
+ * fallback for an empty result is applied by each caller's snapshot construction.
+ */
+export function buildErrorFamiliesFromFeedbacks(
+    feedbacks: readonly FeedbackLike[] | undefined,
+): string[] {
+    if (!feedbacks) {
+        return [];
+    }
+    const families: string[] = [];
+    for (const feedback of feedbacks) {
+        if (feedback.positive === false && feedback.text) {
+            families.push(`build:${feedback.text.substring(0, BUILD_ERROR_FAMILY_MAX_CHARS)}`);
+        }
+    }
+    return families;
+}

--- a/extension/src/extension/services/telemetry/metrics/errorQuotientEngine.ts
+++ b/extension/src/extension/services/telemetry/metrics/errorQuotientEngine.ts
@@ -154,10 +154,11 @@ export class ErrorQuotientEngine implements SessionResettable {
 
     /**
      * Determine confidence from pair count.
-     * ✅ Paper minimum: >=7 events = >=6 pairs [P3, Section 4]
+     * ✅ Paper minimum: >=7 events = >=6 pairs [P3, Section 4].
+     * Derived from the configured MIN_EVENTS_PER_SESSION (events = pairs + 1).
      */
     private _calculateConfidence(pairCount: number): EQConfidence {
-        return pairCount >= 6 ? 'sufficient' : 'insufficient';
+        return pairCount >= this._config.MIN_EVENTS_PER_SESSION - 1 ? 'sufficient' : 'insufficient';
     }
 
     public dispose(): void {

--- a/extension/src/extension/services/telemetry/recording/eventCollectors.ts
+++ b/extension/src/extension/services/telemetry/recording/eventCollectors.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 
+import { buildErrorFamiliesFromFeedbacks } from '@extension/services/telemetry/metrics/buildErrorFamily';
 import { shouldRecordUri } from '@extension/services/telemetry/uriFilter';
 import type { ResultDTO } from '@extension/types';
 
@@ -96,7 +97,6 @@ export function collectDiagnostics(uri: vscode.Uri): DiagnosticsEvent {
 export function collectBuildResult(result: ResultDTO, activeExerciseId?: number): BuildResultEvent {
     const failedTests: string[] = [];
     const failedTestDetails: { testName: string; detail: string }[] = [];
-    const buildErrorFamilies: string[] = [];
     if (result.feedbacks) {
         for (const fb of result.feedbacks) {
             // Unified predicate: explicit false only (undefined = not yet graded, positive = passing).
@@ -105,13 +105,11 @@ export function collectBuildResult(result: ResultDTO, activeExerciseId?: number)
                 failedTests.push(fb.detailText ?? '');
                 // Structured details: carry both test name and failure message.
                 failedTestDetails.push({ testName: fb.text ?? 'unknown', detail: fb.detailText ?? '' });
-                if (fb.text) {
-                    // 200 chars to differentiate similar errors; previously 50 caused family-merging.
-                    buildErrorFamilies.push(`build:${fb.text.substring(0, 200)}`);
-                }
             }
         }
     }
+    // Shared builder: same families (and truncation) as the live EQ path, so replay matches live.
+    const buildErrorFamilies = buildErrorFamiliesFromFeedbacks(result.feedbacks);
     return {
         type: 'buildResult',
         timestamp: Date.now(),

--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -393,7 +393,7 @@ function parseIntervention(d: Record<string, unknown>, timestamp: number): Inter
         return null;
     }
     if (d.blockedReason !== undefined
-        && !isOneOf(d.blockedReason, ['cooldown', 'warmup', 'session-limit', 'low-confidence'] as const)) {
+        && !isOneOf(d.blockedReason, ['cooldown', 'warmup', 'session-limit', 'low-confidence', 'recent-progress', 'last-dismissed'] as const)) {
         return null;
     }
     if (d.suppressionReason !== undefined && !isOneOf(d.suppressionReason, ['user-disabled'] as const)) {

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -42,7 +42,7 @@ import * as vscode from 'vscode';
 
 import type { ResultDTO, WebSocketMessageHandler } from '@extension/types';
 
-import type { RecordedEvent, SerializedErrorSnapshot, SubmissionPayload } from './types';
+import type { InterventionEvent, RecordedEvent, SerializedErrorSnapshot, SubmissionPayload } from './types';
 
 /**
  * Distributive `Omit` over `RecordedEvent` — keeps each union variant intact
@@ -401,7 +401,7 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
         confidence: 'sufficient' | 'insufficient',
         triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained',
         opts?: {
-            blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+            blockedReason?: InterventionEvent['blockedReason'];
             suppressionReason?: 'user-disabled';
             dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
             rawWanted?: boolean;

--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -224,7 +224,7 @@ export interface InterventionEvent {
     confidence: 'sufficient' | 'insufficient';
     triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
     /** Populated when action='blocked'. Identifies why the intervention was blocked. */
-    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence' | 'recent-progress' | 'last-dismissed';
     /** Populated when action='suppressed'. Identifies the suppression source. */
     suppressionReason?: 'user-disabled';
     /** Populated when action='dismissed'. Identifies how the intervention was dismissed. */

--- a/extension/src/extension/services/telemetry/types.ts
+++ b/extension/src/extension/services/telemetry/types.ts
@@ -170,10 +170,6 @@ export interface EQConfig {
     readonly SESSION_INACTIVITY_SPLIT_MS: number;
     /** Dedup window in ms [Engineering choice] */
     readonly DEDUP_WINDOW_MS: number;
-    /** Diagnostic stabilization debounce in ms [ADAPTATION: optional, default off] */
-    readonly DIAGNOSTIC_STABILIZATION_MS: number;
-    /** Whether diagnostic stabilization trigger is enabled [Engineering choice] */
-    readonly DIAGNOSTIC_STABILIZATION_ENABLED: boolean;
 }
 
 /** Default EQ configuration with paper-validated values */
@@ -184,8 +180,6 @@ export const DEFAULT_EQ_CONFIG: EQConfig = {
     MIN_EVENTS_PER_SESSION: 7,
     SESSION_INACTIVITY_SPLIT_MS: 30 * 60 * 1000, // 30 minutes
     DEDUP_WINDOW_MS: 5 * 1000, // 5 seconds
-    DIAGNOSTIC_STABILIZATION_MS: 2_000, // 2 seconds debounce
-    DIAGNOSTIC_STABILIZATION_ENABLED: false, // off by default
 };
 
 /**
@@ -261,10 +255,18 @@ export interface CompileEquivalentEvent {
  *
  * - 'cooldown'        — InterventionService internal cooldown (notification/proactive only)
  * - 'warmup'          — Exercise hasn't reached the 5-minute warmup yet
+ * - 'recent-progress' — Student made progress within the 2-minute grace period
  * - 'session-limit'   — Max interventions per session exceeded
+ * - 'last-dismissed'  — Previous intervention was dismissed (non-proactive blocked)
  * - 'low-confidence'  — EQ above threshold but confidence gate is 'insufficient'
  */
-export type InterventionBlockedReason = 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+export type InterventionBlockedReason =
+    | 'cooldown'
+    | 'warmup'
+    | 'session-limit'
+    | 'low-confidence'
+    | 'recent-progress'
+    | 'last-dismissed';
 
 /**
  * Reason why an intervention was dismissed.

--- a/extension/test/logic/telemetry/blockedReason.test.ts
+++ b/extension/test/logic/telemetry/blockedReason.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { InterventionDecisionEngine } from '@extension/services/telemetry/decision/interventionDecisionEngine';
+import { InterventionFilter } from '@extension/services/telemetry/interventionFilter';
+import type { InterventionState } from '@extension/services/telemetry/types';
+
+const SIX_MINUTES_MS = 6 * 60 * 1000;
+
+function freshState(overrides: Partial<InterventionState> = {}): InterventionState {
+    return {
+        lastInterventionTime: 0,
+        sessionInterventionCount: 0,
+        lastDismissed: false,
+        lastAccepted: false,
+        ...overrides,
+    };
+}
+
+/** A filter that is past the 5-minute warmup, so later gates are reachable. */
+function warmedUpFilter(): InterventionFilter {
+    const filter = new InterventionFilter();
+    filter.setExerciseStartTime(Date.now() - SIX_MINUTES_MS);
+    return filter;
+}
+
+describe('InterventionDecisionEngine blockedReason attribution', () => {
+    it('reports warmup when the exercise has not run long enough', () => {
+        const engine = new InterventionDecisionEngine(new InterventionFilter()); // never warmed up
+        const result = engine.evaluate(0.4, 'sufficient', 'idle', freshState());
+        expect(result.shouldIntervene).toBe(false);
+        expect(result.blockedReason).toBe('warmup');
+    });
+
+    it('reports recent-progress when the student just made progress', () => {
+        const filter = warmedUpFilter();
+        filter.recordProgress();
+        const engine = new InterventionDecisionEngine(filter);
+        const result = engine.evaluate(0.4, 'sufficient', 'idle', freshState());
+        expect(result.shouldIntervene).toBe(false);
+        expect(result.blockedReason).toBe('recent-progress');
+    });
+
+    it('reports last-dismissed when a non-proactive intervention follows a dismissal', () => {
+        const engine = new InterventionDecisionEngine(warmedUpFilter());
+        const result = engine.evaluate(0.4, 'sufficient', 'idle', freshState({ lastDismissed: true }));
+        expect(result.level).toBe('notification');
+        expect(result.shouldIntervene).toBe(false);
+        expect(result.blockedReason).toBe('last-dismissed');
+    });
+
+    it('reports session-limit when the per-session cap is reached', () => {
+        const engine = new InterventionDecisionEngine(warmedUpFilter());
+        const result = engine.evaluate(0.4, 'sufficient', 'idle', freshState({ sessionInterventionCount: 3 }));
+        expect(result.shouldIntervene).toBe(false);
+        expect(result.blockedReason).toBe('session-limit');
+    });
+
+    it('has no blockedReason when all guardrails pass', () => {
+        const engine = new InterventionDecisionEngine(warmedUpFilter());
+        const result = engine.evaluate(0.4, 'sufficient', 'idle', freshState());
+        expect(result.shouldIntervene).toBe(true);
+        expect(result.blockedReason).toBeUndefined();
+    });
+
+    it('allows a proactive intervention past the session limit for severe EQ (>= 0.85)', () => {
+        const engine = new InterventionDecisionEngine(warmedUpFilter());
+        const result = engine.evaluate(0.9, 'sufficient', 'idle', freshState({ sessionInterventionCount: 3 }));
+        expect(result.level).toBe('proactive');
+        expect(result.shouldIntervene).toBe(true);
+        expect(result.blockedReason).toBeUndefined();
+    });
+
+    it('still blocks a proactive intervention past the session limit when EQ is below the severe override', () => {
+        const engine = new InterventionDecisionEngine(warmedUpFilter());
+        const result = engine.evaluate(0.7, 'sufficient', 'idle', freshState({ sessionInterventionCount: 3 }));
+        expect(result.level).toBe('proactive');
+        expect(result.shouldIntervene).toBe(false);
+        expect(result.blockedReason).toBe('session-limit');
+    });
+});

--- a/extension/test/logic/telemetry/buildErrorFamily.test.ts
+++ b/extension/test/logic/telemetry/buildErrorFamily.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    BUILD_ERROR_FAMILY_MAX_CHARS,
+    buildErrorFamiliesFromFeedbacks,
+} from '@extension/services/telemetry/metrics/buildErrorFamily';
+
+describe('buildErrorFamiliesFromFeedbacks', () => {
+    it('maps each failed feedback with text to a build:<text> family', () => {
+        const families = buildErrorFamiliesFromFeedbacks([
+            { positive: false, text: 'NullPointerException in test A' },
+            { positive: false, text: 'AssertionError in test B' },
+        ]);
+        expect(families).toEqual([
+            'build:NullPointerException in test A',
+            'build:AssertionError in test B',
+        ]);
+    });
+
+    it('ignores passing, ungraded, and text-less feedbacks', () => {
+        const families = buildErrorFamiliesFromFeedbacks([
+            { positive: true, text: 'passed' },
+            { positive: undefined, text: 'not yet graded' },
+            { positive: false, text: undefined },
+            { positive: false, text: '' },
+            { positive: false, text: 'real failure' },
+        ]);
+        expect(families).toEqual(['build:real failure']);
+    });
+
+    it('truncates the family key at BUILD_ERROR_FAMILY_MAX_CHARS (200) chars', () => {
+        const longText = 'x'.repeat(500);
+        const [family] = buildErrorFamiliesFromFeedbacks([{ positive: false, text: longText }]);
+        expect(BUILD_ERROR_FAMILY_MAX_CHARS).toBe(200);
+        expect(family).toBe(`build:${'x'.repeat(200)}`);
+    });
+
+    it('keeps two failures distinct when they share the first 50 chars but differ before 200 (regression against the old 50-char merge)', () => {
+        // Prefix is > 50 chars, so a 50-char truncation would collapse both into one family.
+        const prefix = 'CompilationError: cannot find symbol in a very long line ';
+        const families = buildErrorFamiliesFromFeedbacks([
+            { positive: false, text: `${prefix}variable fooooooooo` },
+            { positive: false, text: `${prefix}variable barrrrrrrr` },
+        ]);
+        expect(new Set(families).size).toBe(2);
+    });
+
+    it('returns an empty array for undefined or empty feedbacks', () => {
+        expect(buildErrorFamiliesFromFeedbacks(undefined)).toEqual([]);
+        expect(buildErrorFamiliesFromFeedbacks([])).toEqual([]);
+    });
+});

--- a/extension/test/logic/telemetry/buildFamilyConsistency.test.ts
+++ b/extension/test/logic/telemetry/buildFamilyConsistency.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildErrorFamiliesFromFeedbacks } from '@extension/services/telemetry/metrics/buildErrorFamily';
+import { collectBuildResult } from '@extension/services/telemetry/recording/eventCollectors';
+import { createSnapshotFromBuildEvent } from '@extension/services/telemetry/replay/snapshotReconstructor';
+import type { ResultDTO } from '@extension/types';
+
+/**
+ * Regression guard for the live/recording/replay build-error-family divergence:
+ * the recording collector and the replay reconstructor must yield exactly the
+ * families produced by the single shared builder (which the live EQ path also uses).
+ */
+function failedBuild(feedbacks: { positive?: boolean; text?: string }[]): ResultDTO {
+    return {
+        successful: false,
+        submission: { buildFailed: true },
+        feedbacks,
+    } as unknown as ResultDTO;
+}
+
+describe('build-error family consistency across recording and replay', () => {
+    it('recording → replay reproduces exactly the shared builder families', () => {
+        const result = failedBuild([
+            { positive: false, text: 'Cannot find symbol foo' },
+            { positive: false, text: 'Method bar not found' },
+            { positive: true, text: 'passing test' },
+        ]);
+
+        const event = collectBuildResult(result);
+        const snapshot = createSnapshotFromBuildEvent(event);
+
+        const expected = new Set(buildErrorFamiliesFromFeedbacks(result.feedbacks));
+        expect(snapshot.errorFamilies).toEqual(expected);
+    });
+
+    it('does not merge two failures that differ only after the first 50 characters', () => {
+        const prefix = 'CompilationError: cannot find symbol in a very long line ';
+        const result = failedBuild([
+            { positive: false, text: `${prefix}variable fooooooooo` },
+            { positive: false, text: `${prefix}variable barrrrrrrr` },
+        ]);
+
+        const snapshot = createSnapshotFromBuildEvent(collectBuildResult(result));
+        expect(snapshot.errorFamilies.size).toBe(2);
+    });
+});

--- a/extension/test/logic/telemetry/eqConfidenceConfig.test.ts
+++ b/extension/test/logic/telemetry/eqConfidenceConfig.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { ErrorQuotientEngine } from '@extension/services/telemetry/metrics/errorQuotientEngine';
+import { DEFAULT_EQ_CONFIG, type ErrorSnapshot } from '@extension/services/telemetry/types';
+
+function snap(timestamp: number): ErrorSnapshot {
+    return { timestamp, hasErrors: true, errorFamilies: new Set(['ts:2304']), errorCount: 1 };
+}
+
+describe('EQ confidence honors MIN_EVENTS_PER_SESSION', () => {
+    it('uses the configured minimum instead of a hardcoded 6 pairs', () => {
+        const engine = new ErrorQuotientEngine({ ...DEFAULT_EQ_CONFIG, MIN_EVENTS_PER_SESSION: 3 });
+        engine.seedSnapshots([snap(0), snap(1), snap(2)]); // 2 pairs >= (3 - 1)
+        expect(engine.getCurrentEQ().confidence).toBe('sufficient');
+    });
+
+    it('keeps the paper default: 5 pairs insufficient, 6 pairs sufficient', () => {
+        const engine = new ErrorQuotientEngine(); // default MIN_EVENTS_PER_SESSION = 7
+        engine.seedSnapshots(Array.from({ length: 6 }, (_, i) => snap(i))); // 5 pairs
+        expect(engine.getCurrentEQ().confidence).toBe('insufficient');
+        engine.seedSnapshots(Array.from({ length: 7 }, (_, i) => snap(i))); // 6 pairs
+        expect(engine.getCurrentEQ().confidence).toBe('sufficient');
+    });
+});

--- a/extension/test/logic/telemetry/manualPaste.test.ts
+++ b/extension/test/logic/telemetry/manualPaste.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLikelyManualPaste } from '@extension/services/telemetry/eventPipeline/compileEquivalentEmitter';
+
+type Change = Parameters<typeof isLikelyManualPaste>[0];
+
+function change(text: string, opts: { rangeLength?: number; isEmpty?: boolean; isSingleLine?: boolean } = {}): Change {
+    return {
+        text,
+        rangeLength: opts.rangeLength ?? 0,
+        range: { isEmpty: opts.isEmpty ?? true, isSingleLine: opts.isSingleLine ?? false },
+    } as unknown as Change;
+}
+
+describe('isLikelyManualPaste respects the configurable minimum line count', () => {
+    it('treats a 2-line insert as paste with the default minimum (2)', () => {
+        expect(isLikelyManualPaste(change('a\nb'))).toBe(true);
+    });
+
+    it('does NOT treat a 2-line insert as paste when the minimum is raised to 3', () => {
+        expect(isLikelyManualPaste(change('a\nb'), 3)).toBe(false);
+    });
+
+    it('treats a 3-line insert as paste when the minimum is 3', () => {
+        expect(isLikelyManualPaste(change('a\nb\nc'), 3)).toBe(true);
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -234,6 +234,17 @@ suite('parseRecordedEvent — per-variant happy path', () => {
         assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
     });
 
+    for (const blockedReason of ['recent-progress', 'last-dismissed'] as const) {
+        test(`intervention — blockedReason='${blockedReason}' round-trips`, () => {
+            const e: RecordedEvent = {
+                type: 'intervention', timestamp: ts, action: 'blocked', level: 'notification',
+                shouldIntervene: false, eq: 0.5, confidence: 'sufficient',
+                triggerType: 'idle', blockedReason, rawWanted: true,
+            };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
     test('viewNavigation', () => {
         const e: RecordedEvent = {
             type: 'viewNavigation', timestamp: ts, from: 'dashboard', to: 'exerciseDetail',

--- a/recording-viewer/src/generated/recordingTypes.ts
+++ b/recording-viewer/src/generated/recordingTypes.ts
@@ -219,7 +219,7 @@ export interface InterventionEvent {
     confidence: 'sufficient' | 'insufficient';
     triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
     /** Populated when action='blocked'. Identifies why the intervention was blocked. */
-    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence';
+    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence' | 'recent-progress' | 'last-dismissed';
     /** Populated when action='suppressed'. Identifies the suppression source. */
     suppressionReason?: 'user-disabled';
     /** Populated when action='dismissed'. Identifies how the intervention was dismissed. */


### PR DESCRIPTION
## Context
A code-smell pass surfaced three correctness / data-quality defects in the struggle-detection telemetry that corrupt the recorded and replayed evaluation data. This PR fixes all three. Branches off `dev`, targets `dev`.

## Fixes

### 1. Build-error family truncation divergence
The live EQ path built families as `build:<text[0..50]>` while the recording path used 200 chars. Since the shared-family check drives the +3 EQ pair weight, replayed EQ could not reproduce the live curve. A single `metrics/buildErrorFamily.ts` (one `BUILD_ERROR_FAMILY_MAX_CHARS = 200` constant) now feeds both the live snapshot and the recorder, so live == recording == replay by construction. Value unified to 200 (the deliberate correction; study not yet run).

### 2. Mislabeled `blockedReason`
`InterventionFilter.shouldInterveneEQ` returned a bare boolean, so the decision engine guessed the reason in `_computeBlockedReason` and could only ever report `warmup` or `session-limit` — `recent-progress` and `last-dismissed` blocks were silently recorded as `warmup`. The filter now returns `{ ok, reason }`; the engine records the real reason and `_computeBlockedReason` (with its duplicated `LIMIT=3` / `0.85`) is removed. The two new reasons are added to the recorded schema (viewer types regenerated via `sync-types`) and the parser allowlist.

### 3. Config that didn't configure
`MIN_EVENTS_PER_SESSION` and `MULTILINE_PASTE_MIN_LINES` were declared in config but hardcoded at the use sites — now wired. The unused `DIAGNOSTIC_STABILIZATION_*` fields are removed. The `0.85` severe-EQ proactive override is now a named constant.

## Testing
- `tsc --noEmit` (extension) + `eslint src test` + `recording-viewer` `tsc -b`: clean
- vitest 807 passing (19 new logic tests under `test/logic/telemetry/`)
- mocha unit 1235 passing / 0 failures · mocha struggle 135 passing