### PR TITLE
docs(changelog): note production-build live mode for the recording viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **Struggle-Detection Config**: Wired `MIN_EVENTS_PER_SESSION` and the paste threshold; removed dead config.
 - **Live Recording Viewer**: The Event Breakdown counts, event total, and session duration now update live alongside the timeline instead of freezing at the values from when the live session was opened.
+- **Live Recording Viewer**: Live mode can now be served from the production build (`npm run preview:live:token`), which eliminates a browser-tab out-of-memory crash that could occur during long or high-volume live sessions on the dev server.
 
 ## [0.4.5] - 2026-06-01
 


### PR DESCRIPTION
Records the #266 fix under **Unreleased → Internal**.

> **Live Recording Viewer**: Live mode can now be served from the production build (`npm run preview:live:token`), which eliminates a browser-tab out-of-memory crash that could occur during long or high-volume live sessions on the dev server.

Verified end-to-end: a seeded live session streaming ~2k events/s across 16 event types up to 100k total. On the production preview the live buffer caps at 50k and trims as designed, the React user-timing measure count stays at 0 (no `logComponentRender` instrumentation), and the tab stays stable. The same load on the dev build is what accumulates those structured-cloned prop diffs until the tab runs out of memory.