### PR TITLE
fix(submit): prevent and surface git index-lock contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Replay Fidelity**: Live and recording paths share one build-error-family builder, so replayed EQ matches the live curve.
 - **Intervention Block Reasons**: Withheld interventions record the real gate; `recent-progress`/`last-dismissed` no longer logged as `warmup`.
 - **Test Results With Hidden Names**: The "See test results" overview now lists results for exercises that hide test names from students (`showTestNamesToStudents` disabled), instead of showing "No test results available".
+- **Submission Git Locks**: Submitting is now guarded against a double-click, and a busy or stale Git index lock surfaces an actionable message instead of raw git output or a misleading "No local changes detected".
 
 ### Internal
 

--- a/extension/src/extension/controller/commands/repositorySubmitCommands.ts
+++ b/extension/src/extension/controller/commands/repositorySubmitCommands.ts
@@ -30,6 +30,31 @@ function capRecordedCommitMessage(message: string | undefined): string | undefin
 }
 
 /**
+ * User-facing message shown when a git step fails because another process holds
+ * the repository's index lock. Replaces the raw `fatal: Unable to create
+ * '.git/index.lock'` git output, which is opaque to students.
+ */
+const GIT_LOCK_USER_MESSAGE =
+    'Another Git operation is currently using this repository, so the submission was stopped. '
+    + 'Wait for it to finish (and close other Git tools such as the Source Control panel or lazygit), then try again. '
+    + 'If this keeps happening, a previous Git process may have left a stale lock file at .git/index.lock that you can delete manually.';
+
+/**
+ * Whether a thrown git error is an index-lock contention failure. Scans both the
+ * error message and any captured `stderr` (execFile rejections carry it) for the
+ * stable, language-independent `index.lock` marker rather than the localized
+ * "Another git process seems to be running" sentence.
+ */
+function isGitLockError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+    const { message, stderr } = error as { message?: unknown; stderr?: unknown };
+    const haystack = `${typeof message === 'string' ? message : ''}\n${typeof stderr === 'string' ? stderr : ''}`;
+    return haystack.toLowerCase().includes('index.lock');
+}
+
+/**
  * Helper functions injected via the constructor so tests can substitute
  * deterministic doubles. The defaults wire up to the production modules.
  *
@@ -50,6 +75,16 @@ const defaultDeps: RepositorySubmitCommandsDeps = {
 export class RepositorySubmitCommands {
     private readonly deps: RepositorySubmitCommandsDeps;
 
+    /**
+     * Guards against a re-entrant submit (e.g. a double-click on the Submit
+     * button, which is not disabled while a submission runs). A second submit
+     * while one is in flight would race the first on the same repository's git
+     * index and self-inflict an `.git/index.lock` collision. Scoped to this
+     * handler's git pipeline; it is a double-click mitigation, not a repo-wide
+     * mutex (VS Code's built-in Git and other tools can still touch the repo).
+     */
+    private _submitInFlight = false;
+
     constructor(
         private readonly context: CommandContext,
         private readonly gitService: workspaceServices.GitService = new workspaceServices.GitService(),
@@ -67,6 +102,14 @@ export class RepositorySubmitCommands {
     }
 
     private handleSubmitExercise = async (message: WebviewToExtensionMessage): Promise<void> => {
+        // Reject re-entrant submits before emitting any telemetry, so a blocked
+        // duplicate never produces an orphan `started` without a terminal event.
+        if (this._submitInFlight) {
+            vscode.window.showInformationMessage('A submission is already in progress. Please wait for it to finish.');
+            return;
+        }
+        this._submitInFlight = true;
+
         let participationId: number | undefined;
         let failureReason: SubmissionFailureReason = 'other';
         let resolvedCommitMessage: string | undefined;   // function-scoped: assigned inside withProgress, read at the succeeded emit
@@ -104,7 +147,10 @@ export class RepositorySubmitCommands {
 
                 const result = await this.deps.checkWorkspaceFiles(workspaceFolder, {
                     includeContent: false,
-                    applyFilters: false
+                    applyFilters: false,
+                    // Surface a `git status` failure (e.g. index.lock contention)
+                    // instead of letting it collapse into a false "no changes".
+                    throwOnGitError: true
                 });
 
                 if (!result.hasChanges) {
@@ -136,6 +182,12 @@ export class RepositorySubmitCommands {
                         failureReason = 'merge-conflict';
                         throw new Error('Merge conflict detected. Please resolve conflicts manually using git and try again.');
                     }
+                    if (isGitLockError(pullError)) {
+                        // `git push` does not take the index lock, so a swallowed pull lock
+                        // would let us push on an un-rebased branch and report a false
+                        // success. Surface it instead so the outer catch shows the lock message.
+                        throw pullError;
+                    }
                     logger.warn('Pull failed, but continuing with push:', LogCategory.SUBMISSION, pullMessage);
                 }
 
@@ -149,8 +201,8 @@ export class RepositorySubmitCommands {
             });
 
             // succeeded — the only success site. The post-success work below cannot throw into the
-            // outer catch (the websocket reconnect has its own inner try/catch), but succeededEmitted
-            // also hardens the "exactly one terminal per started" invariant against future edits.
+            // outer catch (recheck is fire-and-forget and the websocket reconnect has its own .catch),
+            // but succeededEmitted also hardens the "exactly one terminal per started" invariant.
             if (participationId !== undefined) {
                 fireSubmission({ status: 'succeeded', participationId, commitMessage: capRecordedCommitMessage(resolvedCommitMessage) });
                 succeededEmitted = true;
@@ -165,11 +217,11 @@ export class RepositorySubmitCommands {
             const websocketService = this.context.getWebsocketService?.();
             if (websocketService && !websocketService.isConnected()) {
                 logger.info('🔌 Submission successful - ensuring WebSocket connection for result updates...', LogCategory.WEBSOCKET);
-                try {
-                    await websocketService.connect();
-                } catch (wsError) {
+                // Fire-and-forget: a hanging connect() must not keep _submitInFlight
+                // set after the git work is done and `succeeded` was emitted.
+                void websocketService.connect().catch(wsError => {
                     logger.error('Failed to connect WebSocket after submission:', LogCategory.WEBSOCKET, wsError);
-                }
+                });
             }
         } catch (error: unknown) {
             logger.error('Submit exercise error:', LogCategory.SUBMISSION, error);
@@ -178,6 +230,13 @@ export class RepositorySubmitCommands {
             if (errorMessage === GIT_IDENTITY_NOT_CONFIGURED) {
                 // Sentinel constant (not free-text parsing): identity flow already navigated the user.
                 failureReason = 'git-identity-missing';
+            } else if (isGitLockError(error)) {
+                // A lock can throw at any git step (status, add, commit, pull, push);
+                // replace the raw git output with actionable guidance and record a
+                // uniform 'other' reason (a lock is an environment failure, not e.g.
+                // a genuine push rejection) regardless of which step the lock hit.
+                failureReason = 'other';
+                vscode.window.showErrorMessage(GIT_LOCK_USER_MESSAGE);
             } else {
                 vscode.window.showErrorMessage(errorMessage);
             }
@@ -185,6 +244,8 @@ export class RepositorySubmitCommands {
             if (participationId !== undefined && !succeededEmitted) {
                 fireSubmission({ status: 'failed', participationId, failureReason });
             }
+        } finally {
+            this._submitInFlight = false;
         }
     };
 

--- a/extension/src/extension/services/workspace/workspaceFileChecker.ts
+++ b/extension/src/extension/services/workspace/workspaceFileChecker.ts
@@ -65,6 +65,13 @@ interface FileCheckOptions {
     includeDirty?: boolean;
     /** Optional override for dirty files (used for testing or custom collection) */
     dirtyFilesOverride?: string[];
+    /**
+     * Propagate a `git status` failure instead of swallowing it. Off by default
+     * so existing callers (status polling, file watchers) keep their best-effort
+     * behaviour; the submit flow opts in so an unreadable/locked repo surfaces
+     * as an error rather than a misleading "no changes" result.
+     */
+    throwOnGitError?: boolean;
 }
 
 export interface FileInfo {
@@ -145,7 +152,8 @@ export async function checkWorkspaceFiles(
         applyFilters = false,
         checkUnpushed = false,
         includeDirty = false,
-        dirtyFilesOverride
+        dirtyFilesOverride,
+        throwOnGitError = false
     } = options;
 
     const allFiles = new Set<string>();
@@ -252,6 +260,11 @@ export async function checkWorkspaceFiles(
         }
     } catch (error) {
         logger.error('Git status failed', LogCategory.FILE_MONITOR, error);
+        // Submit opts into fail-fast so a locked/unreadable repo is not misread
+        // as "no changes"; all other callers keep the best-effort behaviour.
+        if (throwOnGitError) {
+            throw error;
+        }
     }
 
     // 3. Get unpushed commits (if requested)

--- a/extension/test/unit/controller/repositorySubmitCommands.test.ts
+++ b/extension/test/unit/controller/repositorySubmitCommands.test.ts
@@ -205,7 +205,7 @@ suite('RepositorySubmitCommands', () => {
         sinon.assert.calledOnce(recheckRepoStatus);
     });
 
-    test('submitExercise awaits websocket.connect when isConnected() is false; logs but does not surface user error if connect throws', async () => {
+    test('submitExercise reconnects websocket fire-and-forget when isConnected() is false; logs but does not surface user error if connect rejects', async () => {
         const isConnected = sandbox.stub().returns(false);
         const connect = sandbox.stub().rejects(new Error('ws boom'));
         const wsService = { isConnected, connect };
@@ -223,9 +223,9 @@ suite('RepositorySubmitCommands', () => {
         sinon.assert.calledOnce(isConnected);
         sinon.assert.calledOnce(connect);
 
-        // The catch block in the outer try should NOT have shown an error message,
-        // because the websocket reconnect logic runs AFTER the success notification and
-        // its failure is logger.error()'d, not surfaced to the user.
+        // The reconnect is fire-and-forget (void connect().catch(...)), runs AFTER the
+        // success notification, and its failure is logger.error()'d, never surfaced as a
+        // user-facing error message.
         const userFacingErrorCalls = showErrorMessage.getCalls().filter(c => {
             const arg = c.args[0] as string;
             return typeof arg === 'string' && (arg.toLowerCase().includes('ws boom') || arg.toLowerCase().includes('websocket'));
@@ -612,5 +612,157 @@ suite('RepositorySubmitCommands', () => {
         } as never);
 
         assert.strictEqual(fireSubmission.callCount, 0);
+    });
+
+    test('re-entrant submit is rejected while one is in flight: no duplicate pipeline, no extra telemetry', async () => {
+        // Hold the first submit inside withProgress by leaving checkWorkspaceFiles pending.
+        let resolveCheck!: (v: { hasChanges: boolean; files: unknown[] }) => void;
+        const checkPromise = new Promise<{ hasChanges: boolean; files: unknown[] }>(res => { resolveCheck = res; });
+        checkWorkspaceFiles = sandbox.stub().returns(checkPromise);
+
+        const { ctx, fireSubmission } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+        const handler = mod.getHandlers()[WebviewCmd.SubmitExercise];
+        const msg = {
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never;
+
+        const p1 = handler(msg);   // suspends on the pending checkWorkspaceFiles, flag set, 'started' emitted
+        await handler(msg);        // second call hits the re-entrancy guard
+
+        sinon.assert.calledWith(showInformationMessage, 'A submission is already in progress. Please wait for it to finish.');
+        sinon.assert.calledOnce(checkWorkspaceFiles);   // the duplicate never entered the pipeline
+        // Only the first submit's 'started' fired; the blocked duplicate emitted no event.
+        assert.strictEqual(fireSubmission.callCount, 1);
+        assert.strictEqual(fireSubmission.getCall(0).args[0].status, 'started');
+
+        resolveCheck({ hasChanges: true, files: [] });
+        await p1;
+
+        // The first submit ran the full pipeline through to its terminal 'succeeded'.
+        sinon.assert.calledOnce(stubs.addAll);
+        assert.strictEqual(fireSubmission.callCount, 2);
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'succeeded');
+    });
+
+    test('a failed submit resets the in-flight flag so the next submit proceeds', async () => {
+        const addAll = sandbox.stub();
+        addAll.onFirstCall().rejects(new Error('disk full'));
+        addAll.onSecondCall().resolves(undefined);
+
+        const { ctx } = buildContext();
+        const { svc, stubs } = makeGitService({ addAll });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+        const handler = mod.getHandlers()[WebviewCmd.SubmitExercise];
+        const msg = {
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never;
+
+        await handler(msg);   // fails at addAll → finally clears the flag
+        await handler(msg);   // must proceed because the flag was reset
+
+        sinon.assert.calledTwice(stubs.addAll);
+        const successCall = showInformationMessage.getCalls().find(c => String(c.args[0]).includes('Successfully submitted "Foo"'));
+        assert.ok(successCall, 'the second submit after a failure should reach success');
+    });
+
+    test('a hanging WebSocket reconnect does not keep the in-flight flag stuck', async () => {
+        const isConnected = sandbox.stub().returns(false);
+        const connect = sandbox.stub().returns(new Promise(() => { /* never resolves */ }));
+        const { ctx } = buildContext({ getWebsocketService: () => ({ isConnected, connect }) });
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+        const handler = mod.getHandlers()[WebviewCmd.SubmitExercise];
+        const msg = {
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never;
+
+        await handler(msg);   // succeeds; connect() fired but never resolves (fire-and-forget)
+        await handler(msg);   // must still proceed — proves the flag was not held by the hanging connect
+
+        sinon.assert.called(connect);
+        sinon.assert.calledTwice(stubs.addAll);
+    });
+
+    test('an index.lock failure shows the friendly lock message instead of raw git output', async () => {
+        const lockErr = new Error("Command failed: git add -A\nfatal: Unable to create '/repo/.git/index.lock': File exists. Another git process seems to be running...");
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ addAll: sandbox.stub().rejects(lockErr) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        const friendly = showErrorMessage.getCalls().find(c => String(c.args[0]).includes('Another Git operation is currently using this repository'));
+        assert.ok(friendly, 'expected the friendly index.lock message');
+        const rawLeak = showErrorMessage.getCalls().find(c => String(c.args[0]).includes('fatal: Unable to create'));
+        assert.ok(!rawLeak, 'raw git lock output must not be surfaced to the user');
+
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'other');
+    });
+
+    test('an index.lock failure during the status check maps to the friendly message and never stages', async () => {
+        checkWorkspaceFiles = sandbox.stub().rejects(new Error("fatal: Unable to create '/repo/.git/index.lock': File exists"));
+        const { ctx, fireSubmission } = buildContext();
+        const { svc, stubs } = makeGitService();
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        const friendly = showErrorMessage.getCalls().find(c => String(c.args[0]).includes('Another Git operation is currently using this repository'));
+        assert.ok(friendly, 'expected the friendly index.lock message for a status-phase lock');
+        // The submit must opt the status check into fail-fast so a lock isn't read as "no changes".
+        sinon.assert.calledWithMatch(checkWorkspaceFiles, sinon.match.any, sinon.match.has('throwOnGitError', true));
+        sinon.assert.notCalled(stubs.addAll);
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'other');
+    });
+
+    test('an index.lock failure during pull surfaces the friendly message and does not push or report success', async () => {
+        const lockErr = new Error("fatal: Unable to create '/repo/.git/index.lock': File exists. Another git process seems to be running...");
+        const { ctx, fireSubmission } = buildContext();
+        const { svc, stubs } = makeGitService({ pullWithRebase: sandbox.stub().rejects(lockErr) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        // A pull lock must NOT fall through to push (push does not take the index lock)
+        // or emit a false 'succeeded'.
+        sinon.assert.notCalled(stubs.push);
+        const friendly = showErrorMessage.getCalls().find(c => String(c.args[0]).includes('Another Git operation is currently using this repository'));
+        assert.ok(friendly, 'expected the friendly index.lock message for a pull-phase lock');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'other');
+    });
+
+    test('an index.lock failure during push maps to the friendly message with a uniform other reason', async () => {
+        const lockErr = new Error("fatal: Unable to create '/repo/.git/index.lock': File exists");
+        const { ctx, fireSubmission } = buildContext();
+        const { svc } = makeGitService({ push: sandbox.stub().rejects(lockErr) });
+        const mod = new RepositorySubmitCommands(ctx, svc, makeDeps());
+
+        await mod.getHandlers()[WebviewCmd.SubmitExercise]({
+            type: 'command', command: WebviewCmd.SubmitExercise,
+            payload: { participationId: 42, exerciseTitle: 'Foo', commitMessage: 'x' },
+        } as never);
+
+        const friendly = showErrorMessage.getCalls().find(c => String(c.args[0]).includes('Another Git operation is currently using this repository'));
+        assert.ok(friendly, 'expected the friendly index.lock message for a push-phase lock');
+        // A lock at push is recorded as the uniform 'other', not 'push-failed'.
+        assert.strictEqual(fireSubmission.getCall(1).args[0].status, 'failed');
+        assert.strictEqual(fireSubmission.getCall(1).args[0].failureReason, 'other');
     });
 });

--- a/extension/test/unit/utils/workspaceFileChecker.test.ts
+++ b/extension/test/unit/utils/workspaceFileChecker.test.ts
@@ -254,6 +254,36 @@ suite('Workspace File Checker Test Suite', () => {
         });
     });
 
+    test('throwOnGitError propagates a git status failure instead of swallowing it', async () => {
+        // Remove the repo so `git status` exits non-zero ("not a git repository"),
+        // a deterministic stand-in for any git-status failure (e.g. index.lock).
+        fs.rmSync(path.join(tempDir, '.git'), { recursive: true, force: true });
+
+        const mockFolder: vscode.WorkspaceFolder = {
+            uri: vscode.Uri.file(tempDir),
+            name: 'test',
+            index: 0
+        };
+
+        await assert.rejects(
+            checkWorkspaceFiles(mockFolder, { throwOnGitError: true }),
+            'Expected the git status failure to propagate when throwOnGitError is set'
+        );
+    });
+
+    test('git status failure is swallowed by default so existing callers keep best-effort behaviour', async () => {
+        fs.rmSync(path.join(tempDir, '.git'), { recursive: true, force: true });
+
+        const mockFolder: vscode.WorkspaceFolder = {
+            uri: vscode.Uri.file(tempDir),
+            name: 'test',
+            index: 0
+        };
+
+        const result = await checkWorkspaceFiles(mockFolder);
+        assert.strictEqual(result.hasChanges, false);
+    });
+
     test('should include files from unpushed commits', async () => {
         const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'artemis-remote-'));
 


### PR DESCRIPTION
## Problem
Submitting an exercise runs `git add -A` then `commit`, `pull --rebase`, `push` against the exercise repo. Two issues surfaced:

1. The Submit handler had no re-entrancy guard, and the button is not disabled while a submission runs, so a double-click could run two git pipelines at once and self-inflict a `.git/index.lock` collision.
2. A lock (a stale lock left by an interrupted git process, or another tool such as the Source Control panel / lazygit) surfaced as the raw `fatal: Unable to create '.git/index.lock'` git output, or degraded into a misleading "No local changes detected to submit."

## Changes
- **Re-entrancy guard** on `handleSubmitExercise` (in-flight flag, reset in `finally`). The guard returns before the `started` telemetry event, preserving the one-terminal-per-`started` invariant.
- **Fire-and-forget WebSocket reconnect** after a successful submit, so a hanging `connect()` cannot keep the in-flight flag set.
- **Friendly lock message**: `isGitLockError` scans the error message and `stderr` for the language-independent `index.lock` marker and shows actionable guidance instead of raw git output. Lock failures record a uniform `other` reason (no telemetry schema change).
- **Pull-phase lock is rethrown** instead of swallowed. `git push` does not take the index lock, so a swallowed pull lock would otherwise push on an un-rebased branch and report a false success.
- **`throwOnGitError` opt-in** on `checkWorkspaceFiles` so the submit's initial `git status` check surfaces a lock instead of collapsing to a false "no changes". Default behaviour and all other callers are unchanged.

Out of scope: disabling the webview Submit button during a submission. The extension-side guard is authoritative; a UI disable would need an extra round-trip message.

## Testing
- `npm run check-types` and `eslint` clean
- Full unit suite: 1274 passing, 0 failures
- vitest: 809 passing
- New unit coverage: re-entrancy block, flag reset after failure, hanging reconnect does not stick the flag, friendly lock message at status/add/pull/push, and `throwOnGitError` propagation.