### PR TITLE
feat(recording-viewer): bottom-right stacking annotation toasts

### DIFF
--- a/recording-viewer/src/App.css
+++ b/recording-viewer/src/App.css
@@ -1738,7 +1738,7 @@
     display: flex; gap: 1.5rem; align-items: center;
     padding: 0.5rem 1rem; background: #1e293b; color: #f1f5f9;
     border-bottom: 1px solid #334155; font-size: 0.85rem;
-    flex-wrap: wrap; position: relative;
+    flex-wrap: wrap;
 }
 .live-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 0.5rem; }
 .live-dot.on { background: #ef4444; box-shadow: 0 0 8px #ef4444; animation: pulse 1.5s infinite; }
@@ -1749,14 +1749,32 @@
 .live-elapsed { color: #e2e8f0; font-weight: 600; font-variant-numeric: tabular-nums; }
 .live-legend { display: flex; gap: 0.4rem; flex-wrap: wrap; }
 .live-legend span { font-family: monospace; }
-.live-toast {
-    position: absolute; top: 100%; right: 1rem;
-    background: #3b82f6; color: white;
-    padding: 0.4rem 0.8rem; border-radius: 4px; margin-top: 0.5rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3); pointer-events: none;
+/* ── Annotation toast stack (bottom-right, viewport-fixed) ─────────────── */
+.annotation-toast-stack {
+    position: fixed; bottom: 1.5rem; right: 1.5rem;
+    display: flex; flex-direction: column; gap: 0.5rem;
+    align-items: flex-end; z-index: 2000; pointer-events: none;
 }
-.live-toast-undo, .live-toast-redo { background: #6b7280; }
-.live-toast-error { background: #ef4444; }
+.annotation-toast {
+    background: #3b82f6; color: white;
+    padding: 0.45rem 0.85rem; border-radius: 6px;
+    font-size: 0.85rem; box-shadow: 0 4px 12px rgba(0,0,0,0.35);
+    pointer-events: none;
+    /* animation-duration is set inline per ToastItem from TOAST_DURATION_MS, so the
+       fade length and the JS removal timer share a single source and cannot drift. */
+    animation-name: annotation-toast-life;
+    animation-timing-function: ease-out;
+    animation-fill-mode: forwards;
+}
+.annotation-toast-undo, .annotation-toast-redo { background: #6b7280; }
+.annotation-toast-error { background: #ef4444; }
+
+@keyframes annotation-toast-life {
+    0%   { opacity: 0; transform: translateY(8px); }
+    8%   { opacity: 1; transform: translateY(0); }
+    85%  { opacity: 1; transform: translateY(0); }
+    100% { opacity: 0; transform: translateY(0); }
+}
 .live-session-badge {
     display: inline-block; background: #ef4444; color: white;
     font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 3px;

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -20,6 +20,7 @@ import { useLiveSessions } from './hooks/useLiveSessions';
 import { useOpenLiveOnSpace } from './hooks/useOpenLiveOnSpace';
 import { useLiveSession } from './hooks/useLiveSession';
 import { useAnnotationMutations, type AnnotationToast } from './hooks/useAnnotationMutations';
+import { ToastStack, appendToast, MAX_TOASTS, TOAST_DURATION_MS, type ActiveToast } from './components/ToastStack';
 import { useLiveHotkeys } from './hooks/useLiveHotkeys';
 import { useResearcherLanePolling } from './hooks/useResearcherLanePolling';
 
@@ -47,7 +48,15 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     const videoPlayerRef = useRef<VideoPlayerHandle>(null);
 
     // Live state
-    const [lastLabelToast, setLastLabelToast] = useState<AnnotationToast | null>(null);
+    const [toasts, setToasts] = useState<ActiveToast[]>([]);
+    const nextToastId = useRef(0);
+    const pushToast = useCallback((toast: AnnotationToast) => {
+        const id = nextToastId.current++;
+        setToasts(prev => appendToast(prev, { ...toast, id }, MAX_TOASTS));
+    }, []);
+    const dismissToast = useCallback((id: number) => {
+        setToasts(prev => prev.filter(t => t.id !== id));
+    }, []);
     const [stickyLive, setStickyLive] = useState(false);
 
     // Pending timeline marker position (click-to-place). The ref mirrors the
@@ -78,6 +87,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         setLoading(true);
         setViewMode('timeline');
         setScrollToTimestamp(null);
+        setToasts([]);
         setStickyLive(isLive); // immediate latch — bypasses polling cadence
         try {
             const eventsUrl = isLive
@@ -151,16 +161,15 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
     const live = useLiveSession(activeSessionId.current, isLiveSession);
 
     const showAnnotationError = useCallback((message: string) => {
-        // Surface mutator failures via the existing toast slot. Keeps the UX
-        // single-channel; the live-mode hotkey path is the only caller.
+        // Surface mutator failures through the toast stack (same channel as adds).
         console.warn('[annotations]', message);
-        setLastLabelToast({ kind: 'error', text: message, at: Date.now() });
-    }, []);
+        pushToast({ kind: 'error', text: message, at: Date.now() });
+    }, [pushToast]);
     const mutator = useAnnotationMutations({
         sessionId: activeSessionId.current,
         raterName: authStatus.raterName,
         setAnnotations,
-        onToast: setLastLabelToast,
+        onToast: pushToast,
         onError: showAnnotationError,
     });
 
@@ -268,6 +277,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         videoTimeRef.current = 0;
         setViewMode('timeline');
         setScrollToTimestamp(null);
+        setToasts([]);
         setZoomedXDomain(null);
         setAutoFollowLive(true);
         setStickyLive(false);
@@ -285,6 +295,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         videoTimeRef.current = 0;
         setViewMode('timeline');
         setScrollToTimestamp(null);
+        setToasts([]);
         setZoomedXDomain(null);
         setAutoFollowLive(true);
         setSession(null);
@@ -593,7 +604,6 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                             totalReceived={live.totalReceived}
                             latestEventTimestamp={live.latestEventTimestamp}
                             startTime={liveElapsedStart}
-                            lastLabelToast={lastLabelToast}
                         />
                     )}
                     <SessionInfo session={session} events={displayedEvents} />
@@ -696,6 +706,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                     )}
                 </div>
             )}
+            <ToastStack toasts={toasts} durationMs={TOAST_DURATION_MS} onDismiss={dismissToast} />
         </div>
     );
 }

--- a/recording-viewer/src/components/LiveControlBar.tsx
+++ b/recording-viewer/src/components/LiveControlBar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { STRUGGLE_LABELS, CONTEXT_LABELS, ALL_LABELS } from '../types';
+import { STRUGGLE_LABELS, CONTEXT_LABELS } from '../types';
 import { CONTEXT_KEYS } from '../hooks/useLiveHotkeys';
-import type { AnnotationToast } from '../hooks/useAnnotationMutations';
 import { formatDuration } from '../utils/format';
 
 const CONTEXT_KEY_BY_VALUE: Record<string, string> = Object.fromEntries(
@@ -19,24 +18,10 @@ interface Props {
     /** Authoritative session start (metadata.startTime or the sessionStart event);
      *  0 when unknown, in which case the elapsed timer is hidden. */
     startTime: number;
-    lastLabelToast: AnnotationToast | null;
-}
-
-function renderToast(toast: AnnotationToast): string {
-    const labelName = toast.label
-        ? (ALL_LABELS.find(l => l.value === toast.label)?.label ?? toast.label)
-        : null;
-    const body = labelName ?? toast.text ?? 'annotation';
-    switch (toast.kind) {
-        case 'add': return `+ ${body}`;
-        case 'undo': return `↶ ${body}`;
-        case 'redo': return `↷ ${body}`;
-        case 'error': return `⚠ ${body}`;
-    }
 }
 
 export function LiveControlBar({
-    connected, bufferSize, totalReceived, latestEventTimestamp, startTime, lastLabelToast,
+    connected, bufferSize, totalReceived, latestEventTimestamp, startTime,
 }: Props) {
     // Re-render every second so the elapsed timer and "last event N s ago" update live
     const [now, setNow] = useState(() => Date.now());
@@ -47,7 +32,6 @@ export function LiveControlBar({
 
     const elapsedMs = startTime > 0 ? Math.max(0, now - startTime) : null;
     const ageMs = latestEventTimestamp ? now - latestEventTimestamp : null;
-    const toastVisible = lastLabelToast && now - lastLabelToast.at < 1500;
 
     return (
         <div className="live-control-bar">
@@ -76,9 +60,6 @@ export function LiveControlBar({
                     <span key={s.value} style={{ color: s.color }}>{CONTEXT_KEY_BY_VALUE[s.value] ?? '?'}={s.label}</span>
                 ))}
             </div>
-            {toastVisible && (
-                <div className={`live-toast live-toast-${lastLabelToast!.kind}`}>{renderToast(lastLabelToast!)}</div>
-            )}
         </div>
     );
 }

--- a/recording-viewer/src/components/ToastStack.tsx
+++ b/recording-viewer/src/components/ToastStack.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useEffect } from 'react';
+import { ALL_LABELS } from '../types';
+import type { AnnotationToast } from '../hooks/annotationController';
+
+/** How long each toast stays on screen before it auto-dismisses. Drives both the
+ *  per-item dismissal timer and the inline `animationDuration`; the CSS keyframe is
+ *  percentage-based, so the fade scales to this single value. */
+export const TOAST_DURATION_MS = 2500;
+/** Max simultaneously visible toasts; a burst beyond this drops the oldest. */
+export const MAX_TOASTS = 5;
+
+export type ActiveToast = AnnotationToast & { id: number };
+
+/** Append `toast`, trimming the oldest entries so the list never exceeds `max`. */
+export function appendToast(list: ActiveToast[], toast: ActiveToast, max: number): ActiveToast[] {
+    const next = [...list, toast];
+    return next.length > max ? next.slice(next.length - max) : next;
+}
+
+function renderToast(toast: AnnotationToast): string {
+    const labelName = toast.label
+        ? (ALL_LABELS.find(l => l.value === toast.label)?.label ?? toast.label)
+        : null;
+    const body = labelName ?? toast.text ?? 'annotation';
+    switch (toast.kind) {
+        case 'add': return `+ ${body}`;
+        case 'undo': return `↶ ${body}`;
+        case 'redo': return `↷ ${body}`;
+        case 'error': return `⚠ ${body}`;
+    }
+    // Compile-time exhaustiveness guard: if a new toast kind is added, this fails to type-check.
+    const _exhaustive: never = toast.kind;
+    return _exhaustive;
+}
+
+interface ToastItemProps {
+    toast: ActiveToast;
+    durationMs: number;
+    onDismiss: (id: number) => void;
+}
+
+function ToastItem({ toast, durationMs, onDismiss }: ToastItemProps) {
+    useEffect(() => {
+        const timer = setTimeout(() => onDismiss(toast.id), durationMs);
+        return () => clearTimeout(timer);
+    }, [toast.id, durationMs, onDismiss]);
+
+    // animationDuration is driven from the single durationMs source so the CSS fade
+    // cannot drift from the JS removal timer.
+    return (
+        <div
+            className={`annotation-toast annotation-toast-${toast.kind}`}
+            style={{ animationDuration: `${durationMs}ms` }}
+        >
+            {renderToast(toast)}
+        </div>
+    );
+}
+
+interface ToastStackProps {
+    toasts: ActiveToast[];
+    durationMs: number;
+    onDismiss: (id: number) => void;
+}
+
+/** Fixed bottom-right overlay. Toasts are passed oldest-first; the newest renders
+ *  last so it sits closest to the corner, with older ones stacked above it. */
+export function ToastStack({ toasts, durationMs, onDismiss }: ToastStackProps) {
+    if (toasts.length === 0) return null;
+    return (
+        <div className="annotation-toast-stack">
+            {toasts.map(t => (
+                <ToastItem key={t.id} toast={t} durationMs={durationMs} onDismiss={onDismiss} />
+            ))}
+        </div>
+    );
+}

--- a/recording-viewer/test/liveControlBar.test.tsx
+++ b/recording-viewer/test/liveControlBar.test.tsx
@@ -7,7 +7,6 @@ const baseProps = {
     bufferSize: 10,
     totalReceived: 10,
     latestEventTimestamp: null,
-    lastLabelToast: null,
 } as const;
 
 describe('LiveControlBar elapsed timer', () => {

--- a/recording-viewer/test/toastStack.test.tsx
+++ b/recording-viewer/test/toastStack.test.tsx
@@ -1,0 +1,102 @@
+import { StrictMode } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { ToastStack, appendToast, type ActiveToast } from '../src/components/ToastStack';
+
+function mk(id: number, over: Partial<ActiveToast> = {}): ActiveToast {
+    return { id, kind: 'add', text: undefined, at: 0, ...over };
+}
+
+describe('appendToast', () => {
+    it('appends to the end', () => {
+        const out = appendToast([mk(0)], mk(1), 5);
+        expect(out.map(t => t.id)).toEqual([0, 1]);
+    });
+
+    it('drops the oldest when over the cap', () => {
+        const start = [mk(0), mk(1), mk(2), mk(3), mk(4)];
+        const out = appendToast(start, mk(5), 5);
+        expect(out.map(t => t.id)).toEqual([1, 2, 3, 4, 5]);
+    });
+});
+
+describe('ToastStack', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('renders nothing when empty', () => {
+        const { container } = render(
+            <ToastStack toasts={[]} durationMs={2500} onDismiss={() => {}} />,
+        );
+        expect(container.querySelector('.annotation-toast-stack')).toBeNull();
+    });
+
+    it('renders toasts in order, newest last (corner)', () => {
+        const toasts = [mk(0, { text: 'first' }), mk(1, { text: 'second' })];
+        const { container } = render(
+            <ToastStack toasts={toasts} durationMs={2500} onDismiss={() => {}} />,
+        );
+        const items = container.querySelectorAll('.annotation-toast');
+        expect(items).toHaveLength(2);
+        expect(items[0].textContent).toBe('+ first');
+        expect(items[1].textContent).toBe('+ second');
+    });
+
+    it('formats each kind and resolves the human label', () => {
+        const toasts: ActiveToast[] = [
+            mk(0, { kind: 'add', label: 'high-struggle' }),
+            mk(1, { kind: 'undo', text: 'x' }),
+            mk(2, { kind: 'redo', text: 'x' }),
+            mk(3, { kind: 'error', text: 'boom' }),
+        ];
+        const { container } = render(
+            <ToastStack toasts={toasts} durationMs={2500} onDismiss={() => {}} />,
+        );
+        const items = container.querySelectorAll('.annotation-toast');
+        expect(items[0].textContent).toBe('+ High struggle');
+        expect(items[1].textContent).toBe('↶ x');
+        expect(items[2].textContent).toBe('↷ x');
+        expect(items[3].textContent).toBe('⚠ boom');
+        expect(items[0].className).toContain('annotation-toast-add');
+        expect(items[3].className).toContain('annotation-toast-error');
+    });
+
+    it('calls onDismiss once after durationMs, not before', () => {
+        const onDismiss = vi.fn();
+        render(<ToastStack toasts={[mk(7)]} durationMs={2500} onDismiss={onDismiss} />);
+
+        act(() => { vi.advanceTimersByTime(2499); });
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => { vi.advanceTimersByTime(1); });
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+        expect(onDismiss).toHaveBeenCalledWith(7);
+    });
+
+    it('dismisses exactly once under StrictMode (double-invoked effects)', () => {
+        const onDismiss = vi.fn();
+        render(
+            <StrictMode>
+                <ToastStack toasts={[mk(3)]} durationMs={2500} onDismiss={onDismiss} />
+            </StrictMode>,
+        );
+        act(() => { vi.advanceTimersByTime(2500); });
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+        expect(onDismiss).toHaveBeenCalledWith(3);
+    });
+
+    it('runs an independent timer per toast across rerenders', () => {
+        const onDismiss = vi.fn();
+        const { rerender } = render(
+            <ToastStack toasts={[mk(0)]} durationMs={2500} onDismiss={onDismiss} />,
+        );
+        act(() => { vi.advanceTimersByTime(1000); });            // t=1000
+        rerender(<ToastStack toasts={[mk(0), mk(1)]} durationMs={2500} onDismiss={onDismiss} />);
+        act(() => { vi.advanceTimersByTime(1500); });            // t=2500 -> toast 0 expires
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+        expect(onDismiss).toHaveBeenCalledWith(0);
+        act(() => { vi.advanceTimersByTime(1000); });            // t=3500 -> toast 1 expires
+        expect(onDismiss).toHaveBeenCalledTimes(2);
+        expect(onDismiss).toHaveBeenCalledWith(1);
+    });
+});


### PR DESCRIPTION
## What

Replaces the recording viewer's single, top-anchored, live-only annotation confirmation toast with a viewport-fixed bottom-right toast **stack** that:

- appears in both **live** and **offline review** modes (previously live only),
- **stacks** multiple toasts when labels are added in quick succession (newest in the corner, max 5, oldest dropped on overflow),
- auto-dismisses each toast after ~2.5s with an independent fade,
- preserves the four kinds (add = blue, undo/redo = gray, error = red) and the human-label rendering.

## Why

The old toast was anchored under the top live-control bar, so it sat near the top of a scrolling page (easy to miss, scrolled away with content) and never appeared when placing labels via click-to-place in recorded sessions.

## How

- New standalone `ToastStack` component rendered unconditionally at the App root (`position: fixed`, bottom-right). Each `ToastItem` self-dismisses via a per-item timer; the fade length is driven from a single `TOAST_DURATION_MS` source (inline `animationDuration`) so the CSS fade and the JS removal cannot drift.
- `App.tsx` now holds a toast **list** (`pushToast` / `dismissToast`) fed by the existing mode-agnostic `onToast` callback; the list is cleared on every session-context switch so no toast bleeds across sessions.
- The old inline toast (and its duplicate `renderToast`) is removed from `LiveControlBar`; the orphaned `.live-toast*` CSS and the now-unused `position: relative` are dropped.

## Testing

- New `toastStack.test.tsx` covers stacking order, the max-5 cap (oldest dropped), auto-dismiss timing, StrictMode double-invoke safety, and independent per-toast clocks.
- `npm run lint`, `npm run test` (312 tests), and `npm run build` all green.
- Manually verified against a live preview (stacking + independent fade + click-to-place) and an offline recorded session.
