### PR TITLE
fix(api): add request timeouts to Artemis API calls

### DIFF
--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -38,6 +38,32 @@ import {
 } from '@extension/types';
 import { CONFIG, getUserAgent, resolveServerUrl } from '@extension/utils';
 
+/**
+ * `fetch` with a timeout backstop. The native `fetch` has no default timeout, so a
+ * server that accepts the connection but never responds would hang the caller forever.
+ * Aborts the request after `timeoutMs` (rejecting with a `TimeoutError`); a caller-
+ * supplied `options.signal` is honoured in addition to the timeout.
+ */
+async function fetchWithTimeout(
+    url: string,
+    options: RequestInit = {},
+    timeoutMs: number = CONFIG.API.REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(
+        () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
+        timeoutMs,
+    );
+    const signal = options.signal
+        ? AbortSignal.any([controller.signal, options.signal])
+        : controller.signal;
+    try {
+        return await fetch(url, { ...options, signal });
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 export class ArtemisApiService {
     private authManager: AuthManager;
     private _onAuthExpired?: () => void | Promise<void>;
@@ -68,7 +94,7 @@ export class ArtemisApiService {
         const headers = await this.authManager.getAuthHeaders();
         const url = `${this.getServerUrl()}${endpoint}`;
 
-        const response = await fetch(url, {
+        const response = await fetchWithTimeout(url, {
             ...options,
             headers: {
                 'Content-Type': 'application/json',
@@ -295,7 +321,7 @@ export class ArtemisApiService {
     async authenticate(username: string, password: string, rememberMe: boolean = false): Promise<AuthenticationResult> {
         const url = `${this.getServerUrl()}${CONFIG.API.ENDPOINTS.AUTHENTICATE}`;
 
-        const response = await fetch(url, {
+        const response = await fetchWithTimeout(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -389,14 +415,14 @@ export class ArtemisApiService {
         }
 
         try {
-            const response = await fetch(`${this.getServerUrl()}${CONFIG.API.ENDPOINTS.LOGOUT}`, {
+            const response = await fetchWithTimeout(`${this.getServerUrl()}${CONFIG.API.ENDPOINTS.LOGOUT}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'User-Agent': getUserAgent(),
                     ...headers,
                 },
-            });
+            }, CONFIG.API.LOGOUT_TIMEOUT_MS);
             if (response.ok) {
                 logger.info('Server-side logout successful', LogCategory.AUTH);
             } else {

--- a/extension/src/extension/utils/constants.ts
+++ b/extension/src/extension/utils/constants.ts
@@ -16,6 +16,13 @@ export const CONFIG = {
             LOGOUT: '/api/core/public/logout',
             RENDER_PROBLEM_STATEMENT: '/api/exercise/problem-statement/render',
         },
+        // Backstop against a server that accepts the connection but never responds.
+        // Generous on purpose so slow networks are not falsely aborted; this only
+        // prevents indefinite hangs on login/chat/API calls.
+        REQUEST_TIMEOUT_MS: 30000,
+        // Server-side logout is best-effort and the logout flow awaits it before
+        // clearing local state, so it gets a much shorter backstop than other calls.
+        LOGOUT_TIMEOUT_MS: 5000,
     },
 } as const;
 

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -1,8 +1,10 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 
 import { ArtemisApiService } from '@extension/api/artemisApi';
 import { AuthManager } from '@extension/services/auth/authManager';
 import { ApiError, MalformedResponseError } from '@extension/types';
+import { CONFIG } from '@extension/utils';
 import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
 
 // Mock fetch
@@ -826,6 +828,59 @@ suite('Artemis API Service Test Suite', () => {
             assert.ok(error instanceof Error);
             assert.ok(error.message.includes('no JWT token received'));
             assert.strictEqual(storeCalled, false, 'credentials should not be stored');
+        }
+    });
+
+    test('should abort a hanging request after the request timeout', async () => {
+        // A server that accepts the connection but never responds: the fetch promise
+        // only settles if its abort signal fires.
+        global.fetch = ((_url: any, options: any) => new Promise((_resolve, reject) => {
+            const signal: AbortSignal | undefined = options?.signal;
+            signal?.addEventListener('abort', () => reject(signal.reason));
+        })) as any;
+
+        const clock = sinon.useFakeTimers();
+        try {
+            const pending = apiService.getCurrentUser();
+            let settled = false;
+            pending.then(() => { settled = true; }, () => { settled = true; });
+
+            await clock.tickAsync(CONFIG.API.REQUEST_TIMEOUT_MS + 1000);
+
+            // settled check fails fast if the timeout is ever removed (rather than hanging CI).
+            assert.ok(settled, 'request should have been aborted after the timeout');
+            await assert.rejects(
+                pending,
+                (err: unknown) => err instanceof DOMException && err.name === 'TimeoutError',
+            );
+        } finally {
+            clock.restore();
+        }
+    });
+
+    test('logoutFromServer aborts on its short timeout and stays best-effort', async () => {
+        // Logout uses a shorter timeout than other calls; verify it aborts well before
+        // the default request timeout and that the best-effort method never rejects.
+        let aborted = false;
+        global.fetch = ((_url: any, options: any) => new Promise((_resolve, reject) => {
+            const signal: AbortSignal | undefined = options?.signal;
+            signal?.addEventListener('abort', () => { aborted = true; reject(signal.reason); });
+        })) as any;
+
+        const clock = sinon.useFakeTimers();
+        try {
+            const done = apiService.logoutFromServer();
+            let resolved = false;
+            let threw = false;
+            done.then(() => { resolved = true; }, () => { threw = true; });
+
+            // Past the logout timeout but below the default request timeout.
+            await clock.tickAsync(CONFIG.API.LOGOUT_TIMEOUT_MS + 500);
+
+            assert.ok(aborted, 'logout request should be aborted by the short logout timeout');
+            assert.ok(resolved && !threw, 'logout must remain best-effort (never reject)');
+        } finally {
+            clock.restore();
         }
     });
 });


### PR DESCRIPTION
## Problem

`ArtemisApiService` issued every network call via the global `fetch()` with **no timeout**. A server that accepts the TCP connection but never responds would hang the caller forever — login, chat-send, and the Iris availability probe could all stall indefinitely with no recovery path. The git execs in the workspace code already set `timeout: 5000`; the HTTP layer had nothing.

## Fix

- New module-level helper `fetchWithTimeout(url, options, timeoutMs)`: a fresh `AbortController` + `setTimeout` that aborts with a `TimeoutError`, `clearTimeout` in `finally` so the timer never leaks, and a caller-supplied `options.signal` is still honoured (via `AbortSignal.any`).
- All three fetch sites (`makeRequest`, `authenticate`, `logoutFromServer`) now use it.
- `CONFIG.API.REQUEST_TIMEOUT_MS = 30000` — a generous backstop chosen so slow networks are **not** falsely aborted; it only prevents indefinite hangs.
- `CONFIG.API.LOGOUT_TIMEOUT_MS = 5000` — the logout flow `await`s the server logout before clearing local state, so the best-effort call gets a much shorter backstop and can't stall logout for 30s.

Manual `AbortController` + `setTimeout` is used (rather than `AbortSignal.timeout`) so the behaviour is controllable by sinon fake timers in tests.

## Testing

- `makeRequest` aborts a hanging request after the configured timeout (fake-timer test, fails fast if the timeout is ever removed).
- `logoutFromServer` aborts on its shorter timeout and stays best-effort (never rejects).
- Full unit suite green (1243 tests), `check-types` + `eslint src test` clean.

Part of #257.
