### PR TITLE
fix(recording-viewer): display intervention blockedReason in the event detail

### DIFF
--- a/recording-viewer/src/utils/eventDisplay.tsx
+++ b/recording-viewer/src/utils/eventDisplay.tsx
@@ -119,6 +119,7 @@ export function eventDetail(event: RecordedEvent): React.ReactNode {
                 <span className="event-detail">
                     {event.action.toUpperCase()} | {event.level} | EQ: <strong>{Math.round(event.eq * 100)}%</strong>
                     {event.triggerType && ` | ${event.triggerType}`}
+                    {event.action === 'blocked' && event.blockedReason && ` | reason: ${event.blockedReason}`}
                 </span>
             );
         case 'eqEngineState':

--- a/recording-viewer/test/interventionRendering.test.tsx
+++ b/recording-viewer/test/interventionRendering.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import type { RecordedEvent } from '../src/types';
+import { eventDetail } from '../src/utils/eventDisplay';
+
+const blocked: RecordedEvent = {
+    type: 'intervention', timestamp: 1000, action: 'blocked', level: 'subtle',
+    shouldIntervene: false, eq: 0.42, confidence: 'sufficient',
+    triggerType: 'idle', blockedReason: 'recent-progress',
+};
+
+// A non-blocked intervention that nonetheless carries a blockedReason. The
+// renderer must ignore it: blockedReason is only meaningful for action='blocked'.
+const nonBlockedWithReason: RecordedEvent = {
+    type: 'intervention', timestamp: 2000, action: 'shown', level: 'notification',
+    shouldIntervene: true, eq: 0.7, confidence: 'sufficient',
+    triggerType: 'execution-error', blockedReason: 'warmup',
+};
+
+describe('intervention event rendering', () => {
+    it('eventDetail surfaces the blockedReason on a blocked intervention', () => {
+        const { container } = render(<>{eventDetail(blocked)}</>);
+        expect(container.textContent).toContain('BLOCKED');
+        expect(container.textContent).toContain('recent-progress');
+    });
+
+    it('eventDetail surfaces last-dismissed as the blockedReason', () => {
+        const { container } = render(<>{eventDetail({ ...blocked, blockedReason: 'last-dismissed' })}</>);
+        expect(container.textContent).toContain('last-dismissed');
+    });
+
+    it('eventDetail does not render a reason for a non-blocked intervention even when blockedReason is present', () => {
+        const { container } = render(<>{eventDetail(nonBlockedWithReason)}</>);
+        expect(container.textContent).not.toContain('reason:');
+        expect(container.textContent).not.toContain('warmup');
+    });
+});


### PR DESCRIPTION
## Problem
The recording-viewer parses and types the intervention `blockedReason` field (including the `recent-progress` / `last-dismissed` values added in #254), but never displays it. A blocked intervention rendered as `BLOCKED | <level> | EQ: X% | <triggerType>` with no indication of *why* it was withheld. Confirmed: `blockedReason` appeared only in `recording-viewer/src/generated/recordingTypes.ts`, in no rendering code.

## Change
`eventDetail` (the single source of truth for both the event-stream detail row and the timeline tooltip) now appends the reason for blocked interventions, following the existing optional-field pattern:

```tsx
{event.action === 'blocked' && event.blockedReason && ` | reason: ${event.blockedReason}`}
```

The guard is keyed on `action === 'blocked'` (matching the schema's "populated when action='blocked'" contract) so a stray `blockedReason` on a non-blocked event is never surfaced.

## Testing
- New `recording-viewer/test/interventionRendering.test.tsx`: asserts the reason renders for blocked interventions (`recent-progress`, `last-dismissed`) and is omitted for a non-blocked intervention even when `blockedReason` is present.
- `tsc -b`, `eslint`, and the full viewer suite (328 tests) pass.

## Context
Surfaces the #254 accurate-`blockedReason` values in the viewer. This satisfies the "viewer displays the new blockedReason values" acceptance item of #255; it does not close #255, which still needs a manual fresh-recording QA pass.