### PR TITLE
feat(exercise-detail): sticky build status strip with countdown, progress bar and result flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ extension/build/
 
 # Superpowers planning artifacts (kept locally as design notes, not tracked)
 docs/superpowers/
+.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Added
+
+- **Sticky Build Status**: Build progress and ETA stay visible in a slim strip at the top of the exercise view while you scroll; the result flashes briefly when the build finishes out of view.
+
 ### Fixed
 
 - **Replay Fidelity**: Live and recording paths share one build-error-family builder, so replayed EQ matches the live curve.

--- a/extension/src/webview/components/exercise/BuildStatusStrip.module.css
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.module.css
@@ -1,0 +1,129 @@
+/* Slim sticky strip pinned to the top of the webview while a build runs
+   and the full SubmissionStatus card is scrolled out of view (#280). */
+.strip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* Below TestResultsOverlay (z-index: 2147483647) */
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background-color: var(--vscode-editorWidget-background, #252526);
+  border-bottom: 1px solid var(--vscode-widget-border, #454545);
+  font-size: 11px;
+  color: var(--vscode-foreground);
+  animation: stripSlideIn 0.2s ease-out;
+}
+
+@keyframes stripSlideIn {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.spinner {
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--vscode-button-background, #007acc);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: stripSpin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes stripSpin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.label {
+  white-space: nowrap;
+}
+
+/* Mirrors SubmissionStatus.module.css buildProgressTrack/-Bar, but slimmer */
+.progressTrack {
+  position: relative;
+  flex: 1;
+  height: 5px;
+  min-width: 50px;
+  background-color: rgba(100, 100, 100, 0.25);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progressBar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0%;
+  background-color: var(--vscode-button-background, #007acc);
+  transition: width 0.3s ease-out;
+}
+
+.progressBarIndeterminate {
+  animation: stripProgressIndeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes stripProgressIndeterminate {
+  0% {
+    left: -40%;
+    width: 30%;
+  }
+  50% {
+    left: 20%;
+    width: 60%;
+  }
+  100% {
+    left: 100%;
+    width: 30%;
+  }
+}
+
+.eta {
+  white-space: nowrap;
+  color: var(--vscode-descriptionForeground, #8a8a8a);
+}
+
+.scrollButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid var(--vscode-widget-border, #454545);
+  border-radius: 3px;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+}
+
+.scrollButton:hover {
+  background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strip {
+    animation: none;
+  }
+
+  .spinner {
+    animation: none;
+  }
+
+  .progressBarIndeterminate {
+    animation: none;
+  }
+}

--- a/extension/src/webview/components/exercise/BuildStatusStrip.module.css
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.module.css
@@ -114,6 +114,26 @@
   background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
 }
 
+/* Result flash */
+.flashSpacer {
+  flex: 1;
+}
+
+.flashIconSuccess {
+  color: var(--vscode-testing-iconPassed, #73c991);
+  flex-shrink: 0;
+}
+
+.flashIconPartial {
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  flex-shrink: 0;
+}
+
+.flashIconFailed {
+  color: var(--vscode-errorForeground, #f48771);
+  flex-shrink: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .strip {
     animation: none;

--- a/extension/src/webview/components/exercise/BuildStatusStrip.module.css
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.module.css
@@ -145,5 +145,10 @@
 
   .progressBarIndeterminate {
     animation: none;
+    /* Static fallback: without the sweep the bar's base width is 0%,
+       which would leave an empty track. */
+    left: 0;
+    width: 100%;
+    opacity: 0.4;
   }
 }

--- a/extension/src/webview/components/exercise/BuildStatusStrip.tsx
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.tsx
@@ -41,7 +41,11 @@ interface FlashContent {
   text: string;
 }
 
-/** Mirrors the badge semantics of the SubmissionStatus card. */
+/**
+ * Text mirrors the SubmissionStatus card's badge. The icon/color variant
+ * follows the score-derived status (per spec), which can differ from the
+ * card's pass-ratio badge color when tests are weighted.
+ */
 function flashContent(
   flash: FlashStatus,
   buildFailed: boolean,

--- a/extension/src/webview/components/exercise/BuildStatusStrip.tsx
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.tsx
@@ -1,0 +1,82 @@
+import clsx from 'clsx';
+import ChevronUp from 'lucide-react/dist/esm/icons/chevron-up';
+
+import { useBuildProgress } from '@webview/hooks/useBuildProgress';
+
+import styles from './BuildStatusStrip.module.css';
+import type { SubmissionStatusType } from './SubmissionStatus';
+
+interface BuildStatusStripProps {
+  status: SubmissionStatusType;
+  /** Whether the full build-status card is currently visible in the viewport. */
+  cardInView: boolean;
+  estimatedCompletionDate?: string;
+  buildStartDate?: string;
+  buildFailed?: boolean;
+  hasTestInfo?: boolean;
+  totalTests?: number;
+  passedTests?: number;
+  /** Scrolls the exercise view back to the full build-status card. */
+  onScrollToCard: () => void;
+}
+
+function isLive(status: SubmissionStatusType): boolean {
+  return status === 'building' || status === 'pending';
+}
+
+/**
+ * Slim fixed strip pinned to the top of the Exercise Detail webview. Shows
+ * the build countdown + progress bar while a build runs and the full
+ * SubmissionStatus card is scrolled out of view (issue #280).
+ */
+export function BuildStatusStrip({
+  status,
+  cardInView,
+  estimatedCompletionDate,
+  buildStartDate,
+  onScrollToCard,
+}: BuildStatusStripProps) {
+  const { etaSeconds, progressPercent } = useBuildProgress(
+    status === 'building',
+    buildStartDate,
+    estimatedCompletionDate,
+  );
+
+  if (cardInView || !isLive(status)) {
+    return null;
+  }
+
+  const hasDeterminateProgress = status === 'building' && progressPercent !== null;
+
+  return (
+    <div className={styles.strip}>
+      <span className={styles.spinner} aria-hidden="true" />
+      {/* Live region scoped to the static label only: the 1Hz ETA countdown
+          and the progress bar are visual-only, otherwise screen readers
+          would announce every tick. */}
+      <span className={styles.label} role="status">
+        {status === 'pending' ? 'Build queued…' : 'Building…'}
+      </span>
+      <div className={styles.progressTrack} aria-hidden="true">
+        <div
+          className={clsx(styles.progressBar, {
+            [styles.progressBarIndeterminate]: !hasDeterminateProgress,
+          })}
+          style={hasDeterminateProgress ? { width: `${progressPercent}%` } : undefined}
+        />
+      </div>
+      {etaSeconds !== null && (
+        <span className={styles.eta} aria-hidden="true">ETA: {etaSeconds}s</span>
+      )}
+      <button
+        type="button"
+        className={styles.scrollButton}
+        onClick={onScrollToCard}
+        aria-label="Scroll to build status"
+        title="Scroll to build status"
+      >
+        <ChevronUp size={14} />
+      </button>
+    </div>
+  );
+}

--- a/extension/src/webview/components/exercise/BuildStatusStrip.tsx
+++ b/extension/src/webview/components/exercise/BuildStatusStrip.tsx
@@ -1,5 +1,9 @@
 import clsx from 'clsx';
+import Check from 'lucide-react/dist/esm/icons/check';
 import ChevronUp from 'lucide-react/dist/esm/icons/chevron-up';
+import TriangleAlert from 'lucide-react/dist/esm/icons/triangle-alert';
+import X from 'lucide-react/dist/esm/icons/x';
+import { useEffect, useRef, useState } from 'react';
 
 import { useBuildProgress } from '@webview/hooks/useBuildProgress';
 
@@ -24,59 +28,172 @@ function isLive(status: SubmissionStatusType): boolean {
   return status === 'building' || status === 'pending';
 }
 
+const RESULT_FLASH_MS = 5000;
+
+type FlashStatus = 'success' | 'partial' | 'failed';
+
+function isFlashable(status: SubmissionStatusType): status is FlashStatus {
+  return status === 'success' || status === 'partial' || status === 'failed';
+}
+
+interface FlashContent {
+  variant: FlashStatus;
+  text: string;
+}
+
+/** Mirrors the badge semantics of the SubmissionStatus card. */
+function flashContent(
+  flash: FlashStatus,
+  buildFailed: boolean,
+  hasTestInfo: boolean,
+  totalTests: number,
+  passedTests: number,
+): FlashContent {
+  if (buildFailed) {
+    return { variant: 'failed', text: 'Build failed' };
+  }
+  if (hasTestInfo && totalTests > 0) {
+    return { variant: flash, text: `${passedTests}/${totalTests} tests passed` };
+  }
+  return flash === 'success'
+    ? { variant: 'success', text: 'Build succeeded' }
+    : { variant: 'failed', text: 'Tests failed' };
+}
+
+const FLASH_ICONS: Record<FlashStatus, typeof Check> = {
+  success: Check,
+  partial: TriangleAlert,
+  failed: X,
+};
+
+// Static lookup instead of a dynamic `styles[...]` key: the production
+// esbuild CSS-modules plugin exports camelCase-only class names, so a
+// computed kebab-case key would silently resolve to undefined.
+const FLASH_ICON_CLASS: Record<FlashStatus, string> = {
+  success: styles.flashIconSuccess,
+  partial: styles.flashIconPartial,
+  failed: styles.flashIconFailed,
+};
+
 /**
  * Slim fixed strip pinned to the top of the Exercise Detail webview. Shows
  * the build countdown + progress bar while a build runs and the full
  * SubmissionStatus card is scrolled out of view (issue #280).
+ *
+ * Also flashes the build result for 5 s when the build finishes out of view,
+ * then disappears automatically.
  */
 export function BuildStatusStrip({
   status,
   cardInView,
   estimatedCompletionDate,
   buildStartDate,
+  buildFailed = false,
+  hasTestInfo = false,
+  totalTests = 0,
+  passedTests = 0,
   onScrollToCard,
 }: BuildStatusStripProps) {
+  const [flashStatus, setFlashStatus] = useState<FlashStatus | null>(null);
+  const prevStatusRef = useRef(status);
+  const prevCardInViewRef = useRef(cardInView);
+
+  // Detect the build-finished transition (live → completed) out of view.
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    const prevCardInView = prevCardInViewRef.current;
+    prevStatusRef.current = status;
+    prevCardInViewRef.current = cardInView;
+
+    if (isLive(status)) {
+      // A new build started — any lingering flash is stale.
+      setFlashStatus(null);
+      return;
+    }
+    // Flash only when the card was out of view in the render before the
+    // completion as well. If the user was just watching the card, they
+    // already saw the build status, so no notification is needed.
+    if (isLive(prev) && isFlashable(status) && !cardInView && !prevCardInView) {
+      setFlashStatus(status);
+    }
+  }, [status, cardInView]);
+
+  // Auto-fade the flash; cancel it when the card scrolls into view.
+  useEffect(() => {
+    if (flashStatus === null) {
+      return;
+    }
+    if (cardInView) {
+      setFlashStatus(null);
+      return;
+    }
+    const timer = setTimeout(() => setFlashStatus(null), RESULT_FLASH_MS);
+    return () => clearTimeout(timer);
+  }, [flashStatus, cardInView]);
+
   const { etaSeconds, progressPercent } = useBuildProgress(
     status === 'building',
     buildStartDate,
     estimatedCompletionDate,
   );
 
-  if (cardInView || !isLive(status)) {
+  if (cardInView) {
     return null;
   }
 
-  const hasDeterminateProgress = status === 'building' && progressPercent !== null;
-
-  return (
-    <div className={styles.strip}>
-      <span className={styles.spinner} aria-hidden="true" />
-      {/* Live region scoped to the static label only: the 1Hz ETA countdown
-          and the progress bar are visual-only, otherwise screen readers
-          would announce every tick. */}
-      <span className={styles.label} role="status">
-        {status === 'pending' ? 'Build queued…' : 'Building…'}
-      </span>
-      <div className={styles.progressTrack} aria-hidden="true">
-        <div
-          className={clsx(styles.progressBar, {
-            [styles.progressBarIndeterminate]: !hasDeterminateProgress,
-          })}
-          style={hasDeterminateProgress ? { width: `${progressPercent}%` } : undefined}
-        />
-      </div>
-      {etaSeconds !== null && (
-        <span className={styles.eta} aria-hidden="true">ETA: {etaSeconds}s</span>
-      )}
-      <button
-        type="button"
-        className={styles.scrollButton}
-        onClick={onScrollToCard}
-        aria-label="Scroll to build status"
-        title="Scroll to build status"
-      >
-        <ChevronUp size={14} />
-      </button>
-    </div>
+  const scrollButton = (
+    <button
+      type="button"
+      className={styles.scrollButton}
+      onClick={onScrollToCard}
+      aria-label="Scroll to build status"
+      title="Scroll to build status"
+    >
+      <ChevronUp size={14} />
+    </button>
   );
+
+  if (isLive(status)) {
+    const hasDeterminateProgress = status === 'building' && progressPercent !== null;
+
+    return (
+      <div className={styles.strip}>
+        <span className={styles.spinner} aria-hidden="true" />
+        {/* Live region scoped to the static label only: the 1Hz ETA countdown
+            and the progress bar are visual-only, otherwise screen readers
+            would announce every tick. */}
+        <span className={styles.label} role="status">
+          {status === 'pending' ? 'Build queued…' : 'Building…'}
+        </span>
+        <div className={styles.progressTrack} aria-hidden="true">
+          <div
+            className={clsx(styles.progressBar, {
+              [styles.progressBarIndeterminate]: !hasDeterminateProgress,
+            })}
+            style={hasDeterminateProgress ? { width: `${progressPercent}%` } : undefined}
+          />
+        </div>
+        {etaSeconds !== null && (
+          <span className={styles.eta} aria-hidden="true">ETA: {etaSeconds}s</span>
+        )}
+        {scrollButton}
+      </div>
+    );
+  }
+
+  if (flashStatus !== null) {
+    const content = flashContent(flashStatus, buildFailed, hasTestInfo, totalTests, passedTests);
+    const Icon = FLASH_ICONS[content.variant];
+
+    return (
+      <div className={styles.strip}>
+        <Icon size={14} className={FLASH_ICON_CLASS[content.variant]} aria-hidden="true" />
+        <span className={styles.label} role="status">{content.text}</span>
+        <span className={styles.flashSpacer} />
+        {scrollButton}
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/extension/src/webview/components/exercise/SubmissionStatus.tsx
+++ b/extension/src/webview/components/exercise/SubmissionStatus.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode } from 'react';
 
 import { Badge } from '@webview/components/Badge';
 import { Button } from '@webview/components/Button';
+import { useBuildProgress } from '@webview/hooks/useBuildProgress';
 
 import styles from './SubmissionStatus.module.css';
 
@@ -59,40 +60,11 @@ export function SubmissionStatus({
   buildStartDate,
 }: SubmissionStatusProps) {
   // ETA countdown for building state
-  const [etaSeconds, setEtaSeconds] = useState<number | null>(null);
-  const [progressPercent, setProgressPercent] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (status !== 'building' || !estimatedCompletionDate || !buildStartDate) {
-      setEtaSeconds(null);
-      setProgressPercent(null);
-      return;
-    }
-
-    const eta = new Date(estimatedCompletionDate).getTime();
-    const start = new Date(buildStartDate).getTime();
-    const totalTime = eta - start;
-
-    if (totalTime <= 0) {
-      setEtaSeconds(null);
-      setProgressPercent(null);
-      return;
-    }
-
-    const update = () => {
-      const now = Date.now();
-      const elapsed = now - start;
-      const remaining = Math.max(0, Math.floor((eta - now) / 1000));
-      const percent = Math.min(100, Math.max(5, (elapsed / totalTime) * 100));
-
-      setEtaSeconds(remaining > 0 ? remaining : null);
-      setProgressPercent(remaining > 0 ? percent : null);
-    };
-
-    update();
-    const interval = setInterval(update, 500);
-    return () => clearInterval(interval);
-  }, [status, estimatedCompletionDate, buildStartDate]);
+  const { etaSeconds, progressPercent } = useBuildProgress(
+    status === 'building',
+    buildStartDate,
+    estimatedCompletionDate,
+  );
 
   // Empty state for programming exercises with no submissions
   if (status === 'no-submission' && exerciseType === 'programming') {

--- a/extension/src/webview/components/exercise/index.ts
+++ b/extension/src/webview/components/exercise/index.ts
@@ -1,2 +1,3 @@
+export { BuildStatusStrip } from './BuildStatusStrip';
 export { ParticipationActions } from './ParticipationActions';
 export { SubmissionStatus } from './SubmissionStatus';

--- a/extension/src/webview/hooks/useBuildProgress.ts
+++ b/extension/src/webview/hooks/useBuildProgress.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export interface BuildProgress {
+interface BuildProgress {
     /** Whole seconds until the estimated completion, or null when unknown/elapsed. */
     etaSeconds: number | null;
     /** Progress percentage clamped to 5–100, or null when unknown/elapsed. */

--- a/extension/src/webview/hooks/useBuildProgress.ts
+++ b/extension/src/webview/hooks/useBuildProgress.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+export interface BuildProgress {
+    /** Whole seconds until the estimated completion, or null when unknown/elapsed. */
+    etaSeconds: number | null;
+    /** Progress percentage clamped to 5–100, or null when unknown/elapsed. */
+    progressPercent: number | null;
+}
+
+/**
+ * Live ETA countdown + progress percentage for a running build, derived
+ * client-side from the buildTimingInfo dates (500 ms tick). Returns nulls
+ * when `isBuilding` is false, timing info is missing, the window is invalid
+ * (eta <= start), or the estimated window has elapsed.
+ */
+export function useBuildProgress(
+    isBuilding: boolean,
+    buildStartDate?: string,
+    estimatedCompletionDate?: string,
+): BuildProgress {
+    const [etaSeconds, setEtaSeconds] = useState<number | null>(null);
+    const [progressPercent, setProgressPercent] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (!isBuilding || !estimatedCompletionDate || !buildStartDate) {
+            setEtaSeconds(null);
+            setProgressPercent(null);
+            return;
+        }
+
+        const eta = new Date(estimatedCompletionDate).getTime();
+        const start = new Date(buildStartDate).getTime();
+        const totalTime = eta - start;
+
+        if (totalTime <= 0) {
+            setEtaSeconds(null);
+            setProgressPercent(null);
+            return;
+        }
+
+        const update = () => {
+            const now = Date.now();
+            const elapsed = now - start;
+            const remaining = Math.max(0, Math.floor((eta - now) / 1000));
+            const percent = Math.min(100, Math.max(5, (elapsed / totalTime) * 100));
+
+            setEtaSeconds(remaining > 0 ? remaining : null);
+            setProgressPercent(remaining > 0 ? percent : null);
+        };
+
+        update();
+        const interval = setInterval(update, 500);
+        return () => clearInterval(interval);
+    }, [isBuilding, estimatedCompletionDate, buildStartDate]);
+
+    return { etaSeconds, progressPercent };
+}

--- a/extension/src/webview/hooks/useInViewport.ts
+++ b/extension/src/webview/hooks/useInViewport.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks whether the given element is inside the viewport.
+ *
+ * Takes the element itself (wire it up via a callback ref into state,
+ * `<div ref={setEl}>`), NOT a RefObject: consumers like ExerciseDetailView
+ * mount the observed element only after loading early-returns resolve, and
+ * only an element-keyed effect re-attaches the observer in that case.
+ *
+ * Defaults to `true` (element considered visible) while the element is
+ * absent and until the first IntersectionObserver callback fires, so
+ * dependent UI (the sticky build strip) never flashes on mount.
+ * Environments without IntersectionObserver (e.g. happy-dom in tests)
+ * permanently report `true`.
+ */
+export function useInViewport(element: Element | null): boolean {
+    const [inViewport, setInViewport] = useState(true);
+
+    useEffect(() => {
+        if (!element || typeof IntersectionObserver === 'undefined') {
+            setInViewport(true);
+            return;
+        }
+
+        const observer = new IntersectionObserver((entries) => {
+            // Entries arrive oldest-first; the last one is the current state.
+            setInViewport(entries[entries.length - 1].isIntersecting);
+        });
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [element]);
+
+    return inViewport;
+}

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -14,11 +14,12 @@ import {
     IconButton,
     SkeletonList,
 } from '@webview/components';
-import { ParticipationActions, SubmissionStatus } from '@webview/components/exercise';
+import { BuildStatusStrip, ParticipationActions, SubmissionStatus } from '@webview/components/exercise';
 import { type ExerciseType, isExerciseType } from '@webview/components/exercise/ParticipationActions';
 import { TestResultsOverlay } from '@webview/components/exercise/TestResultsOverlay';
 import { useExerciseStatusMessages } from '@webview/hooks/useExerciseStatusMessages';
 import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
+import { useInViewport } from '@webview/hooks/useInViewport';
 import { useWebSocketUpdates } from '@webview/hooks/useWebSocketUpdates';
 import { useExerciseDetailStore } from '@webview/stores/useExerciseDetailStore';
 import {
@@ -76,6 +77,14 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
 
     const [openOverviewView, setOpenOverviewView] = useState<OpenViewState | null>(null);
     const [openTaskView, setOpenTaskView] = useState<OpenTaskViewState | null>(null);
+
+    // Sticky build-status strip (#280): track whether the SubmissionStatus
+    // card is visible; the strip only shows while it is scrolled out of view.
+    // Callback-ref state (not useRef): the card mounts only after the loading
+    // early-returns below resolve, so the observer must attach when the
+    // element appears, not on first render.
+    const [submissionStatusEl, setSubmissionStatusEl] = useState<HTMLDivElement | null>(null);
+    const submissionStatusInView = useInViewport(submissionStatusEl);
 
     // Initialize WebSocket updates hook
     useWebSocketUpdates();
@@ -519,39 +528,57 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
 
                 {/* Submission Status */}
                 {hasParticipation && (
-                    <SubmissionStatus
-                        status={submissionStatus}
-                        score={scorePercentage * maxPoints / 100}
-                        maxScore={maxPoints}
-                        scorePercentage={scorePercentage}
-                        exerciseType={exerciseType}
-                        buildFailed={buildFailed}
-                        hasTestInfo={hasTestInfo}
-                        totalTests={totalTests}
-                        passedTests={passedTests}
-                        estimatedCompletionDate={pendingSubmission?.buildTimingInfo?.estimatedCompletionDate}
-                        buildStartDate={pendingSubmission?.buildTimingInfo?.buildStartDate}
-                        onOpenTestResults={handleOverviewOpen}
-                        onViewBuildLog={() => {
-                            if (participationId) {
-                                postCommand(vscodeApi, 'viewBuildLog', {
-                                    participationId,
-                                    resultId: latestResult?.id,
-                                });
-                            }
-                        }}
-                        onGoToSource={() => {
-                            if (participationId) {
-                                postCommand(vscodeApi, 'goToSource', {
-                                    participationId,
-                                    resultId: latestResult?.id,
-                                });
-                            }
-                        }}
-                    />
+                    <div ref={setSubmissionStatusEl}>
+                        <SubmissionStatus
+                            status={submissionStatus}
+                            score={scorePercentage * maxPoints / 100}
+                            maxScore={maxPoints}
+                            scorePercentage={scorePercentage}
+                            exerciseType={exerciseType}
+                            buildFailed={buildFailed}
+                            hasTestInfo={hasTestInfo}
+                            totalTests={totalTests}
+                            passedTests={passedTests}
+                            estimatedCompletionDate={pendingSubmission?.buildTimingInfo?.estimatedCompletionDate}
+                            buildStartDate={pendingSubmission?.buildTimingInfo?.buildStartDate}
+                            onOpenTestResults={handleOverviewOpen}
+                            onViewBuildLog={() => {
+                                if (participationId) {
+                                    postCommand(vscodeApi, 'viewBuildLog', {
+                                        participationId,
+                                        resultId: latestResult?.id,
+                                    });
+                                }
+                            }}
+                            onGoToSource={() => {
+                                if (participationId) {
+                                    postCommand(vscodeApi, 'goToSource', {
+                                        participationId,
+                                        resultId: latestResult?.id,
+                                    });
+                                }
+                            }}
+                        />
+                    </div>
                 )}
 
             </Container>
+
+            {/* Sticky build status strip (#280) — fixed to the top of the
+                webview while a build runs and the card is out of view */}
+            {hasParticipation && isProgramming && (
+                <BuildStatusStrip
+                    status={submissionStatus}
+                    cardInView={submissionStatusInView}
+                    estimatedCompletionDate={pendingSubmission?.buildTimingInfo?.estimatedCompletionDate}
+                    buildStartDate={pendingSubmission?.buildTimingInfo?.buildStartDate}
+                    buildFailed={buildFailed}
+                    hasTestInfo={hasTestInfo}
+                    totalTests={totalTests}
+                    passedTests={passedTests}
+                    onScrollToCard={() => submissionStatusEl?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                />
+            )}
 
             {/* Ask Iris Section */}
             <AskIris

--- a/extension/test/react/components/exercise/BuildStatusStrip.test.tsx
+++ b/extension/test/react/components/exercise/BuildStatusStrip.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BuildStatusStrip } from '@webview/components/exercise/BuildStatusStrip';
@@ -71,5 +71,118 @@ describe('BuildStatusStrip', () => {
         // fireEvent (not userEvent): userEvent's delays interact badly with fake timers
         fireEvent.click(screen.getByRole('button', { name: 'Scroll to build status' }));
         expect(onScrollToCard).toHaveBeenCalledTimes(1);
+    });
+
+    // ── Result flash ─────────────────────────────────────────────────────
+
+    function renderBuildingThenComplete(
+        completedProps: Partial<Parameters<typeof BuildStatusStrip>[0]> = {},
+    ) {
+        const result = render(
+            <BuildStatusStrip status="building" cardInView={false} onScrollToCard={() => undefined} />,
+        );
+        result.rerender(
+            <BuildStatusStrip
+                status="partial"
+                cardInView={false}
+                onScrollToCard={() => undefined}
+                {...completedProps}
+            />,
+        );
+        return result;
+    }
+
+    it('flashes the test summary when the build finishes out of view', () => {
+        renderBuildingThenComplete({ hasTestInfo: true, totalTests: 3, passedTests: 2 });
+        expect(screen.getByText('2/3 tests passed')).toBeInTheDocument();
+    });
+
+    it('flashes "Build failed" when the build itself failed', () => {
+        renderBuildingThenComplete({ status: 'failed', buildFailed: true });
+        expect(screen.getByText('Build failed')).toBeInTheDocument();
+    });
+
+    it('prioritizes the build failure over test info in the flash', () => {
+        renderBuildingThenComplete({
+            status: 'failed',
+            buildFailed: true,
+            hasTestInfo: true,
+            totalTests: 3,
+            passedTests: 2,
+        });
+        expect(screen.getByText('Build failed')).toBeInTheDocument();
+        expect(screen.queryByText('2/3 tests passed')).not.toBeInTheDocument();
+    });
+
+    it('applies a variant color class to the flash icon', () => {
+        const { container } = renderBuildingThenComplete({ hasTestInfo: true, totalTests: 3, passedTests: 2 });
+        // Lucide marks the scroll-button's chevron aria-hidden too, so pick
+        // the svg OUTSIDE the button. Guards against the CSS-module lookup
+        // silently resolving to undefined.
+        const icon = Array.from(container.querySelectorAll('svg[aria-hidden="true"]'))
+            .find((svg) => svg.closest('button') === null);
+        expect(icon).toBeDefined();
+        expect(icon?.getAttribute('class')).toMatch(/flashIcon/);
+    });
+
+    it('flashes "Build succeeded" without test info on success', () => {
+        renderBuildingThenComplete({ status: 'success' });
+        expect(screen.getByText('Build succeeded')).toBeInTheDocument();
+    });
+
+    it('flashes "Tests failed" without test info on failure', () => {
+        renderBuildingThenComplete({ status: 'failed' });
+        expect(screen.getByText('Tests failed')).toBeInTheDocument();
+    });
+
+    it('auto-fades the flash after 5 seconds', () => {
+        renderBuildingThenComplete({ hasTestInfo: true, totalTests: 3, passedTests: 2 });
+        expect(screen.getByText('2/3 tests passed')).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(5_000);
+        });
+        expect(screen.queryByText('2/3 tests passed')).not.toBeInTheDocument();
+    });
+
+    it('hides the flash as soon as the card scrolls into view', () => {
+        const { rerender } = renderBuildingThenComplete({ hasTestInfo: true, totalTests: 3, passedTests: 2 });
+        rerender(
+            <BuildStatusStrip
+                status="partial"
+                cardInView
+                hasTestInfo
+                totalTests={3}
+                passedTests={2}
+                onScrollToCard={() => undefined}
+            />,
+        );
+        expect(screen.queryByText('2/3 tests passed')).not.toBeInTheDocument();
+    });
+
+    it('does not flash when the build finishes while the card is in view', () => {
+        const { rerender, container } = render(
+            <BuildStatusStrip status="building" cardInView onScrollToCard={() => undefined} />,
+        );
+        rerender(
+            <BuildStatusStrip
+                status="partial"
+                cardInView={false}
+                hasTestInfo
+                totalTests={3}
+                passedTests={2}
+                onScrollToCard={() => undefined}
+            />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('shows the live strip again when a new build starts during a flash', () => {
+        const { rerender } = renderBuildingThenComplete({ hasTestInfo: true, totalTests: 3, passedTests: 2 });
+        rerender(
+            <BuildStatusStrip status="building" cardInView={false} onScrollToCard={() => undefined} />,
+        );
+        expect(screen.getByText('Building…')).toBeInTheDocument();
+        expect(screen.queryByText('2/3 tests passed')).not.toBeInTheDocument();
     });
 });

--- a/extension/test/react/components/exercise/BuildStatusStrip.test.tsx
+++ b/extension/test/react/components/exercise/BuildStatusStrip.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BuildStatusStrip } from '@webview/components/exercise/BuildStatusStrip';
+
+describe('BuildStatusStrip', () => {
+    const start = '2026-01-01T10:00:00.000Z';
+    const eta = '2026-01-01T10:01:00.000Z';
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(start));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // ── Live states ──────────────────────────────────────────────────────
+
+    it('renders nothing while the card is in view', () => {
+        const { container } = render(
+            <BuildStatusStrip status="building" cardInView onScrollToCard={() => undefined} />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing for completed states without a flash', () => {
+        const { container } = render(
+            <BuildStatusStrip status="success" cardInView={false} onScrollToCard={() => undefined} />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('shows countdown and ETA while building with timing info', () => {
+        render(
+            <BuildStatusStrip
+                status="building"
+                cardInView={false}
+                buildStartDate={start}
+                estimatedCompletionDate={eta}
+                onScrollToCard={() => undefined}
+            />,
+        );
+        expect(screen.getByText('Building…')).toBeInTheDocument();
+        expect(screen.getByText('ETA: 60s')).toBeInTheDocument();
+    });
+
+    it('omits the ETA when timing info is missing', () => {
+        render(
+            <BuildStatusStrip status="building" cardInView={false} onScrollToCard={() => undefined} />,
+        );
+        expect(screen.getByText('Building…')).toBeInTheDocument();
+        expect(screen.queryByText(/ETA:/)).not.toBeInTheDocument();
+    });
+
+    it('shows the queued message when pending', () => {
+        render(
+            <BuildStatusStrip status="pending" cardInView={false} onScrollToCard={() => undefined} />,
+        );
+        expect(screen.getByText('Build queued…')).toBeInTheDocument();
+    });
+
+    // ── Arrow button ─────────────────────────────────────────────────────
+
+    it('invokes onScrollToCard when the arrow is clicked', () => {
+        const onScrollToCard = vi.fn();
+        render(
+            <BuildStatusStrip status="building" cardInView={false} onScrollToCard={onScrollToCard} />,
+        );
+        // fireEvent (not userEvent): userEvent's delays interact badly with fake timers
+        fireEvent.click(screen.getByRole('button', { name: 'Scroll to build status' }));
+        expect(onScrollToCard).toHaveBeenCalledTimes(1);
+    });
+});

--- a/extension/test/react/hooks/useBuildProgress.test.ts
+++ b/extension/test/react/hooks/useBuildProgress.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBuildProgress } from '@webview/hooks/useBuildProgress';
+
+describe('useBuildProgress', () => {
+    // 60-second build window starting exactly at the mocked system time
+    const start = '2026-01-01T10:00:00.000Z';
+    const eta = '2026-01-01T10:01:00.000Z';
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(start));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns nulls when not building', () => {
+        const { result } = renderHook(() => useBuildProgress(false, start, eta));
+        expect(result.current.etaSeconds).toBeNull();
+        expect(result.current.progressPercent).toBeNull();
+    });
+
+    it('returns nulls when timing info is missing', () => {
+        const { result } = renderHook(() => useBuildProgress(true, undefined, undefined));
+        expect(result.current.etaSeconds).toBeNull();
+        expect(result.current.progressPercent).toBeNull();
+    });
+
+    it('returns nulls when eta is not after start', () => {
+        const { result } = renderHook(() => useBuildProgress(true, eta, start));
+        expect(result.current.etaSeconds).toBeNull();
+        expect(result.current.progressPercent).toBeNull();
+    });
+
+    it('counts down and reports clamped progress', () => {
+        const { result } = renderHook(() => useBuildProgress(true, start, eta));
+
+        // t=0: full ETA remaining, percent clamped to the 5% floor
+        expect(result.current.etaSeconds).toBe(60);
+        expect(result.current.progressPercent).toBe(5);
+
+        act(() => {
+            vi.advanceTimersByTime(30_000);
+        });
+        expect(result.current.etaSeconds).toBe(30);
+        expect(result.current.progressPercent).toBe(50);
+    });
+
+    it('returns nulls once the estimated window has elapsed', () => {
+        const { result } = renderHook(() => useBuildProgress(true, start, eta));
+
+        act(() => {
+            vi.advanceTimersByTime(61_000);
+        });
+        expect(result.current.etaSeconds).toBeNull();
+        expect(result.current.progressPercent).toBeNull();
+    });
+
+    it('resets to nulls when building stops', () => {
+        const { result, rerender } = renderHook(
+            ({ building }: { building: boolean }) => useBuildProgress(building, start, eta),
+            { initialProps: { building: true } },
+        );
+        expect(result.current.etaSeconds).toBe(60);
+
+        rerender({ building: false });
+        expect(result.current.etaSeconds).toBeNull();
+        expect(result.current.progressPercent).toBeNull();
+    });
+});

--- a/extension/test/react/hooks/useInViewport.test.tsx
+++ b/extension/test/react/hooks/useInViewport.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInViewport } from '@webview/hooks/useInViewport';
+
+function Probe() {
+    const [el, setEl] = useState<HTMLDivElement | null>(null);
+    const inViewport = useInViewport(el);
+    return <div ref={setEl} data-testid="probe" data-inviewport={String(inViewport)} />;
+}
+
+/** Probe whose observed element can mount/unmount after the first render. */
+function LateProbe({ mounted }: { mounted: boolean }) {
+    const [el, setEl] = useState<HTMLDivElement | null>(null);
+    const inViewport = useInViewport(el);
+    return (
+        <div data-testid="host" data-inviewport={String(inViewport)}>
+            {mounted && <div ref={setEl} data-testid="late" />}
+        </div>
+    );
+}
+
+describe('useInViewport', () => {
+    let observerCallback: IntersectionObserverCallback;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+
+    beforeEach(() => {
+        // happy-dom has no IntersectionObserver — stub it.
+        // Must use a regular function (not an arrow function) so it is new-able.
+        vi.stubGlobal(
+            'IntersectionObserver',
+            vi.fn(function (callback: IntersectionObserverCallback) {
+                observerCallback = callback;
+                return { observe, disconnect, unobserve: vi.fn() };
+            }),
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function emit(isIntersecting: boolean) {
+        act(() => {
+            observerCallback(
+                [{ isIntersecting } as IntersectionObserverEntry],
+                {} as IntersectionObserver,
+            );
+        });
+    }
+
+    it('defaults to true before the observer fires', () => {
+        render(<Probe />);
+        expect(screen.getByTestId('probe').dataset.inviewport).toBe('true');
+    });
+
+    it('observes the element', () => {
+        render(<Probe />);
+        expect(observe).toHaveBeenCalledWith(screen.getByTestId('probe'));
+    });
+
+    it('reflects intersection changes', () => {
+        render(<Probe />);
+        emit(false);
+        expect(screen.getByTestId('probe').dataset.inviewport).toBe('false');
+        emit(true);
+        expect(screen.getByTestId('probe').dataset.inviewport).toBe('true');
+    });
+
+    it('attaches the observer when the element mounts later (ExerciseDetailView early-return case)', () => {
+        const { rerender } = render(<LateProbe mounted={false} />);
+        expect(observe).not.toHaveBeenCalled();
+
+        rerender(<LateProbe mounted />);
+        expect(observe).toHaveBeenCalledWith(screen.getByTestId('late'));
+        emit(false);
+        expect(screen.getByTestId('host').dataset.inviewport).toBe('false');
+    });
+
+    it('resets to true when the element unmounts', () => {
+        const { rerender } = render(<LateProbe mounted />);
+        emit(false);
+        expect(screen.getByTestId('host').dataset.inviewport).toBe('false');
+
+        rerender(<LateProbe mounted={false} />);
+        expect(screen.getByTestId('host').dataset.inviewport).toBe('true');
+        expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('disconnects on unmount', () => {
+        const { unmount } = render(<Probe />);
+        unmount();
+        expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('stays true when IntersectionObserver is unavailable', () => {
+        vi.unstubAllGlobals(); // remove the stub → IO undefined in happy-dom
+        render(<Probe />);
+        expect(screen.getByTestId('probe').dataset.inviewport).toBe('true');
+    });
+});

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ExtensionMsg } from '@shared/messageContracts';
 import type { ExerciseDetailsResponse } from '@shared/types/apiResponses';
@@ -543,5 +543,86 @@ describe('ExerciseDetailView', () => {
 			expect(screen.queryByText(/no build results yet/i)).not.toBeInTheDocument();
 		});
 		expect(screen.getByText('Passed (2)')).toBeInTheDocument();
+	});
+
+	describe('sticky build status strip', () => {
+		let observerCallback: IntersectionObserverCallback;
+
+		beforeEach(() => {
+			vi.stubGlobal(
+				'IntersectionObserver',
+				vi.fn(function (callback: IntersectionObserverCallback) {
+					observerCallback = callback;
+					return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() };
+				}),
+			);
+		});
+
+		afterEach(() => {
+			vi.unstubAllGlobals();
+		});
+
+		it('shows the strip when a build runs and the card leaves the viewport', () => {
+			// pendingSubmissionsByParticipationId is a TOP-LEVEL store field
+			// (not read from exerciseData) — seed it as a sibling, matching
+			// participation id 99 from the helper. Now-relative timing dates
+			// so the ETA pass-through (view → strip) is exercised end-to-end.
+			useExerciseDetailStore.setState({
+				exerciseData: makeExerciseDataWithParticipation(),
+				pendingSubmissionsByParticipationId: {
+					99: {
+						participationId: 99,
+						state: 'BUILDING',
+						buildTimingInfo: {
+							buildStartDate: new Date(Date.now() - 1_000).toISOString(),
+							estimatedCompletionDate: new Date(Date.now() + 60_000).toISOString(),
+						},
+					},
+				},
+				isLoading: false,
+			});
+			render(<ExerciseDetailView vscodeApi={createMockVsCodeApi()} />);
+
+			// Card visible → no strip
+			expect(screen.queryByText('Building…')).not.toBeInTheDocument();
+
+			// Card scrolls out of view
+			act(() => {
+				observerCallback(
+					[{ isIntersecting: false } as IntersectionObserverEntry],
+					{} as IntersectionObserver,
+				);
+			});
+			expect(screen.getByText('Building…')).toBeInTheDocument();
+			// The card shows its own ETA message, so scope to the strip.
+			const strip = screen.getByText('Building…').parentElement as HTMLElement;
+			expect(within(strip).getByText(/ETA:/)).toBeInTheDocument();
+
+			// Card scrolls back into view → strip disappears
+			act(() => {
+				observerCallback(
+					[{ isIntersecting: true } as IntersectionObserverEntry],
+					{} as IntersectionObserver,
+				);
+			});
+			expect(screen.queryByText('Building…')).not.toBeInTheDocument();
+		});
+
+		it('does not render the strip without a pending build', () => {
+			useExerciseDetailStore.setState({
+				exerciseData: makeExerciseDataWithParticipation({ hasResult: true }),
+				isLoading: false,
+			});
+			render(<ExerciseDetailView vscodeApi={createMockVsCodeApi()} />);
+
+			act(() => {
+				observerCallback(
+					[{ isIntersecting: false } as IntersectionObserverEntry],
+					{} as IntersectionObserver,
+				);
+			});
+			expect(screen.queryByText('Building…')).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Scroll to build status' })).not.toBeInTheDocument();
+		});
 	});
 });

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -608,6 +608,44 @@ describe('ExerciseDetailView', () => {
 			expect(screen.queryByText('Building…')).not.toBeInTheDocument();
 		});
 
+		it('flashes the result when the build finishes while the card is out of view', () => {
+			useExerciseDetailStore.setState({
+				exerciseData: makeExerciseDataWithParticipation(),
+				pendingSubmissionsByParticipationId: {
+					99: { participationId: 99, state: 'BUILDING' },
+				},
+				isLoading: false,
+			});
+			render(<ExerciseDetailView vscodeApi={createMockVsCodeApi()} />);
+
+			act(() => {
+				observerCallback(
+					[{ isIntersecting: false } as IntersectionObserverEntry],
+					{} as IntersectionObserver,
+				);
+			});
+			expect(screen.getByText('Building…')).toBeInTheDocument();
+
+			// Build finishes: the store deletes the pending entry and appends
+			// the result in a single set(), so the view re-renders exactly
+			// once with building → partial.
+			act(() => {
+				useExerciseDetailStore.getState().updateBuildStatus({
+					id: 10,
+					participationId: 99,
+					score: 66.7,
+					successful: false,
+					testCaseCount: 3,
+					passedTestCaseCount: 2,
+					feedbacks: [],
+				});
+			});
+			expect(screen.queryByText('Building…')).not.toBeInTheDocument();
+			// The card badge renders the same text, so scope to the strip's
+			// live region.
+			expect(screen.getByRole('status')).toHaveTextContent('2/3 tests passed');
+		});
+
 		it('does not render the strip without a pending build', () => {
 			useExerciseDetailStore.setState({
 				exerciseData: makeExerciseDataWithParticipation({ hasResult: true }),

--- a/extension/test/react/views/ExerciseDetail/components/SubmissionStatus.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/components/SubmissionStatus.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SubmissionStatus } from '@webview/components/exercise/SubmissionStatus';
 
@@ -121,5 +121,30 @@ describe('SubmissionStatus', () => {
 			/>
 		);
 		expect(screen.getByText(/8\/10/)).toBeInTheDocument();
+	});
+
+	describe('building ETA countdown', () => {
+		const start = '2026-01-01T10:00:00.000Z';
+		const eta = '2026-01-01T10:01:00.000Z';
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(start));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('shows the ETA countdown when building with timing info', () => {
+			render(
+				<SubmissionStatus
+					status="building"
+					buildStartDate={start}
+					estimatedCompletionDate={eta}
+				/>,
+			);
+			expect(screen.getByText('Building your submission... (ETA: 60s)')).toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
Closes #280

## Summary

While a submission builds, the Exercise Detail webview now pins a slim strip to the top of the view whenever the build-status card is scrolled out of sight:

- **Live strip:** spinner, progress bar (determinate with `buildTimingInfo`, indeterminate shimmer without) and a live `ETA: Ns` countdown — same data source and 500 ms tick as the card.
- **Result flash:** if the build finishes while the card is out of view, the strip shows the result for 5 s (mirroring the card's badge text: `2/3 tests passed`, `Build failed`, …) and then disappears, so a finished build can no longer be missed.
- **Scroll-back arrow:** an up-arrow button smooth-scrolls back to the full card.

## Implementation notes

- `useBuildProgress` extracts the ETA/progress logic from `SubmissionStatus` (behavior-preserving refactor, regression-tested) so card and strip share one implementation.
- `useInViewport` tracks card visibility via IntersectionObserver. It takes the element via callback-ref state instead of a `RefObject` because the view early-returns while loading, so the observed card mounts late.
- The strip renders `position: fixed` (z-index below `TestResultsOverlay`) and is themed entirely via `--vscode-*` variables.
- A11y: the live region is scoped to the static label so screen readers announce state changes once, not every countdown tick; `prefers-reduced-motion` disables the animations with a static fallback bar.
- No changes to WebSocket handling or the store.

## Test plan

- [x] 23 new vitest tests (hooks, strip states, flash timing with fake timers, store-driven integration through `updateBuildStatus`) — full suite 843/843 green
- [x] `npm run lint`, `npm run check-types` clean
- [ ] Manual check in the Extension Development Host: submit, scroll down, observe strip + countdown; let the build finish out of view, observe the 5 s result flash; arrow scrolls back to the card; light + dark theme
