### PR TITLE
docs(changelog): note test-results fix for hidden test names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **Replay Fidelity**: Live and recording paths share one build-error-family builder, so replayed EQ matches the live curve.
 - **Intervention Block Reasons**: Withheld interventions record the real gate; `recent-progress`/`last-dismissed` no longer logged as `warmup`.
+- **Test Results With Hidden Names**: The "See test results" overview now lists results for exercises that hide test names from students (`showTestNamesToStudents` disabled), instead of showing "No test results available".
 
 ### Internal
 


### PR DESCRIPTION
Adds an Unreleased `### Fixed` entry for the test-results overview fix shipped in #262 (test results were not shown when an exercise hides test names via `showTestNamesToStudents`).