### PR TITLE
fix(workspace): parse git status with -z to handle renames and spaced paths

### DIFF
--- a/extension/src/extension/services/workspace/workspaceFileChecker.ts
+++ b/extension/src/extension/services/workspace/workspaceFileChecker.ts
@@ -83,6 +83,43 @@ export interface FileCheckResult {
 }
 
 /**
+ * Parse the output of `git status --porcelain=v1 -z`.
+ *
+ * The `-z` format terminates each record with a NUL byte and, unlike the default
+ * porcelain format, does NOT C-quote paths containing spaces or special characters.
+ * Rename/copy entries (status code `R`/`C`) span two NUL-separated fields: the
+ * destination path (carrying the `XY ` prefix) followed by the bare source path.
+ * We keep the destination (the file that exists on disk now) and skip the source.
+ *
+ * @returns changed file paths, relative to the repository root.
+ */
+export function parseGitStatusZ(stdout: string): string[] {
+    const paths: string[] = [];
+    const fields = stdout.split('\0');
+
+    for (let i = 0; i < fields.length; i++) {
+        const field = fields[i];
+        // A status record is "XY PATH": two-char status, separator space, path.
+        // The final field after the trailing NUL is empty; shorter fields are malformed.
+        if (field.length < 4) {
+            continue;
+        }
+        const status = field.slice(0, 2);
+        const filePath = field.slice(3);
+        if (filePath) {
+            paths.push(filePath);
+        }
+        // Rename/copy records are followed by the original path as a separate
+        // field; consume it so it is not mis-parsed as its own status record.
+        if (status.includes('R') || status.includes('C')) {
+            i++;
+        }
+    }
+
+    return paths;
+}
+
+/**
  * Unified workspace file checker
  * Handles all file checking scenarios with configurable options
  */
@@ -201,25 +238,17 @@ export async function checkWorkspaceFiles(
         }
     }
 
-    // 2. Get files from git status
+    // 2. Get files from git status.
+    // The NUL-terminated porcelain format (-z) leaves paths unquoted and lists
+    // rename/copy destinations explicitly, which the old line+slice(3) parser mangled.
     try {
-        const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], {
+        const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain=v1', '-z'], {
             cwd: folder.uri.fsPath,
             timeout: 5000
         });
 
-        if (statusOutput.trim().length > 0) {
-            statusOutput
-                .split('\n')
-                .filter(line => line.trim().length > 0)
-                .forEach(line => {
-                    if (line.length > 3) {
-                        const fileName = line.slice(3).trim();
-                        if (fileName) {
-                            allFiles.add(fileName);
-                        }
-                    }
-                });
+        for (const file of parseGitStatusZ(statusOutput)) {
+            allFiles.add(file);
         }
     } catch (error) {
         logger.error('Git status failed', LogCategory.FILE_MONITOR, error);

--- a/extension/test/unit/utils/workspaceFileChecker.test.ts
+++ b/extension/test/unit/utils/workspaceFileChecker.test.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
+import { checkWorkspaceFiles, parseGitStatusZ } from '@extension/services/workspace/workspaceFileChecker';
 
 suite('Workspace File Checker Test Suite', () => {
     let tempDir: string;
@@ -176,6 +176,82 @@ suite('Workspace File Checker Test Suite', () => {
         assert.strictEqual(result.includedCount, 1);
         assert.strictEqual(result.files[0].path, 'Dirty.java');
         assert.strictEqual(result.files[0].status, 'included');
+    });
+
+    test('should record the new path for renames and unquoted paths with spaces', async () => {
+        execSync('git config user.email "test@example.com"', { cwd: tempDir });
+        execSync('git config user.name "Test User"', { cwd: tempDir });
+
+        // Commit a file so it can be renamed
+        fs.writeFileSync(path.join(tempDir, 'Original.java'), 'class Original {}');
+        execSync('git add Original.java', { cwd: tempDir });
+        execSync('git commit -m "initial"', { cwd: tempDir });
+
+        // Staged rename: git status reports "R  Original.java -> Renamed.java"
+        execSync('git mv Original.java Renamed.java', { cwd: tempDir });
+
+        // Untracked file whose path contains a space (porcelain quotes it without -z)
+        fs.writeFileSync(path.join(tempDir, 'New Helper.java'), 'class NewHelper {}');
+
+        const mockFolder: vscode.WorkspaceFolder = {
+            uri: vscode.Uri.file(tempDir),
+            name: 'test',
+            index: 0
+        };
+
+        const result = await checkWorkspaceFiles(mockFolder, { applyFilters: false });
+        const paths = result.files.map(f => f.path);
+
+        // Rename records the NEW path, never the "old -> new" arrow form
+        assert.ok(paths.includes('Renamed.java'), `expected Renamed.java, got ${JSON.stringify(paths)}`);
+        assert.ok(!paths.some(p => p.includes('->')), `arrow path leaked: ${JSON.stringify(paths)}`);
+        // Path with a space is recorded raw, without surrounding quotes
+        assert.ok(paths.includes('New Helper.java'), `expected unquoted spaced path, got ${JSON.stringify(paths)}`);
+        assert.ok(!paths.some(p => p.startsWith('"')), `quoted path leaked: ${JSON.stringify(paths)}`);
+    });
+
+    suite('parseGitStatusZ', () => {
+        test('returns relative paths for modified and untracked entries', () => {
+            const out = ' M src/Foo.java\0?? New.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['src/Foo.java', 'New.java']);
+        });
+
+        test('keeps the destination of a rename and drops the source', () => {
+            // -z format: "XY <new>\0<old>\0" (new path first, then the original)
+            const out = 'R  new/Path.java\0old/Path.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['new/Path.java']);
+        });
+
+        test('keeps the destination of a copy and drops the source', () => {
+            const out = 'C  copy.java\0orig.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['copy.java']);
+        });
+
+        test('keeps paths containing spaces verbatim (no quoting in -z)', () => {
+            const out = ' M with space.txt\0?? new file.txt\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['with space.txt', 'new file.txt']);
+        });
+
+        test('stays aligned across consecutive renames', () => {
+            const out = 'R  b.java\0a.java\0R  d.java\0c.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['b.java', 'd.java']);
+        });
+
+        test('returns an empty array for empty output', () => {
+            assert.deepStrictEqual(parseGitStatusZ(''), []);
+        });
+
+        test('ignores malformed short fields', () => {
+            const out = 'XY\0 M real.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['real.java']);
+        });
+
+        test('preserves leading and trailing whitespace in file names', () => {
+            // The old line-based parser called .trim(), which corrupted names that
+            // legitimately begin or end with a space. -z carries them verbatim.
+            const out = '?? trailing .java\0??  leading.java\0';
+            assert.deepStrictEqual(parseGitStatusZ(out), ['trailing .java', ' leading.java']);
+        });
     });
 
     test('should include files from unpushed commits', async () => {


### PR DESCRIPTION
## Problem

`checkWorkspaceFiles` collected changed files via `git status --porcelain` and parsed each line with `line.slice(3).trim()`. This mangled:

- **Renames** — `R  old.java -> new.java` was recorded verbatim as the "filename" `old.java -> new.java`, so the renamed file was silently dropped from the change set sent to Iris.
- **Paths with spaces** — porcelain C-quotes them (`"with space.java"`), so the literal quotes ended up in the path and the file failed to read.
- **Edge whitespace** — the `.trim()` corrupted names with legitimate leading/trailing spaces.

## Fix

- Switch to `git status --porcelain=v1 -z`: NUL-terminated records, paths are **not** quoted, and rename/copy entries list the destination first, then the source.
- New pure helper `parseGitStatusZ()` splits on NUL, keeps the rename/copy **destination** (the file that exists on disk) and skips the source. No more `.trim()`.

## Testing

- Integration test with a real staged `git mv` rename + a space-in-name file.
- 8 unit tests for `parseGitStatusZ` (rename, copy, consecutive-rename alignment, spaces, leading/trailing whitespace, empty, malformed short fields).
- Full unit suite green (1240 tests), `check-types` + `eslint src test` clean.

Part of #257.
