### PR TITLE
fix(recording-viewer): run live mode on production build to stop OOM crash

### DIFF
--- a/recording-viewer/package.json
+++ b/recording-viewer/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "dev:live": "node -e \"if(!process.env.RECORDING_VIEWER_TOKEN){console.error('RECORDING_VIEWER_TOKEN must be set');process.exit(1)}\" && vite",
     "dev:live:token": "echo '\\n>>> Live token: artemis_admin\\n' && RECORDING_VIEWER_TOKEN=artemis_admin vite",
+    "preview:live": "node -e \"if(!process.env.RECORDING_VIEWER_TOKEN){console.error('RECORDING_VIEWER_TOKEN must be set');process.exit(1)}\" && npm run build && vite preview",
+    "preview:live:token": "echo '\\n>>> Live token: artemis_admin (production build)\\n' && RECORDING_VIEWER_TOKEN=artemis_admin npm run build && RECORDING_VIEWER_TOKEN=artemis_admin vite preview",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "merge-annotations": "tsx scripts/merge-annotations.ts",

--- a/recording-viewer/server/recordingsApiPlugin.ts
+++ b/recording-viewer/server/recordingsApiPlugin.ts
@@ -1,0 +1,44 @@
+import { createRecordingsApi } from './recordingsApi';
+import type { AppConfig, IncomingRequest, ServerResponse } from './types';
+
+/**
+ * Minimal shape shared by Vite's dev (`ViteDevServer`) and preview
+ * (`PreviewServer`) objects: both expose a connect-style `middlewares` stack.
+ */
+interface MiddlewareServer {
+    middlewares: {
+        use(fn: (req: IncomingRequest, res: ServerResponse, next: () => void) => void): void;
+    };
+}
+
+/**
+ * Vite plugin that serves the recordings API.
+ *
+ * The same handler is mounted on BOTH the dev server (`configureServer`) and the
+ * preview server (`configurePreviewServer`). The preview hook is what lets a live
+ * study run against the production build (`vite build && vite preview`) instead of
+ * the dev server.
+ *
+ * Why that matters: React's development build instruments every component render
+ * with `performance.measure(..., { detail })`, structured-cloning a diff of the
+ * component's props. In live mode the large, identity-changing `events` array is
+ * passed to several components every animation frame, so those clones pile up in
+ * the never-cleared user-timing buffer until the tab runs out of memory and
+ * crashes. The production build carries no such instrumentation, so serving the
+ * built app via `vite preview` makes that crash structurally impossible.
+ *
+ * Both hooks reuse one handler instance so the live-tailer registry and upload
+ * locks are shared rather than duplicated.
+ */
+export function createRecordingsApiPlugin(config: AppConfig) {
+    const handler = createRecordingsApi(config);
+    // Block body (no implicit return): `middlewares.use()` returns the connect app,
+    // and Vite treats a hook's return value as a post-hook to invoke. Returning that
+    // app would make Vite call it with no request and crash the preview server.
+    const mount = (server: MiddlewareServer) => { server.middlewares.use(handler); };
+    return {
+        name: 'recordings-api',
+        configureServer: mount,
+        configurePreviewServer: mount,
+    };
+}

--- a/recording-viewer/test/server/recordingsApiPlugin.test.ts
+++ b/recording-viewer/test/server/recordingsApiPlugin.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRecordingsApiPlugin } from '../../server/recordingsApiPlugin';
+import type { AppConfig } from '../../server/types';
+
+const config: AppConfig = {
+    recordingsDir: '/tmp/recording-viewer-plugin-test',
+    liveToken: 'tok',
+    researcherToken: undefined,
+    sessionSecret: 'x'.repeat(64),
+    allowWrite: false,
+};
+
+// Mimics connect's chaining contract: `app.use()` returns the app. This is what
+// makes the "hooks must return undefined" assertion meaningful — a hook that
+// implicitly returns `middlewares.use(...)` would leak the app, not undefined.
+function fakeMiddlewareServer() {
+    const middlewares = { use: vi.fn(() => middlewares) };
+    return { middlewares };
+}
+
+describe('createRecordingsApiPlugin', () => {
+    it('exposes both the dev and preview server hooks', () => {
+        const plugin = createRecordingsApiPlugin(config);
+        expect(plugin.name).toBe('recordings-api');
+        expect(typeof plugin.configureServer).toBe('function');
+        expect(typeof plugin.configurePreviewServer).toBe('function');
+    });
+
+    // The live-mode tab crash only happens on the React dev build, so studies must be
+    // able to run the production build via `vite preview`. That requires the recordings
+    // API to be mounted on the preview server too, using the very same handler instance
+    // as the dev server (one LiveTailerRegistry, one set of upload locks).
+    it('mounts the same handler instance on both the dev and preview servers', () => {
+        const plugin = createRecordingsApiPlugin(config);
+        const dev = fakeMiddlewareServer();
+        const preview = fakeMiddlewareServer();
+
+        // The hooks must return undefined: `middlewares.use()` returns the connect app,
+        // and Vite invokes a hook's return value as a post-hook — returning the app would
+        // crash the preview server (it would be called with no request).
+        expect(plugin.configureServer(dev)).toBeUndefined();
+        expect(plugin.configurePreviewServer(preview)).toBeUndefined();
+
+        expect(dev.middlewares.use).toHaveBeenCalledTimes(1);
+        expect(preview.middlewares.use).toHaveBeenCalledTimes(1);
+
+        const devHandler = dev.middlewares.use.mock.calls[0][0];
+        const previewHandler = preview.middlewares.use.mock.calls[0][0];
+        expect(typeof devHandler).toBe('function');
+        expect(devHandler).toBe(previewHandler);
+    });
+});

--- a/recording-viewer/vite.config.ts
+++ b/recording-viewer/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import os from 'os'
-import { createRecordingsApi } from './server/recordingsApi'
-import type { AppConfig, IncomingRequest, ServerResponse } from './server/types'
+import { createRecordingsApiPlugin } from './server/recordingsApiPlugin'
+import type { AppConfig } from './server/types'
 import { validateStartupConfig, resolveSessionSecret } from './server/startupValidation'
 
 const RECORDINGS_DIR = path.join(
@@ -17,16 +17,7 @@ validateStartupConfig({ liveToken, researcherToken })
 const sessionSecret = resolveSessionSecret(process.env.RECORDING_VIEWER_SESSION_SECRET, console.warn)
 const allowWrite = process.env.RECORDING_VIEWER_ALLOW_WRITE === '1' || !liveToken
 
-function recordingsApiPlugin() {
-    const config: AppConfig = { recordingsDir: RECORDINGS_DIR, liveToken, researcherToken, sessionSecret, allowWrite }
-    const handler = createRecordingsApi(config)
-    return {
-        name: 'recordings-api',
-        configureServer(server: { middlewares: { use: (fn: (req: IncomingRequest, res: ServerResponse, next: () => void) => void) => void } }) {
-            server.middlewares.use(handler)
-        },
-    }
-}
+const apiConfig: AppConfig = { recordingsDir: RECORDINGS_DIR, liveToken, researcherToken, sessionSecret, allowWrite }
 
 function resolveBindHost(): string {
     const explicit = process.env.RECORDING_VIEWER_BIND;
@@ -44,8 +35,15 @@ function resolveBindHost(): string {
     return hasToken ? '0.0.0.0' : '127.0.0.1';
 }
 
+const bindHost = resolveBindHost()
+
 // https://vite.dev/config/
 export default defineConfig({
-    plugins: [react(), recordingsApiPlugin()],
-    server: { host: resolveBindHost() },
+    plugins: [react(), createRecordingsApiPlugin(apiConfig)],
+    server: { host: bindHost },
+    // Preview serves the production build, which is how a live study should run:
+    // the production React build has no dev-mode `performance.measure` component
+    // instrumentation, so the live-mode out-of-memory tab crash cannot occur.
+    // Mirror the dev host and pin the port so raters reach the same LAN URL.
+    preview: { host: bindHost, port: 5173, strictPort: true },
 })


### PR DESCRIPTION
## Problem

In **live mode** the recording viewer sometimes crashes the browser tab. The console shows:

```
GET /api/recordings/<id>/video-sync 404 (Not Found)        # harmless, unrelated
Uncaught DataCloneError: Failed to execute 'measure' on 'Performance':
  Data cannot be cloned, out of memory.                    # the crash
Uncaught Error: Should not already be working.             # fallout
```

## Root cause

This is a **React development-build** pathology, not an app bug. In dev, `logComponentRender` instruments every component render via `performance.measure(..., { detail })`, structured-cloning a **diff of the component's props** into the user-timing buffer. That buffer is never cleared.

Live mode flushes a **fresh, large `events` array** (up to the live cap) to several heavy components on every animation-frame flush. So React structured-clones those large arrays for the DevTools "Components" track many times per second; the clones accumulate until the tab runs **out of memory**. The throw lands inside React's commit phase (`commitPassiveMountOnFiber`), leaving the reconciler half-finished → `Should not already be working` → tab dies.

The production React build has **no** such instrumentation, so the crash cannot occur there. The viewer was stuck on the dev build only because the recordings API was mounted exclusively as a Vite **dev** middleware (`configureServer`), forcing live studies onto `vite` (dev).

## Fix

Mount the same API handler on the **preview** server too, so live studies run the **production build**:

- `server/recordingsApiPlugin.ts` (new): one handler mounted via both `configureServer` and `configurePreviewServer` (shared `LiveTailerRegistry` / upload locks). The hook uses a block body so it returns `undefined` — `middlewares.use()` returns the connect app, and Vite would otherwise invoke that return value as a post-hook and crash preview startup.
- `vite.config.ts`: use the plugin factory; add `preview` host/port (mirror the dev host, pin `5173` so raters reach the same LAN URL, `strictPort` to fail loud on a conflict).
- `package.json`: `preview:live` / `preview:live:token` scripts (`npm run build` + `vite preview`, so the canonical `tsc -b` typecheck runs).
- `test/server/recordingsApiPlugin.test.ts`: assert both hooks mount the same handler instance and return `undefined` (the fake mirrors connect's chaining, so the guard actually catches the post-hook regression).

Scope is intentionally minimal (production-build wiring only); the live event cap is unchanged.

## Verification

- `npm run build` (tsc -b + vite build) succeeds.
- `vite preview` starts, binds the LAN interface on `:5173`, serves the SPA, and `/api/auth/status` returns JSON (API mounted on preview, not the SPA fallback).
- Full suite: 294 passed. eslint clean.
- The new regression test goes red without the block-body fix (verified).

Usage for a study: `npm run preview:live:token` (or set `RECORDING_VIEWER_TOKEN` and run `npm run preview:live`). `dev:live*` stay available for development.