### PR TITLE
fix(recording-viewer): keep Event Breakdown live in live mode

### DIFF
--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -561,7 +561,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                             lastLabelToast={lastLabelToast}
                         />
                     )}
-                    <SessionInfo session={session} />
+                    <SessionInfo session={session} events={displayedEvents} />
                     <div className="view-toggle-row">
                         <div className="view-toggle">
                             <button

--- a/recording-viewer/src/components/SessionInfo.tsx
+++ b/recording-viewer/src/components/SessionInfo.tsx
@@ -1,4 +1,4 @@
-import type { LoadedSession } from '../types.ts';
+import type { LoadedSession, RecordedEvent } from '../types.ts';
 import { ALL_EVENT_TYPES } from '../constants.ts';
 import { formatDuration, formatTime } from '../utils/format.ts';
 import { orderTypesActiveFirst } from '../utils/timelineLayout.ts';
@@ -6,10 +6,16 @@ import { EventBadge } from './EventBadge.tsx';
 
 interface Props {
     session: LoadedSession;
+    /**
+     * Events to summarise. In live mode these are the streamed events, which
+     * grow over time and differ from the open-time `session.events` snapshot;
+     * passing them explicitly keeps the breakdown, totals and duration live.
+     */
+    events: RecordedEvent[];
 }
 
-export function SessionInfo({ session }: Props) {
-    const { metadata, events } = session;
+export function SessionInfo({ session, events }: Props) {
+    const { metadata } = session;
 
     const eventTypeCounts = new Map<string, number>();
     for (const event of events) {

--- a/recording-viewer/test/sessionInfo.test.tsx
+++ b/recording-viewer/test/sessionInfo.test.tsx
@@ -14,12 +14,13 @@ describe('SessionInfo event breakdown', () => {
     it('lists every event type, active ones first (curated order) then empty ones', () => {
         // sessionStart is index 0 of ALL_EVENT_TYPES, save is later — so active
         // order should be [sessionStart, save] regardless of count.
-        const session = makeSession([
+        const events = [
             ev('sessionStart', 1),
             ev('save', 2),
             ev('sessionStart', 3),
-        ]);
-        const { container } = render(<SessionInfo session={session} />);
+        ];
+        const session = makeSession(events);
+        const { container } = render(<SessionInfo session={session} events={events} />);
         const rows = container.querySelectorAll('.event-breakdown .event-count-row');
 
         // Every type is shown.
@@ -38,5 +39,30 @@ describe('SessionInfo event breakdown', () => {
         expect(emptyRows.length).toBe(ALL_EVENT_TYPES.length - 2);
         expect(rows[2].classList.contains('empty')).toBe(true);
         expect(rows[2].textContent).toContain('0');
+    });
+
+    it('counts the events prop, not session.events (live mode reflects streamed events)', () => {
+        // In live mode session.events stays at the open-time snapshot (here empty)
+        // while events stream in via the `events` prop. The breakdown, the Events
+        // total and the duration must all reflect the live events, not the snapshot.
+        const session = makeSession([]);
+        const liveEvents = [ev('sessionStart', 1000), ev('save', 2000), ev('sessionStart', 5000)];
+        const { container } = render(<SessionInfo session={session} events={liveEvents} />);
+
+        const rows = container.querySelectorAll('.event-breakdown .event-count-row');
+        expect(rows[0].textContent).toContain('sessionStart');
+        expect(rows[0].textContent).toContain('2');
+        expect(rows[1].textContent).toContain('save');
+        expect(rows[1].textContent).toContain('1');
+
+        // The non-empty rows are exactly the two live types.
+        const activeRows = container.querySelectorAll('.event-breakdown .event-count-row:not(.empty)');
+        expect(activeRows.length).toBe(2);
+
+        // The totals and duration also reflect the live events, not the snapshot.
+        // With no metadata the info-grid values are [Start, End, Duration, Events].
+        const values = container.querySelectorAll('.info-grid .value');
+        expect(values[2].textContent).toBe('4s'); // duration 5000 - 1000 = 4000ms
+        expect(values[3].textContent).toBe('3'); // events total
     });
 });


### PR DESCRIPTION
## Problem

In the recording viewer's **live** mode, the **Event Breakdown** panel stayed at `0` for every event type even though the timeline lanes and event list below it updated live with streamed events. The Events total and Start/End/Duration in Session Info were frozen for the same reason.

## Root cause

`App` builds a live-merged event array and feeds it to every timeline consumer:

```ts
const liveEventsForDisplay = useDeferredValue(live.events);
const displayedEvents = useMemo(() =>
    isLiveSession ? liveEventsForDisplay : session.events, [...]);
// SessionTimeline / TrackingTimeline / EventStream all get events={displayedEvents}
```

`SessionInfo` was the only consumer still passed `session={session}` and counting `session.events` internally. In live mode `session.events` is the open-time snapshot (a tail fetch or empty) and never grows as `live.events` streams in via SSE, so its breakdown and totals froze while everything else stayed live.

## Fix

`SessionInfo` now takes an explicit `events` prop and summarises that (metadata still comes from `session`). `App` passes `events={displayedEvents}`, the same render-time source of truth the timelines already use. In replay mode `displayedEvents === session.events`, so recorded sessions are unchanged; only live mode is corrected. This fixes the breakdown, the Events total and Start/End/Duration together.

## Tests

- New regression test (`sessionInfo.test.tsx`): with an empty `session.events` snapshot but a populated `events` prop, the breakdown counts, the Events total and the duration all reflect the live events.
- Updated the existing breakdown test to the new signature.

Full viewer suite 292/292 passes; `tsc -b` and eslint clean.
