### PR TITLE
docs(changelog): add unreleased struggle-detection fidelity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Replay Fidelity**: Live and recording paths share one build-error-family builder, so replayed EQ matches the live curve.
+- **Intervention Block Reasons**: Withheld interventions record the real gate; `recent-progress`/`last-dismissed` no longer logged as `warmup`.
+
+### Internal
+
+- **Struggle-Detection Config**: Wired `MIN_EVENTS_PER_SESSION` and the paste threshold; removed dead config.
+
 ## [0.4.5] - 2026-06-01
 
 ### Added


### PR DESCRIPTION
Adds the #254 struggle-detection fidelity fixes to the `[Unreleased]` changelog section (replay-fidelity build-family unification, accurate intervention `blockedReason`, config cleanup).