### PR TITLE
chore(version): set dev version to 0.4.6-dev

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.5",
+  "version": "0.4.6-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Sets `extension/package.json` to `0.4.6-dev` so the dev branch is clearly in-progress toward 0.4.6, rather than sitting at the released `0.4.5`. This makes dev builds, telemetry, and recording `recorderVersion` distinguishable from the published release.

Notes:
- **CHANGELOG heading stays `## [Unreleased]`** on purpose. `scripts/prepare-release.sh` and `scripts/create-release.sh` match that literal to cut the versioned section and extract release notes; renaming it would break the release pipeline. `prepare-release.sh` overwrites this version field with the real release number at release time.
- Verified `npx @vscode/vsce package --no-dependencies` (the CI "Build & VSIX package" step) accepts the `-dev` prerelease version and packages successfully.
- `npm ci` is unaffected: the lockfile root version was already stale (0.4.4) against 0.4.5 and CI was green, so it does not enforce the root version match. Lockfile left untouched to keep the change minimal (mirrors how `prepare-release.sh` only edits `package.json`).
- No code or test asserts the exact version; runtime only reads `pkg.version` for display/user-agent/`recorderVersion`, all of which accept the `-dev` string.