### PR TITLE
refactor(telemetry): derive intervention enums from single-source const tuples

### DIFF
--- a/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
+++ b/extension/src/extension/services/telemetry/recording/parseRecordedData.ts
@@ -19,6 +19,14 @@
  * shares one list instead of maintaining its own (see #215).
  */
 
+import {
+    INTERVENTION_BLOCKED_REASONS,
+    INTERVENTION_DISMISS_REASONS,
+    INTERVENTION_LEVELS,
+    INTERVENTION_SUPPRESSION_REASONS,
+    TRIGGER_TYPES,
+} from '@extension/services/telemetry/types';
+
 import type {
     BreakpointChangeEvent,
     BuildResultEvent,
@@ -66,6 +74,7 @@ import type {
     VisibleRangeChangeEvent,
     WindowFocusEvent,
 } from './types';
+import { INTERVENTION_RECORD_ACTIONS } from './types';
 
 // ── Primitive guards ──────────────────────────────────────────────────
 
@@ -383,26 +392,15 @@ function parseEqEngineState(d: Record<string, unknown>, timestamp: number): EqEn
 }
 
 function parseIntervention(d: Record<string, unknown>, timestamp: number): InterventionEvent | null {
-    if (!isOneOf(d.action, ['shown', 'accepted', 'dismissed', 'blocked', 'suppressed'] as const)) { return null; }
-    if (!isOneOf(d.level, ['subtle', 'notification', 'proactive'] as const)) { return null; }
+    if (!isOneOf(d.action, INTERVENTION_RECORD_ACTIONS)) { return null; }
+    if (!isOneOf(d.level, INTERVENTION_LEVELS)) { return null; }
     if (!isBoolean(d.shouldIntervene)) { return null; }
     if (!isFiniteNumber(d.eq)) { return null; }
     if (!isOneOf(d.confidence, ['sufficient', 'insufficient'] as const)) { return null; }
-    if (d.triggerType !== undefined
-        && !isOneOf(d.triggerType, ['execution-error', 'multiline-paste', 'idle', 'selection-maintained'] as const)) {
-        return null;
-    }
-    if (d.blockedReason !== undefined
-        && !isOneOf(d.blockedReason, ['cooldown', 'warmup', 'session-limit', 'low-confidence', 'recent-progress', 'last-dismissed'] as const)) {
-        return null;
-    }
-    if (d.suppressionReason !== undefined && !isOneOf(d.suppressionReason, ['user-disabled'] as const)) {
-        return null;
-    }
-    if (d.dismissReason !== undefined
-        && !isOneOf(d.dismissReason, ['user-action', 'hidden', 'replaced', 'session-end'] as const)) {
-        return null;
-    }
+    if (d.triggerType !== undefined && !isOneOf(d.triggerType, TRIGGER_TYPES)) { return null; }
+    if (d.blockedReason !== undefined && !isOneOf(d.blockedReason, INTERVENTION_BLOCKED_REASONS)) { return null; }
+    if (d.suppressionReason !== undefined && !isOneOf(d.suppressionReason, INTERVENTION_SUPPRESSION_REASONS)) { return null; }
+    if (d.dismissReason !== undefined && !isOneOf(d.dismissReason, INTERVENTION_DISMISS_REASONS)) { return null; }
     if (!isOptBoolean(d.rawWanted)) { return null; }
     return stripUndefined({
         type: 'intervention' as const,

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -40,9 +40,10 @@
 
 import * as vscode from 'vscode';
 
+import type { InterventionBlockedReason, InterventionDismissReason, InterventionLevel, InterventionSuppressionReason, TriggerType } from '@extension/services/telemetry/types';
 import type { ResultDTO, WebSocketMessageHandler } from '@extension/types';
 
-import type { InterventionEvent, RecordedEvent, SerializedErrorSnapshot, SubmissionPayload } from './types';
+import type { InterventionRecordAction, RecordedEvent, SerializedErrorSnapshot, SubmissionPayload } from './types';
 
 /**
  * Distributive `Omit` over `RecordedEvent` — keeps each union variant intact
@@ -394,16 +395,16 @@ export class SessionRecorder implements WebSocketMessageHandler {
     }
 
     recordIntervention(
-        action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed',
-        level: 'subtle' | 'notification' | 'proactive',
+        action: InterventionRecordAction,
+        level: InterventionLevel,
         shouldIntervene: boolean,
         eq: number,
         confidence: 'sufficient' | 'insufficient',
-        triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained',
+        triggerType?: TriggerType,
         opts?: {
-            blockedReason?: InterventionEvent['blockedReason'];
-            suppressionReason?: 'user-disabled';
-            dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+            blockedReason?: InterventionBlockedReason;
+            suppressionReason?: InterventionSuppressionReason;
+            dismissReason?: InterventionDismissReason;
             rawWanted?: boolean;
         },
     ): void {

--- a/extension/src/extension/services/telemetry/recording/types.ts
+++ b/extension/src/extension/services/telemetry/recording/types.ts
@@ -5,6 +5,14 @@
  * Serialized as one JSON object per line in JSONL files.
  */
 
+import type {
+    InterventionBlockedReason,
+    InterventionDismissReason,
+    InterventionLevel,
+    InterventionSuppressionReason,
+    TriggerType,
+} from '@extension/services/telemetry/types';
+
 // ── Serialization helpers ─────────────────────────────────────────────
 
 export interface SerializedRange {
@@ -213,22 +221,31 @@ export interface EqEngineStateEvent {
     confidence: 'sufficient' | 'insufficient';
 }
 
+/**
+ * Recorded intervention action. Recording-specific (the live decision side has
+ * no 'action' concept), so the single source lives here rather than in the
+ * telemetry types. Trigger/blocked/dismiss/suppression vocabularies are shared
+ * with the live domain and imported from `../types`.
+ */
+export const INTERVENTION_RECORD_ACTIONS = ['shown', 'accepted', 'dismissed', 'blocked', 'suppressed'] as const;
+export type InterventionRecordAction = typeof INTERVENTION_RECORD_ACTIONS[number];
+
 export interface InterventionEvent {
     type: 'intervention';
     timestamp: number;
-    action: 'shown' | 'accepted' | 'dismissed' | 'blocked' | 'suppressed';
-    level: 'subtle' | 'notification' | 'proactive';
+    action: InterventionRecordAction;
+    level: InterventionLevel;
     /** True for shown/accepted/dismissed/suppressed; false for blocked. */
     shouldIntervene: boolean;
     eq: number;
     confidence: 'sufficient' | 'insufficient';
-    triggerType?: 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
+    triggerType?: TriggerType;
     /** Populated when action='blocked'. Identifies why the intervention was blocked. */
-    blockedReason?: 'cooldown' | 'warmup' | 'session-limit' | 'low-confidence' | 'recent-progress' | 'last-dismissed';
+    blockedReason?: InterventionBlockedReason;
     /** Populated when action='suppressed'. Identifies the suppression source. */
-    suppressionReason?: 'user-disabled';
+    suppressionReason?: InterventionSuppressionReason;
     /** Populated when action='dismissed'. Identifies how the intervention was dismissed. */
-    dismissReason?: 'user-action' | 'hidden' | 'replaced' | 'session-end';
+    dismissReason?: InterventionDismissReason;
     /**
      * Whether the EQ was above the severity threshold, regardless of confidence/guardrails.
      * Populated when action='blocked' to explain the signal that was suppressed.

--- a/extension/src/extension/services/telemetry/types.ts
+++ b/extension/src/extension/services/telemetry/types.ts
@@ -1,4 +1,7 @@
-import * as vscode from 'vscode';
+// Type-only: this module is value-imported by the replay parser, which also
+// runs in a plain Node process (scripts/validate-recording.ts). Keeping vscode
+// type-only guarantees no runtime 'vscode' resolution leaks into that path.
+import type * as vscode from 'vscode';
 
 // ── Session lifecycle ───────────────────────────────────────────────
 
@@ -59,9 +62,16 @@ export interface TrackedDiagnostic {
 export type InactivityPattern = 'active' | 'thinking' | 'confusion' | 'giving-up';
 
 /**
- * Recommended intervention action
+ * Active intervention levels (excludes 'none'). Single source for the level
+ * vocabulary shared by the decision engine and the recording schema.
  */
-export type RecommendedAction = 'none' | 'subtle' | 'notification' | 'proactive';
+export const INTERVENTION_LEVELS = ['subtle', 'notification', 'proactive'] as const;
+export type InterventionLevel = typeof INTERVENTION_LEVELS[number];
+
+/**
+ * Recommended intervention action: an active level or 'none'.
+ */
+export type RecommendedAction = 'none' | InterventionLevel;
 
 /**
  * Struggle context for Iris chat integration.
@@ -185,7 +195,8 @@ export const DEFAULT_EQ_CONFIG: EQConfig = {
 /**
  * Trigger types from Pu et al. 2025 [P11, Section 4, Figure 4]
  */
-export type TriggerType = 'execution-error' | 'multiline-paste' | 'idle' | 'selection-maintained';
+export const TRIGGER_TYPES = ['execution-error', 'multiline-paste', 'idle', 'selection-maintained'] as const;
+export type TriggerType = typeof TRIGGER_TYPES[number];
 
 /**
  * Trigger configuration — paper-validated thresholds [P11, Section 4]
@@ -260,13 +271,15 @@ export interface CompileEquivalentEvent {
  * - 'last-dismissed'  — Previous intervention was dismissed (non-proactive blocked)
  * - 'low-confidence'  — EQ above threshold but confidence gate is 'insufficient'
  */
-export type InterventionBlockedReason =
-    | 'cooldown'
-    | 'warmup'
-    | 'session-limit'
-    | 'low-confidence'
-    | 'recent-progress'
-    | 'last-dismissed';
+export const INTERVENTION_BLOCKED_REASONS = [
+    'cooldown',
+    'warmup',
+    'session-limit',
+    'low-confidence',
+    'recent-progress',
+    'last-dismissed',
+] as const;
+export type InterventionBlockedReason = typeof INTERVENTION_BLOCKED_REASONS[number];
 
 /**
  * Reason why an intervention was dismissed.
@@ -276,7 +289,8 @@ export type InterventionBlockedReason =
  * - 'replaced'     — A newer intervention replaced the current one
  * - 'session-end'  — Session ended while intervention was pending
  */
-export type InterventionDismissReason = 'user-action' | 'hidden' | 'replaced' | 'session-end';
+export const INTERVENTION_DISMISS_REASONS = ['user-action', 'hidden', 'replaced', 'session-end'] as const;
+export type InterventionDismissReason = typeof INTERVENTION_DISMISS_REASONS[number];
 
 /**
  * Reason a wanted intervention was suppressed without being delivered to the user.
@@ -288,7 +302,8 @@ export type InterventionDismissReason = 'user-action' | 'hidden' | 'replaced' | 
  * and are rate-limited. Suppression comes from explicit user/config choice and
  * is NOT rate-limited so the per-opportunity signal stays intact.
  */
-export type InterventionSuppressionReason = 'user-disabled';
+export const INTERVENTION_SUPPRESSION_REASONS = ['user-disabled'] as const;
+export type InterventionSuppressionReason = typeof INTERVENTION_SUPPRESSION_REASONS[number];
 
 /**
  * Payload of `TelemetryManager.onDidSuppressIntervention`.

--- a/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
+++ b/extension/test/unit/services/telemetry/recording/parseRecordedData.test.ts
@@ -20,7 +20,15 @@
 import * as assert from 'assert';
 
 import { KNOWN_EVENT_TYPES, parseRecordedEvent, parseSessionMetadata } from '@extension/services/telemetry/recording/parseRecordedData';
-import type { RecordedEvent, SessionMetadata } from '@extension/services/telemetry/recording/types';
+import type { InterventionEvent, RecordedEvent, SessionMetadata } from '@extension/services/telemetry/recording/types';
+import { INTERVENTION_RECORD_ACTIONS } from '@extension/services/telemetry/recording/types';
+import {
+    INTERVENTION_BLOCKED_REASONS,
+    INTERVENTION_DISMISS_REASONS,
+    INTERVENTION_LEVELS,
+    INTERVENTION_SUPPRESSION_REASONS,
+    TRIGGER_TYPES,
+} from '@extension/services/telemetry/types';
 
 const ts = 1700000000000;
 
@@ -712,5 +720,87 @@ suite('KNOWN_EVENT_TYPES — drift regression for #215', () => {
         for (const t of ['', 'totallyMadeUp', 'toString', '__proto__', 'constructor']) {
             assert.ok(!KNOWN_EVENT_TYPES.has(t), `KNOWN_EVENT_TYPES unexpectedly contains '${t}'`);
         }
+    });
+});
+
+/**
+ * Single-source guard for the intervention enum vocabulary (#257).
+ *
+ * The InterventionEvent field types and the parser's isOneOf checks now derive
+ * from the SAME exported const tuples. This suite asserts the property that
+ * matters for replay fidelity: every declared enum value round-trips through
+ * the parser (none silently dropped), and an unknown value is rejected. The
+ * fixtures are typed as RecordedEvent, so a tuple/type drift also fails to
+ * compile — the runtime checks below are the belt to that suspenders.
+ */
+suite('parseRecordedEvent — intervention enum single-source guard (#257)', () => {
+    function baseIntervention(): InterventionEvent {
+        return {
+            type: 'intervention', timestamp: ts, action: 'shown', level: 'subtle',
+            shouldIntervene: true, eq: 0.3, confidence: 'sufficient',
+        };
+    }
+
+    for (const action of INTERVENTION_RECORD_ACTIONS) {
+        test(`action='${action}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), action };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    for (const level of INTERVENTION_LEVELS) {
+        test(`level='${level}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), level };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    for (const triggerType of TRIGGER_TYPES) {
+        test(`triggerType='${triggerType}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), triggerType };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    for (const blockedReason of INTERVENTION_BLOCKED_REASONS) {
+        test(`blockedReason='${blockedReason}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), action: 'blocked', shouldIntervene: false, blockedReason };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    for (const dismissReason of INTERVENTION_DISMISS_REASONS) {
+        test(`dismissReason='${dismissReason}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), action: 'dismissed', dismissReason };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    for (const suppressionReason of INTERVENTION_SUPPRESSION_REASONS) {
+        test(`suppressionReason='${suppressionReason}' round-trips`, () => {
+            const e: RecordedEvent = { ...baseIntervention(), action: 'suppressed', suppressionReason };
+            assert.deepStrictEqual(parseRecordedEvent(clone(e)), clone(e));
+        });
+    }
+
+    // One rejection per field family: an unknown value must reject the whole
+    // event (returns null), proving the guard is actually wired to the parser.
+    test('rejects unknown action', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), action: 'exploded' }), null);
+    });
+    test('rejects unknown level', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), level: 'whisper' }), null);
+    });
+    test('rejects unknown triggerType', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), triggerType: 'telepathy' }), null);
+    });
+    test('rejects unknown blockedReason', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), action: 'blocked', shouldIntervene: false, blockedReason: 'vibes' }), null);
+    });
+    test('rejects unknown dismissReason', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), action: 'dismissed', dismissReason: 'ragequit' }), null);
+    });
+    test('rejects unknown suppressionReason', () => {
+        assert.strictEqual(parseRecordedEvent({ ...baseIntervention(), action: 'suppressed', suppressionReason: 'gremlins' }), null);
     });
 });


### PR DESCRIPTION
## What

Collapses the duplicated intervention enum vocabulary to a single source so the replay parser can't silently desync from the type.

`action` / `level` / `triggerType` / `blockedReason` / `dismissReason` / `suppressionReason` were each spelled out in up to four places: the canonical telemetry types, the recording `InterventionEvent`, the parser's `isOneOf` guards, and `recordIntervention`'s params. Adding a value to one copy while missing the parser made the parser reject the event, so it was silently dropped on replay (a replay-fidelity corruption).

## How

- `telemetry/types.ts`: `TriggerType`, `InterventionBlockedReason`, `InterventionDismissReason`, `InterventionSuppressionReason` now derive from exported `const`-asserted tuples. Added `INTERVENTION_LEVELS` + `InterventionLevel`; `RecommendedAction = 'none' | InterventionLevel` (identical union, single source).
- `recording/types.ts`: added the recording-only `INTERVENTION_RECORD_ACTIONS` + `InterventionRecordAction`; `InterventionEvent` fields reference the derived/imported types.
- `parseRecordedData.ts`: the `isOneOf` guards consume the same tuples (no more inline literals).
- `sessionRecorder.ts`: `recordIntervention` params use the named types.
- Made `telemetry/types.ts`'s `vscode` import type-only, so value-importing the tuples adds no runtime `vscode` dependency to the replay parser / `validate-recording` (plain Node) path.

Adding an enum value now updates the type AND the parser guard from one array; the parser cannot reject a value the type allows.

## Tests

New guard suite in `parseRecordedData.test.ts`: every declared value of every tuple round-trips through the parser (fixtures typed as `RecordedEvent`, so tuple/type drift also fails to compile), plus one rejection per field family.

Verification: `check-types`, `eslint`, full mocha unit suite (1312 passing), vitest (810 passing), `knip`, and `validate-recording` all green.

## Out of scope

The `decision.level` narrowing casts in `sessionRecorderWiring.ts` and the `RecommendedAction` copies in the webview/shared message types are separate #257 items (not replay-fidelity risks).

Addresses the triplicated-intervention-schemas item in #257.
