### PR TITLE
feat(recording-viewer): place timeline markers at a clicked position

### DIFF
--- a/recording-viewer/src/App.css
+++ b/recording-viewer/src/App.css
@@ -1520,6 +1520,33 @@
     z-index: 5;
 }
 
+.pending-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    border-left: 2px dashed #e6a23c;
+    opacity: 0.9;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.pending-line-label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin-left: 4px;
+    padding: 1px 4px;
+    font-size: 10px;
+    line-height: 1.3;
+    color: #fff;
+    background: #e6a23c;
+    border-radius: 3px;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 6;
+}
+
 /* Session chart overlay (zoom rect + playhead for the recharts EQ chart).
    Matches the former recharts ReferenceArea/ReferenceLine visuals. */
 .session-zoom-rect {

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -50,6 +50,17 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     const [lastLabelToast, setLastLabelToast] = useState<AnnotationToast | null>(null);
     const [stickyLive, setStickyLive] = useState(false);
 
+    // Pending timeline marker position (click-to-place). The ref mirrors the
+    // state synchronously so a label keypress immediately after a click reads
+    // the fresh value (an effect-based mirror would lag a commit and re-introduce
+    // the race).
+    const [pendingTimestamp, setPendingTimestamp] = useState<number | null>(null);
+    const pendingTsRef = useRef<number | null>(null);
+    const setPending = useCallback((ts: number | null) => {
+        pendingTsRef.current = ts;   // synchronous, no render lag
+        setPendingTimestamp(ts);
+    }, []);
+
     // Track most recently ended live session so latch-on cannot flip back to live
     // during the brief window between sessionEnd event arrival and metadata.json
     // being written by the recorder (the live-sessions endpoint may still report
@@ -217,17 +228,30 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     // reference timestamp is the latest observed event; in offline mode it is
     // the current video playback cursor projected onto the absolute event
     // timeline (or session start as a fallback when no video is playing).
+    const onEscape = useCallback(() => {
+        if (pendingTsRef.current != null) { setPending(null); return true; }
+        return false;
+    }, [setPending]);
+
     useLiveHotkeys(
         !isResearcher && session !== null,
+        // pendingTimestamp is intentionally NOT a dep — it is read via the ref so
+        // the window keydown listener does not re-subscribe on pending changes.
         useCallback((label) => {
             const referenceTs = isLiveSession
                 ? live.latestEventTimestamp
-                : (session?.metadata?.startTime ?? 0) + videoTimeRef.current * 1000;
-            mutator.addLabel(label, referenceTs);
-        }, [mutator, live.latestEventTimestamp, isLiveSession, session]),
+                : (pendingTsRef.current ?? (session?.metadata?.startTime ?? 0) + videoTimeRef.current * 1000);
+            mutator.addLabel(label, referenceTs, { persistTimestamp: !isLiveSession });
+            if (pendingTsRef.current != null) setPending(null);
+        }, [mutator, live.latestEventTimestamp, isLiveSession, session, setPending]),
         mutator.undoLast,
         mutator.redoLast,
+        onEscape,
     );
+
+    // Force-clear pending on every session boundary / live toggle so it can never
+    // leak across sessions or into live mode.
+    useEffect(() => { setPending(null); }, [session, isLiveSession, setPending]);
 
     const handleFileSession = useCallback((loaded: LoadedSession) => {
         activeSessionId.current = null;
@@ -473,6 +497,12 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         ? `/api/recordings/${encodeURIComponent(activeSessionId.current)}/subtitles?v=${videoCacheBust}`
         : null;
 
+    // Click-to-place is only meaningful in a server-backed archival session. A
+    // file-loaded session has activeSessionId.current === null (addLabel is a
+    // silent no-op). Reading the ref during render is safe: every file-vs-server
+    // transition sets it synchronously and then re-renders via setSession.
+    const isServerSession = session !== null && activeSessionId.current !== null;
+
     return (
         <div className="app">
             <header className="app-header">
@@ -640,6 +670,8 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                                 onSeekVideo={videoSyncConfig ? handleVideoSeek : undefined}
                                 videoTimeAtSessionStartSeconds={videoSyncConfig?.videoTimeAtSessionStartSeconds}
                                 onZoomChange={handleZoomChange}
+                                pendingTimestamp={pendingTimestamp}
+                                onSetPendingPosition={isServerSession && !writesDisabled ? setPending : undefined}
                             />
                         </div>
                     )}

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -224,10 +224,10 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     // the lanes refresh; the researcher's video/zoom/scroll stay put.
     useResearcherLanePolling(isResearcher && isLiveSession, activeSessionId, apiFetch, setResearcherLanes);
 
-    // Hotkeys enabled for any rater with a session loaded. In live mode the
-    // reference timestamp is the latest observed event; in offline mode it is
-    // the current video playback cursor projected onto the absolute event
-    // timeline (or session start as a fallback when no video is playing).
+    // Hotkeys enabled for any rater with a session loaded. The reference timestamp
+    // is a clicked pending position if one is set (in any mode); otherwise the
+    // latest observed event in live mode, or the video playback cursor projected
+    // onto the absolute event timeline (session start as a fallback) when offline.
     const onEscape = useCallback(() => {
         if (pendingTsRef.current != null) { setPending(null); return true; }
         return false;
@@ -238,11 +238,16 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         // pendingTimestamp is intentionally NOT a dep — it is read via the ref so
         // the window keydown listener does not re-subscribe on pending changes.
         useCallback((label) => {
-            const referenceTs = isLiveSession
-                ? live.latestEventTimestamp
-                : (pendingTsRef.current ?? (session?.metadata?.startTime ?? 0) + videoTimeRef.current * 1000);
-            mutator.addLabel(label, referenceTs, { persistTimestamp: !isLiveSession });
-            if (pendingTsRef.current != null) setPending(null);
+            // A clicked pending position overrides the default anchor in ANY mode
+            // (live edge or offline playhead) and is always persisted at its exact
+            // timestamp. Without a pending click, live keeps server-receive-time.
+            const pending = pendingTsRef.current;
+            const referenceTs = pending
+                ?? (isLiveSession
+                    ? live.latestEventTimestamp
+                    : (session?.metadata?.startTime ?? 0) + videoTimeRef.current * 1000);
+            mutator.addLabel(label, referenceTs, { persistTimestamp: pending != null || !isLiveSession });
+            if (pending != null) setPending(null);
         }, [mutator, live.latestEventTimestamp, isLiveSession, session, setPending]),
         mutator.undoLast,
         mutator.redoLast,
@@ -671,7 +676,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                                 videoTimeAtSessionStartSeconds={videoSyncConfig?.videoTimeAtSessionStartSeconds}
                                 onZoomChange={handleZoomChange}
                                 pendingTimestamp={pendingTimestamp}
-                                onSetPendingPosition={isServerSession && !writesDisabled ? setPending : undefined}
+                                onSetPendingPosition={isServerSession && !isResearcher ? setPending : undefined}
                             />
                         </div>
                     )}

--- a/recording-viewer/src/components/TrackingTimeline.tsx
+++ b/recording-viewer/src/components/TrackingTimeline.tsx
@@ -578,8 +578,8 @@ export function TrackingTimeline({
                 {isZoomed && 'Drag to pan'}
                 {isZoomed && onSeekVideo && ' \u00b7 '}
                 {onSeekVideo && 'Shift+Click to jump video'}
-                {onSetPendingPosition && !readOnly && (onSeekVideo || isZoomed) && ' \u00b7 '}
-                {onSetPendingPosition && !readOnly && (
+                {onSetPendingPosition && (onSeekVideo || isZoomed) && ' \u00b7 '}
+                {onSetPendingPosition && (
                     pendingTimestamp != null
                         ? `Marked ${formatOffset(pendingTimestamp - sessionStartTime)} \u00b7 press 1-5 / q-u to place \u00b7 Esc to cancel`
                         : 'Click to mark a spot, then press a label key'

--- a/recording-viewer/src/components/TrackingTimeline.tsx
+++ b/recording-viewer/src/components/TrackingTimeline.tsx
@@ -16,6 +16,7 @@ import {
     hitTestAnnotation,
     hitTestDot,
     orderTypesActiveFirst,
+    timeToX,
     xToTime,
     type AnnotationGroup,
     type Bin,
@@ -31,7 +32,8 @@ interface Props {
     enabledTypes: Set<EventType>;
     /** When true, only lanes with events are shown (the empty ones are hidden). */
     hideEmptyLanes?: boolean;
-    onAddAnnotation?: (timestamp: number, text: string) => void;
+    pendingTimestamp?: number | null;
+    onSetPendingPosition?: (timestamp: number) => void;
     onUpdateAnnotation?: (id: string, text: string) => void;
     onDeleteAnnotation?: (id: string) => void;
     readOnly?: boolean;
@@ -65,7 +67,8 @@ export function TrackingTimeline({
     annotations,
     enabledTypes,
     hideEmptyLanes = false,
-    onAddAnnotation,
+    pendingTimestamp,
+    onSetPendingPosition,
     onUpdateAnnotation,
     onDeleteAnnotation,
     readOnly,
@@ -87,8 +90,6 @@ export function TrackingTimeline({
     const [hoveredDotKey, setHoveredDotKey] = useState<string | null>(null);
     const [editingAnnotId, setEditingAnnotId] = useState<string | null>(null);
     const [editText, setEditText] = useState('');
-    const [annotateTimestamp, setAnnotateTimestamp] = useState<number | null>(null);
-    const [annotateText, setAnnotateText] = useState('');
 
     // Pre-group events by type once per event-list change. Avoids a full
     // events.filter pass per lane on every xDomain/zoom/pan update.
@@ -136,7 +137,7 @@ export function TrackingTimeline({
         return false;
     }, [visibleLanes, laneBins, annotationGroups]);
 
-    const { handlePanStart, isZoomed } = useTimelinePan({
+    const { handlePanStart, isZoomed, didPanRef } = useTimelinePan({
         xDomain,
         fullXDomain,
         svgWidth: timelineWidth,
@@ -347,22 +348,22 @@ export function TrackingTimeline({
         };
     }, []);
 
-    // Canvas click: dot-first, annotation-next, shift+click additionally seeks
+    // Canvas click: annotation popover, else set a pending position; shift+click additionally seeks
     const handleCanvasClick = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+        // A click that concludes a drag-pan must be fully swallowed: no pending set, no popover, no seek.
+        if (didPanRef.current) { didPanRef.current = false; return; }
         const rect = canvasContainerRef.current?.getBoundingClientRect();
         if (!rect) return;
         const x = e.clientX - rect.left;
         const y = e.clientY - rect.top;
 
-        const dotHit = hitTestDot(x, y, visibleLanes, laneBins);
-        const annotHit = !dotHit ? hitTestAnnotation(x, y, visibleLanes, annotationGroups) : null;
+        const annotHit = hitTestAnnotation(x, y, visibleLanes, annotationGroups);
 
-        if (dotHit) {
-            if (!readOnly && onAddAnnotation) {
-                setAnnotateTimestamp(dotHit.bin.firstTimestamp);
-            }
-        } else if (annotHit) {
+        if (annotHit) {
             setAnnotPopover({ x, y, annotations: annotHit.group.annotations });
+        } else if (!e.shiftKey && onSetPendingPosition) {
+            const ts = xToTime(x, sessionStartTime, xDomain, timelineWidth);
+            if (ts != null) onSetPendingPosition(ts);
         }
 
         // Shift+click additionally seeks the video to the click position,
@@ -371,7 +372,7 @@ export function TrackingTimeline({
             const ts = xToTime(x, sessionStartTime, xDomain, timelineWidth);
             if (ts != null) onSeekVideo(ts);
         }
-    }, [visibleLanes, laneBins, annotationGroups, readOnly, onAddAnnotation, onSeekVideo, sessionStartTime, xDomain, timelineWidth]);
+    }, [didPanRef, visibleLanes, annotationGroups, onSetPendingPosition, onSeekVideo, sessionStartTime, xDomain, timelineWidth]);
 
     if (visibleLanes.length === 0) {
         return (
@@ -423,6 +424,28 @@ export function TrackingTimeline({
                             style={{ height: visibleLanes.length * LANE_HEIGHT, display: 'none' }}
                         />
                     )}
+
+                    {/* Pending placement ghost line */}
+                    {(() => {
+                        const px = pendingTimestamp != null
+                            ? timeToX(pendingTimestamp, sessionStartTime, xDomain, timelineWidth)
+                            : null;
+                        if (px == null || px < 0 || px > timelineWidth) return null;
+                        return (
+                            <>
+                                <div
+                                    className="pending-line"
+                                    style={{ transform: `translateX(${px}px)`, height: visibleLanes.length * LANE_HEIGHT }}
+                                />
+                                <div
+                                    className="pending-line-label"
+                                    style={{ transform: `translateX(${px}px)` }}
+                                >
+                                    {formatOffset(pendingTimestamp! - sessionStartTime)}
+                                </div>
+                            </>
+                        );
+                    })()}
 
                     {/* Tooltip */}
                     {tooltip && (
@@ -555,51 +578,13 @@ export function TrackingTimeline({
                 {isZoomed && 'Drag to pan'}
                 {isZoomed && onSeekVideo && ' \u00b7 '}
                 {onSeekVideo && 'Shift+Click to jump video'}
+                {onSetPendingPosition && !readOnly && (onSeekVideo || isZoomed) && ' \u00b7 '}
+                {onSetPendingPosition && !readOnly && (
+                    pendingTimestamp != null
+                        ? `Marked ${formatOffset(pendingTimestamp - sessionStartTime)} \u00b7 press 1-5 / q-u to place \u00b7 Esc to cancel`
+                        : 'Click to mark a spot, then press a label key'
+                )}
             </p>
-
-            {/* Annotate from dot click */}
-            {annotateTimestamp !== null && !readOnly && onAddAnnotation && (
-                <div className="tracking-annotate-form">
-                    <span className="mono" style={{ flexShrink: 0, color: 'var(--text-muted)', fontSize: 11 }}>
-                        {formatOffset(annotateTimestamp - sessionStartTime)}
-                    </span>
-                    <input
-                        autoFocus
-                        className="annotation-input"
-                        placeholder="Annotation text..."
-                        value={annotateText}
-                        onChange={e => setAnnotateText(e.target.value)}
-                        onKeyDown={e => {
-                            if (e.key === 'Enter' && annotateText.trim()) {
-                                onAddAnnotation?.(annotateTimestamp, annotateText.trim());
-                                setAnnotateTimestamp(null);
-                                setAnnotateText('');
-                            }
-                            if (e.key === 'Escape') {
-                                setAnnotateTimestamp(null);
-                                setAnnotateText('');
-                            }
-                        }}
-                    />
-                    <button
-                        className="annotation-save-btn"
-                        disabled={!annotateText.trim()}
-                        onClick={() => {
-                            onAddAnnotation(annotateTimestamp, annotateText.trim());
-                            setAnnotateTimestamp(null);
-                            setAnnotateText('');
-                        }}
-                    >
-                        Add
-                    </button>
-                    <button
-                        className="annotation-cancel-btn"
-                        onClick={() => { setAnnotateTimestamp(null); setAnnotateText(''); }}
-                    >
-                        Cancel
-                    </button>
-                </div>
-            )}
         </div>
     );
 }

--- a/recording-viewer/src/hooks/annotationController.ts
+++ b/recording-viewer/src/hooks/annotationController.ts
@@ -10,7 +10,7 @@ export interface AnnotationToast {
 export interface AnnotationMutator {
     /** Enqueue an add. Optimistic insertion happens inside the queue body so the
      *  redo-stack invalidation is atomic with the new entry. */
-    addLabel: (label: AnnotationLabel, referenceTs: number | null) => void;
+    addLabel: (label: AnnotationLabel, referenceTs: number | null, options?: { persistTimestamp?: boolean }) => void;
     /** Enqueue an undo of whatever is the last real annotation at the moment
      *  the queue reaches this operation (not at call time). */
     undoLast: () => void;
@@ -80,16 +80,19 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
         });
     }
 
-    const addLabel: AnnotationMutator['addLabel'] = (label, referenceTs) => {
+    const addLabel: AnnotationMutator['addLabel'] = (label, referenceTs, options) => {
         enqueue(async (capturedGen, sessionId) => {
             // Intent invalidates redo, ATOMIC with the new entry insertion.
             redoStack = [];
 
             const tempId = makeTempId();
-            // referenceTs is used for the LOCAL optimistic display only: it positions
-            // the temp annotation on the timeline at roughly the right moment while
-            // the POST is in-flight. The server always timestamps live annotations
-            // at its own receive time, so we do NOT send referenceTs to it.
+            // The optimistic temp annotation always uses referenceTs for LOCAL display,
+            // positioning it on the timeline at the clicked/playhead moment while the
+            // POST is in-flight. For LIVE adds (no persistTimestamp) we omit `timestamp`
+            // from the POST so the server stamps the annotation at its own receive time.
+            // For OFFLINE/archival adds (persistTimestamp: true) we send referenceTs as
+            // the authoritative timestamp so the marker persists at the clicked/playhead
+            // position instead of snapping to the server's receive time.
             const optimistic: Annotation = {
                 id: tempId,
                 timestamp: referenceTs ?? Date.now(),
@@ -101,13 +104,12 @@ export function createAnnotationController(args: AnnotationControllerArgs): Anno
             if (capturedGen === gen) emit();
 
             try {
+                const body: { label: AnnotationLabel; text: string; timestamp?: number } = { label, text: '' };
+                if (options?.persistTimestamp && referenceTs != null) body.timestamp = referenceTs;
                 const res = await doFetch(`/api/recordings/${encodeURIComponent(sessionId)}/annotations`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        label,
-                        text: '',
-                    }),
+                    body: JSON.stringify(body),
                 });
                 if (capturedGen !== gen) return;
                 if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/recording-viewer/src/hooks/useLiveHotkeys.ts
+++ b/recording-viewer/src/hooks/useLiveHotkeys.ts
@@ -12,6 +12,7 @@ export interface LiveHotkeyHandlers {
     onLabel: (label: AnnotationLabel) => void;
     onUndo?: () => void;
     onRedo?: () => void;
+    onEscape?: () => boolean; // returns true if it consumed the Escape (had something to clear)
 }
 
 /** Pure function form of the keydown handler. Exported for unit testing.
@@ -20,6 +21,11 @@ export interface LiveHotkeyHandlers {
 export function handleLiveHotkey(e: KeyboardEvent, handlers: LiveHotkeyHandlers): void {
     const target = e.target as HTMLElement | null;
     if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+
+    if (e.key === 'Escape') {
+        if (handlers.onEscape?.()) e.preventDefault();
+        return;
+    }
 
     const key = e.key.toLowerCase();
     const ctrl = e.ctrlKey;
@@ -59,11 +65,12 @@ export function useLiveHotkeys(
     onLabel: (label: AnnotationLabel) => void,
     onUndo?: () => void,
     onRedo?: () => void,
+    onEscape?: () => boolean,
 ): void {
     useEffect(() => {
         if (!enabled) return;
-        const handler = (e: KeyboardEvent) => handleLiveHotkey(e, { onLabel, onUndo, onRedo });
+        const handler = (e: KeyboardEvent) => handleLiveHotkey(e, { onLabel, onUndo, onRedo, onEscape });
         window.addEventListener('keydown', handler);
         return () => window.removeEventListener('keydown', handler);
-    }, [enabled, onLabel, onUndo, onRedo]);
+    }, [enabled, onLabel, onUndo, onRedo, onEscape]);
 }

--- a/recording-viewer/src/hooks/useTimelinePan.ts
+++ b/recording-viewer/src/hooks/useTimelinePan.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useCallback } from 'react';
 
+/** A drag of more than this many pixels counts as a real pan and suppresses the trailing click. */
+const DRAG_CLICK_SUPPRESS_PX = 4;
+
 interface UseTimelinePanOptions {
     xDomain: [number, number];
     fullXDomain?: [number, number];
@@ -23,6 +26,7 @@ interface UseTimelinePanOptions {
  */
 export function useTimelinePan({ xDomain, fullXDomain, svgWidth, onZoomChange, leftOffset = 0, suppressPanPredicate }: UseTimelinePanOptions) {
     const isPanningRef = useRef(false);
+    const didPanRef = useRef(false);
     const panStartXRef = useRef(0);
     const panStartDomainRef = useRef<[number, number]>([0, 0]);
 
@@ -35,6 +39,7 @@ export function useTimelinePan({ xDomain, fullXDomain, svgWidth, onZoomChange, l
     }, [onZoomChange, fullXDomain, xDomain, svgWidth, leftOffset]);
 
     const handlePanStart = useCallback((e: React.MouseEvent) => {
+        didPanRef.current = false;
         if (!onZoomChange || !isZoomed || e.button !== 0) return;
         // Don't start pan if clicking on interactive elements
         const target = e.target as Element;
@@ -53,6 +58,7 @@ export function useTimelinePan({ xDomain, fullXDomain, svgWidth, onZoomChange, l
             const { onZoomChange: zoomCb, fullXDomain: full, xDomain: domain, svgWidth: width } = latestRef.current;
             if (!zoomCb || width <= 0) return;
             const dx = e.clientX - panStartXRef.current;
+            if (Math.abs(dx) > DRAG_CLICK_SUPPRESS_PX) didPanRef.current = true;
             const [startMin, startMax] = panStartDomainRef.current;
             const range = startMax - startMin;
             const domainDelta = -(dx / width) * range;
@@ -84,5 +90,5 @@ export function useTimelinePan({ xDomain, fullXDomain, svgWidth, onZoomChange, l
         };
     }, []);
 
-    return { handlePanStart, isZoomed };
+    return { handlePanStart, isZoomed, didPanRef };
 }

--- a/recording-viewer/test/annotationController.test.ts
+++ b/recording-viewer/test/annotationController.test.ts
@@ -124,6 +124,53 @@ describe('addLabel', () => {
     });
 });
 
+describe('addLabel persistTimestamp (offline click-to-place regression guard)', () => {
+    it('persistTimestamp: true sends timestamp === referenceTs in the POST body', async () => {
+        h.ctrl.addLabel('medium-struggle', 1_234_567, { persistTimestamp: true });
+        await Promise.resolve(); await Promise.resolve();
+        expect(h.pending).toHaveLength(1);
+        expect(h.pending[0].init?.method).toBe('POST');
+        const body = JSON.parse(h.pending[0].init?.body as string);
+        expect(body.timestamp).toBe(1_234_567);
+        expect(body.label).toBe('medium-struggle');
+        // Resolve so the queue drains cleanly.
+        h.pending[0].resolve(jsonResponse({ annotation: annot('real-ts', { timestamp: 1_234_567 }) }));
+        await h.ctrl.drain();
+        expect(h.onError).not.toHaveBeenCalled();
+    });
+
+    it('default add (no options) omits timestamp from the POST body', async () => {
+        h.ctrl.addLabel('confident', 1_234_567);
+        await Promise.resolve(); await Promise.resolve();
+        expect(h.pending).toHaveLength(1);
+        const body = JSON.parse(h.pending[0].init?.body as string);
+        expect(body).not.toHaveProperty('timestamp');
+        expect(body.label).toBe('confident');
+        h.pending[0].resolve(jsonResponse({ annotation: annot('real-live') }));
+        await h.ctrl.drain();
+    });
+
+    it('persistTimestamp: false omits timestamp from the POST body', async () => {
+        h.ctrl.addLabel('blocked', 1_234_567, { persistTimestamp: false });
+        await Promise.resolve(); await Promise.resolve();
+        expect(h.pending).toHaveLength(1);
+        const body = JSON.parse(h.pending[0].init?.body as string);
+        expect(body).not.toHaveProperty('timestamp');
+        h.pending[0].resolve(jsonResponse({ annotation: annot('real-live-2') }));
+        await h.ctrl.drain();
+    });
+
+    it('persistTimestamp: true but referenceTs null still omits timestamp (guarded by referenceTs != null)', async () => {
+        h.ctrl.addLabel('idle', null, { persistTimestamp: true });
+        await Promise.resolve(); await Promise.resolve();
+        expect(h.pending).toHaveLength(1);
+        const body = JSON.parse(h.pending[0].init?.body as string);
+        expect(body).not.toHaveProperty('timestamp');
+        h.pending[0].resolve(jsonResponse({ annotation: annot('real-null') }));
+        await h.ctrl.drain();
+    });
+});
+
 describe('temp-id race (codex r2 critical)', () => {
     it('undoLast queued during in-flight addLabel uses the REAL id', async () => {
         h.ctrl.addLabel('confident', 1_000);

--- a/recording-viewer/test/liveHotkeys.test.ts
+++ b/recording-viewer/test/liveHotkeys.test.ts
@@ -166,3 +166,50 @@ describe('handleLiveHotkey — label hotkeys still work', () => {
         expect(h.onLabel).not.toHaveBeenCalled();
     });
 });
+
+describe('handleLiveHotkey — Escape (click-to-place pending clear)', () => {
+    it('Escape with onEscape returning true consumes the event (preventDefault) and does NOT fire onLabel', () => {
+        const onEscape = vi.fn<[], boolean>(() => true);
+        const h = { ...makeHandlers(), onEscape };
+        const e = makeEvent({ key: 'Escape' });
+        handleLiveHotkey(e, h);
+        expect(onEscape).toHaveBeenCalledTimes(1);
+        expect(e.preventDefault).toHaveBeenCalled();
+        expect(h.onLabel).not.toHaveBeenCalled();
+        expect(h.onUndo).not.toHaveBeenCalled();
+        expect(h.onRedo).not.toHaveBeenCalled();
+    });
+
+    it('Escape with onEscape returning false is a no-op and does NOT call preventDefault', () => {
+        const onEscape = vi.fn<[], boolean>(() => false);
+        const h = { ...makeHandlers(), onEscape };
+        const e = makeEvent({ key: 'Escape' });
+        handleLiveHotkey(e, h);
+        expect(onEscape).toHaveBeenCalledTimes(1);
+        expect(e.preventDefault).not.toHaveBeenCalled();
+        expect(h.onLabel).not.toHaveBeenCalled();
+    });
+
+    it('Escape with no onEscape handler is a no-op (no crash, no preventDefault)', () => {
+        const e = makeEvent({ key: 'Escape' });
+        handleLiveHotkey(e, { onLabel: vi.fn() });
+        expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('a normal label key ("3") still fires onLabel even when onEscape is provided', () => {
+        const onEscape = vi.fn<[], boolean>(() => true);
+        const h = { ...makeHandlers(), onEscape };
+        handleLiveHotkey(makeEvent({ key: '3' }), h);
+        expect(h.onLabel).toHaveBeenCalledWith('medium-struggle');
+        expect(onEscape).not.toHaveBeenCalled();
+    });
+
+    it('Escape is suppressed inside an input target (guard runs before the Escape branch)', () => {
+        const onEscape = vi.fn<[], boolean>(() => true);
+        const h = { ...makeHandlers(), onEscape };
+        const e = makeEvent({ key: 'Escape', target: { tagName: 'INPUT' } });
+        handleLiveHotkey(e, h);
+        expect(onEscape).not.toHaveBeenCalled();
+        expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What
In an archival session you can now place a struggle/context marker at a clicked timeline position, independent of the video playhead.

- Click a position on the `TrackingTimeline` to arm a pending position (dashed amber guide + offset label).
- Press a label key (`1`-`5` struggle, `q w e r t i u` context) to commit the marker at that timestamp.
- `Esc` clears the pending position; `Shift+click` (seek) and live mode are unchanged.

## Bug fix included
`addLabel` never persisted its timestamp: the POST omitted `timestamp`, so the server stamped annotations at its own receive time. Offline labels therefore snapped to the current wall clock once the request resolved. This sends the explicit timestamp for offline adds, fixing both the new feature and the pre-existing offline playhead labeling. The server already honors an explicit `timestamp`; live mode keeps receive-time semantics.

## Notes
- Pending state is cleared across session/live transitions and gated to server-backed archival sessions (file-loaded sessions cannot persist).
- Clicks that conclude a drag-pan are ignored, so panning a zoomed timeline never drops a stray marker.
- Removed the dead dot-click annotation form (`onAddAnnotation` was never wired up).

## Tests
- `npm test` 303/303, `npm run build` and `npm run lint` clean.
- Added unit tests: `useLiveHotkeys` Escape handling (+5) and `annotationController` `persistTimestamp` (+4).