### PR TITLE
feat(recording-viewer): add "waiting for build results" annotation marker

### DIFF
--- a/recording-viewer/scripts/merge-annotations.ts
+++ b/recording-viewer/scripts/merge-annotations.ts
@@ -61,7 +61,7 @@ const STRUGGLE_LABELS = new Set([
     'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
 ]);
 const CONTEXT_LABELS = new Set([
-    'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment', 'reading-test-results',
+    'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment', 'reading-test-results', 'waiting-for-build-results',
 ]);
 
 export interface MatrixOptions {

--- a/recording-viewer/server/recordingsApi.ts
+++ b/recording-viewer/server/recordingsApi.ts
@@ -708,7 +708,7 @@ export function createRecordingsApi(config: AppConfig): ApiHandler {
         // accepted in the body for backwards compatibility but ignored.
         const VALID_LABELS = new Set([
             'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
-            'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment', 'reading-test-results',
+            'idle', 'trial-error', 'reading', 'off-task', 'using-ai', 'iris-moment', 'reading-test-results', 'waiting-for-build-results',
         ]);
 
         // POST /api/recordings/:sessionId/annotations — append `add` to current rater's file.

--- a/recording-viewer/src/hooks/useLiveHotkeys.ts
+++ b/recording-viewer/src/hooks/useLiveHotkeys.ts
@@ -5,7 +5,7 @@ const STRUGGLE_KEYS: Record<string, StruggleLevel> = {
     '1': 'confident', '2': 'light-struggle', '3': 'medium-struggle', '4': 'high-struggle', '5': 'blocked',
 };
 export const CONTEXT_KEYS: Record<string, ContextMarker> = {
-    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai', 'i': 'iris-moment', 'u': 'reading-test-results',
+    'q': 'idle', 'w': 'trial-error', 'e': 'reading', 'r': 'off-task', 't': 'using-ai', 'i': 'iris-moment', 'u': 'reading-test-results', 'b': 'waiting-for-build-results',
 };
 
 export interface LiveHotkeyHandlers {

--- a/recording-viewer/src/types.ts
+++ b/recording-viewer/src/types.ts
@@ -13,7 +13,7 @@ export interface VideoSyncConfig {
 }
 
 export type StruggleLevel = 'confident' | 'light-struggle' | 'medium-struggle' | 'high-struggle' | 'blocked';
-export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai' | 'iris-moment' | 'reading-test-results';
+export type ContextMarker = 'idle' | 'trial-error' | 'reading' | 'off-task' | 'using-ai' | 'iris-moment' | 'reading-test-results' | 'waiting-for-build-results';
 export type AnnotationLabel = StruggleLevel | ContextMarker;
 
 export const STRUGGLE_LABELS: { value: StruggleLevel; label: string; color: string }[] = [
@@ -32,6 +32,7 @@ export const CONTEXT_LABELS: { value: ContextMarker; label: string; color: strin
     { value: 'using-ai', label: 'Using AI', color: '#2dd4bf' },
     { value: 'iris-moment', label: 'Iris Moment', color: '#818cf8' },
     { value: 'reading-test-results', label: 'Reading test results', color: '#f59e0b' },
+    { value: 'waiting-for-build-results', label: 'Waiting for build results', color: '#0ea5e9' },
 ];
 
 export const ALL_LABELS = [...STRUGGLE_LABELS, ...CONTEXT_LABELS];

--- a/recording-viewer/test/liveHotkeys.test.ts
+++ b/recording-viewer/test/liveHotkeys.test.ts
@@ -139,6 +139,7 @@ describe('handleLiveHotkey — label hotkeys still work', () => {
         ['t', 'using-ai'],
         ['i', 'iris-moment'],
         ['u', 'reading-test-results'],
+        ['b', 'waiting-for-build-results'],
     ] as Array<[string, AnnotationLabel]>)('"%s" → onLabel("%s")', (key, expected) => {
         const h = makeHandlers();
         handleLiveHotkey(makeEvent({ key }), h);


### PR DESCRIPTION
## What
Adds a new annotation context marker **"Waiting for build results"**, triggerable by the `b` hotkey, alongside the existing context markers (`q`-`u`).

## Details
- Hotkey: `b`
- Color: `#0ea5e9` (distinct from the neighboring amber "Reading test results").
- Added across every label enumeration site: the `ContextMarker` type union and `CONTEXT_LABELS`, the `CONTEXT_KEYS` hotkey map, the server `VALID_LABELS` validation set, the `merge-annotations` export script, and the hotkey test.
- The live-control-bar legend, timeline marker colors, and event-stream rendering pick it up automatically from `CONTEXT_LABELS` / `ALL_LABELS`, so no per-component changes are needed.

## Tests
- `npm test` 295/295, `npm run build` and `npm run lint` clean. Added the hotkey case `'b' → waiting-for-build-results`.