### PR TITLE
fix(auth): keep stored credentials on transient startup failures

### DIFF
--- a/extension/src/extension/services/auth/authFlowHandler.ts
+++ b/extension/src/extension/services/auth/authFlowHandler.ts
@@ -7,6 +7,7 @@ import { ArtemisApiService } from '@extension/api';
 import type { UserInfo } from '@extension/controller/appStateManager';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { getTheiaEnvironment } from '@extension/theia';
+import { ApiError } from '@extension/types';
 import { CONFIG, resolveServerUrl, VSCODE_CONFIG } from '@extension/utils';
 
 import { AuthManager } from './authManager';
@@ -54,21 +55,34 @@ export class AuthFlowHandler {
 
     public async checkExistingAuthentication(): Promise<void> {
         try {
-            const hasAuth = await this._authManager.hasAuthToken();
-            if (hasAuth) {
-                this._postMessage({ type: ExtensionMsg.ShowLoading, message: 'Checking stored credentials...' });
-                this._postMessage({ type: ExtensionMsg.UpdateLoading, message: 'Loading user information...' });
+            let hasAuth = false;
+            try {
+                hasAuth = await this._authManager.hasAuthToken();
+            } catch (error) {
+                // Reading the stored token failed — clearing it would be pointless
+                // and destructive, so just fall back to the login UI.
+                logger.error('Error reading stored authentication state', LogCategory.AUTH, error);
+                this._callbacks.hideLoadingAndSendServerUrl();
+                return;
+            }
 
-                try {
-                    const user = await this._artemisApi.getCurrentUser();
-                    const serverUrl = this._getServerUrl();
-                    logger.info(`Auto-authenticated user: ${user.login}`, LogCategory.AUTH);
-                    await this._callbacks.onAuthenticated({
-                        username: user.login || 'User',
-                        serverUrl: serverUrl,
-                        user: user
-                    });
-                } catch (userError) {
+            if (!hasAuth) {
+                this._callbacks.hideLoadingAndSendServerUrl();
+                return;
+            }
+
+            this._postMessage({ type: ExtensionMsg.ShowLoading, message: 'Checking stored credentials...' });
+            this._postMessage({ type: ExtensionMsg.UpdateLoading, message: 'Loading user information...' });
+
+            let user;
+            try {
+                user = await this._artemisApi.getCurrentUser();
+            } catch (userError) {
+                // Only a 401 means the stored token is actually invalid. A timeout,
+                // network error, or 5xx is a transient reachability problem — keep
+                // the credentials so a blip (e.g. slow network at startup) does not
+                // log the user out.
+                if (userError instanceof ApiError && userError.status === 401) {
                     logger.info('Stored credentials are invalid, clearing...', LogCategory.AUTH);
                     await this._authManager.clear();
 
@@ -76,21 +90,29 @@ export class AuthFlowHandler {
                     if (updater) {
                         await updater(false);
                     }
-
-                    this._callbacks.hideLoadingAndSendServerUrl();
+                } else {
+                    logger.warn('Could not verify stored credentials (server unreachable?); keeping them', LogCategory.AUTH, userError);
                 }
-            } else {
                 this._callbacks.hideLoadingAndSendServerUrl();
+                return;
             }
+
+            // Credentials are valid. A failure in post-auth wiring must NOT be
+            // mistaken for invalid credentials, so it is handled by the
+            // non-clearing outer catch below and never clears a valid token.
+            const serverUrl = this._getServerUrl();
+            logger.info(`Auto-authenticated user: ${user.login}`, LogCategory.AUTH);
+            await this._callbacks.onAuthenticated({
+                username: user.login || 'User',
+                serverUrl: serverUrl,
+                user: user
+            });
         } catch (error) {
-            logger.error('Error checking existing authentication', LogCategory.AUTH, error);
-            await this._authManager.clear();
-
-            const updater = this._getAuthContextUpdater();
-            if (updater) {
-                await updater(false);
-            }
-
+            // Safety net: never strand the startup loading UI. Crucially this does
+            // NOT clear credentials — a transient or post-auth failure must not log
+            // the user out (the only credential-clearing path is the inline 401
+            // branch above, which runs before reaching here).
+            logger.error('Startup authentication did not complete (credentials kept)', LogCategory.AUTH, error);
             this._callbacks.hideLoadingAndSendServerUrl();
         }
     }

--- a/extension/test/unit/services/auth/authFlowHandler.test.ts
+++ b/extension/test/unit/services/auth/authFlowHandler.test.ts
@@ -1,0 +1,113 @@
+import * as assert from 'assert';
+
+import { ArtemisApiService } from '@extension/api';
+import { AuthFlowHandler } from '@extension/services/auth/authFlowHandler';
+import { AuthManager } from '@extension/services/auth/authManager';
+import { ApiError } from '@extension/types';
+
+suite('AuthFlowHandler.checkExistingAuthentication', () => {
+    interface HarnessOpts {
+        hasAuthToken?: () => Promise<boolean>;
+        getCurrentUser: () => Promise<unknown>;
+        onAuthenticated?: (info: unknown) => Promise<void>;
+        updater?: (isAuthenticated: boolean) => Promise<void>;
+    }
+
+    function makeHandler(opts: HarnessOpts) {
+        const state = {
+            cleared: false,
+            hideCalled: false,
+            authenticatedWith: undefined as unknown,
+            updaterCalledWith: undefined as boolean | undefined,
+        };
+        const authManager = {
+            hasAuthToken: opts.hasAuthToken ?? (async () => true),
+            clear: async () => { state.cleared = true; },
+        } as unknown as AuthManager;
+        const artemisApi = { getCurrentUser: opts.getCurrentUser } as unknown as ArtemisApiService;
+        const updater = opts.updater ?? (async (isAuthenticated: boolean) => { state.updaterCalledWith = isAuthenticated; });
+        const handler = new AuthFlowHandler(
+            authManager,
+            artemisApi,
+            () => updater,
+            () => { /* postMessage */ },
+            {
+                onAuthenticated: opts.onAuthenticated ?? (async (info) => { state.authenticatedWith = info; }),
+                hideLoadingAndSendServerUrl: () => { state.hideCalled = true; },
+                showLogin: () => { /* noop */ },
+            },
+        );
+        return { handler, state };
+    }
+
+    test('keeps credentials when the server times out (no clear)', async () => {
+        const { handler, state } = makeHandler({ getCurrentUser: async () => { throw new DOMException('Request timed out', 'TimeoutError'); } });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false, 'must NOT clear stored credentials on a timeout');
+        assert.strictEqual(state.hideCalled, true, 'must recover the UI');
+    });
+
+    test('keeps credentials on a network error (no clear)', async () => {
+        const { handler, state } = makeHandler({ getCurrentUser: async () => { throw new TypeError('fetch failed'); } });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false, 'must NOT clear stored credentials on a network error');
+        assert.strictEqual(state.hideCalled, true);
+    });
+
+    test('keeps credentials on a non-401 server error (no clear)', async () => {
+        const { handler, state } = makeHandler({ getCurrentUser: async () => { throw new ApiError('Server error', 503); } });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false, 'must NOT clear on a transient 5xx');
+        assert.strictEqual(state.hideCalled, true);
+    });
+
+    test('clears credentials and marks context unauthenticated on a 401', async () => {
+        const { handler, state } = makeHandler({ getCurrentUser: async () => { throw new ApiError('Authentication failed', 401); } });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, true, 'must clear stored credentials on 401');
+        assert.strictEqual(state.updaterCalledWith, false, 'must mark the auth context unauthenticated');
+        assert.strictEqual(state.hideCalled, true);
+    });
+
+    test('recovers the UI even if the auth-context updater throws on 401', async () => {
+        const { handler, state } = makeHandler({
+            getCurrentUser: async () => { throw new ApiError('Authentication failed', 401); },
+            updater: async () => { throw new Error('setContext boom'); },
+        });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, true, 'credentials are still cleared on 401');
+        assert.strictEqual(state.hideCalled, true, 'must still recover the UI when the updater throws');
+    });
+
+    test('does not clear and recovers the UI when post-auth wiring fails after a valid fetch', async () => {
+        const { handler, state } = makeHandler({
+            getCurrentUser: async () => ({ login: 'test' }),
+            onAuthenticated: async () => { throw new Error('wiring boom'); },
+        });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false, 'valid credentials must survive a post-auth wiring failure');
+        assert.strictEqual(state.hideCalled, true, 'must recover the UI rather than strand the loader');
+    });
+
+    test('does not clear and recovers the UI when reading the stored token fails', async () => {
+        const { handler, state } = makeHandler({
+            hasAuthToken: async () => { throw new Error('secrets read failed'); },
+            getCurrentUser: async () => { throw new Error('should not be called'); },
+        });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false, 'must NOT clear when the token cannot even be read');
+        assert.strictEqual(state.hideCalled, true);
+    });
+
+    test('happy path authenticates and does not reset to the login view', async () => {
+        const { handler, state } = makeHandler({ getCurrentUser: async () => ({ login: 'alice' }) });
+        await handler.checkExistingAuthentication();
+        assert.strictEqual(state.cleared, false);
+        assert.strictEqual(state.hideCalled, false, 'a successful auto-login must not send the login view');
+        assert.ok(state.authenticatedWith, 'onAuthenticated must be called');
+        const payload = state.authenticatedWith as { username: string; serverUrl: string; user: { login: string } };
+        assert.strictEqual(payload.username, 'alice');
+        assert.strictEqual(payload.user.login, 'alice', 'must forward the fetched user');
+        assert.ok(payload.serverUrl, 'must include the resolved server URL');
+    });
+});


### PR DESCRIPTION
## Problem (regression surfaced by the #259 re-review)

`AuthFlowHandler.checkExistingAuthentication()` cleared the stored token on **any** `getCurrentUser()` failure. Before the request-timeout work in #259, a hung server hung forever and never reached that branch; afterwards a 30s `TimeoutError` (or a network error / 5xx) does — so **a transient reachability problem at startup silently logged the user out** (e.g. a student on a slow/flaky network reopening VS Code).

Codex's review also flagged two recovery regressions in the first cut of this fix: a throwing auth-context updater on 401, or a failing `onAuthenticated()`, could strand the startup loading spinner.

## Fix

- **Clear only on a definitive auth-invalid signal (`ApiError` 401).** Timeout / network / 5xx now **keep** the credentials and fall back to the login UI so the user can retry. (`makeRequest()` already treats 401 as the sole auth-invalid signal.)
- **Split `getCurrentUser()` from `onAuthenticated()`** so a post-auth wiring failure is never misclassified as invalid credentials.
- **Non-clearing outer safety-net catch** so the startup loading UI always recovers — even if the auth-context updater throws on 401 — without ever clearing a valid token.

## Testing

New `authFlowHandler.test.ts` (8 cases) pins the contract: timeout/network/5xx keep credentials; 401 clears + marks context unauthenticated; UI recovers even when the updater throws on 401; post-auth failure keeps credentials and recovers the UI; `hasAuthToken` read failure keeps credentials and recovers; happy path forwards the full `onAuthenticated` payload and does not reset to login.

Full mocha unit suite green (1251), vitest 804, `check-types` + `eslint src test` clean.

Part of #257; follow-up to #259. (The separate LOW "body-read timeout" finding from #259 is intentionally **not** in this PR.)
