### PR TITLE
docs(changelog): note live Event Breakdown fix in the recording viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 ### Internal
 
 - **Struggle-Detection Config**: Wired `MIN_EVENTS_PER_SESSION` and the paste threshold; removed dead config.
+- **Live Recording Viewer**: The Event Breakdown counts, event total, and session duration now update live alongside the timeline instead of freezing at the values from when the live session was opened.
 
 ## [0.4.5] - 2026-06-01
 


### PR DESCRIPTION
Adds an Unreleased `### Internal` entry for the recording-viewer live-mode fix shipped in #264 (Event Breakdown, event total and duration now update live instead of freezing at the open-time snapshot).