### PR TITLE
feat(recording-viewer): researcher rater struggle-comparison view

### DIFF
--- a/recording-viewer/src/App.css
+++ b/recording-viewer/src/App.css
@@ -1780,3 +1780,28 @@
     font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 3px;
     margin-right: 0.5rem; font-weight: bold; animation: pulse 1.5s infinite;
 }
+
+/* ── Researcher rater comparison view ─────────────────────────────────── */
+.rater-compare { padding: 0.5rem 0; }
+.rater-compare-empty { color: #94a3b8; padding: 1.5rem; text-align: center; }
+.rater-compare-header {
+    display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+.rater-compare-legend { display: flex; gap: 0.75rem; flex-wrap: wrap; font-size: 0.8rem; color: #cbd5e1; }
+.rater-legend-item { display: inline-flex; align-items: center; gap: 0.35rem; }
+.rater-legend-swatch { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
+.rater-compare-grid { display: grid; grid-template-columns: 110px 1fr; align-items: start; }
+.rater-compare-labels { display: flex; flex-direction: column; justify-content: space-between; }
+.rater-level-label { font-size: 0.72rem; color: #94a3b8; line-height: 1; }
+.rater-row-label {
+    display: flex; align-items: center; gap: 0.35rem;
+    font-size: 0.78rem; color: #cbd5e1;
+}
+.rater-compare-plot { position: relative; background: rgba(255,255,255,0.02); border: 1px solid #222; }
+.rater-compare-tooltip {
+    position: absolute; z-index: 10; pointer-events: none;
+    background: #1e1e2e; color: #e2e8f0; border: 1px solid #334155;
+    padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.75rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4); white-space: nowrap;
+}

--- a/recording-viewer/src/App.tsx
+++ b/recording-viewer/src/App.tsx
@@ -21,6 +21,7 @@ import { useOpenLiveOnSpace } from './hooks/useOpenLiveOnSpace';
 import { useLiveSession } from './hooks/useLiveSession';
 import { useAnnotationMutations, type AnnotationToast } from './hooks/useAnnotationMutations';
 import { ToastStack, appendToast, MAX_TOASTS, TOAST_DURATION_MS, type ActiveToast } from './components/ToastStack';
+import { RaterComparisonView } from './components/RaterComparisonView';
 import { useLiveHotkeys } from './hooks/useLiveHotkeys';
 import { useResearcherLanePolling } from './hooks/useResearcherLanePolling';
 
@@ -399,7 +400,7 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
         }
         return liveStartRef.current.start;
     }, [session, displayedEvents]);
-    const [viewMode, setViewMode] = useState<'timeline' | 'list'>('timeline');
+    const [viewMode, setViewMode] = useState<'timeline' | 'list' | 'compare'>('timeline');
     const [scrollToTimestamp, setScrollToTimestamp] = useState<number | null>(null);
     const [zoomedXDomain, setZoomedXDomain] = useState<[number, number] | null>(null);
     const [autoFollowLive, setAutoFollowLive] = useState(true);
@@ -621,6 +622,14 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                             >
                                 List
                             </button>
+                            {isResearcher && researcherLanes && xDomain && (
+                                <button
+                                    className={`view-toggle-btn ${viewMode === 'compare' ? 'active' : ''}`}
+                                    onClick={() => setViewMode('compare')}
+                                >
+                                    Compare
+                                </button>
+                            )}
                         </div>
                         {viewMode === 'timeline' && xDomain && (
                             <div className="zoom-controls">
@@ -701,6 +710,15 @@ export function RecordingViewerApp({ authStatus }: RecordingViewerAppProps) {
                             onScrollComplete={handleScrollComplete}
                             videoTimeRef={videoTimeRef}
                             isVideoPlaying={isVideoPlaying}
+                            onSeekVideo={videoSyncConfig ? handleVideoSeek : undefined}
+                        />
+                    )}
+                    {viewMode === 'compare' && researcherLanes && xDomain && (
+                        <RaterComparisonView
+                            researcherLanes={researcherLanes}
+                            xDomain={xDomain}
+                            sessionStartTime={sessionStartTime}
+                            videoTimeRef={videoTimeRef}
                             onSeekVideo={videoSyncConfig ? handleVideoSeek : undefined}
                         />
                     )}

--- a/recording-viewer/src/components/RaterComparisonView.tsx
+++ b/recording-viewer/src/components/RaterComparisonView.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { STRUGGLE_LABELS } from '../types';
+import { formatOffset } from '../utils/format';
+import { SessionChartOverlay } from './SessionChartOverlay';
+import {
+    toStruggleSeries, buildStepSegments, computeDivergenceSegments,
+    RANKED_LEVELS, type Mark, type RaterLaneInput,
+} from '../utils/raterComparison';
+
+const LEVEL_LABEL: Record<string, string> = Object.fromEntries(STRUGGLE_LABELS.map(l => [l.value, l.label]));
+const SEVERITY_COLOR: Record<string, string> = Object.fromEntries(STRUGGLE_LABELS.map(l => [l.value, l.color]));
+
+const OVERLAY_PLOT_H = 150;
+const OVERLAY_PAD_TOP = 12;
+const OVERLAY_PAD_BOTTOM = 12;
+const STACK_ROW_H = 28;
+const STACK_SEG_PAD = 4;
+
+interface TooltipState { left: number; top: number; lines: string[]; }
+
+interface Props {
+    researcherLanes: RaterLaneInput[];
+    xDomain: [number, number];
+    sessionStartTime: number;
+    videoTimeRef?: React.RefObject<number>;
+    onSeekVideo?: (timestamp: number) => void;
+}
+
+export function RaterComparisonView({ researcherLanes, xDomain, sessionStartTime, videoTimeRef, onSeekVideo }: Props) {
+    const [mode, setMode] = useState<'overlaid' | 'stacked'>('overlaid');
+    const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+    const plotRef = useRef<HTMLDivElement>(null);
+    const [width, setWidth] = useState(0);
+
+    useEffect(() => {
+        const el = plotRef.current;
+        if (!el) return;
+        const ro = new ResizeObserver(entries => {
+            for (const e of entries) setWidth(e.contentRect.width);
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    const series = useMemo(() => toStruggleSeries(researcherLanes), [researcherLanes]);
+    // App's xDomain is OFFSET space (timestamp - sessionStartTime); marks carry ABSOLUTE
+    // timestamps (needed for onSeekVideo). Convert the domain to absolute so both live in
+    // one space for positioning, step segments, and divergence.
+    const domainAbs = useMemo<[number, number]>(
+        () => [xDomain[0] + sessionStartTime, xDomain[1] + sessionStartTime],
+        [xDomain, sessionStartTime],
+    );
+    const divergence = useMemo(() => computeDivergenceSegments(series, domainAbs), [series, domainAbs]);
+
+    const [da0, da1] = domainAbs;
+    const span = da1 - da0;
+    const xScale = (t: number) => (span > 0 ? ((t - da0) / span) * width : 0);
+    const plotH = mode === 'overlaid' ? OVERLAY_PLOT_H : Math.max(STACK_ROW_H, series.length * STACK_ROW_H);
+
+    const yForRank = (rank: number) => {
+        const innerH = OVERLAY_PLOT_H - OVERLAY_PAD_TOP - OVERLAY_PAD_BOTTOM;
+        return OVERLAY_PAD_TOP + (1 - rank / (RANKED_LEVELS.length - 1)) * innerH;
+    };
+    const tipLines = (rater: string, label: string, t: number, text: string) =>
+        [rater, label, `+${formatOffset(t - sessionStartTime)}`, ...(text ? [text] : [])];
+    const showTip = (e: React.MouseEvent, lines: string[]) => {
+        const rect = plotRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        setTooltip({ left: e.clientX - rect.left + 12, top: e.clientY - rect.top + 12, lines });
+    };
+    const hideTip = () => setTooltip(null);
+
+    if (series.length === 0) {
+        return (
+            <div className="rater-compare">
+                <div className="rater-compare-empty">No struggle ratings to compare yet.</div>
+            </div>
+        );
+    }
+
+    const stepPath = (marks: Mark[]): string => {
+        let d = `M ${xScale(marks[0].t)} ${yForRank(marks[0].rank)}`;
+        let prevY = yForRank(marks[0].rank);
+        for (let i = 1; i < marks.length; i++) {
+            const x = xScale(marks[i].t);
+            const y = yForRank(marks[i].rank);
+            d += ` L ${x} ${prevY} L ${x} ${y}`;
+            prevY = y;
+        }
+        d += ` L ${xScale(da1)} ${prevY}`;
+        return d;
+    };
+
+    return (
+        <div className="rater-compare">
+            <div className="rater-compare-header">
+                <div className="view-toggle">
+                    <button className={`view-toggle-btn ${mode === 'overlaid' ? 'active' : ''}`} onClick={() => setMode('overlaid')}>Overlaid</button>
+                    <button className={`view-toggle-btn ${mode === 'stacked' ? 'active' : ''}`} onClick={() => setMode('stacked')}>Stacked</button>
+                </div>
+                <div className="rater-compare-legend">
+                    {series.map(s => (
+                        <span key={s.raterId} className="rater-legend-item">
+                            <span className="rater-legend-swatch" style={{ background: s.color }} />{s.raterName}
+                        </span>
+                    ))}
+                </div>
+            </div>
+
+            <div className="rater-compare-grid">
+                <div
+                    className="rater-compare-labels"
+                    style={mode === 'overlaid'
+                        ? { height: OVERLAY_PLOT_H, padding: `${OVERLAY_PAD_TOP}px 0 ${OVERLAY_PAD_BOTTOM}px` }
+                        : undefined}
+                >
+                    {mode === 'overlaid'
+                        ? [...RANKED_LEVELS].reverse().map(lvl => (
+                            <div key={lvl} className="rater-level-label">{LEVEL_LABEL[lvl]}</div>
+                          ))
+                        : series.map(s => (
+                            <div key={s.raterId} className="rater-row-label" style={{ height: STACK_ROW_H }}>
+                                <span className="rater-legend-swatch" style={{ background: s.color }} />{s.raterName}
+                            </div>
+                          ))}
+                </div>
+
+                <div className="rater-compare-plot" ref={plotRef}>
+                    <svg width="100%" height={plotH} style={{ display: 'block' }}>
+                        {divergence.map(([s, e], i) => (
+                            <rect key={`div-${i}`} x={xScale(s)} y={0} width={Math.max(0, xScale(e) - xScale(s))} height={plotH} fill="rgba(239,68,68,0.14)" />
+                        ))}
+
+                        {mode === 'overlaid' && (
+                            <>
+                                {RANKED_LEVELS.map((lvl, r) => (
+                                    <line key={lvl} x1={0} x2={width} y1={yForRank(r)} y2={yForRank(r)} stroke="#2a2a3a" strokeWidth={1} />
+                                ))}
+                                {series.map(s => (
+                                    <g key={s.raterId}>
+                                        <path d={stepPath(s.marks)} fill="none" stroke={s.color} strokeWidth={2} />
+                                        {s.marks.map(m => (
+                                            <circle
+                                                key={m.id} cx={xScale(m.t)} cy={yForRank(m.rank)} r={4}
+                                                fill={s.color} stroke="#1e1e2e" strokeWidth={1.5}
+                                                style={{ cursor: onSeekVideo ? 'pointer' : 'default' }}
+                                                onMouseEnter={ev => showTip(ev, tipLines(s.raterName, LEVEL_LABEL[m.label], m.t, m.text))}
+                                                onMouseMove={ev => showTip(ev, tipLines(s.raterName, LEVEL_LABEL[m.label], m.t, m.text))}
+                                                onMouseLeave={hideTip}
+                                                onClick={() => onSeekVideo?.(m.t)}
+                                            />
+                                        ))}
+                                    </g>
+                                ))}
+                            </>
+                        )}
+
+                        {mode === 'stacked' && series.map((s, k) => {
+                            const y0 = k * STACK_ROW_H;
+                            return (
+                                <g key={s.raterId}>
+                                    {buildStepSegments(s.marks, da1).map(seg => {
+                                        const x = xScale(seg.startT);
+                                        return (
+                                            <rect
+                                                key={seg.mark.id} x={x} y={y0 + STACK_SEG_PAD}
+                                                width={Math.max(0, xScale(seg.endT) - x)} height={STACK_ROW_H - 2 * STACK_SEG_PAD}
+                                                rx={2} fill={SEVERITY_COLOR[seg.label]}
+                                                style={{ cursor: onSeekVideo ? 'pointer' : 'default' }}
+                                                onMouseEnter={ev => showTip(ev, tipLines(s.raterName, LEVEL_LABEL[seg.label], seg.startT, seg.mark.text))}
+                                                onMouseMove={ev => showTip(ev, tipLines(s.raterName, LEVEL_LABEL[seg.label], seg.startT, seg.mark.text))}
+                                                onMouseLeave={hideTip}
+                                                onClick={() => onSeekVideo?.(seg.mark.t)}
+                                            />
+                                        );
+                                    })}
+                                </g>
+                            );
+                        })}
+                    </svg>
+
+                    {width > 0 && (
+                        <SessionChartOverlay
+                            xDomain={xDomain}
+                            topOffset={0}
+                            videoTimeRef={videoTimeRef}
+                            sessionStartTime={sessionStartTime}
+                        />
+                    )}
+                    {tooltip && (
+                        <div className="rater-compare-tooltip" style={{ left: tooltip.left, top: tooltip.top }}>
+                            {tooltip.lines.map((l, i) => <div key={i}>{l}</div>)}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/recording-viewer/src/components/SessionChartOverlay.tsx
+++ b/recording-viewer/src/components/SessionChartOverlay.tsx
@@ -5,6 +5,7 @@ interface Props {
     zoomedRange?: [number, number];
     videoTimeRef?: React.RefObject<number>;
     sessionStartTime: number;
+    topOffset?: number;
 }
 
 /**
@@ -19,7 +20,7 @@ interface Props {
  */
 const CHART_TOP_OFFSET = 10;
 
-export function SessionChartOverlay({ xDomain, zoomedRange, videoTimeRef, sessionStartTime }: Props) {
+export function SessionChartOverlay({ xDomain, zoomedRange, videoTimeRef, sessionStartTime, topOffset = CHART_TOP_OFFSET }: Props) {
     const containerRef = useRef<HTMLDivElement>(null);
     const playheadRef = useRef<HTMLDivElement>(null);
     const [width, setWidth] = useState(0);
@@ -79,7 +80,7 @@ export function SessionChartOverlay({ xDomain, zoomedRange, videoTimeRef, sessio
             className="session-chart-overlay"
             style={{
                 position: 'absolute',
-                top: CHART_TOP_OFFSET,
+                top: topOffset,
                 left: 0,
                 right: 0,
                 bottom: 0,

--- a/recording-viewer/src/components/SessionTimeline.tsx
+++ b/recording-viewer/src/components/SessionTimeline.tsx
@@ -11,6 +11,7 @@ import {
     Dot,
 } from 'recharts';
 import type { Annotation, RecordedEvent, EqSnapshotEvent, ReplayEqSnapshot } from '../types.ts';
+import { STRUGGLE_LABELS } from '../types.ts';
 import { formatOffset } from '../utils/format.ts';
 import { raterLaneColor } from '../utils/raterColor.ts';
 import { EventBadge } from './EventBadge.tsx';
@@ -400,6 +401,10 @@ export function SessionTimeline({ events, sessionStartTime, replayEq, annotation
                                         const off = a.timestamp - sessionStartTime;
                                         const leftPct = xSpan > 0 ? ((off - xDomain[0]) / xSpan) * 100 : 0;
                                         if (leftPct < 0 || leftPct > 100) return null;
+                                        // Struggle marks are filled by severity (confident green -> blocked red);
+                                        // context markers / unlabelled notes keep the rater color. The lane badge
+                                        // (rater color) still identifies whose row this is.
+                                        const dotColor = STRUGGLE_LABELS.find(l => l.value === a.label)?.color ?? color;
                                         return (
                                             <div
                                                 key={a.id}
@@ -412,7 +417,7 @@ export function SessionTimeline({ events, sessionStartTime, replayEq, annotation
                                                     width: 10,
                                                     height: 10,
                                                     borderRadius: '50%',
-                                                    background: color,
+                                                    background: dotColor,
                                                     border: '1.5px solid #1e1e2e',
                                                     boxShadow: '0 0 0 1px rgba(0,0,0,0.4)',
                                                 }}

--- a/recording-viewer/src/utils/raterComparison.ts
+++ b/recording-viewer/src/utils/raterComparison.ts
@@ -1,0 +1,112 @@
+import type { Annotation, StruggleLevel } from '../types';
+import { raterLaneColor } from './raterColor';
+
+export const RANKED_LEVELS: StruggleLevel[] = [
+    'confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked',
+];
+
+export const STRUGGLE_RANK: Record<StruggleLevel, number> = {
+    'confident': 0, 'light-struggle': 1, 'medium-struggle': 2, 'high-struggle': 3, 'blocked': 4,
+};
+
+const STRUGGLE_SET = new Set<string>(RANKED_LEVELS);
+
+export function isStruggleLabel(label: string | undefined): label is StruggleLevel {
+    return label != null && STRUGGLE_SET.has(label);
+}
+
+export interface Mark {
+    id: string;
+    t: number;          // absolute timestamp (ms)
+    rank: number;       // 0..4
+    label: StruggleLevel;
+    text: string;
+}
+
+export interface RaterSeries {
+    raterId: string;
+    raterName: string;
+    color: string;      // rater color (raterLaneColor)
+    marks: Mark[];      // ascending by t
+}
+
+export interface RaterLaneInput {
+    raterId: string;
+    raterName: string;
+    annotations: Annotation[];
+}
+
+export function toStruggleSeries(lanes: RaterLaneInput[]): RaterSeries[] {
+    const out: RaterSeries[] = [];
+    for (const lane of lanes) {
+        const marks: Mark[] = [];
+        for (const a of lane.annotations) {
+            if (!isStruggleLabel(a.label)) continue;
+            marks.push({ id: a.id, t: a.timestamp, rank: STRUGGLE_RANK[a.label], label: a.label, text: a.text ?? '' });
+        }
+        if (marks.length === 0) continue;
+        marks.sort((x, y) => x.t - y.t);
+        out.push({ raterId: lane.raterId, raterName: lane.raterName, color: raterLaneColor(lane.raterId), marks });
+    }
+    return out;
+}
+
+export interface Segment {
+    startT: number;
+    endT: number;
+    rank: number;
+    label: StruggleLevel;
+    mark: Mark;
+}
+
+/** Each mark spans [mark.t, nextMark.t); the last spans [lastMark.t, domainEnd]. */
+export function buildStepSegments(marks: Mark[], domainEnd: number): Segment[] {
+    const segs: Segment[] = [];
+    for (let i = 0; i < marks.length; i++) {
+        const m = marks[i];
+        const endT = i + 1 < marks.length ? marks[i + 1].t : domainEnd;
+        segs.push({ startT: m.t, endT, rank: m.rank, label: m.label, mark: m });
+    }
+    return segs;
+}
+
+export const DIVERGENCE_THRESHOLD = 2;
+
+/** Time intervals where >=2 raters' current (step-held) ranks span >= threshold levels. */
+export function computeDivergenceSegments(
+    series: RaterSeries[],
+    domain: [number, number],
+    threshold: number = DIVERGENCE_THRESHOLD,
+): Array<[number, number]> {
+    const pointSet = new Set<number>([domain[0]]);
+    for (const s of series) for (const m of s.marks) {
+        if (m.t > domain[0] && m.t < domain[1]) pointSet.add(m.t);
+    }
+    const points = [...pointSet].sort((a, b) => a - b);
+    points.push(domain[1]);
+
+    const raw: Array<[number, number]> = [];
+    for (let i = 0; i + 1 < points.length; i++) {
+        const start = points[i];
+        const end = points[i + 1];
+        if (end <= start) continue;
+        const ranks: number[] = [];
+        for (const s of series) {
+            let cur: number | null = null;
+            for (const m of s.marks) {
+                if (m.t <= start) cur = m.rank; else break;
+            }
+            if (cur != null) ranks.push(cur);
+        }
+        if (ranks.length >= 2 && Math.max(...ranks) - Math.min(...ranks) >= threshold) {
+            raw.push([start, end]);
+        }
+    }
+    const merged: Array<[number, number]> = [];
+    for (const [s, e] of raw) {
+        const last = merged[merged.length - 1];
+        if (last && s <= last[1]) last[1] = Math.max(last[1], e);
+        else merged.push([s, e]);
+    }
+    return merged;
+}

--- a/recording-viewer/test/raterComparison.test.ts
+++ b/recording-viewer/test/raterComparison.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import type { Annotation } from '../src/types';
+import {
+    STRUGGLE_RANK, RANKED_LEVELS, isStruggleLabel,
+    toStruggleSeries, buildStepSegments, computeDivergenceSegments,
+} from '../src/utils/raterComparison';
+
+function ann(id: string, t: number, label: string): Annotation {
+    return { id, timestamp: t, label: label as Annotation['label'], text: '', createdAt: t };
+}
+
+describe('rank constants', () => {
+    it('orders confident..blocked 0..4', () => {
+        expect(RANKED_LEVELS).toEqual(['confident', 'light-struggle', 'medium-struggle', 'high-struggle', 'blocked']);
+        expect(STRUGGLE_RANK.confident).toBe(0);
+        expect(STRUGGLE_RANK.blocked).toBe(4);
+    });
+    it('isStruggleLabel accepts struggle levels, rejects context/empty', () => {
+        expect(isStruggleLabel('high-struggle')).toBe(true);
+        expect(isStruggleLabel('reading')).toBe(false);
+        expect(isStruggleLabel('')).toBe(false);
+        expect(isStruggleLabel(undefined)).toBe(false);
+    });
+});
+
+describe('toStruggleSeries', () => {
+    it('filters non-struggle labels, sorts by time, drops empty raters', () => {
+        const lanes = [
+            { raterId: 'r_a', raterName: 'Alice', annotations: [
+                ann('a2', 1500, 'blocked'), ann('a1', 1100, 'confident'), ann('a3', 1300, 'reading'),
+            ] },
+            { raterId: 'r_b', raterName: 'Bob', annotations: [ann('b1', 1200, 'idle')] }, // context only -> dropped
+        ];
+        const series = toStruggleSeries(lanes);
+        expect(series).toHaveLength(1);
+        expect(series[0].raterId).toBe('r_a');
+        expect(series[0].marks.map(m => m.id)).toEqual(['a1', 'a2']); // sorted, context dropped
+        expect(series[0].marks.map(m => m.rank)).toEqual([0, 4]);
+        expect(typeof series[0].color).toBe('string');
+    });
+});
+
+describe('buildStepSegments', () => {
+    it('each mark holds until the next; last holds to domainEnd', () => {
+        const series = toStruggleSeries([{ raterId: 'r_a', raterName: 'Alice', annotations: [
+            ann('a1', 1100, 'confident'), ann('a2', 1500, 'blocked'),
+        ] }]);
+        const segs = buildStepSegments(series[0].marks, 2000);
+        expect(segs).toEqual([
+            { startT: 1100, endT: 1500, rank: 0, label: 'confident', mark: series[0].marks[0] },
+            { startT: 1500, endT: 2000, rank: 4, label: 'blocked', mark: series[0].marks[1] },
+        ]);
+    });
+});
+
+describe('computeDivergenceSegments', () => {
+    const domain: [number, number] = [1000, 2000];
+    it('returns nothing when raters agree', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 1100, 'confident')] },
+            { raterId: 'r_b', raterName: 'B', annotations: [ann('b1', 1100, 'light-struggle')] }, // spread 1 < 2
+        ]);
+        expect(computeDivergenceSegments(series, domain)).toEqual([]);
+    });
+    it('flags intervals where two raters are >=2 levels apart, merging adjacents', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 1100, 'confident'), ann('a2', 1500, 'blocked')] },
+            { raterId: 'r_b', raterName: 'B', annotations: [ann('b1', 1200, 'medium-struggle')] },
+        ]);
+        // [1200,1500): A=0,B=2 spread2; [1500,2000): A=4,B=2 spread2 -> merged [1200,2000]
+        expect(computeDivergenceSegments(series, domain)).toEqual([[1200, 2000]]);
+    });
+    it('needs at least two raters with a value', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 1100, 'confident'), ann('a2', 1500, 'blocked')] },
+        ]);
+        expect(computeDivergenceSegments(series, domain)).toEqual([]);
+    });
+    it('carries a pre-domain mark into the first interval', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 900, 'confident')] }, // before domain[0]
+            { raterId: 'r_b', raterName: 'B', annotations: [ann('b1', 1100, 'blocked')] },
+        ]);
+        // [1000,1100): only A has a value -> none; [1100,2000): A=0 (carried), B=4 -> diverge
+        expect(computeDivergenceSegments(series, domain)).toEqual([[1100, 2000]]);
+    });
+    it('counts a mark exactly at domain[0]', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 1000, 'confident')] },
+            { raterId: 'r_b', raterName: 'B', annotations: [ann('b1', 1000, 'blocked')] },
+        ]);
+        expect(computeDivergenceSegments(series, domain)).toEqual([[1000, 2000]]);
+    });
+    it('a mark exactly at domain[1] opens no new interval', () => {
+        const series = toStruggleSeries([
+            { raterId: 'r_a', raterName: 'A', annotations: [ann('a1', 1100, 'confident'), ann('a2', 2000, 'blocked')] },
+            { raterId: 'r_b', raterName: 'B', annotations: [ann('b1', 1100, 'confident')] },
+        ]);
+        // both agree (confident) through (1100,2000); the 2000 mark is at the edge -> no interval after it
+        expect(computeDivergenceSegments(series, domain)).toEqual([]);
+    });
+});

--- a/recording-viewer/test/raterComparisonView.test.tsx
+++ b/recording-viewer/test/raterComparisonView.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { RaterComparisonView } from '../src/components/RaterComparisonView';
+import type { Annotation } from '../src/types';
+
+function ann(id: string, t: number, label: string, raterId = 'r_a'): Annotation {
+    return { id, timestamp: t, label: label as Annotation['label'], text: '', createdAt: t, raterId, raterName: raterId };
+}
+// App's xDomain is OFFSET space; with sessionStartTime=1000 this maps to absolute
+// [1000, 2000], so the absolute marks 1100/1200/1500 fall inside.
+const xDomain: [number, number] = [0, 1000];
+function lanes() {
+    return [
+        { raterId: 'r_a', raterName: 'Alice', annotations: [ann('a1', 1100, 'confident'), ann('a2', 1500, 'blocked')] },
+        { raterId: 'r_b', raterName: 'Bob', annotations: [ann('b1', 1200, 'medium-struggle', 'r_b')] },
+    ];
+}
+
+describe('RaterComparisonView', () => {
+    it('shows an empty state when no struggle ratings exist', () => {
+        const onlyContext = [{ raterId: 'r_a', raterName: 'Alice', annotations: [ann('a1', 1100, 'reading')] }];
+        render(<RaterComparisonView researcherLanes={onlyContext} xDomain={xDomain} sessionStartTime={1000} />);
+        expect(screen.getByText(/no struggle ratings/i)).toBeInTheDocument();
+    });
+
+    it('toggles between overlaid (level labels + step paths) and stacked (rater rows)', () => {
+        const { container } = render(<RaterComparisonView researcherLanes={lanes()} xDomain={xDomain} sessionStartTime={1000} />);
+        expect(container.querySelectorAll('.rater-level-label')).toHaveLength(5);
+        expect(container.querySelectorAll('.rater-row-label')).toHaveLength(0);
+        expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Stacked' }));
+        expect(container.querySelectorAll('.rater-row-label')).toHaveLength(2);
+        expect(container.querySelectorAll('.rater-level-label')).toHaveLength(0);
+        expect(container.querySelectorAll('rect').length).toBeGreaterThan(0);
+    });
+
+    it('seeks the video to the mark timestamp on click', () => {
+        const onSeekVideo = vi.fn();
+        const { container } = render(
+            <RaterComparisonView researcherLanes={lanes()} xDomain={xDomain} sessionStartTime={1000} onSeekVideo={onSeekVideo} />,
+        );
+        const circle = container.querySelector('circle');
+        expect(circle).not.toBeNull();
+        fireEvent.click(circle!);
+        expect(onSeekVideo).toHaveBeenCalledTimes(1);
+        expect(onSeekVideo).toHaveBeenCalledWith(1100); // Alice's first mark
+    });
+});

--- a/recording-viewer/test/setupTests.ts
+++ b/recording-viewer/test/setupTests.ts
@@ -5,3 +5,12 @@ import { cleanup } from '@testing-library/react';
 afterEach(() => {
     cleanup();
 });
+
+// jsdom has no ResizeObserver; stub it so components that observe layout can render.
+if (!('ResizeObserver' in globalThis)) {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as unknown as typeof ResizeObserver;
+}


### PR DESCRIPTION
## What

Adds a researcher-only **Compare** view for seeing how multiple raters rated **struggle severity over time**, plus a small enhancement to the existing per-rater rows.

- **New Compare view-mode** (researcher only, third toggle next to Timeline/List): plots each rater's struggle rating (ordinal `confident` → `blocked`; context markers excluded) over the session timeline, switchable between:
  - **Overlaid** — one step-line per rater (rater color) against a severity y-axis,
  - **Stacked** — one row per rater with severity-colored bands.
  - Hover tooltip (rater / level / time / note), click → video seek (absolute timestamp), and a red **divergence highlight** where ≥2 raters differ by ≥2 levels.
  - Works both live and archival (consumes the existing `researcherLanes`).
- **Researcher-lane dots** in the existing timeline are now colored by **struggle severity** (green→red); context-marker and unlabelled dots keep the rater color, and the lane name badge stays the rater color for identity.

## How

- New pure transform module `raterComparison.ts` (struggle filtering, ordinal ranks, step segments, divergence intervals) — fully unit-tested including boundary cases.
- New `RaterComparisonView` SVG component; reuses `raterLaneColor`, `STRUGGLE_LABELS` colors, and `SessionChartOverlay` for the playhead (which gains an optional `topOffset` prop; the existing EQ-chart caller is unaffected).
- App gains `viewMode === 'compare'`, researcher-gated. The compare view converts App's offset-space `xDomain` to absolute internally for positioning, and passes the offset domain unchanged to `SessionChartOverlay`.

## Testing

- `raterComparison.test.ts` (transforms incl. divergence boundary cases: pre-domain carry-over, marks at the domain edges) and `raterComparisonView.test.tsx` (empty state, mode toggle, click-to-seek).
- `npm run lint`, `npm run test` (325 tests), and `npm run build` all green.
- Manually verified in a researcher preview against a 3-rater session: both modes, divergence band, tooltips, click-to-seek, and severity-colored lane dots.
