### PR TITLE
refactor(recording): harden recorder teardown contract, fix write-lane TOCTOU

### DIFF
--- a/extension/src/extension/dataCollection/index.ts
+++ b/extension/src/extension/dataCollection/index.ts
@@ -56,9 +56,9 @@ export function wireDataCollection(deps: DataCollectionDeps): DataCollectionHand
             if (disposed) { return; }
             disposed = true;
             try {
-                await (sessionRecorder as SessionRecorder).dispose();
+                await (sessionRecorder as SessionRecorder).shutdown();
             } catch (err) {
-                logger.error('Failed to dispose SessionRecorder', LogCategory.TELEMETRY, err);
+                logger.error('Failed to shut down SessionRecorder', LogCategory.TELEMETRY, err);
             }
             recorderDisposable.dispose();
             paletteCommands.dispose();

--- a/extension/src/extension/services/telemetry/recording/lifecycleController.ts
+++ b/extension/src/extension/services/telemetry/recording/lifecycleController.ts
@@ -318,7 +318,7 @@ export class LifecycleController {
         return this._enqueueLifecycle('endSession', () => this._doFinalize(reason));
     }
 
-    /** Drains any pending lifecycle op. Used by SessionRecorder.dispose(). */
+    /** Drains any pending lifecycle op. Used by SessionRecorder.shutdown(). */
     async drainPending(): Promise<void> {
         try {
             await this._lifecyclePromise;

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -83,8 +83,8 @@ type StartupContributor = StartupContributorFromModule;
 
 type RecorderPhase = RecorderPhaseFromState;
 
-export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandler {
-    // ── Dispose guard ─────────────────────────────────────────────────
+export class SessionRecorder implements WebSocketMessageHandler {
+    // ── Shutdown guard ────────────────────────────────────────────────
 
     private _disposed = false;
 
@@ -486,21 +486,28 @@ export class SessionRecorder implements vscode.Disposable, WebSocketMessageHandl
         });
     }
 
-    // ── Disposable ────────────────────────────────────────────────────
+    // ── Shutdown ──────────────────────────────────────────────────────
 
-    async dispose(): Promise<void> {
+    /**
+     * Awaitable teardown. Deliberately NOT named `dispose()` and the class does
+     * NOT implement `vscode.Disposable`: the durability guarantee (buffered
+     * events flushed to disk) only holds if this is awaited, so it must never be
+     * registered in `context.subscriptions` where VS Code would fire-and-forget it.
+     * The durable path is `deactivate()` → DataCollectionHandle → here.
+     */
+    async shutdown(): Promise<void> {
         if (this._disposed) { return; }
         this._disposed = true;
         if (this._phase === 'recording' || this._phase === 'starting') {
             try {
                 await this.endSession('deactivate');
             } catch (err: unknown) {
-                logger.error('Failed to end recording session during dispose', LogCategory.TELEMETRY, err);
+                logger.error('Failed to end recording session during shutdown', LogCategory.TELEMETRY, err);
             }
         }
         await this._lifecycle.drainPending();
         this._observation.disposeSubscriptions();
-        await this._writer.dispose();
+        await this._writer.shutdown();
         this._onDidChangeState.dispose();
     }
 

--- a/extension/src/extension/services/telemetry/recording/storageWriter.ts
+++ b/extension/src/extension/services/telemetry/recording/storageWriter.ts
@@ -6,7 +6,7 @@
  *
  * ## Durability Policy
  *
- * On graceful shutdown (dispose() is awaited), data integrity is guaranteed:
+ * On graceful shutdown (shutdown() is awaited), data integrity is guaranteed:
  * all buffered events are written before the method returns. On extension-host
  * crash, process-kill, or any fatal failure that bypasses `finally` execution,
  * up to `BUFFER_THRESHOLD` (10) events may be lost. Lifecycle events
@@ -14,7 +14,7 @@
  * event and share the same crash-durability boundary.
  *
  * On graceful extension unload, `deactivate()` in `extension.ts` is async
- * and explicitly awaits `SessionRecorder.dispose()`, so all buffered events
+ * and explicitly awaits `SessionRecorder.shutdown()`, so all buffered events
  * reach disk before the extension host tears down the process.
  *
  * ## Serialisation (Write Lane)
@@ -53,7 +53,7 @@ const LANE_DRAIN_TIMEOUT_MS = 5_000;
  * Extracted so tests can inject a mock without fighting Node's non-configurable
  * module property descriptors.
  *
- * Note: `appendFileSync` exists solely for the dispose() sync-fallback path,
+ * Note: `appendFileSync` exists solely for the shutdown() sync-fallback path,
  * which runs when the write lane is idle and we need the lowest-latency
  * shutdown (no microtask scheduling overhead).
  */
@@ -108,7 +108,7 @@ export class RecordingStorageWriter {
 
     /**
      * True when no write is executing and no write is queued.
-     * Safe to use a sync fallback in `dispose()` only when this is true.
+     * Safe to use a sync fallback in `shutdown()` only when this is true.
      */
     private get _laneIdle(): boolean {
         return this._activeWrites === 0 && this._queuedWrites === 0;
@@ -184,10 +184,13 @@ export class RecordingStorageWriter {
         if (this._disabled || !this._snapshotsDir) {
             return false;
         }
+        // Capture before enqueuing: abort()/endSession() may null the field
+        // before this lane work runs (abort() does not drain the lane).
+        const snapshotsDir = this._snapshotsDir;
         let success = false;
         await this._enqueueLaneWork(async () => {
             const sanitized = this._sanitizeFileName(uri);
-            const snapshotPath = path.join(this._snapshotsDir!, `${sanitized}.txt`);
+            const snapshotPath = path.join(snapshotsDir, `${sanitized}.txt`);
             const truncated = content.length > MAX_SNAPSHOT_BYTES
                 ? content.slice(0, MAX_SNAPSHOT_BYTES) + '\n[TRUNCATED at 1MB]'
                 : content;
@@ -202,13 +205,16 @@ export class RecordingStorageWriter {
         if (this._disabled || !this._sessionDir) {
             return;
         }
+        // Capture before enqueuing (see writeSnapshot): the field may be nulled
+        // by abort()/endSession() before this lane work runs.
+        const sessionDir = this._sessionDir;
         const enriched: SessionMetadata = {
             ...metadata,
             schemaVersion: 2,
             recorderVersion: this._recorderVersion,
         };
         return this._enqueueLaneWork(async () => {
-            const metadataPath = path.join(this._sessionDir!, 'metadata.json');
+            const metadataPath = path.join(sessionDir, 'metadata.json');
             await this._fs.writeFile(metadataPath, JSON.stringify(enriched, null, 2), 'utf-8');
             this._consecutiveErrors = 0;
         }, 'Failed to write session metadata');
@@ -240,8 +246,10 @@ export class RecordingStorageWriter {
     }
 
     /**
-     * Awaitable dispose. On graceful shutdown, guarantees all buffered events
-     * are written to disk before returning.
+     * Awaitable shutdown. Guarantees all buffered events are written to disk
+     * before returning. Deliberately NOT named `dispose()`: it must be awaited
+     * for the durability guarantee to hold, so it must never be mistaken for a
+     * synchronous `vscode.Disposable.dispose()`.
      *
      * If the lane is already idle (no active/queued writes), a synchronous
      * fallback writes the remaining buffer directly for minimal latency.
@@ -252,7 +260,7 @@ export class RecordingStorageWriter {
      * completes. If the drain times out, the remaining buffer is lost and a
      * warning is logged.
      */
-    async dispose(): Promise<void> {
+    async shutdown(): Promise<void> {
         if (this._disposed) { return; }
         this._disposed = true;
         this._stopFlushTimer();
@@ -265,7 +273,7 @@ export class RecordingStorageWriter {
                     this._fs.appendFileSync(this._eventsPath, lines, 'utf-8');
                     this._buffer.length = 0;
                 } catch (err) {
-                    logger.warn('Recording writer dispose: sync fallback write failed', LogCategory.TELEMETRY, err);
+                    logger.warn('Recording writer shutdown: sync fallback write failed', LogCategory.TELEMETRY, err);
                 }
             }
         } else {
@@ -285,7 +293,7 @@ export class RecordingStorageWriter {
                 await this._drainLane();
             } else {
                 logger.warn(
-                    'Recording writer dispose: lane drain timed out, accepting buffer loss',
+                    'Recording writer shutdown: lane drain timed out, accepting buffer loss',
                     LogCategory.TELEMETRY,
                 );
             }

--- a/extension/test/e2e/recording.e2e.test.ts
+++ b/extension/test/e2e/recording.e2e.test.ts
@@ -55,7 +55,7 @@ suite('Session Recorder — E2E (VS Code only)', function () {
 
     teardown(async () => {
         if (recorder && !(recorder as unknown as { _disposed: boolean })._disposed) {
-            try { await recorder.dispose(); } catch { /* best-effort */ }
+            try { await recorder.shutdown(); } catch { /* best-effort */ }
         }
         recorder = undefined;
         if (storageDir) {

--- a/extension/test/logic/dataCollection/fullSeam.test.ts
+++ b/extension/test/logic/dataCollection/fullSeam.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 // Spies referenced inside vi.mock factories MUST be hoisted (vitest requirement).
 const h = vi.hoisted(() => ({
     registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
-    recorderDispose: vi.fn().mockResolvedValue(undefined),
+    recorderShutdown: vi.fn().mockResolvedValue(undefined),
     recorderDisposable: { dispose: vi.fn() },
     promptIfPending: vi.fn().mockResolvedValue(undefined),
     consentDispose: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock('@extension/services/auth/consentService', () => ({
     ConsentService: class { promptIfPending = h.promptIfPending; dispose = h.consentDispose; },
 }));
 vi.mock('@extension/activation/sessionRecorderWiring', () => ({
-    wireSessionRecorder: () => ({ sessionRecorder: { dispose: h.recorderDispose }, disposable: h.recorderDisposable }),
+    wireSessionRecorder: () => ({ sessionRecorder: { shutdown: h.recorderShutdown }, disposable: h.recorderDisposable }),
 }));
 vi.mock('@extension/services/telemetry/replay', () => ({ executeReplayCommand: h.executeReplayCommand }));
 vi.mock('@extension/services/loggingService', () => ({ logger: { error: vi.fn() }, LogCategory: { TELEMETRY: 'telemetry' } }));
@@ -44,10 +44,10 @@ describe('full data-collection seam', () => {
     });
 
     it('dispose awaits the recorder flush and is idempotent', async () => {
-        h.recorderDispose.mockClear();
+        h.recorderShutdown.mockClear();
         const handle = wireDataCollection(deps);
         await handle.dispose();
         await handle.dispose();
-        expect(h.recorderDispose).toHaveBeenCalledOnce();
+        expect(h.recorderShutdown).toHaveBeenCalledOnce();
     });
 });

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -246,7 +246,7 @@ async function makeWiringHarness(
         },
         dispose: async () => {
             wiring.disposable.dispose();
-            try { await wiring.sessionRecorder.dispose(); } catch { /* ignore */ }
+            try { await wiring.sessionRecorder.shutdown(); } catch { /* ignore */ }
             telemetryManager.dispose();
             try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
             // Stubs are restored centrally via the suite-level sandbox in teardown.

--- a/extension/test/unit/services/telemetry/recording/chatRecording.test.ts
+++ b/extension/test/unit/services/telemetry/recording/chatRecording.test.ts
@@ -100,7 +100,7 @@ suite('SessionRecorder — Block H: Chat Recording', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── H.1: Send-attempt lifecycle ───────────────────────────────────────

--- a/extension/test/unit/services/telemetry/recording/debugRecording.test.ts
+++ b/extension/test/unit/services/telemetry/recording/debugRecording.test.ts
@@ -199,7 +199,7 @@ suite('Debugger recording — phase gating (white-box)', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // T5: events recorded while recording carry their structure into the stream.

--- a/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorder.test.ts
@@ -181,7 +181,7 @@ suite('SessionRecorder (Block AB+E)', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test: Basic start sequence ────────────────────────────────────────
@@ -519,7 +519,7 @@ suite('SessionRecorder (Block AB+E)', () => {
         recorder.recordIrisChatSent('msg-2');
         recorder.recordIrisChatSent('msg-3');
 
-        await recorder.dispose();
+        await recorder.shutdown();
 
         const events = collectWrittenEvents(fs);
         const chatMsgs = events.filter(e => e.type === 'irisChatMessage');
@@ -937,7 +937,7 @@ suite('SessionRecorder — intervention suppression and configuration provenance
         assert.strictEqual(intervention!.rawWanted, true);
         assert.strictEqual(intervention!.level, 'notification');
         assert.strictEqual(intervention!.triggerType, 'execution-error');
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     test('recordConfigurationSnapshot persists both keys', async () => {
@@ -951,7 +951,7 @@ suite('SessionRecorder — intervention suppression and configuration provenance
         assert.ok(snap, 'configurationSnapshot missing');
         assert.strictEqual(snap!.struggleDetectionEnabled, true);
         assert.strictEqual(snap!.showInterventions, false);
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     test('recordConfigurationChange persists only the changed key', async () => {
@@ -964,7 +964,7 @@ suite('SessionRecorder — intervention suppression and configuration provenance
         const change = events.find(e => e.type === 'configurationChange') as ConfigurationChangeEvent | undefined;
         assert.ok(change, 'configurationChange missing');
         assert.deepStrictEqual(change!.changes, { showInterventions: false });
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 });
 
@@ -1009,7 +1009,7 @@ suite('SessionRecorder finalization path characterization', () => {
         assert.strictEqual(meta.eventCount, events.length,
             `metadata.eventCount (${meta.eventCount}) must equal JSONL event count (${events.length})`);
 
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     test('Test A2: consent-downgrade path produces well-formed metadata and sessionEnd as last event', async () => {
@@ -1050,7 +1050,7 @@ suite('SessionRecorder finalization path characterization', () => {
         assert.strictEqual(meta.eventCount, events.length,
             `metadata.eventCount (${meta.eventCount}) must equal JSONL event count (${events.length})`);
 
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test B: flush vs discard for pending debounce payloads ──────────
@@ -1082,7 +1082,7 @@ suite('SessionRecorder finalization path characterization', () => {
             `endSession must flush pending selectionChange (not found). types=${s1Types.join(',')}`);
         assert.ok(s1EndIdx > s1SelIdx,
             'flushed selectionChange must appear before sessionEnd');
-        try { await s1.recorder.dispose(); } catch { /* ignore */ }
+        try { await s1.recorder.shutdown(); } catch { /* ignore */ }
 
         // Scenario 2: disable discards the pending payload.
         const s2 = makeRecorder();
@@ -1106,7 +1106,7 @@ suite('SessionRecorder finalization path characterization', () => {
         const s2EndIdx = s2Types.lastIndexOf('sessionEnd');
         assert.ok(s2ConsentIdx >= 0, 'consentChange must appear after disable()');
         assert.ok(s2EndIdx > s2ConsentIdx, 'sessionEnd must come after consentChange');
-        try { await s2.recorder.dispose(); } catch { /* ignore */ }
+        try { await s2.recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test C: recorder can start a new session cleanly after both paths ──
@@ -1123,7 +1123,7 @@ suite('SessionRecorder finalization path characterization', () => {
         recorder.recordIrisChatSent('session-31-msg');
         await recorder.endSession();
 
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
 
         const events = collectWrittenEvents(fs);
         const starts = events.filter(e => e.type === 'sessionStart') as Array<{ exerciseId: number }>;
@@ -1159,7 +1159,7 @@ suite('SessionRecorder finalization path characterization', () => {
         recorder.recordIrisChatSent('session-41-msg');
         await recorder.endSession();
 
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
 
         const events = collectWrittenEvents(fs);
         const starts = events.filter(e => e.type === 'sessionStart') as Array<{ exerciseId: number }>;

--- a/extension/test/unit/services/telemetry/recording/sessionRecorderViewEvents.test.ts
+++ b/extension/test/unit/services/telemetry/recording/sessionRecorderViewEvents.test.ts
@@ -97,7 +97,7 @@ suite('SessionRecorder — view events', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     test('recordTestResultsOverviewOpened emits opened event with counts', async () => {

--- a/extension/test/unit/services/telemetry/recording/snapshotRetry.test.ts
+++ b/extension/test/unit/services/telemetry/recording/snapshotRetry.test.ts
@@ -149,7 +149,7 @@ suite('SessionRecorder — Block G: Snapshot Retry', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test 1: writeSnapshot returns false on error, true on success ─────

--- a/extension/test/unit/services/telemetry/recording/storageWriter.test.ts
+++ b/extension/test/unit/services/telemetry/recording/storageWriter.test.ts
@@ -142,7 +142,7 @@ suite('RecordingStorageWriter (Block D)', () => {
 
     teardown(async () => {
         // Always stop internal timer. Dispose is idempotent.
-        try { await writer.dispose(); } catch { /* ignore */ }
+        try { await writer.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test 1: Ordering under 100 parallel appendEvent calls ─────────────────
@@ -242,7 +242,7 @@ suite('RecordingStorageWriter (Block D)', () => {
             // Clear prior appendedChunks so we only check what dispose writes
             fakeFs.appendedChunks = [];
 
-            await writer.dispose();
+            await writer.shutdown();
 
             // Sync fallback should have been called
             assert.strictEqual(fakeFs.syncChunks.length, 1, 'appendFileSync should be called once');
@@ -280,7 +280,7 @@ suite('RecordingStorageWriter (Block D)', () => {
             handle.resolve();
 
             // dispose() should await the drain and then do a final flush
-            await writer.dispose();
+            await writer.shutdown();
 
             // Sync fallback should NOT have been called (lane was busy)
             assert.strictEqual(fakeFs.syncChunks.length, 0, 'appendFileSync should NOT be called when lane is busy');

--- a/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
+++ b/extension/test/unit/services/telemetry/recording/terminalShellExecution.test.ts
@@ -141,7 +141,7 @@ suite('TerminalCollector characterization tests', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test 1: abortAllPending via disable() ─────────────────────────────

--- a/extension/test/unit/services/telemetry/recording/workspaceEvents.test.ts
+++ b/extension/test/unit/services/telemetry/recording/workspaceEvents.test.ts
@@ -116,7 +116,7 @@ suite('Block K — workspace file events (white-box)', () => {
     });
 
     teardown(async () => {
-        try { await recorder.dispose(); } catch { /* ignore */ }
+        try { await recorder.shutdown(); } catch { /* ignore */ }
     });
 
     // ── Test 1: fileCreate ───────────────────────────────────────────────


### PR DESCRIPTION
## Two recording-lifecycle smells from the audit (#257)

### #4 — Write-lane TOCTOU masked by non-null assertions (latent bug)

`writeSnapshot` / `writeMetadata` guarded `_snapshotsDir` / `_sessionDir`, then used the field via a non-null assertion (`this._snapshotsDir!`) **inside a queued write-lane lambda**. `abort()` nulls those fields **without draining the lane**, so the lambda could run after the field was cleared → `path.join(undefined, …)` (caught by the lane error handler, so bounded — but a real hole the `!` hid).

**Fix:** capture the directory into a local `const` right after the guard and close over the local. Removes both `!` assertions. `_enqueueFlush` was left as-is on purpose — its guard runs *inside* the lambda at execution time, so there's no TOCTOU there.

### #3 — `async dispose()` masquerading as a `vscode.Disposable` (API hardening)

`SessionRecorder` declared `implements vscode.Disposable`, but its `dispose()` was `async` (`Promise<void>`). The durability guarantee (buffered JSONL flushed to disk) only holds when the call is **awaited**. Today the durable path (`deactivate()` → `DataCollectionHandle` → recorder) does await it, so this is **not a current bug** — but because `dispose(): Promise<void>` is structurally a `vscode.Disposable`, nothing stops a future change from pushing the recorder into `context.subscriptions`, where VS Code would fire-and-forget it and silently lose buffered events.

**Fix:** rename `SessionRecorder.dispose()` and `RecordingStorageWriter.dispose()` → `shutdown()`, and drop the misleading `implements vscode.Disposable`. There's now no `dispose` to structurally match, so the awaitable teardown can't be mistaken for a sync disposable. The durable teardown chain is unchanged.

## Notes

- Behaviour-preserving. ~22 test call sites renamed mechanically (compiler-verified).
- `DataCollectionHandle.dispose()` (one level up) is also async, but it's its own named interface with a doc comment that deliberately documents the await-and-not-in-subscriptions decision — left as-is rather than churn the activation file + Open-VSX seam. Can be renamed for uniformity if wanted.

## Testing

- Full unit suite green (1243 tests), recorder-e2e 4/4, `check-types` + `eslint src test` clean.

Part of #257.
