### PR TITLE
fix(exercise): list test results when test names are hidden

### DIFF
--- a/extension/src/webview/utils/exerciseStatus.ts
+++ b/extension/src/webview/utils/exerciseStatus.ts
@@ -73,15 +73,37 @@ interface FeedbackInput {
     testCase?: { id?: number; testName?: string };
 }
 
+// Prefixes Artemis encodes in `feedback.text` to mark non-test automatic
+// feedback (kept in sync with the server's feedback.model.ts identifiers).
+const SCA_FEEDBACK_IDENTIFIER = 'SCAFeedbackIdentifier:';
+const SUBMISSION_POLICY_FEEDBACK_IDENTIFIER = 'SubPolFeedbackIdentifier:';
+
+/**
+ * Whether a result feedback describes a programming test case.
+ *
+ * Mirrors the Artemis web client's `Feedback.isTestCaseFeedback`
+ * (`type === AUTOMATIC && !!testCase`): a feedback that references a test case
+ * IS a test feedback even when the test name is hidden from students
+ * (`showTestNamesToStudents = false`, where Artemis omits both `text` and
+ * `testCase.testName`). Older results without a `testCase` relation are
+ * identified by their name-bearing `text`, excluding static-code-analysis and
+ * submission-policy feedback (both carry an identifier prefix and no testCase).
+ */
+export function isTestCaseFeedback(f: FeedbackInput): boolean {
+    if (f.type && f.type !== 'AUTOMATIC') { return false; }
+    if (f.testCase) { return true; }
+    return !!f.text
+        && !f.text.startsWith(SCA_FEEDBACK_IDENTIFIER)
+        && !f.text.startsWith(SUBMISSION_POLICY_FEEDBACK_IDENTIFIER);
+}
+
 /**
  * Transforms Artemis result feedbacks into structured test case results.
- * Filters out SCA feedback identifiers and keeps only test-related entries.
+ * Keeps only test-case feedback (see {@link isTestCaseFeedback}); the name
+ * falls back to a generic 'Test' when hidden, matching the Artemis web client.
  */
 export function transformFeedbacksToTestCases(feedbacks: FeedbackInput[]): TestCaseResult[] {
-    const testFeedbacks = feedbacks.filter(f =>
-        f.testCase?.testName || ((!f.type || f.type === 'AUTOMATIC') && f.text && !f.text.startsWith('SCAFeedbackIdentifier:'))
-    );
-    return testFeedbacks.map(f => ({
+    return feedbacks.filter(isTestCaseFeedback).map(f => ({
         name: f.testCase?.testName ?? f.text ?? 'Test',
         passed: f.positive ?? false,
         message: f.detailText,

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -27,6 +27,7 @@ import {
     determineParticipationStatus,
     determineSubmissionStatus,
     getLatestById,
+    isTestCaseFeedback,
     transformFeedbacksToTestCases,
 } from '@webview/utils/exerciseStatus';
 import { formatDate } from '@webview/utils/formatDate';
@@ -218,13 +219,12 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     // Results live on submission.results (not on participation directly)
     const latestResult = getLatestById(latestSubmission?.results);
 
-    // Build test cases from feedbacks for detailed display
-    // The result details API returns feedbacks with testCase objects containing testName
+    // Build test cases from feedbacks for detailed display. Test-case feedback
+    // is identified by isTestCaseFeedback (Artemis parity); the test name may be
+    // hidden (showTestNamesToStudents=false) and is not required.
     const buildFailed = latestSubmission?.buildFailed ?? false;
     const feedbacks = latestResult?.feedbacks ?? [];
-    const testFeedbacks = feedbacks.filter(f =>
-        f.testCase?.testName || ((!f.type || f.type === 'AUTOMATIC') && f.text && !f.text.startsWith('SCAFeedbackIdentifier:'))
-    );
+    const testFeedbacks = feedbacks.filter(isTestCaseFeedback);
     const testCases = transformFeedbacksToTestCases(feedbacks);
 
     // Use Artemis-provided test case counts when available, fall back to feedbacks

--- a/extension/test/react/utils/exerciseStatus.test.ts
+++ b/extension/test/react/utils/exerciseStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyTaskTests, countsForTelemetry } from '@webview/utils/exerciseStatus';
+import { classifyTaskTests, countsForTelemetry, transformFeedbacksToTestCases } from '@webview/utils/exerciseStatus';
 
 describe('classifyTaskTests', () => {
     it('returns no-result when latestResult is undefined', () => {
@@ -113,6 +113,57 @@ describe('classifyTaskTests', () => {
         if (state.kind === 'success') {
             expect(state.passed[0].name).toBe('Fallback name');
         }
+    });
+});
+
+describe('transformFeedbacksToTestCases', () => {
+    // Feedbacks exactly as Artemis delivers them when showTestNamesToStudents=false:
+    // no `text`, no `testCase.testName`, only `detailText` + `testCase.id`.
+    // Mirrors Feedback.isTestCaseFeedback (type==AUTOMATIC && !!testCase).
+    const hiddenNameFeedbacks = [
+        { type: 'AUTOMATIC', positive: false, detailText: 'Method: isValidSelection', testCase: { id: 364902 } },
+        { type: 'AUTOMATIC', positive: false, detailText: 'Method: doOverlap', testCase: { id: 370396 } },
+        { type: 'AUTOMATIC', positive: true, detailText: 'Method: getName', testCase: { id: 370393 } },
+    ];
+
+    it('keeps test feedbacks even when the test name is hidden (showTestNamesToStudents=false)', () => {
+        const result = transformFeedbacksToTestCases(hiddenNameFeedbacks);
+
+        expect(result).toHaveLength(3);
+        expect(result[0]).toMatchObject({
+            id: 364902,
+            name: 'Test', // generic fallback, same as the Artemis web client
+            passed: false,
+            message: 'Method: isValidSelection', // detailText is preserved
+        });
+        expect(result[2].passed).toBe(true);
+    });
+
+    it('still excludes static code analysis and submission policy feedback (no testCase)', () => {
+        const feedbacks = [
+            { type: 'AUTOMATIC', positive: false, text: 'SCAFeedbackIdentifier:checkstyle', detailText: 'sca' },
+            { type: 'AUTOMATIC', positive: false, text: 'SubPolFeedbackIdentifier:limit', detailText: 'policy' },
+            { type: 'AUTOMATIC', positive: false, detailText: 'a real test', testCase: { id: 1 } },
+        ];
+        const result = transformFeedbacksToTestCases(feedbacks);
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe(1);
+    });
+
+    it('keeps the test name when it is visible (showTestNamesToStudents=true)', () => {
+        const result = transformFeedbacksToTestCases([
+            { type: 'AUTOMATIC', positive: true, testCase: { id: 5, testName: 'testDoOverlap()' }, detailText: 'ok' },
+        ]);
+        expect(result).toEqual([{ id: 5, name: 'testDoOverlap()', passed: true, message: 'ok' }]);
+    });
+
+    it('keeps a testCase-bearing feedback even when the testCase has no id (Artemis !!testCase parity)', () => {
+        const result = transformFeedbacksToTestCases([
+            { type: 'AUTOMATIC', positive: false, detailText: 'no id but is a test', testCase: {} },
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ name: 'Test', passed: false, message: 'no id but is a test' });
+        expect(result[0].id).toBeUndefined();
     });
 });
 

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -346,6 +346,47 @@ describe('ExerciseDetailView', () => {
 		expect(closedPayload.durationMs).toBeGreaterThanOrEqual(0);
 	});
 
+	it('overview lists test results when test names are hidden (showTestNamesToStudents=false)', async () => {
+		// Feedbacks as Artemis sends them with hidden test names: no text, no
+		// testCase.testName, only detailText + testCase.id. Regression test for
+		// the "No test results available." bug — the list must be populated.
+		useExerciseDetailStore.setState({
+			exerciseData: makeExerciseData({
+				exercise: {
+					id: 42, title: 'My Exercise', type: 'programming',
+					maxPoints: 10, bonusPoints: 0, problemStatement: 'Solve.',
+					course: { id: 1, title: 'Test Course', shortName: 'TC' },
+					studentParticipations: [{
+						id: 99,
+						repositoryUri: 'https://git.example.com/repo',
+						submissions: [{
+							id: 1,
+							submissionDate: '2025-01-01T00:00:00Z',
+							results: [{
+								id: 10, score: 0, successful: false,
+								completionDate: '2025-01-01T00:00:00Z',
+								testCaseCount: 2, passedTestCaseCount: 0,
+								feedbacks: [
+									{ type: 'AUTOMATIC', positive: false, detailText: 'Method: isValidSelection', testCase: { id: 364902 } },
+									{ type: 'AUTOMATIC', positive: false, detailText: 'Method: doOverlap', testCase: { id: 370396 } },
+								],
+							}],
+						}],
+					}],
+				},
+			}),
+			isLoading: false,
+		});
+		const mockApi = createMockVsCodeApi();
+		render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+		await userEvent.click(screen.getByRole('button', { name: /see test results/i }));
+
+		expect(screen.queryByText('No test results available.')).not.toBeInTheDocument();
+		expect(screen.getByText('Failed (2)')).toBeInTheDocument();
+		expect(screen.getByText('Method: isValidSelection')).toBeInTheDocument();
+	});
+
 	it('posts taskFeedbackOpened with filtered testIds and counts when a [task] span is clicked', async () => {
 		useExerciseDetailStore.setState({
 			exerciseData: makeExerciseDataWithParticipation({ hasResult: true }),


### PR DESCRIPTION
## Problem

Clicking **See test results** showed **"No test results available."** even though the latest result contained failing-test feedback. It reproduces on exercises configured with `showTestNamesToStudents: false`.

## Root cause

When test names are hidden, Artemis sends test-case feedback **without** `text` and **without** `testCase.testName`, only `detailText` plus a `testCase.id`. The overview's feedback filter required a visible name (`testCase.testName` or a non-SCA `text`), so it discarded every feedback and produced an empty list. The button still appeared because the count derives from the server-authoritative `testCaseCount`, not from the filtered list.

This is independent of account/machine and of WebSocket vs. REST shape: even the rich REST result lacks `text`/`testName` here. The only trigger is the exercise setting.

## Fix

- Add `isTestCaseFeedback`, mirroring the Artemis web client's `Feedback.isTestCaseFeedback` (`type === AUTOMATIC && !!testCase`): a feedback that references a test case is a test feedback regardless of whether the name is visible. Legacy results without a `testCase` relation still match via `text`, excluding static-code-analysis and submission-policy feedback (identifier prefixes, no `testCase`).
- Reuse the predicate in `ExerciseDetailView`, removing the duplicated inline filter so the two cannot drift.
- Hidden names fall back to a generic "Test" label (exactly what the Artemis web client does); the per-feedback `detailText` is still shown as the row message.

Verified against the Artemis client source (`feedback.model.ts`, `programming-feedback-item.service.ts`).

## Tests

- Unit (`exerciseStatus.test.ts`): hidden-name feedbacks kept; `testCase` present without `id` kept; SCA and submission-policy feedback excluded; visible names preserved.
- View-level (`ExerciseDetailView.test.tsx`): seeding hidden-name feedbacks and opening the overview renders the failed rows instead of the empty state.

All 809 vitest tests pass; `tsc --noEmit` and eslint are clean.
