### PR TITLE
refactor(sensing): single sensor hub for recorder and EQ pipeline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,10 @@
 
 - **All PRs branch off `dev`** and merge back into `dev`.
 - **Only `dev` gets merged into `main`** — never push or merge feature branches directly into main.
+- **Temporary exception (struggle engine v2):** this work happens on the integration branch
+  `feat/struggle-engine-v2`. Its PRs branch off and merge back into that branch, NOT into
+  `dev`. The final merge of `feat/struggle-engine-v2` into `dev` is a separate manual
+  decision later.
 
 ## Dependency Management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Internal
 
+- **Sensing Layer**: A single `SensorHub` (`services/sensing/`) now owns all VS Code event subscriptions and state reads for telemetry; the session recorder, the EQ pipeline, and the inactivity/diagnostics services consume typed hub channels. No behavior change; recordings stay schema-v2 identical.
 - **Struggle-Detection Config**: Wired `MIN_EVENTS_PER_SESSION` and the paste threshold; removed dead config.
 - **Live Recording Viewer**: The Event Breakdown counts, event total, and session duration now update live alongside the timeline instead of freezing at the values from when the live session was opened.
 - **Live Recording Viewer**: Live mode can now be served from the production build (`npm run preview:live:token`), which eliminates a browser-tab out-of-memory crash that could occur during long or high-volume live sessions on the dev server.

--- a/docs/superpowers/plans/2026-06-12-pr1-sensing-layer.md
+++ b/docs/superpowers/plans/2026-06-12-pr1-sensing-layer.md
@@ -105,10 +105,12 @@ import { VsCodeSensorHub } from '@extension/services/sensing/sensorHub';
 suite('VsCodeSensorHub', () => {
     test('relays text changes with an arrival timestamp', async () => {
         const hub = new VsCodeSensorHub();
+        // Open FIRST: VS Code fires onDidChangeTextDocument for the initial
+        // content fill, so subscribing before open would see 2 events.
+        const doc = await vscode.workspace.openTextDocument({ content: 'abc', language: 'plaintext' });
         const received: TextChangeSignal[] = [];
         const sub = hub.onDidChangeTextDocument(signal => received.push(signal));
 
-        const doc = await vscode.workspace.openTextDocument({ content: 'abc', language: 'plaintext' });
         const edit = new vscode.WorkspaceEdit();
         edit.insert(doc.uri, new vscode.Position(0, 0), 'x');
         const before = Date.now();

--- a/docs/superpowers/plans/2026-06-12-pr1-sensing-layer.md
+++ b/docs/superpowers/plans/2026-06-12-pr1-sensing-layer.md
@@ -520,6 +520,8 @@ git add src/extension/services/sensing test/unit/services/sensing
 git commit -m "refactor(sensing): add SensorHub, the single VS Code event/state reader"
 ```
 
+**Task 2 implementation record (commit `920b2909` is the source of truth):** implemented as specified, plus review hardening of LazyRelay: one Set entry PER SUBSCRIPTION (`{ call }` wrapper objects) so duplicate listener functions keep independent refcounts; per-listener try/catch in `_fan` with `logger.error(..., LogCategory.TELEMETRY, ...)` so a throwing consumer cannot suppress delivery to others; `_disposed` guard makes post-dispose attaches inert (no source resurrection); capability gate reads `?? true`; first test subscribes after `openTextDocument` (initial content fill fires the event). Test file has 6 tests (the 4 planned + fan-out isolation/duplicates + dispose-detaches/post-dispose-inert).
+
 ### Task 3: DiagnosticsSettleCollector (save-triggered settle snapshot)
 
 **Files:**

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -10,6 +10,7 @@ import { CourseDataCache } from '@extension/services/courseDataCache';
 import { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
 import { LogCategory, logger } from '@extension/services/loggingService';
+import { VsCodeSensorHub } from '@extension/services/sensing';
 import { TelemetryManager } from '@extension/services/telemetry';
 import { createProviderRegistry } from '@extension/services/ui';
 import { ArtemisWebsocketService, WebSocketStatusBarService } from '@extension/services/websocket';
@@ -63,7 +64,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	const artemisWebsocketService = new ArtemisWebsocketService(authManager);
 	const buildErrorCodeLensProvider = new BuildErrorCodeLensProvider();
 	const exerciseRegistry = new ExerciseRegistry();
-	const telemetryManager = new TelemetryManager(exerciseRegistry);
+	const sensorHub = new VsCodeSensorHub(capabilities);
+	context.subscriptions.push(sensorHub);
+	const telemetryManager = new TelemetryManager(exerciseRegistry, sensorHub);
 	activeTelemetryManager = telemetryManager;
 	telemetryManager.setWebsocketService(artemisWebsocketService);
 
@@ -228,6 +231,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		capabilities,
 		exerciseRegistry,
 		contextStore,
+		sensorHub,
 	});
 
 	// Configuration listener

--- a/extension/src/extension/activation/sessionRecorderWiring.ts
+++ b/extension/src/extension/activation/sessionRecorderWiring.ts
@@ -4,6 +4,7 @@ import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/pro
 import type { ConsentService } from '@extension/services/auth/consentService';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import type { ContextStore } from '@extension/services/iris/context/contextStore';
+import type { SensorHub } from '@extension/services/sensing';
 import type { TelemetryManager } from '@extension/services/telemetry';
 import type { SessionRecorder } from '@extension/services/telemetry/recording';
 import {
@@ -28,6 +29,7 @@ interface RecorderWiringDeps {
     capabilities?: PlatformCapabilities;
     exerciseRegistry?: ExerciseRegistry;
     contextStore: ContextStore;
+    sensorHub: SensorHub;
 }
 
 interface RecorderWiringResult {
@@ -39,10 +41,10 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
     const {
         context, consentService, artemisWebsocketService,
         telemetryManager, artemisWebviewProvider, chatWebviewProvider,
-        capabilities, exerciseRegistry, contextStore,
+        capabilities, exerciseRegistry, contextStore, sensorHub,
     } = deps;
 
-    const sessionRecorder = new SessionRecorderImpl(context.globalStorageUri, capabilities, exerciseRegistry);
+    const sessionRecorder = new SessionRecorderImpl(context.globalStorageUri, capabilities, exerciseRegistry, undefined, sensorHub);
 
     if (consentService.isExtendedCollectionEnabled) {
         sessionRecorder.enable();
@@ -227,7 +229,7 @@ export function wireSessionRecorder(deps: RecorderWiringDeps): RecorderWiringRes
     // in replay. Breakpoints are workspace-global, independent of debug sessions.
     disposables.push(sessionRecorder.registerStartupContributor((ctx): RecordedEvent[] => {
         const root = ctx.exerciseRoot ? vscode.Uri.parse(ctx.exerciseRoot) : undefined;
-        const snapshot = collectInitialBreakpointSnapshot(vscode.debug.breakpoints, root, ctx.timestamp);
+        const snapshot = collectInitialBreakpointSnapshot(sensorHub.readBreakpoints(), root, ctx.timestamp);
         return snapshot ? [snapshot] : [];
     }));
 

--- a/extension/src/extension/dataCollection/index.ts
+++ b/extension/src/extension/dataCollection/index.ts
@@ -45,6 +45,7 @@ export function wireDataCollection(deps: DataCollectionDeps): DataCollectionHand
         capabilities: deps.capabilities,
         exerciseRegistry: deps.exerciseRegistry,
         contextStore: deps.contextStore,
+        sensorHub: deps.sensorHub,
     });
 
     // Prompt after wiring so a consent change immediately reaches the recorder.

--- a/extension/src/extension/dataCollection/types.ts
+++ b/extension/src/extension/dataCollection/types.ts
@@ -3,6 +3,7 @@ import type * as vscode from 'vscode';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/provider';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import type { ContextStore } from '@extension/services/iris/context/contextStore';
+import type { SensorHub } from '@extension/services/sensing';
 import type { TelemetryManager } from '@extension/services/telemetry';
 import type { ArtemisWebsocketService } from '@extension/services/websocket';
 import type { PlatformCapabilities } from '@extension/theia';
@@ -17,6 +18,7 @@ export interface DataCollectionDeps {
     capabilities?: PlatformCapabilities;
     exerciseRegistry?: ExerciseRegistry;
     contextStore: ContextStore;
+    sensorHub: SensorHub;
 }
 
 /**

--- a/extension/src/extension/services/sensing/collectors/diagnosticsSettle.ts
+++ b/extension/src/extension/services/sensing/collectors/diagnosticsSettle.ts
@@ -1,0 +1,56 @@
+// extension/src/extension/services/sensing/collectors/diagnosticsSettle.ts
+import * as vscode from 'vscode';
+
+import type { DiagnosticsSettledSignal, SaveSignal } from '@extension/services/sensing/types';
+import { shouldRecordUri } from '@extension/services/telemetry/uriFilter';
+
+/**
+ * Save-triggered diagnostics settle snapshot.
+ *
+ * After a save on a recordable URI, waits DIAGNOSTICS_SETTLE_MS for the
+ * language server to update, then emits one bulk diagnostics dump. Saves
+ * within the window coalesce into a single timer, exactly matching the v1
+ * CompileEquivalentEmitter save path this replaces (engineering choice,
+ * calibrated for LS latency).
+ */
+export class DiagnosticsSettleCollector implements vscode.Disposable {
+    static readonly DIAGNOSTICS_SETTLE_MS = 500;
+
+    private _timer: ReturnType<typeof setTimeout> | undefined;
+    private _lastSaveSeq = 0;
+    private readonly _subscription: vscode.Disposable;
+    private readonly _onDidSettle = new vscode.EventEmitter<DiagnosticsSettledSignal>();
+    readonly onDidSettle = this._onDidSettle.event;
+
+    constructor(
+        onSave: vscode.Event<SaveSignal>,
+        private readonly _readAllDiagnostics: () => ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]>,
+    ) {
+        this._subscription = onSave(({ seq, document }) => {
+            if (!shouldRecordUri(document.uri)) {
+                return;
+            }
+            this._lastSaveSeq = seq;
+            if (this._timer) {
+                clearTimeout(this._timer);
+            }
+            this._timer = setTimeout(() => {
+                this._timer = undefined;
+                this._onDidSettle.fire({
+                    ts: Date.now(),
+                    savedSeq: this._lastSaveSeq,
+                    entries: this._readAllDiagnostics(),
+                });
+            }, DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS);
+        });
+    }
+
+    dispose(): void {
+        if (this._timer) {
+            clearTimeout(this._timer);
+            this._timer = undefined;
+        }
+        this._subscription.dispose();
+        this._onDidSettle.dispose();
+    }
+}

--- a/extension/src/extension/services/sensing/index.ts
+++ b/extension/src/extension/services/sensing/index.ts
@@ -1,0 +1,5 @@
+// extension/src/extension/services/sensing/index.ts
+export type { SensorHub } from './sensorHub';
+export { VsCodeSensorHub } from './sensorHub';
+export { nextSensorSeq } from './sequence';
+export type * from './types';

--- a/extension/src/extension/services/sensing/sensorHub.ts
+++ b/extension/src/extension/services/sensing/sensorHub.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { PlatformCapabilities } from '@extension/theia';
 
+import { DiagnosticsSettleCollector } from './collectors/diagnosticsSettle';
 import { nextSensorSeq } from './sequence';
 import type {
     ActiveEditorSignal,
@@ -30,6 +31,8 @@ import type {
  * these typed channels instead of subscribing to `vscode.*` itself, and uses
  * the read* methods instead of global state reads. Policy (phase gates,
  * URI filters, debouncing, consent) lives in the consumers, NOT here.
+ * Exception: derived channels like onDiagnosticsSettled bundle the URI filter
+ * and settle debounce that define the channel itself.
  *
  * Production creates exactly ONE hub (extension.ts) and injects it
  * everywhere. The default-constructed hubs in TelemetryManager/SessionRecorder
@@ -244,9 +247,16 @@ export class VsCodeSensorHub implements SensorHub {
             hasShellExecution ? h => vscode.window.onDidEndTerminalShellExecution(h) : () => NOOP_SUBSCRIPTION,
             (event: vscode.TerminalShellExecutionEndEvent): ShellExecutionEndSignal => ({ ts: Date.now(), event }),
         );
-        // Task 3 replaces this inert stub with the DiagnosticsSettleCollector wiring.
+        // Derived channel: the settle collector (and through it the underlying
+        // save listener) exists only while someone consumes settled diagnostics.
         this.onDiagnosticsSettled = this._relay(
-            () => NOOP_SUBSCRIPTION,
+            handler => {
+                const collector = new DiagnosticsSettleCollector(
+                    this.onDidSaveTextDocument,
+                    () => this.readAllDiagnostics(),
+                );
+                return vscode.Disposable.from(collector.onDidSettle(handler), collector);
+            },
             (signal: DiagnosticsSettledSignal) => signal,
         );
     }

--- a/extension/src/extension/services/sensing/sensorHub.ts
+++ b/extension/src/extension/services/sensing/sensorHub.ts
@@ -142,8 +142,13 @@ class LazyRelay<TRaw, TSignal> implements vscode.Disposable {
     }
 }
 
-/** Inert subscription for APIs the current platform does not provide. */
-const NOOP_SUBSCRIPTION = new vscode.Disposable(() => { /* platform lacks this API */ });
+/**
+ * Inert subscription for APIs the current platform does not provide.
+ * Deliberately an object literal, not `new vscode.Disposable(...)`: this is
+ * module-level code, and constructing a VS Code class at import time breaks
+ * consumers loaded under partial `vscode` mocks (the vitest logic tests).
+ */
+const NOOP_SUBSCRIPTION: vscode.Disposable = { dispose: () => { /* platform lacks this API */ } };
 
 export class VsCodeSensorHub implements SensorHub {
     private readonly _disposables: vscode.Disposable[] = [];

--- a/extension/src/extension/services/sensing/sensorHub.ts
+++ b/extension/src/extension/services/sensing/sensorHub.ts
@@ -1,0 +1,246 @@
+import * as vscode from 'vscode';
+
+import type { PlatformCapabilities } from '@extension/theia';
+
+import { nextSensorSeq } from './sequence';
+import type {
+    ActiveEditorSignal,
+    BreakpointsSignal,
+    DebugSessionSignal,
+    DiagnosticsChangeSignal,
+    DiagnosticsSettledSignal,
+    FileRenameSignal,
+    FileSetSignal,
+    SaveSignal,
+    SelectionSignal,
+    ShellExecutionEndSignal,
+    ShellExecutionStartSignal,
+    TerminalSignal,
+    TextChangeSignal,
+    TextDocumentSignal,
+    VisibleRangesSignal,
+    WindowStateSignal,
+} from './types';
+
+/**
+ * The single place that reads VS Code APIs for behavioral sensing.
+ *
+ * Every consumer (session recorder, EQ logger, struggle engine) attaches to
+ * these typed channels instead of subscribing to `vscode.*` itself, and uses
+ * the read* methods instead of global state reads. Policy (phase gates,
+ * URI filters, debouncing, consent) lives in the consumers, NOT here.
+ *
+ * Production creates exactly ONE hub (extension.ts) and injects it
+ * everywhere. The default-constructed hubs in TelemetryManager/SessionRecorder
+ * exist only so tests can construct those classes standalone.
+ */
+export interface SensorHub extends vscode.Disposable {
+    readonly onDidChangeTextDocument: vscode.Event<TextChangeSignal>;
+    readonly onDidSaveTextDocument: vscode.Event<SaveSignal>;
+    readonly onDidChangeActiveTextEditor: vscode.Event<ActiveEditorSignal>;
+    readonly onDidChangeDiagnostics: vscode.Event<DiagnosticsChangeSignal>;
+    /** Save-triggered settle snapshot (500 ms after a save burst). */
+    readonly onDiagnosticsSettled: vscode.Event<DiagnosticsSettledSignal>;
+    readonly onDidChangeWindowState: vscode.Event<WindowStateSignal>;
+    readonly onDidChangeTextEditorSelection: vscode.Event<SelectionSignal>;
+    readonly onDidChangeTextEditorVisibleRanges: vscode.Event<VisibleRangesSignal>;
+    readonly onDidOpenTerminal: vscode.Event<TerminalSignal>;
+    readonly onDidCloseTerminal: vscode.Event<TerminalSignal>;
+    readonly onDidCreateFiles: vscode.Event<FileSetSignal>;
+    readonly onDidDeleteFiles: vscode.Event<FileSetSignal>;
+    readonly onDidRenameFiles: vscode.Event<FileRenameSignal>;
+    readonly onDidOpenTextDocument: vscode.Event<TextDocumentSignal>;
+    readonly onDidCloseTextDocument: vscode.Event<TextDocumentSignal>;
+    readonly onDidStartDebugSession: vscode.Event<DebugSessionSignal>;
+    readonly onDidTerminateDebugSession: vscode.Event<DebugSessionSignal>;
+    readonly onDidChangeActiveDebugSession: vscode.Event<DebugSessionSignal>;
+    readonly onDidChangeBreakpoints: vscode.Event<BreakpointsSignal>;
+    /** Not fired on platforms without the shellIntegration API (Theia). */
+    readonly onDidStartTerminalShellExecution: vscode.Event<ShellExecutionStartSignal>;
+    readonly onDidEndTerminalShellExecution: vscode.Event<ShellExecutionEndSignal>;
+
+    readAllDiagnostics(): ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]>;
+    readDiagnostics(uri: vscode.Uri): readonly vscode.Diagnostic[];
+    readWindowFocused(): boolean;
+    readVisibleTextEditors(): readonly vscode.TextEditor[];
+    readActiveTextEditor(): vscode.TextEditor | undefined;
+    readTerminals(): readonly vscode.Terminal[];
+    readBreakpoints(): readonly vscode.Breakpoint[];
+}
+
+/**
+ * A hub channel that subscribes to its VS Code source event only while at
+ * least one consumer is attached, and unsubscribes when the last detaches
+ * (PR1 decision log #1a). Fan-out is synchronous in attach order.
+ */
+class LazyRelay<TRaw, TSignal> implements vscode.Disposable {
+    private readonly _listeners = new Set<(signal: TSignal) => void>();
+    private _source: vscode.Disposable | undefined;
+
+    constructor(
+        private readonly _subscribe: (handler: (raw: TRaw) => void) => vscode.Disposable,
+        private readonly _map: (raw: TRaw) => TSignal,
+    ) {}
+
+    readonly event: vscode.Event<TSignal> = (listener, thisArgs?, disposables?) => {
+        const bound: (signal: TSignal) => void =
+            thisArgs !== undefined ? listener.bind(thisArgs) : listener;
+        this._listeners.add(bound);
+        if (this._listeners.size === 1) {
+            this._source = this._subscribe(raw => this._fan(this._map(raw)));
+        }
+        const subscription = new vscode.Disposable(() => {
+            this._listeners.delete(bound);
+            if (this._listeners.size === 0) {
+                this._source?.dispose();
+                this._source = undefined;
+            }
+        });
+        disposables?.push(subscription);
+        return subscription;
+    };
+
+    private _fan(signal: TSignal): void {
+        // Copy: a listener may attach/detach during fan-out.
+        for (const listener of [...this._listeners]) {
+            listener(signal);
+        }
+    }
+
+    dispose(): void {
+        this._listeners.clear();
+        this._source?.dispose();
+        this._source = undefined;
+    }
+}
+
+/** Inert subscription for APIs the current platform does not provide. */
+const NOOP_SUBSCRIPTION = new vscode.Disposable(() => { /* platform lacks this API */ });
+
+export class VsCodeSensorHub implements SensorHub {
+    private readonly _disposables: vscode.Disposable[] = [];
+
+    /** Create a lazily-subscribing channel and track it for dispose(). */
+    private _relay<TRaw, TSignal>(
+        subscribe: (handler: (raw: TRaw) => void) => vscode.Disposable,
+        map: (raw: TRaw) => TSignal,
+    ): vscode.Event<TSignal> {
+        const relay = new LazyRelay(subscribe, map);
+        this._disposables.push(relay);
+        return relay.event;
+    }
+
+    readonly onDidChangeTextDocument = this._relay(
+        h => vscode.workspace.onDidChangeTextDocument(h),
+        (event: vscode.TextDocumentChangeEvent): TextChangeSignal => ({ ts: Date.now(), event }),
+    );
+    readonly onDidSaveTextDocument = this._relay(
+        h => vscode.workspace.onDidSaveTextDocument(h),
+        (document: vscode.TextDocument): SaveSignal => ({ ts: Date.now(), seq: nextSensorSeq(), document }),
+    );
+    readonly onDidChangeActiveTextEditor = this._relay(
+        h => vscode.window.onDidChangeActiveTextEditor(h),
+        (editor: vscode.TextEditor | undefined): ActiveEditorSignal => ({ ts: Date.now(), editor }),
+    );
+    readonly onDidChangeDiagnostics = this._relay(
+        h => vscode.languages.onDidChangeDiagnostics(h),
+        (event: vscode.DiagnosticChangeEvent): DiagnosticsChangeSignal => ({ ts: Date.now(), uris: event.uris }),
+    );
+    readonly onDidChangeWindowState = this._relay(
+        h => vscode.window.onDidChangeWindowState(h),
+        (state: vscode.WindowState): WindowStateSignal => ({ ts: Date.now(), state }),
+    );
+    readonly onDidChangeTextEditorSelection = this._relay(
+        h => vscode.window.onDidChangeTextEditorSelection(h),
+        (event: vscode.TextEditorSelectionChangeEvent): SelectionSignal => ({ ts: Date.now(), event }),
+    );
+    readonly onDidChangeTextEditorVisibleRanges = this._relay(
+        h => vscode.window.onDidChangeTextEditorVisibleRanges(h),
+        (event: vscode.TextEditorVisibleRangesChangeEvent): VisibleRangesSignal => ({ ts: Date.now(), event }),
+    );
+    readonly onDidOpenTerminal = this._relay(
+        h => vscode.window.onDidOpenTerminal(h),
+        (terminal: vscode.Terminal): TerminalSignal => ({ ts: Date.now(), terminal }),
+    );
+    readonly onDidCloseTerminal = this._relay(
+        h => vscode.window.onDidCloseTerminal(h),
+        (terminal: vscode.Terminal): TerminalSignal => ({ ts: Date.now(), terminal }),
+    );
+    readonly onDidCreateFiles = this._relay(
+        h => vscode.workspace.onDidCreateFiles(h),
+        (event: vscode.FileCreateEvent): FileSetSignal => ({ ts: Date.now(), files: event.files }),
+    );
+    readonly onDidDeleteFiles = this._relay(
+        h => vscode.workspace.onDidDeleteFiles(h),
+        (event: vscode.FileDeleteEvent): FileSetSignal => ({ ts: Date.now(), files: event.files }),
+    );
+    readonly onDidRenameFiles = this._relay(
+        h => vscode.workspace.onDidRenameFiles(h),
+        (event: vscode.FileRenameEvent): FileRenameSignal => ({ ts: Date.now(), files: event.files }),
+    );
+    readonly onDidOpenTextDocument = this._relay(
+        h => vscode.workspace.onDidOpenTextDocument(h),
+        (document: vscode.TextDocument): TextDocumentSignal => ({ ts: Date.now(), document }),
+    );
+    readonly onDidCloseTextDocument = this._relay(
+        h => vscode.workspace.onDidCloseTextDocument(h),
+        (document: vscode.TextDocument): TextDocumentSignal => ({ ts: Date.now(), document }),
+    );
+    readonly onDidStartDebugSession = this._relay(
+        h => vscode.debug.onDidStartDebugSession(h),
+        (session: vscode.DebugSession): DebugSessionSignal => ({ ts: Date.now(), session }),
+    );
+    readonly onDidTerminateDebugSession = this._relay(
+        h => vscode.debug.onDidTerminateDebugSession(h),
+        (session: vscode.DebugSession): DebugSessionSignal => ({ ts: Date.now(), session }),
+    );
+    readonly onDidChangeActiveDebugSession = this._relay(
+        h => vscode.debug.onDidChangeActiveDebugSession(h),
+        (session: vscode.DebugSession | undefined): DebugSessionSignal => ({ ts: Date.now(), session }),
+    );
+    readonly onDidChangeBreakpoints = this._relay(
+        h => vscode.debug.onDidChangeBreakpoints(h),
+        (event: vscode.BreakpointsChangeEvent): BreakpointsSignal => ({ ts: Date.now(), event }),
+    );
+    // Capability-dependent and derived channels are assigned in the constructor.
+    readonly onDidStartTerminalShellExecution: vscode.Event<ShellExecutionStartSignal>;
+    readonly onDidEndTerminalShellExecution: vscode.Event<ShellExecutionEndSignal>;
+    readonly onDiagnosticsSettled: vscode.Event<DiagnosticsSettledSignal>;
+
+    constructor(capabilities?: PlatformCapabilities) {
+        // Shell-execution API is Desktop-only; the capability flag guards the
+        // subscription so Theia builds never touch the missing API.
+        const hasShellExecution = capabilities?.hasTerminalShellExecution !== false;
+        this.onDidStartTerminalShellExecution = this._relay(
+            hasShellExecution ? h => vscode.window.onDidStartTerminalShellExecution(h) : () => NOOP_SUBSCRIPTION,
+            (event: vscode.TerminalShellExecutionStartEvent): ShellExecutionStartSignal => ({ ts: Date.now(), event }),
+        );
+        this.onDidEndTerminalShellExecution = this._relay(
+            hasShellExecution ? h => vscode.window.onDidEndTerminalShellExecution(h) : () => NOOP_SUBSCRIPTION,
+            (event: vscode.TerminalShellExecutionEndEvent): ShellExecutionEndSignal => ({ ts: Date.now(), event }),
+        );
+        // Task 3 replaces this inert stub with the DiagnosticsSettleCollector wiring.
+        this.onDiagnosticsSettled = this._relay(
+            () => NOOP_SUBSCRIPTION,
+            (signal: DiagnosticsSettledSignal) => signal,
+        );
+    }
+
+    readAllDiagnostics(): ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]> {
+        return vscode.languages.getDiagnostics();
+    }
+    readDiagnostics(uri: vscode.Uri): readonly vscode.Diagnostic[] {
+        return vscode.languages.getDiagnostics(uri);
+    }
+    readWindowFocused(): boolean { return vscode.window.state.focused; }
+    readVisibleTextEditors(): readonly vscode.TextEditor[] { return vscode.window.visibleTextEditors; }
+    readActiveTextEditor(): vscode.TextEditor | undefined { return vscode.window.activeTextEditor; }
+    readTerminals(): readonly vscode.Terminal[] { return vscode.window.terminals; }
+    readBreakpoints(): readonly vscode.Breakpoint[] { return vscode.debug.breakpoints; }
+
+    dispose(): void {
+        while (this._disposables.length > 0) {
+            this._disposables.pop()?.dispose();
+        }
+    }
+}

--- a/extension/src/extension/services/sensing/sensorHub.ts
+++ b/extension/src/extension/services/sensing/sensorHub.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { LogCategory, logger } from '@extension/services/loggingService';
 import type { PlatformCapabilities } from '@extension/theia';
 
 import { nextSensorSeq } from './sequence';
@@ -74,8 +75,13 @@ export interface SensorHub extends vscode.Disposable {
  * (PR1 decision log #1a). Fan-out is synchronous in attach order.
  */
 class LazyRelay<TRaw, TSignal> implements vscode.Disposable {
-    private readonly _listeners = new Set<(signal: TSignal) => void>();
+    // One entry per subscription (NOT per unique function): the same listener
+    // registered twice must hold two independent subscriptions, exactly like
+    // vscode.EventEmitter. A Set of raw functions would silently collapse
+    // duplicates and corrupt the refcount.
+    private readonly _subscriptions = new Set<{ call: (signal: TSignal) => void }>();
     private _source: vscode.Disposable | undefined;
+    private _disposed = false;
 
     constructor(
         private readonly _subscribe: (handler: (raw: TRaw) => void) => vscode.Disposable,
@@ -83,15 +89,24 @@ class LazyRelay<TRaw, TSignal> implements vscode.Disposable {
     ) {}
 
     readonly event: vscode.Event<TSignal> = (listener, thisArgs?, disposables?) => {
+        if (this._disposed) {
+            // Post-dispose attach must not resurrect the VS Code subscription:
+            // dispose() drains the hub's tracking, so a resurrected source
+            // could never be cleaned up again.
+            const inert = new vscode.Disposable(() => { /* relay disposed */ });
+            disposables?.push(inert);
+            return inert;
+        }
         const bound: (signal: TSignal) => void =
             thisArgs !== undefined ? listener.bind(thisArgs) : listener;
-        this._listeners.add(bound);
-        if (this._listeners.size === 1) {
+        const entry = { call: bound };
+        this._subscriptions.add(entry);
+        if (this._subscriptions.size === 1) {
             this._source = this._subscribe(raw => this._fan(this._map(raw)));
         }
         const subscription = new vscode.Disposable(() => {
-            this._listeners.delete(bound);
-            if (this._listeners.size === 0) {
+            this._subscriptions.delete(entry);
+            if (this._subscriptions.size === 0) {
                 this._source?.dispose();
                 this._source = undefined;
             }
@@ -101,14 +116,24 @@ class LazyRelay<TRaw, TSignal> implements vscode.Disposable {
     };
 
     private _fan(signal: TSignal): void {
-        // Copy: a listener may attach/detach during fan-out.
-        for (const listener of [...this._listeners]) {
-            listener(signal);
+        // Copy: a subscription may attach/detach during fan-out. Chosen
+        // semantics: a subscription disposed mid-fan-out still receives the
+        // in-flight signal. Errors are isolated per listener so one throwing
+        // consumer cannot suppress delivery to the others (matching the
+        // pre-hub world, where each consumer held its own VS Code
+        // subscription and VS Code isolated listener errors).
+        for (const entry of [...this._subscriptions]) {
+            try {
+                entry.call(signal);
+            } catch (err) {
+                logger.error('Sensor channel listener threw', LogCategory.TELEMETRY, err);
+            }
         }
     }
 
     dispose(): void {
-        this._listeners.clear();
+        this._disposed = true;
+        this._subscriptions.clear();
         this._source?.dispose();
         this._source = undefined;
     }
@@ -210,7 +235,7 @@ export class VsCodeSensorHub implements SensorHub {
     constructor(capabilities?: PlatformCapabilities) {
         // Shell-execution API is Desktop-only; the capability flag guards the
         // subscription so Theia builds never touch the missing API.
-        const hasShellExecution = capabilities?.hasTerminalShellExecution !== false;
+        const hasShellExecution = capabilities?.hasTerminalShellExecution ?? true;
         this.onDidStartTerminalShellExecution = this._relay(
             hasShellExecution ? h => vscode.window.onDidStartTerminalShellExecution(h) : () => NOOP_SUBSCRIPTION,
             (event: vscode.TerminalShellExecutionStartEvent): ShellExecutionStartSignal => ({ ts: Date.now(), event }),

--- a/extension/src/extension/services/sensing/sequence.ts
+++ b/extension/src/extension/services/sensing/sequence.ts
@@ -1,0 +1,14 @@
+// extension/src/extension/services/sensing/sequence.ts
+/**
+ * Strictly monotonic ordering token for sensor events. All sensing and
+ * session-lifecycle code runs on the extension host's single JS thread, so
+ * consuming one counter yields a strict total order: an event that happened
+ * before another always carries a smaller token. Used where timestamp
+ * comparison would be ambiguous within one millisecond (decision log #1b).
+ */
+let counter = 0;
+
+export function nextSensorSeq(): number {
+    counter += 1;
+    return counter;
+}

--- a/extension/src/extension/services/sensing/types.ts
+++ b/extension/src/extension/services/sensing/types.ts
@@ -1,0 +1,48 @@
+// extension/src/extension/services/sensing/types.ts
+/**
+ * Typed payloads for the sensing layer (see services/sensing/sensorHub.ts).
+ *
+ * `ts` is the canonical arrival timestamp: Date.now() captured synchronously
+ * when the VS Code event fires, before any fan-out. Downstream consumers that
+ * need event time must use this value instead of re-stamping, so that live
+ * operation and offline replay agree (struggle-engine requirement).
+ */
+import type * as vscode from 'vscode';
+
+export interface Stamped {
+    readonly ts: number;
+}
+
+export interface TextChangeSignal extends Stamped { readonly event: vscode.TextDocumentChangeEvent }
+export interface SaveSignal extends Stamped {
+    /** Strictly monotonic arrival token (see sensing/sequence.ts). */
+    readonly seq: number;
+    readonly document: vscode.TextDocument;
+}
+export interface ActiveEditorSignal extends Stamped { readonly editor: vscode.TextEditor | undefined }
+export interface DiagnosticsChangeSignal extends Stamped { readonly uris: readonly vscode.Uri[] }
+/** Bulk diagnostics dump taken 500 ms after a save burst (language-server settle). */
+export interface DiagnosticsSettledSignal extends Stamped {
+    /**
+     * Ordering token of the most recent save in the coalesced burst. Consumers
+     * with session semantics (EQ emitter) compare it against their own
+     * session-start token to drop settles whose triggering save predates the
+     * session (PR1 decision log #1b). Tokens, not timestamps: a save and a
+     * session switch in the same millisecond must still be strictly ordered.
+     */
+    readonly savedSeq: number;
+    readonly entries: ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]>;
+}
+export interface WindowStateSignal extends Stamped { readonly state: vscode.WindowState }
+export interface SelectionSignal extends Stamped { readonly event: vscode.TextEditorSelectionChangeEvent }
+export interface VisibleRangesSignal extends Stamped { readonly event: vscode.TextEditorVisibleRangesChangeEvent }
+export interface TerminalSignal extends Stamped { readonly terminal: vscode.Terminal }
+export interface FileSetSignal extends Stamped { readonly files: readonly vscode.Uri[] }
+export interface FileRenameSignal extends Stamped {
+    readonly files: ReadonlyArray<{ readonly oldUri: vscode.Uri; readonly newUri: vscode.Uri }>;
+}
+export interface TextDocumentSignal extends Stamped { readonly document: vscode.TextDocument }
+export interface DebugSessionSignal extends Stamped { readonly session: vscode.DebugSession | undefined }
+export interface BreakpointsSignal extends Stamped { readonly event: vscode.BreakpointsChangeEvent }
+export interface ShellExecutionStartSignal extends Stamped { readonly event: vscode.TerminalShellExecutionStartEvent }
+export interface ShellExecutionEndSignal extends Stamped { readonly event: vscode.TerminalShellExecutionEndEvent }

--- a/extension/src/extension/services/sensing/types.ts
+++ b/extension/src/extension/services/sensing/types.ts
@@ -9,7 +9,7 @@
  */
 import type * as vscode from 'vscode';
 
-export interface Stamped {
+interface Stamped {
     readonly ts: number;
 }
 

--- a/extension/src/extension/services/telemetry/diagnosticPersistenceService.ts
+++ b/extension/src/extension/services/telemetry/diagnosticPersistenceService.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 
+import { type SensorHub, VsCodeSensorHub } from '@extension/services/sensing';
+
 import { SessionResettable, SessionStartContext, TrackedDiagnostic } from './types';
 
 /**
@@ -9,6 +11,8 @@ import { SessionResettable, SessionStartContext, TrackedDiagnostic } from './typ
  */
 export class DiagnosticPersistenceService implements vscode.Disposable, SessionResettable {
     private readonly _disposables: vscode.Disposable[] = [];
+    private readonly _hub: SensorHub;
+    private readonly _ownsHub: boolean;
     protected readonly _trackedDiagnostics: Map<string, TrackedDiagnostic> = new Map();
     private _cleanupTimer: NodeJS.Timeout | undefined;
 
@@ -20,7 +24,9 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
     protected readonly _onDidUpdateDiagnostics = new vscode.EventEmitter<TrackedDiagnostic[]>();
     public readonly onDidUpdateDiagnostics = this._onDidUpdateDiagnostics.event;
 
-    constructor() {
+    constructor(sensorHub?: SensorHub) {
+        this._hub = sensorHub ?? new VsCodeSensorHub();
+        this._ownsHub = sensorHub === undefined;
         this._startTracking();
         this._startCleanupTimer();
     }
@@ -38,6 +44,10 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
 
         this._onDidUpdateDiagnostics.dispose();
         this._trackedDiagnostics.clear();
+
+        if (this._ownsHub) {
+            this._hub.dispose();
+        }
     }
 
     /**
@@ -52,8 +62,8 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
      * Start listening to diagnostic changes
      */
     private _startTracking(): void {
-        const diagnosticListener = vscode.languages.onDidChangeDiagnostics(event => {
-            this._handleDiagnosticChange(event);
+        const diagnosticListener = this._hub.onDidChangeDiagnostics(({ uris }) => {
+            this._handleDiagnosticChange(uris);
         });
         this._disposables.push(diagnosticListener);
 
@@ -74,7 +84,7 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
      * Process all diagnostics in the workspace
      */
     private _processAllWorkspaceDiagnostics(): void {
-        const allDiagnostics = vscode.languages.getDiagnostics();
+        const allDiagnostics = this._hub.readAllDiagnostics();
         for (const [uri, diagnostics] of allDiagnostics) {
             this._updateDiagnosticsForUri(uri, diagnostics);
         }
@@ -83,14 +93,14 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
     /**
      * Handle diagnostic change events
      */
-    private _handleDiagnosticChange(event: vscode.DiagnosticChangeEvent): void {
-        for (const uri of event.uris) {
-            const diagnostics = vscode.languages.getDiagnostics(uri);
+    private _handleDiagnosticChange(uris: readonly vscode.Uri[]): void {
+        for (const uri of uris) {
+            const diagnostics = this._hub.readDiagnostics(uri);
             this._updateDiagnosticsForUri(uri, diagnostics);
         }
 
         // Mark diagnostics that no longer exist as resolved
-        this._markMissingDiagnosticsResolved(event.uris);
+        this._markMissingDiagnosticsResolved(uris);
 
         this._onDidUpdateDiagnostics.fire(Array.from(this._trackedDiagnostics.values()));
     }
@@ -158,7 +168,7 @@ export class DiagnosticPersistenceService implements vscode.Disposable, SessionR
             if (changedUriStrings.has(tracked.uri) && !tracked.resolved) {
                 // Check if this diagnostic still exists
                 const uri = vscode.Uri.parse(tracked.uri);
-                const currentDiagnostics = vscode.languages.getDiagnostics(uri);
+                const currentDiagnostics = this._hub.readDiagnostics(uri);
                 const stillExists = currentDiagnostics.some(d =>
                     this._generateDiagnosticId(uri, d) === id
                 );

--- a/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
+++ b/extension/src/extension/services/telemetry/eventPipeline/compileEquivalentEmitter.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { type DiagnosticsSettledSignal, nextSensorSeq } from '@extension/services/sensing';
 import { buildErrorFamiliesFromFeedbacks } from '@extension/services/telemetry/metrics/buildErrorFamily';
 import { shouldDedupSnapshot } from '@extension/services/telemetry/metrics/snapshotDedup';
 import {
@@ -18,20 +19,17 @@ import { ResultDTO } from '@extension/types';
 import { LINT_SOURCE_DENYLIST } from './lintDenylist';
 
 /**
- * Emits CompileEquivalentEvents from save events and build results.
+ * Emits CompileEquivalentEvents from settled diagnostics dumps and build results.
  *
  * [ADAPTATION] Paper: "Compilation Event" = student clicks Compile in BlueJ.
- * VS Code: save event (with 500ms LS delay) or Artemis build result.
+ * VS Code: save event (500ms LS settle, handled by the sensing layer) or
+ * Artemis build result.
  */
 export class CompileEquivalentEmitter implements vscode.Disposable, SessionResettable {
-    /** Delay after save for Language Server to update diagnostics [Engineering choice] */
-    private static readonly LS_SETTLE_DELAY_MS = 500;
-
-    private readonly _disposables: vscode.Disposable[] = [];
     private readonly _config: EQConfig;
     private _exerciseRoot: vscode.Uri | undefined;
     private _lastSnapshot: ErrorSnapshot | undefined;
-    private _saveTimeout: NodeJS.Timeout | undefined;
+    private _sessionStartSeq = 0;
 
     private readonly _onDidEmitCompileEquivalent = new vscode.EventEmitter<CompileEquivalentEvent>();
     public readonly onDidEmitCompileEquivalent = this._onDidEmitCompileEquivalent.event;
@@ -41,44 +39,30 @@ export class CompileEquivalentEmitter implements vscode.Disposable, SessionReset
     }
 
     public dispose(): void {
-        if (this._saveTimeout) {
-            clearTimeout(this._saveTimeout);
-            this._saveTimeout = undefined;
-        }
-        while (this._disposables.length > 0) {
-            this._disposables.pop()?.dispose();
-        }
         this._onDidEmitCompileEquivalent.dispose();
     }
 
     /**
-     * Handle a save event — delays 500ms for LS to update diagnostics,
-     * then creates an ErrorSnapshot from current diagnostics.
+     * Handle a settled diagnostics dump from the sensing layer (save-triggered,
+     * 500 ms LS settle; see sensing/collectors/diagnosticsSettle.ts). Fires
+     * onDidEmitCompileEquivalent when the snapshot is novel.
      */
-    public handleSaveEvent(doc: vscode.TextDocument): void {
-        // Only handle recordable documents (file: scheme, not git/output/etc.)
-        if (!shouldRecordUri(doc.uri)) {
+    public handleDiagnosticsSettled(signal: DiagnosticsSettledSignal): void {
+        if (signal.savedSeq < this._sessionStartSeq) {
+            // The triggering save belongs to the previous session; v1 cleared
+            // its pending save timer at this boundary (decision log #1b).
             return;
         }
-
-        // Clear any pending save timeout (coalesce rapid saves)
-        if (this._saveTimeout) {
-            clearTimeout(this._saveTimeout);
+        const snapshot = this.createErrorSnapshotFromDiagnostics(signal.entries, signal.ts);
+        if (!this._shouldAddSnapshot(snapshot)) {
+            return;
         }
-
-        // 500ms delay for Language Server to process [Engineering choice]
-        this._saveTimeout = setTimeout(() => {
-            this._saveTimeout = undefined;
-            const snapshot = this.createErrorSnapshotFromDiagnostics();
-            if (this._shouldAddSnapshot(snapshot)) {
-                this._lastSnapshot = snapshot;
-                this._onDidEmitCompileEquivalent.fire({
-                    timestamp: snapshot.timestamp,
-                    source: 'save',
-                    snapshot,
-                });
-            }
-        }, CompileEquivalentEmitter.LS_SETTLE_DELAY_MS);
+        this._lastSnapshot = snapshot;
+        this._onDidEmitCompileEquivalent.fire({
+            timestamp: snapshot.timestamp,
+            source: 'save',
+            snapshot,
+        });
     }
 
     /**
@@ -112,6 +96,7 @@ export class CompileEquivalentEmitter implements vscode.Disposable, SessionReset
     public onSessionStart(context: SessionStartContext): void {
         this.reset();
         this.setExerciseRoot(context.exerciseRoot);
+        this._sessionStartSeq = nextSensorSeq();
     }
 
     /**
@@ -119,42 +104,32 @@ export class CompileEquivalentEmitter implements vscode.Disposable, SessionReset
      */
     public reset(): void {
         this._lastSnapshot = undefined;
-        if (this._saveTimeout) {
-            clearTimeout(this._saveTimeout);
-            this._saveTimeout = undefined;
-        }
     }
 
     /**
-     * Create an ErrorSnapshot from current VS Code diagnostics.
+     * Create an ErrorSnapshot from a settled diagnostics dump (sensor event).
      * Filters to exercise files, severity=Error, and excludes lint sources.
      */
-    public createErrorSnapshotFromDiagnostics(): ErrorSnapshot {
-        const allDiagnostics = vscode.languages.getDiagnostics();
+    private createErrorSnapshotFromDiagnostics(
+        entries: ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]>,
+        timestamp: number,
+    ): ErrorSnapshot {
         const errorFamilies = new Set<string>();
         let errorCount = 0;
 
-        for (const [uri, diagnostics] of allDiagnostics) {
-            // Exercise scoping: only include URIs that pass the central filter.
+        for (const [uri, diagnostics] of entries) {
             if (!shouldRecordUri(uri, this._exerciseRoot)) {
                 continue;
             }
-
             for (const d of diagnostics) {
                 if (isCompilerDiagnostic(d)) {
-                    const family = getErrorFamily(d);
-                    errorFamilies.add(family);
+                    errorFamilies.add(getErrorFamily(d));
                     errorCount++;
                 }
             }
         }
 
-        return {
-            timestamp: Date.now(),
-            hasErrors: errorCount > 0,
-            errorFamilies,
-            errorCount,
-        };
+        return { timestamp, hasErrors: errorCount > 0, errorFamilies, errorCount };
     }
 
     /**

--- a/extension/src/extension/services/telemetry/inactivityService.ts
+++ b/extension/src/extension/services/telemetry/inactivityService.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { type SensorHub, VsCodeSensorHub } from '@extension/services/sensing';
+
 import { InactivityPattern, SessionResettable, SessionStartContext } from './types';
 
 /**
@@ -8,6 +10,8 @@ import { InactivityPattern, SessionResettable, SessionStartContext } from './typ
  */
 export class InactivityService implements vscode.Disposable, SessionResettable {
     private readonly _disposables: vscode.Disposable[] = [];
+    private readonly _hub: SensorHub;
+    private readonly _ownsHub: boolean;
     private _lastEditTimestamp: number = Date.now();
     /**
      * Weak activity timestamp for cursor movements.
@@ -42,8 +46,10 @@ export class InactivityService implements vscode.Disposable, SessionResettable {
     private readonly _onDidResumeActivity = new vscode.EventEmitter<void>();
     public readonly onDidResumeActivity = this._onDidResumeActivity.event;
 
-    constructor() {
-        this._startTracking();
+    constructor(sensorHub?: SensorHub) {
+        this._hub = sensorHub ?? new VsCodeSensorHub();
+        this._ownsHub = sensorHub === undefined;
+        this._startTracking(this._hub);
         this._startPatternCheck();
     }
 
@@ -59,13 +65,17 @@ export class InactivityService implements vscode.Disposable, SessionResettable {
         }
 
         this._onDidResumeActivity.dispose();
+
+        if (this._ownsHub) {
+            this._hub.dispose();
+        }
     }
 
     /**
      * Start listening to document changes
      */
-    private _startTracking(): void {
-        const changeListener = vscode.workspace.onDidChangeTextDocument(event => {
+    private _startTracking(hub: SensorHub): void {
+        const changeListener = hub.onDidChangeTextDocument(({ event }) => {
             // Ignore non-file schemes and empty changes
             if (event.document.uri.scheme !== 'file' || event.contentChanges.length === 0) {
                 return;
@@ -75,7 +85,7 @@ export class InactivityService implements vscode.Disposable, SessionResettable {
         this._disposables.push(changeListener);
 
         // Also track when user saves
-        const saveListener = vscode.workspace.onDidSaveTextDocument(document => {
+        const saveListener = hub.onDidSaveTextDocument(({ document }) => {
             if (document.uri.scheme === 'file') {
                 this._recordActivity();
             }
@@ -86,7 +96,7 @@ export class InactivityService implements vscode.Disposable, SessionResettable {
         // Cursor movement prevents 'active' -> 'thinking' transition
         // but does NOT reset deeper inactivity states ('thinking' -> 'confusion' or 'confusion' -> 'giving-up')
         // Research shows cursor movement without editing often indicates confusion/reading
-        const selectionListener = vscode.window.onDidChangeTextEditorSelection(event => {
+        const selectionListener = hub.onDidChangeTextEditorSelection(({ event }) => {
             if (event.textEditor.document.uri.scheme === 'file') {
                 this._recordWeakActivity();
             }

--- a/extension/src/extension/services/telemetry/recording/eventCollectors.ts
+++ b/extension/src/extension/services/telemetry/recording/eventCollectors.ts
@@ -84,8 +84,7 @@ export function collectFileSwitch(
     };
 }
 
-export function collectDiagnostics(uri: vscode.Uri): DiagnosticsEvent {
-    const diagnostics = vscode.languages.getDiagnostics(uri);
+export function collectDiagnostics(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): DiagnosticsEvent {
     return {
         type: 'diagnostics',
         timestamp: Date.now(),

--- a/extension/src/extension/services/telemetry/recording/lifecycleController.ts
+++ b/extension/src/extension/services/telemetry/recording/lifecycleController.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
+import type { SensorHub } from '@extension/services/sensing';
 import type { ObservationRegistry } from '@extension/services/telemetry/recording/observation/observationRegistry';
 import type { SnapshotManager } from '@extension/services/telemetry/recording/snapshots/snapshotManager';
 import type { StartupCapture, StartupContext } from '@extension/services/telemetry/recording/startup/startupCapture';
@@ -231,6 +232,7 @@ interface LifecycleControllerDeps {
     snapshots: SnapshotManager;
     observation: ObservationRegistry;
     startup: StartupCapture;
+    hub: SensorHub;
     /**
      * Synchronous hook fired after state transitions that should notify
      * SessionRecorder's onDidChangeState subscribers. Facade implementation
@@ -409,7 +411,7 @@ export class LifecycleController {
         });
         const exerciseRootUri = exerciseRoot ? vscode.Uri.parse(exerciseRoot) : undefined;
         this._deps.observation.setExerciseContext(exerciseRootUri);
-        this._deps.observation.seedActiveEditor(vscode.window.activeTextEditor?.document.uri.toString());
+        this._deps.observation.seedActiveEditor(this._deps.hub.readActiveTextEditor()?.document.uri.toString());
 
         await this._deps.writer.initSession(sessionId);
 

--- a/extension/src/extension/services/telemetry/recording/observation/observationRegistry.ts
+++ b/extension/src/extension/services/telemetry/recording/observation/observationRegistry.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
+import type { SensorHub } from '@extension/services/sensing';
 import {
     collectBreakpointChange,
     collectDebugSession,
@@ -17,7 +18,6 @@ import type { RecorderLifecycleState } from '@extension/services/telemetry/recor
 import type { SnapshotManager } from '@extension/services/telemetry/recording/snapshots/snapshotManager';
 import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
 import { shouldRecordUri } from '@extension/services/telemetry/uriFilter';
-import type { PlatformCapabilities } from '@extension/theia';
 
 import { TerminalCollector } from './terminalCollector';
 
@@ -29,12 +29,13 @@ interface ObservationRegistryDeps {
         opts: { allowDuringStartup?: boolean; allowDuringEnding?: boolean },
         generation: number,
     ) => void;
-    capabilities?: PlatformCapabilities;
+    hub: SensorHub;
 }
 
 /**
- * Owns every VS Code `onDidChange*` subscription used by the recorder, plus
- * the debounce state for selection/visibleRange events.
+ * Owns the recorder's handler attachment to the SensorHub (the hub owns the
+ * actual VS Code subscriptions), plus the debounce state for
+ * selection/visibleRange events.
  *
  * Listener lifetime matches the consent enable/disable cycle, not the
  * session lifecycle: once enabled, subscriptions persist across session
@@ -97,10 +98,11 @@ export class ObservationRegistry {
     // ── Subscription registration (enable-scoped) ─────────────────────
 
     enable(): void {
+        const hub = this._deps.hub;
         const recordingPhase = (): boolean => this._deps.state.phase === 'recording';
 
         // Text changes
-        const textChange = vscode.workspace.onDidChangeTextDocument(event => {
+        const textChange = hub.onDidChangeTextDocument(({ event }) => {
             if (!recordingPhase()) { return; }
             if (!shouldRecordUri(event.document.uri, this._exerciseRootUri)) { return; }
             if (event.contentChanges.length === 0) { return; }
@@ -109,7 +111,7 @@ export class ObservationRegistry {
         this._eventListenerDisposables.push(textChange);
 
         // File save
-        const save = vscode.workspace.onDidSaveTextDocument(doc => {
+        const save = hub.onDidSaveTextDocument(({ document: doc }) => {
             if (!recordingPhase()) { return; }
             if (!shouldRecordUri(doc.uri, this._exerciseRootUri)) { return; }
             this._deps.record(collectSave(doc), {}, this._deps.state.currentGeneration);
@@ -117,7 +119,7 @@ export class ObservationRegistry {
         this._eventListenerDisposables.push(save);
 
         // Active editor switch + snapshot on first open
-        const editorSwitch = vscode.window.onDidChangeActiveTextEditor(editor => {
+        const editorSwitch = hub.onDidChangeActiveTextEditor(({ editor }) => {
             if (!recordingPhase()) { return; }
             const prev = this._lastActiveEditorUri;
             const toUri = editor?.document.uri.toString();
@@ -135,17 +137,17 @@ export class ObservationRegistry {
         this._eventListenerDisposables.push(editorSwitch);
 
         // Diagnostics changes
-        const diagnosticsChange = vscode.languages.onDidChangeDiagnostics(event => {
+        const diagnosticsChange = hub.onDidChangeDiagnostics(({ uris }) => {
             if (!recordingPhase()) { return; }
-            for (const uri of event.uris) {
+            for (const uri of uris) {
                 if (!shouldRecordUri(uri, this._exerciseRootUri)) { continue; }
-                this._deps.record(collectDiagnostics(uri), {}, this._deps.state.currentGeneration);
+                this._deps.record(collectDiagnostics(uri, hub.readDiagnostics(uri)), {}, this._deps.state.currentGeneration);
             }
         });
         this._eventListenerDisposables.push(diagnosticsChange);
 
         // Window focus
-        const windowFocus = vscode.window.onDidChangeWindowState(state => {
+        const windowFocus = hub.onDidChangeWindowState(({ state }) => {
             if (!recordingPhase()) { return; }
             this._deps.record(collectWindowFocus(state), {}, this._deps.state.currentGeneration);
         });
@@ -154,7 +156,7 @@ export class ObservationRegistry {
         // Selection changes (debounced 200ms, per-URI — Block J).
         // Payload serialized at trigger time; generation captured at trigger
         // time and passed to the delayed record call.
-        const selectionChange = vscode.window.onDidChangeTextEditorSelection(event => {
+        const selectionChange = hub.onDidChangeTextEditorSelection(({ event }) => {
             if (!recordingPhase()) { return; }
             if (!shouldRecordUri(event.textEditor.document.uri, this._exerciseRootUri)) { return; }
             const uri = event.textEditor.document.uri.toString();
@@ -175,7 +177,7 @@ export class ObservationRegistry {
         this._eventListenerDisposables.push(selectionChange);
 
         // Visible range changes (debounced 300ms, per-URI — Block J).
-        const visibleRangeChange = vscode.window.onDidChangeTextEditorVisibleRanges(event => {
+        const visibleRangeChange = hub.onDidChangeTextEditorVisibleRanges(({ event }) => {
             if (!recordingPhase()) { return; }
             if (!shouldRecordUri(event.textEditor.document.uri, this._exerciseRootUri)) { return; }
             const uri = event.textEditor.document.uri.toString();
@@ -196,7 +198,7 @@ export class ObservationRegistry {
         this._eventListenerDisposables.push(visibleRangeChange);
 
         // Terminal open/close
-        const terminalOpen = vscode.window.onDidOpenTerminal(terminal => {
+        const terminalOpen = hub.onDidOpenTerminal(({ terminal }) => {
             if (!recordingPhase()) { return; }
             this._deps.record({
                 type: 'terminalOpenClose',
@@ -207,7 +209,7 @@ export class ObservationRegistry {
         });
         this._eventListenerDisposables.push(terminalOpen);
 
-        const terminalClose = vscode.window.onDidCloseTerminal(terminal => {
+        const terminalClose = hub.onDidCloseTerminal(({ terminal }) => {
             if (!recordingPhase()) { return; }
             this._deps.record({
                 type: 'terminalOpenClose',
@@ -224,18 +226,18 @@ export class ObservationRegistry {
         // (`_emitMultiFileEvent`, `_emitTextDocumentEvent`). fileRename has its
         // own shape (two URIs per entry, accept-if-either-side-in-root) and
         // stays inline.
-        const fileCreate = vscode.workspace.onDidCreateFiles(event =>
-            this._emitMultiFileEvent(event.files, 'fileCreate'));
+        const fileCreate = hub.onDidCreateFiles(({ files }) =>
+            this._emitMultiFileEvent(files, 'fileCreate'));
         this._eventListenerDisposables.push(fileCreate);
 
-        const fileDelete = vscode.workspace.onDidDeleteFiles(event =>
-            this._emitMultiFileEvent(event.files, 'fileDelete'));
+        const fileDelete = hub.onDidDeleteFiles(({ files }) =>
+            this._emitMultiFileEvent(files, 'fileDelete'));
         this._eventListenerDisposables.push(fileDelete);
 
-        const fileRename = vscode.workspace.onDidRenameFiles(event => {
+        const fileRename = hub.onDidRenameFiles(({ files }) => {
             if (!recordingPhase()) { return; }
             const gen = this._deps.state.currentGeneration;
-            for (const { oldUri, newUri } of event.files) {
+            for (const { oldUri, newUri } of files) {
                 if (!shouldRecordUri(oldUri, this._exerciseRootUri) && !shouldRecordUri(newUri, this._exerciseRootUri)) {
                     continue;
                 }
@@ -249,42 +251,42 @@ export class ObservationRegistry {
         });
         this._eventListenerDisposables.push(fileRename);
 
-        const textDocumentOpen = vscode.workspace.onDidOpenTextDocument(doc =>
+        const textDocumentOpen = hub.onDidOpenTextDocument(({ document: doc }) =>
             this._emitTextDocumentEvent(doc, 'textDocumentOpen'));
         this._eventListenerDisposables.push(textDocumentOpen);
 
-        const textDocumentClose = vscode.workspace.onDidCloseTextDocument(doc =>
+        const textDocumentClose = hub.onDidCloseTextDocument(({ document: doc }) =>
             this._emitTextDocumentEvent(doc, 'textDocumentClose'));
         this._eventListenerDisposables.push(textDocumentClose);
 
         // Debug session lifecycle
-        const debugStart = vscode.debug.onDidStartDebugSession(s =>
-            this._recordDebugSession('started', s));
+        const debugStart = hub.onDidStartDebugSession(({ session }) =>
+            this._recordDebugSession('started', session));
         this._eventListenerDisposables.push(debugStart);
 
-        const debugTerminate = vscode.debug.onDidTerminateDebugSession(s =>
-            this._recordDebugSession('terminated', s));
+        const debugTerminate = hub.onDidTerminateDebugSession(({ session }) =>
+            this._recordDebugSession('terminated', session));
         this._eventListenerDisposables.push(debugTerminate);
 
-        const debugActive = vscode.debug.onDidChangeActiveDebugSession(s =>
-            this._recordDebugSession('activeChanged', s));
+        const debugActive = hub.onDidChangeActiveDebugSession(({ session }) =>
+            this._recordDebugSession('activeChanged', session));
         this._eventListenerDisposables.push(debugActive);
 
         // Breakpoint changes. onDidChangeBreakpoints carries three arrays; each
         // is processed independently and empty arrays emit nothing. The VS Code
         // API does not guarantee one event per user action, so no coalescing is
         // assumed; breakpoint changes are low-frequency, no debounce is applied.
-        const breakpointChange = vscode.debug.onDidChangeBreakpoints(event => {
+        const breakpointChange = hub.onDidChangeBreakpoints(({ event }) => {
             this._emitBreakpointChange('added', event.added);
             this._emitBreakpointChange('removed', event.removed);
             this._emitBreakpointChange('changed', event.changed);
         });
         this._eventListenerDisposables.push(breakpointChange);
 
-        // Terminal shell execution tracking — only available in VS Code Desktop
-        if (this._deps.capabilities?.hasTerminalShellExecution !== false) {
-            this._terminalCollector.register(this._eventListenerDisposables);
-        }
+        // Terminal shell execution tracking. The hub's channels never fire on
+        // platforms without the shellIntegration API, so no capability gate
+        // is needed here.
+        this._terminalCollector.register(hub, this._eventListenerDisposables);
     }
 
     // ── Teardown paths ────────────────────────────────────────────────
@@ -341,8 +343,9 @@ export class ObservationRegistry {
     }
 
     /**
-     * Final cleanup: clear any leftover timers and dispose all vscode
-     * subscriptions. Idempotent. Last-active-editor is reset so a fresh
+     * Final cleanup: clear any leftover timers and detach all hub-channel
+     * subscriptions (the underlying VS Code source unsubscribes only when the
+     * last hub consumer detaches). Idempotent. Last-active-editor is reset so a fresh
      * enable starts with a clean slate.
      *
      * Pending terminal executions are aborted and cleared here too. In normal

--- a/extension/src/extension/services/telemetry/recording/observation/terminalCollector.ts
+++ b/extension/src/extension/services/telemetry/recording/observation/terminalCollector.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
+import type { SensorHub } from '@extension/services/sensing';
 import type { RecorderLifecycleState } from '@extension/services/telemetry/recording/lifecycleController';
 import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
 
@@ -37,13 +38,13 @@ export class TerminalCollector {
     constructor(private readonly _deps: TerminalCollectorDeps) {}
 
     /**
-     * Register shellExecStart/End listeners. The caller pushes the returned
-     * disposables into its own tracking array.
+     * Attach shellExecStart/End handlers to the hub channels; the subscriptions
+     * are pushed into the caller's tracking array.
      */
-    register(disposables: vscode.Disposable[]): void {
+    register(hub: SensorHub, disposables: vscode.Disposable[]): void {
         const recordingPhase = (): boolean => this._deps.state.phase === 'recording';
 
-        const shellExecStart = vscode.window.onDidStartTerminalShellExecution(event => {
+        const shellExecStart = hub.onDidStartTerminalShellExecution(({ event }) => {
             if (!recordingPhase()) { return; }
             const entry: PendingExecution = {
                 output: '', startTime: Date.now(), truncated: false,
@@ -55,7 +56,7 @@ export class TerminalCollector {
         });
         disposables.push(shellExecStart);
 
-        const shellExecEnd = vscode.window.onDidEndTerminalShellExecution(event => {
+        const shellExecEnd = hub.onDidEndTerminalShellExecution(({ event }) => {
             if (!recordingPhase()) { return; }
             const entry = this._pendingExecutions.get(event.execution);
             if (!entry) { return; }

--- a/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
+++ b/extension/src/extension/services/telemetry/recording/sessionRecorder.ts
@@ -1,7 +1,7 @@
 /**
  * Main orchestrator for session recording.
  *
- * Runs parallel to TelemetryManager with its own VS Code listeners.
+ * Runs parallel to TelemetryManager, consuming the shared SensorHub (or an owned default hub when none is injected) instead of holding its own VS Code listeners.
  * Only active when consent is Extended. Writes JSONL event streams
  * to {globalStorageUri}/recordings/{sessionId}/.
  *
@@ -58,6 +58,7 @@ type RecordedEventWithoutTimestamp = RecordedEvent extends infer E
     : never;
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { LogCategory, logger } from '@extension/services/loggingService';
+import { type SensorHub, VsCodeSensorHub } from '@extension/services/sensing';
 import { shouldAcceptBuildResult } from '@extension/services/telemetry/buildResultGuard';
 import type { PlatformCapabilities } from '@extension/theia';
 
@@ -113,8 +114,10 @@ export class SessionRecorder implements WebSocketMessageHandler {
     private readonly _onDidChangeState = new vscode.EventEmitter<RecordingState>();
     public readonly onDidChangeState = this._onDidChangeState.event;
 
-    private readonly _capabilities?: PlatformCapabilities;
     private readonly _exerciseRegistry?: ExerciseRegistry;
+
+    private readonly _sensorHub: SensorHub;
+    private readonly _ownsHub: boolean;
 
     private readonly _lifecycle: LifecycleController;
 
@@ -124,9 +127,12 @@ export class SessionRecorder implements WebSocketMessageHandler {
         exerciseRegistry?: ExerciseRegistry,
         /** Injection point for tests. Production uses the default writer. */
         writer?: RecordingStorageWriter,
+        /** Shared hub injected by production wiring; default exists for standalone construction in tests. */
+        sensorHub?: SensorHub,
     ) {
+        this._sensorHub = sensorHub ?? new VsCodeSensorHub(capabilities);
+        this._ownsHub = sensorHub === undefined;
         this._writer = writer ?? new RecordingStorageWriter(globalStorageUri.fsPath);
-        this._capabilities = capabilities;
         this._exerciseRegistry = exerciseRegistry;
         this._snapshots = new SnapshotManager({
             state: this._state,
@@ -136,12 +142,13 @@ export class SessionRecorder implements WebSocketMessageHandler {
         });
         this._startup = new StartupCapture({
             record: (event, opts, gen) => this._lifecycle.recordInternal(event, opts, gen),
+            hub: this._sensorHub,
         });
         this._observation = new ObservationRegistry({
             state: this._state,
             snapshots: this._snapshots,
             record: (event, opts, gen) => this._lifecycle.recordInternal(event, opts, gen),
-            capabilities: this._capabilities,
+            hub: this._sensorHub,
         });
         this._lifecycle = new LifecycleController({
             state: this._state,
@@ -149,6 +156,7 @@ export class SessionRecorder implements WebSocketMessageHandler {
             snapshots: this._snapshots,
             observation: this._observation,
             startup: this._startup,
+            hub: this._sensorHub,
             onStateChange: () => this._fireStateChange(),
         });
     }
@@ -519,6 +527,7 @@ export class SessionRecorder implements WebSocketMessageHandler {
      * events flushed to disk) only holds if this is awaited, so it must never be
      * registered in `context.subscriptions` where VS Code would fire-and-forget it.
      * The durable path is `deactivate()` → DataCollectionHandle → here.
+     * After shutdown disposes an owned hub, channel attaches become inert; a recorder must not be re-enabled past shutdown().
      */
     async shutdown(): Promise<void> {
         if (this._disposed) { return; }
@@ -534,6 +543,9 @@ export class SessionRecorder implements WebSocketMessageHandler {
         this._observation.disposeSubscriptions();
         await this._writer.shutdown();
         this._onDidChangeState.dispose();
+        if (this._ownsHub) {
+            this._sensorHub.dispose();
+        }
     }
 
     // ── Private: State notification ─────────────────────────────────────

--- a/extension/src/extension/services/telemetry/recording/startup/startupCapture.ts
+++ b/extension/src/extension/services/telemetry/recording/startup/startupCapture.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { LogCategory, logger } from '@extension/services/loggingService';
+import type { SensorHub } from '@extension/services/sensing';
 import { collectDiagnostics, collectSelectionChange, collectVisibleRangeChange } from '@extension/services/telemetry/recording/eventCollectors';
 import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
 import { shouldRecordUri } from '@extension/services/telemetry/uriFilter';
@@ -29,6 +30,7 @@ interface StartupCaptureDeps {
         opts: { allowDuringStartup?: boolean; allowDuringEnding?: boolean },
         generation: number,
     ) => void;
+    hub: SensorHub;
 }
 
 /**
@@ -83,13 +85,13 @@ export class StartupCapture {
     }
 
     private _emitInitialDiagnostics(generation: number, exerciseRootUri: vscode.Uri | undefined): void {
-        const allDiagnostics = vscode.languages.getDiagnostics();
+        const allDiagnostics = this._deps.hub.readAllDiagnostics();
         for (const [uri, diagnostics] of allDiagnostics) {
             if (!shouldRecordUri(uri, exerciseRootUri) || diagnostics.length === 0) {
                 continue;
             }
             this._deps.record(
-                collectDiagnostics(uri),
+                collectDiagnostics(uri, this._deps.hub.readDiagnostics(uri)),
                 { allowDuringStartup: true },
                 generation,
             );
@@ -122,7 +124,7 @@ export class StartupCapture {
                 {
                     type: 'windowFocus',
                     timestamp: Date.now(),
-                    focused: vscode.window.state.focused,
+                    focused: this._deps.hub.readWindowFocused(),
                 },
                 { allowDuringStartup: true },
                 generation,
@@ -132,7 +134,7 @@ export class StartupCapture {
         }
 
         // 2. Selection + visible range for every visible file editor.
-        for (const editor of vscode.window.visibleTextEditors) {
+        for (const editor of this._deps.hub.readVisibleTextEditors()) {
             if (!shouldRecordUri(editor.document.uri, exerciseRootUri)) {
                 continue;
             }
@@ -153,7 +155,7 @@ export class StartupCapture {
         }
 
         // 3. fileSwitch for the active editor (if any).
-        const activeUri = vscode.window.activeTextEditor?.document.uri;
+        const activeUri = this._deps.hub.readActiveTextEditor()?.document.uri;
         if (activeUri && shouldRecordUri(activeUri, exerciseRootUri)) {
             this._deps.record(
                 { type: 'fileSwitch', timestamp: Date.now(), fromUri: undefined, toUri: activeUri.toString() },
@@ -164,7 +166,7 @@ export class StartupCapture {
         }
 
         // 4. terminalOpenClose('opened') for every already-open terminal.
-        for (const terminal of vscode.window.terminals) {
+        for (const terminal of this._deps.hub.readTerminals()) {
             this._deps.record(
                 {
                     type: 'terminalOpenClose',

--- a/extension/src/extension/services/telemetry/replay/replayEngine.ts
+++ b/extension/src/extension/services/telemetry/replay/replayEngine.ts
@@ -26,7 +26,7 @@ interface ReplayEqSnapshot {
     errorFamilies: string[];
 }
 
-/** Stabilization window — mirrors CompileEquivalentEmitter's 500ms setTimeout */
+/** Stabilization window - mirrors DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS (sensing layer). */
 const LOOKAHEAD_WINDOW_MS = 500;
 
 /**

--- a/extension/src/extension/services/telemetry/telemetryManager.ts
+++ b/extension/src/extension/services/telemetry/telemetryManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { LogCategory, logger } from '@extension/services/loggingService';
+import { type SensorHub, VsCodeSensorHub } from '@extension/services/sensing';
 import { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
 import { ResultDTO, WebSocketMessageHandler } from '@extension/types';
 import { VSCODE_CONFIG } from '@extension/utils/constants';
@@ -39,6 +40,8 @@ import {
 export class TelemetryManager implements vscode.Disposable, WebSocketMessageHandler {
     private readonly _disposables: vscode.Disposable[] = [];
     private _disposed = false;
+    private readonly _sensorHub: SensorHub;
+    private readonly _ownsHub: boolean;
 
     // Sub-services (kept from old system)
     private readonly _diagnosticService: DiagnosticPersistenceService;
@@ -95,14 +98,19 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
     private readonly _onDidSuppressIntervention = new vscode.EventEmitter<SuppressedInterventionPayload>();
     public readonly onDidSuppressIntervention = this._onDidSuppressIntervention.event;
 
-    constructor(exerciseRegistry?: ExerciseRegistry) {
+    constructor(exerciseRegistry?: ExerciseRegistry, sensorHub?: SensorHub) {
+        // Production injects the shared hub from extension.ts; the owned
+        // default exists for tests and is desktop-only (no capability gating).
+        this._sensorHub = sensorHub ?? new VsCodeSensorHub();
+        this._ownsHub = sensorHub === undefined;
+
         this._exerciseRegistry = exerciseRegistry;
         this._outputChannel = vscode.window.createOutputChannel('Artemis Telemetry');
         this._disposables.push(this._outputChannel);
 
         // Initialize kept services
-        this._diagnosticService = new DiagnosticPersistenceService();
-        this._inactivityService = new InactivityService();
+        this._diagnosticService = new DiagnosticPersistenceService(this._sensorHub);
+        this._inactivityService = new InactivityService(this._sensorHub);
         this._buildTracker = new BuildResultTracker();
         this._interventionService = new InterventionService();
         this._interventionFilter = new InterventionFilter();
@@ -182,6 +190,10 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
 
         while (this._disposables.length > 0) {
             this._disposables.pop()?.dispose();
+        }
+
+        if (this._ownsHub) {
+            this._sensorHub.dispose();
         }
 
         this._onDidCalculateEQ.dispose();
@@ -298,16 +310,19 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
     // ==================== Event Handlers ====================
 
     private _setupEventHandlers(): void {
-        // Save event → CompileEquivalentEmitter
-        const saveListener = vscode.workspace.onDidSaveTextDocument(doc => {
+        // Settled diagnostics (save + 500ms LS settle) → CompileEquivalentEmitter.
+        // Note: the isEnabled gate moved from save-time to settle-time (PR1
+        // decision log #5) — only observable when the setting flips inside
+        // the 500 ms settle window.
+        const settleListener = this._sensorHub.onDiagnosticsSettled(signal => {
             if (this._isEnabled) {
-                this._compileEmitter.handleSaveEvent(doc);
+                this._compileEmitter.handleDiagnosticsSettled(signal);
             }
         });
-        this._disposables.push(saveListener);
+        this._disposables.push(settleListener);
 
         // Text change → BoundaryTriggerEmitter (paste detection)
-        const changeListener = vscode.workspace.onDidChangeTextDocument(event => {
+        const changeListener = this._sensorHub.onDidChangeTextDocument(({ event }) => {
             if (this._isEnabled) {
                 this._triggerEmitter.handleTextDocumentChange(event);
             }
@@ -315,7 +330,7 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         this._disposables.push(changeListener);
 
         // Selection change → BoundaryTriggerEmitter (selection-maintained)
-        const selectionListener = vscode.window.onDidChangeTextEditorSelection(event => {
+        const selectionListener = this._sensorHub.onDidChangeTextEditorSelection(({ event }) => {
             if (this._isEnabled) {
                 this._triggerEmitter.handleSelectionChange(event);
             }
@@ -378,7 +393,7 @@ export class TelemetryManager implements vscode.Disposable, WebSocketMessageHand
         // Window focus resume — log when window regains focus with active exercise.
         // InactivityService will naturally pick up activity from subsequent user actions
         // (text changes, saves, selections). No explicit recordActivity needed.
-        const windowStateListener = vscode.window.onDidChangeWindowState(state => {
+        const windowStateListener = this._sensorHub.onDidChangeWindowState(({ state }) => {
             if (state.focused && this._activeExerciseId !== undefined) {
                 this._log('Window regained focus with active exercise session');
             }

--- a/extension/test/__shared__/testSensorHub.ts
+++ b/extension/test/__shared__/testSensorHub.ts
@@ -1,0 +1,89 @@
+// extension/test/__shared__/testSensorHub.ts
+/**
+ * Controllable SensorHub for tests: every channel is backed by a public
+ * EventEmitter (fire via `hub.emit.<channel>.fire(...)`), state reads return
+ * stubbable values (assign `hub.stub.<name>`).
+ */
+import * as vscode from 'vscode';
+
+import type { SensorHub } from '@extension/services/sensing/sensorHub';
+import type {
+    ActiveEditorSignal, BreakpointsSignal, DebugSessionSignal, DiagnosticsChangeSignal,
+    DiagnosticsSettledSignal, FileRenameSignal, FileSetSignal, SaveSignal, SelectionSignal,
+    ShellExecutionEndSignal, ShellExecutionStartSignal, TerminalSignal, TextChangeSignal,
+    TextDocumentSignal, VisibleRangesSignal, WindowStateSignal,
+} from '@extension/services/sensing/types';
+
+export class TestSensorHub implements SensorHub {
+    readonly emit = {
+        textChange: new vscode.EventEmitter<TextChangeSignal>(),
+        save: new vscode.EventEmitter<SaveSignal>(),
+        activeEditor: new vscode.EventEmitter<ActiveEditorSignal>(),
+        diagnostics: new vscode.EventEmitter<DiagnosticsChangeSignal>(),
+        diagnosticsSettled: new vscode.EventEmitter<DiagnosticsSettledSignal>(),
+        windowState: new vscode.EventEmitter<WindowStateSignal>(),
+        selection: new vscode.EventEmitter<SelectionSignal>(),
+        visibleRanges: new vscode.EventEmitter<VisibleRangesSignal>(),
+        terminalOpen: new vscode.EventEmitter<TerminalSignal>(),
+        terminalClose: new vscode.EventEmitter<TerminalSignal>(),
+        fileCreate: new vscode.EventEmitter<FileSetSignal>(),
+        fileDelete: new vscode.EventEmitter<FileSetSignal>(),
+        fileRename: new vscode.EventEmitter<FileRenameSignal>(),
+        docOpen: new vscode.EventEmitter<TextDocumentSignal>(),
+        docClose: new vscode.EventEmitter<TextDocumentSignal>(),
+        debugStart: new vscode.EventEmitter<DebugSessionSignal>(),
+        debugTerminate: new vscode.EventEmitter<DebugSessionSignal>(),
+        debugActive: new vscode.EventEmitter<DebugSessionSignal>(),
+        breakpoints: new vscode.EventEmitter<BreakpointsSignal>(),
+        shellStart: new vscode.EventEmitter<ShellExecutionStartSignal>(),
+        shellEnd: new vscode.EventEmitter<ShellExecutionEndSignal>(),
+    };
+
+    readonly stub = {
+        allDiagnostics: [] as Array<[vscode.Uri, vscode.Diagnostic[]]>,
+        diagnosticsByUri: new Map<string, vscode.Diagnostic[]>(),
+        windowFocused: true,
+        visibleTextEditors: [] as vscode.TextEditor[],
+        activeTextEditor: undefined as vscode.TextEditor | undefined,
+        terminals: [] as vscode.Terminal[],
+        breakpoints: [] as vscode.Breakpoint[],
+    };
+
+    readonly onDidChangeTextDocument = this.emit.textChange.event;
+    readonly onDidSaveTextDocument = this.emit.save.event;
+    readonly onDidChangeActiveTextEditor = this.emit.activeEditor.event;
+    readonly onDidChangeDiagnostics = this.emit.diagnostics.event;
+    readonly onDiagnosticsSettled = this.emit.diagnosticsSettled.event;
+    readonly onDidChangeWindowState = this.emit.windowState.event;
+    readonly onDidChangeTextEditorSelection = this.emit.selection.event;
+    readonly onDidChangeTextEditorVisibleRanges = this.emit.visibleRanges.event;
+    readonly onDidOpenTerminal = this.emit.terminalOpen.event;
+    readonly onDidCloseTerminal = this.emit.terminalClose.event;
+    readonly onDidCreateFiles = this.emit.fileCreate.event;
+    readonly onDidDeleteFiles = this.emit.fileDelete.event;
+    readonly onDidRenameFiles = this.emit.fileRename.event;
+    readonly onDidOpenTextDocument = this.emit.docOpen.event;
+    readonly onDidCloseTextDocument = this.emit.docClose.event;
+    readonly onDidStartDebugSession = this.emit.debugStart.event;
+    readonly onDidTerminateDebugSession = this.emit.debugTerminate.event;
+    readonly onDidChangeActiveDebugSession = this.emit.debugActive.event;
+    readonly onDidChangeBreakpoints = this.emit.breakpoints.event;
+    readonly onDidStartTerminalShellExecution = this.emit.shellStart.event;
+    readonly onDidEndTerminalShellExecution = this.emit.shellEnd.event;
+
+    readAllDiagnostics(): ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]> { return this.stub.allDiagnostics; }
+    readDiagnostics(uri: vscode.Uri): readonly vscode.Diagnostic[] {
+        return this.stub.diagnosticsByUri.get(uri.toString()) ?? [];
+    }
+    readWindowFocused(): boolean { return this.stub.windowFocused; }
+    readVisibleTextEditors(): readonly vscode.TextEditor[] { return this.stub.visibleTextEditors; }
+    readActiveTextEditor(): vscode.TextEditor | undefined { return this.stub.activeTextEditor; }
+    readTerminals(): readonly vscode.Terminal[] { return this.stub.terminals; }
+    readBreakpoints(): readonly vscode.Breakpoint[] { return this.stub.breakpoints; }
+
+    dispose(): void {
+        for (const emitter of Object.values(this.emit)) {
+            emitter.dispose();
+        }
+    }
+}

--- a/extension/test/unit/activation/sessionRecorderWiring.test.ts
+++ b/extension/test/unit/activation/sessionRecorderWiring.test.ts
@@ -45,6 +45,7 @@ import type {
 import { TelemetryManager } from '@extension/services/telemetry/telemetryManager';
 import type { InterventionDecision } from '@extension/services/telemetry/types';
 import type { ArtemisWebsocketService } from '@extension/services/websocket';
+import { TestSensorHub } from '@test/__shared__/testSensorHub';
 
 interface MutableConfigState {
     enabled: boolean;
@@ -182,6 +183,7 @@ async function readAllRecordedEvents(tmpDir: string): Promise<RecordedEvent[]> {
 interface WiringHarness {
     telemetryManager: TelemetryManager;
     recorder: SessionRecorder;
+    sensorHub: TestSensorHub;
     artemisWebviewProvider: ArtemisWebviewProvider;
     chatProvider: ChatProviderStub;
     tmpDir: string;
@@ -236,6 +238,7 @@ async function makeWiringHarness(
     const ctx = { globalStorageUri: vscode.Uri.file(tmpDir), subscriptions: [] } as unknown as vscode.ExtensionContext;
     const artemisProvider = stubWebviewProvider();
     const chatProvider = stubChatProvider();
+    const sensorHub = new TestSensorHub();
     const wiring = wireSessionRecorder({
         context: ctx,
         consentService: stubConsent(true),
@@ -246,11 +249,13 @@ async function makeWiringHarness(
         capabilities: undefined,
         exerciseRegistry: undefined,
         contextStore,
+        sensorHub,
     });
 
     return {
         telemetryManager,
         recorder: wiring.sessionRecorder,
+        sensorHub,
         artemisWebviewProvider: artemisProvider,
         chatProvider,
         tmpDir,
@@ -266,6 +271,7 @@ async function makeWiringHarness(
             wiring.disposable.dispose();
             try { await wiring.sessionRecorder.shutdown(); } catch { /* ignore */ }
             telemetryManager.dispose();
+            sensorHub.dispose();
             try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
             // Stubs are restored centrally via the suite-level sandbox in teardown.
         },
@@ -356,10 +362,10 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
         const inRootBp = new vscode.SourceBreakpoint(new vscode.Location(inRootUri, new vscode.Position(4, 0)));
         const outOfRootBp = new vscode.SourceBreakpoint(new vscode.Location(outOfRootUri, new vscode.Position(0, 0)));
         try {
-            // Pre-existing breakpoints BEFORE the session (idle phase ⇒ the live
-            // listener does not record the add; only the startup contributor does).
-            vscode.debug.removeBreakpoints([...vscode.debug.breakpoints]);
-            vscode.debug.addBreakpoints([inRootBp, outOfRootBp]);
+            // Pre-existing breakpoints BEFORE the session: seeding the hub stub
+            // does not fire onDidChangeBreakpoints, so the live listener does not
+            // record the add; only the startup contributor sees them.
+            harness.sensorHub.stub.breakpoints = [inRootBp, outOfRootBp];
 
             await harness.recorder.startSession(42, undefined, exerciseRoot.toString());
             await harness.recorder.endSession();
@@ -373,7 +379,6 @@ suite('sessionRecorderWiring — suppression and configuration provenance', () =
             assert.strictEqual(snap!.breakpoints[0].line, 4, 'snapshot line 0-based 4');
             assert.strictEqual(snap!.breakpoints[0].id, inRootBp.id, 'snapshot bp id matches the SourceBreakpoint');
         } finally {
-            vscode.debug.removeBreakpoints([...vscode.debug.breakpoints]);
             await harness.dispose();
         }
     });

--- a/extension/test/unit/services/sensing/diagnosticsSettle.test.ts
+++ b/extension/test/unit/services/sensing/diagnosticsSettle.test.ts
@@ -1,0 +1,74 @@
+// extension/test/unit/services/sensing/diagnosticsSettle.test.ts
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { DiagnosticsSettleCollector } from '@extension/services/sensing/collectors/diagnosticsSettle';
+import { nextSensorSeq } from '@extension/services/sensing/sequence';
+import type { DiagnosticsSettledSignal, SaveSignal } from '@extension/services/sensing/types';
+
+function fakeSaveSignal(path: string, scheme = 'file'): SaveSignal {
+    const uri = scheme === 'file' ? vscode.Uri.file(path) : vscode.Uri.parse(`${scheme}:${path}`);
+    return { ts: Date.now(), seq: nextSensorSeq(), document: { uri } as vscode.TextDocument };
+}
+
+suite('DiagnosticsSettleCollector', () => {
+    let emitter: vscode.EventEmitter<SaveSignal>;
+    let collector: DiagnosticsSettleCollector;
+    let received: DiagnosticsSettledSignal[];
+    let clock: sinon.SinonFakeTimers;
+    const dump: Array<[vscode.Uri, vscode.Diagnostic[]]> = [
+        [vscode.Uri.file('/w/A.java'), [new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), 'boom', vscode.DiagnosticSeverity.Error)]],
+    ];
+
+    setup(() => {
+        clock = sinon.useFakeTimers({
+            toFake: ['Date', 'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'],
+            shouldClearNativeTimers: true,
+        });
+        emitter = new vscode.EventEmitter<SaveSignal>();
+        collector = new DiagnosticsSettleCollector(emitter.event, () => dump);
+        received = [];
+        collector.onDidSettle(signal => received.push(signal));
+    });
+
+    teardown(() => {
+        collector.dispose();
+        emitter.dispose();
+        clock.restore();
+    });
+
+    test('emits one settled dump 500ms after a save, carrying the save ordering token', async () => {
+        const save = fakeSaveSignal('/w/A.java');
+        emitter.fire(save);
+        assert.strictEqual(received.length, 0, 'must not emit before the settle window');
+        clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+        assert.strictEqual(received.length, 1);
+        assert.strictEqual(received[0].entries, dump);
+        assert.strictEqual(received[0].savedSeq, save.seq);
+        assert.ok(received[0].ts >= save.ts);
+    });
+
+    test('coalesces rapid saves into a single emission with the LAST save token', async () => {
+        emitter.fire(fakeSaveSignal('/w/A.java'));
+        clock.tick(100);
+        const second = fakeSaveSignal('/w/B.java');
+        emitter.fire(second);
+        clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+        assert.strictEqual(received.length, 1);
+        assert.strictEqual(received[0].savedSeq, second.seq);
+    });
+
+    test('ignores non-recordable URIs', async () => {
+        emitter.fire(fakeSaveSignal('/x', 'untitled'));
+        clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+        assert.strictEqual(received.length, 0);
+    });
+
+    test('dispose cancels a pending settle', async () => {
+        emitter.fire(fakeSaveSignal('/w/A.java'));
+        collector.dispose();
+        clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+        assert.strictEqual(received.length, 0);
+    });
+});

--- a/extension/test/unit/services/sensing/sensorHub.test.ts
+++ b/extension/test/unit/services/sensing/sensorHub.test.ts
@@ -64,6 +64,64 @@ suite('VsCodeSensorHub', () => {
         }
     });
 
+    test('fan-out isolates listener errors and supports duplicate listeners', () => {
+        const original = vscode.window.onDidOpenTerminal;
+        let handler: ((t: vscode.Terminal) => void) | undefined;
+        let active = 0;
+        (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal =
+            ((listener: (t: vscode.Terminal) => void) => {
+                active++;
+                handler = listener;
+                return new vscode.Disposable(() => { active--; handler = undefined; });
+            }) as typeof vscode.window.onDidOpenTerminal;
+        try {
+            const hub = new VsCodeSensorHub();
+            let calls = 0;
+            const counting = (): void => { calls++; };
+            const throwing = (): void => { throw new Error('consumer bug'); };
+
+            const s1 = hub.onDidOpenTerminal(throwing);
+            const s2 = hub.onDidOpenTerminal(counting);
+            const s3 = hub.onDidOpenTerminal(counting); // same fn twice = two subscriptions
+            handler?.({} as vscode.Terminal);
+            assert.strictEqual(calls, 2, 'error in one listener must not suppress others; duplicates deliver twice');
+
+            s2.dispose();
+            handler?.({} as vscode.Terminal);
+            assert.strictEqual(calls, 3, 'remaining duplicate subscription still delivers');
+            assert.strictEqual(active, 1, 'source stays while subscriptions remain');
+
+            s1.dispose();
+            s3.dispose();
+            assert.strictEqual(active, 0, 'last subscription detaches the source');
+            hub.dispose();
+        } finally {
+            (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal = original;
+        }
+    });
+
+    test('hub.dispose() detaches sources and post-dispose attach stays inert', () => {
+        const original = vscode.window.onDidOpenTerminal;
+        let active = 0;
+        (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal =
+            ((_listener: (t: vscode.Terminal) => void) => {
+                active++;
+                return new vscode.Disposable(() => { active--; });
+            }) as typeof vscode.window.onDidOpenTerminal;
+        try {
+            const hub = new VsCodeSensorHub();
+            hub.onDidOpenTerminal(() => { /* consumer */ });
+            assert.strictEqual(active, 1);
+            hub.dispose();
+            assert.strictEqual(active, 0, 'dispose() must detach the underlying source');
+            const sub = hub.onDidOpenTerminal(() => { /* late consumer */ });
+            assert.strictEqual(active, 0, 'post-dispose attach must not resurrect the source');
+            sub.dispose();
+        } finally {
+            (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal = original;
+        }
+    });
+
     test('state reads delegate to the live VS Code namespace', () => {
         const hub = new VsCodeSensorHub();
         assert.deepStrictEqual(hub.readAllDiagnostics(), vscode.languages.getDiagnostics());

--- a/extension/test/unit/services/sensing/sensorHub.test.ts
+++ b/extension/test/unit/services/sensing/sensorHub.test.ts
@@ -1,9 +1,11 @@
 // extension/test/unit/services/sensing/sensorHub.test.ts
 import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 
+import { DiagnosticsSettleCollector } from '@extension/services/sensing/collectors/diagnosticsSettle';
 import { VsCodeSensorHub } from '@extension/services/sensing/sensorHub';
-import type { TextChangeSignal } from '@extension/services/sensing/types';
+import type { DiagnosticsSettledSignal, TextChangeSignal } from '@extension/services/sensing/types';
 
 suite('VsCodeSensorHub', () => {
     test('relays text changes with an arrival timestamp', async () => {
@@ -131,5 +133,42 @@ suite('VsCodeSensorHub', () => {
         assert.strictEqual(hub.readTerminals().length, vscode.window.terminals.length);
         assert.strictEqual(hub.readBreakpoints().length, vscode.debug.breakpoints.length);
         hub.dispose();
+    });
+
+    test('settle channel: one underlying save listener for N consumers, torn down with the last', () => {
+        const original = vscode.workspace.onDidSaveTextDocument;
+        let saveListeners = 0;
+        let fireSave: ((doc: vscode.TextDocument) => void) | undefined;
+        (vscode.workspace as { onDidSaveTextDocument: typeof vscode.workspace.onDidSaveTextDocument }).onDidSaveTextDocument =
+            ((listener: (doc: vscode.TextDocument) => void) => {
+                saveListeners++;
+                fireSave = listener;
+                return new vscode.Disposable(() => { saveListeners--; fireSave = undefined; });
+            }) as typeof vscode.workspace.onDidSaveTextDocument;
+        const clock = sinon.useFakeTimers();
+        try {
+            const hub = new VsCodeSensorHub();
+            const received: DiagnosticsSettledSignal[] = [];
+            const s1 = hub.onDiagnosticsSettled(signal => received.push(signal));
+            const s2 = hub.onDiagnosticsSettled(signal => received.push(signal));
+            assert.strictEqual(saveListeners, 1, 'N settle consumers share one save listener');
+
+            fireSave?.({ uri: vscode.Uri.file('/w/A.java') } as vscode.TextDocument);
+            clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+            assert.strictEqual(received.length, 2, 'both consumers receive the settled dump');
+
+            s1.dispose();
+            assert.strictEqual(saveListeners, 1, 'collector stays while a consumer remains');
+
+            fireSave?.({ uri: vscode.Uri.file('/w/B.java') } as vscode.TextDocument);
+            s2.dispose();
+            assert.strictEqual(saveListeners, 0, 'last consumer tears down collector and save listener');
+            clock.tick(DiagnosticsSettleCollector.DIAGNOSTICS_SETTLE_MS + 1);
+            assert.strictEqual(received.length, 2, 'pending settle cancelled on teardown, no late emission');
+            hub.dispose();
+        } finally {
+            clock.restore();
+            (vscode.workspace as { onDidSaveTextDocument: typeof vscode.workspace.onDidSaveTextDocument }).onDidSaveTextDocument = original;
+        }
     });
 });

--- a/extension/test/unit/services/sensing/sensorHub.test.ts
+++ b/extension/test/unit/services/sensing/sensorHub.test.ts
@@ -1,0 +1,77 @@
+// extension/test/unit/services/sensing/sensorHub.test.ts
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+import { VsCodeSensorHub } from '@extension/services/sensing/sensorHub';
+import type { TextChangeSignal } from '@extension/services/sensing/types';
+
+suite('VsCodeSensorHub', () => {
+    test('relays text changes with an arrival timestamp', async () => {
+        const hub = new VsCodeSensorHub();
+
+        // Subscribe AFTER openTextDocument: VS Code fires onDidChangeTextDocument for the
+        // initial content fill, which would cause the listener to see 2 events instead of 1.
+        const doc = await vscode.workspace.openTextDocument({ content: 'abc', language: 'plaintext' });
+        const received: TextChangeSignal[] = [];
+        const sub = hub.onDidChangeTextDocument(signal => received.push(signal));
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(doc.uri, new vscode.Position(0, 0), 'x');
+        const before = Date.now();
+        await vscode.workspace.applyEdit(edit);
+        // onDidChangeTextDocument fires synchronously during applyEdit.
+        assert.strictEqual(received.length, 1);
+        assert.strictEqual(received[0].event.document.uri.toString(), doc.uri.toString());
+        assert.ok(received[0].ts >= before && received[0].ts <= Date.now());
+
+        sub.dispose();
+        hub.dispose();
+    });
+
+    test('dispose() stops relaying', async () => {
+        const hub = new VsCodeSensorHub();
+        let count = 0;
+        hub.onDidChangeTextDocument(() => count++);
+        hub.dispose();
+
+        const doc = await vscode.workspace.openTextDocument({ content: 'abc' });
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(doc.uri, new vscode.Position(0, 0), 'y');
+        await vscode.workspace.applyEdit(edit);
+        assert.strictEqual(count, 0);
+    });
+
+    test('underlying VS Code subscription attaches lazily and detaches with the last listener', () => {
+        const original = vscode.window.onDidOpenTerminal;
+        let active = 0;
+        (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal =
+            ((_listener: (t: vscode.Terminal) => void) => {
+                active++;
+                return new vscode.Disposable(() => { active--; });
+            }) as typeof vscode.window.onDidOpenTerminal;
+        try {
+            const hub = new VsCodeSensorHub();
+            assert.strictEqual(active, 0, 'no listener before a consumer attaches');
+            const s1 = hub.onDidOpenTerminal(() => { /* consumer 1 */ });
+            const s2 = hub.onDidOpenTerminal(() => { /* consumer 2 */ });
+            assert.strictEqual(active, 1, 'one shared listener for many consumers');
+            s1.dispose();
+            assert.strictEqual(active, 1, 'listener stays while a consumer remains');
+            s2.dispose();
+            assert.strictEqual(active, 0, 'last consumer detaches the listener');
+            hub.dispose();
+        } finally {
+            (vscode.window as { onDidOpenTerminal: typeof vscode.window.onDidOpenTerminal }).onDidOpenTerminal = original;
+        }
+    });
+
+    test('state reads delegate to the live VS Code namespace', () => {
+        const hub = new VsCodeSensorHub();
+        assert.deepStrictEqual(hub.readAllDiagnostics(), vscode.languages.getDiagnostics());
+        assert.strictEqual(hub.readWindowFocused(), vscode.window.state.focused);
+        assert.strictEqual(hub.readActiveTextEditor(), vscode.window.activeTextEditor);
+        assert.strictEqual(hub.readVisibleTextEditors().length, vscode.window.visibleTextEditors.length);
+        assert.strictEqual(hub.readTerminals().length, vscode.window.terminals.length);
+        assert.strictEqual(hub.readBreakpoints().length, vscode.debug.breakpoints.length);
+        hub.dispose();
+    });
+});

--- a/extension/test/unit/services/telemetry/eqSettlePath.test.ts
+++ b/extension/test/unit/services/telemetry/eqSettlePath.test.ts
@@ -1,0 +1,95 @@
+// extension/test/unit/services/telemetry/eqSettlePath.test.ts
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { nextSensorSeq } from '@extension/services/sensing/sequence';
+import { TelemetryManager } from '@extension/services/telemetry/telemetryManager';
+import { TestSensorHub } from '@test/__shared__/testSensorHub';
+
+function errorEntry(path: string, message: string): [vscode.Uri, vscode.Diagnostic[]] {
+    const diag = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), message, vscode.DiagnosticSeverity.Error);
+    diag.source = 'java';
+    diag.code = 'E001';
+    return [vscode.Uri.file(path), [diag]];
+}
+
+suite('EQ settle path via SensorHub', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        // TelemetryManager constructs an InterventionService, which registers
+        // commands on the global registry — stub it so repeated construction
+        // across tests does not collide (same pattern as the other
+        // TelemetryManager suites).
+        sandbox.stub(vscode.commands, 'registerCommand').returns(new vscode.Disposable(() => { /* noop */ }));
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('a settled diagnostics dump produces one EQ snapshot with source=save', () => {
+        const hub = new TestSensorHub();
+        const tm = new TelemetryManager(undefined, hub);
+        const calculated: { source: string }[] = [];
+        tm.onDidCalculateEQ(e => calculated.push(e));
+        tm.startExerciseSession(1);
+
+        hub.emit.diagnosticsSettled.fire({
+            ts: Date.now(),
+            savedSeq: nextSensorSeq(), // save AFTER session start: must be processed
+            entries: [errorEntry('/w/A.java', 'boom')],
+        });
+        assert.strictEqual(calculated.length, 1);
+        assert.strictEqual(calculated[0].source, 'save');
+
+        // Identical dump inside the dedup window: no second snapshot.
+        hub.emit.diagnosticsSettled.fire({
+            ts: Date.now(),
+            savedSeq: nextSensorSeq(),
+            entries: [errorEntry('/w/A.java', 'boom')],
+        });
+        assert.strictEqual(calculated.length, 1);
+
+        tm.dispose();
+        hub.dispose();
+    });
+
+    test('a settle whose save predates the session start is dropped (cross-session guard)', () => {
+        const hub = new TestSensorHub();
+        const tm = new TelemetryManager(undefined, hub);
+        const calculated: unknown[] = [];
+        tm.onDidCalculateEQ(e => calculated.push(e));
+
+        const staleSaveSeq = nextSensorSeq(); // save happened, THEN the session switched
+        tm.startExerciseSession(1);           // draws a later token internally
+        hub.emit.diagnosticsSettled.fire({
+            ts: Date.now(),
+            savedSeq: staleSaveSeq,
+            entries: [errorEntry('/w/A.java', 'boom')],
+        });
+        assert.strictEqual(calculated.length, 0, 'stale settle must not leak into the new session');
+
+        tm.dispose();
+        hub.dispose();
+    });
+
+    test('a settle before any session start is processed (v1 parity)', () => {
+        const hub = new TestSensorHub();
+        const tm = new TelemetryManager(undefined, hub);
+        const calculated: unknown[] = [];
+        tm.onDidCalculateEQ(e => calculated.push(e));
+
+        hub.emit.diagnosticsSettled.fire({
+            ts: Date.now(),
+            savedSeq: nextSensorSeq(),
+            entries: [errorEntry('/w/A.java', 'boom')],
+        });
+        assert.strictEqual(calculated.length, 1, 'pre-session settles must flow like in v1');
+
+        tm.dispose();
+        hub.dispose();
+    });
+});

--- a/extension/test/unit/services/telemetry/recording/observationLifecycle.test.ts
+++ b/extension/test/unit/services/telemetry/recording/observationLifecycle.test.ts
@@ -1,0 +1,134 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+import type { SelectionSignal } from '@extension/services/sensing/types';
+import { SessionRecorder } from '@extension/services/telemetry/recording/sessionRecorder';
+import type { RecordingFs } from '@extension/services/telemetry/recording/storageWriter';
+import { RecordingStorageWriter } from '@extension/services/telemetry/recording/storageWriter';
+import type { RecordedEvent } from '@extension/services/telemetry/recording/types';
+import { TestSensorHub } from '@test/__shared__/testSensorHub';
+
+class MemFs implements RecordingFs {
+    appendedChunks: string[] = [];
+    syncChunks: string[] = [];
+    mkdir(): Promise<string | undefined> { return Promise.resolve(undefined); }
+    writeFile(): Promise<void> { return Promise.resolve(); }
+    appendFile(_p: string, data: string, _enc: BufferEncoding): Promise<void> { this.appendedChunks.push(data); return Promise.resolve(); }
+    rm(): Promise<void> { return Promise.resolve(); }
+    appendFileSync(_p: string, data: string, _enc: BufferEncoding): void { this.syncChunks.push(data); }
+}
+
+function writtenEvents(fs: MemFs): RecordedEvent[] {
+    return [...fs.appendedChunks, ...fs.syncChunks]
+        .flatMap(chunk => chunk.split('\n').filter(Boolean))
+        .map(line => JSON.parse(line) as RecordedEvent);
+}
+
+function selectionSignal(path: string): SelectionSignal {
+    const uri = vscode.Uri.file(path);
+    const editor = {
+        document: { uri },
+        selections: [new vscode.Selection(0, 0, 0, 1)],
+    } as unknown as vscode.TextEditor;
+    return {
+        ts: Date.now(),
+        event: {
+            textEditor: editor,
+            kind: vscode.TextEditorSelectionChangeKind.Keyboard,
+            selections: editor.selections,
+        } as vscode.TextEditorSelectionChangeEvent,
+    };
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function makeRecorder(): { recorder: SessionRecorder; fs: MemFs; hub: TestSensorHub } {
+    const fs = new MemFs();
+    const writer = new RecordingStorageWriter('/fake-base', fs, 'test-version');
+    const hub = new TestSensorHub();
+    const recorder = new SessionRecorder(
+        vscode.Uri.file('/fake-base'),
+        { hasTerminalShellExecution: false, hasVscodeGitExtension: false },
+        undefined,
+        writer,
+        hub,
+    );
+    return { recorder, fs, hub };
+}
+
+suite('Observation lifecycle via SensorHub (PR1 tier-b equivalence)', () => {
+    test('selection bursts within the debounce window record exactly one event', async () => {
+        const { recorder, fs, hub } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(1);
+
+        hub.emit.selection.fire(selectionSignal('/w/F.java'));
+        await sleep(50);
+        hub.emit.selection.fire(selectionSignal('/w/F.java'));
+        await sleep(300); // > 200ms debounce
+        await recorder.endSession();
+
+        const selections = writtenEvents(fs).filter(e => e.type === 'selectionChange');
+        assert.strictEqual(selections.length, 1);
+        await recorder.shutdown();
+    });
+
+    test('consent downgrade discards buffered debounce payloads', async () => {
+        const { recorder, fs, hub } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(1);
+
+        hub.emit.selection.fire(selectionSignal('/w/F.java'));
+        recorder.disable(); // GDPR path: pending payload must never hit disk
+        await sleep(300);
+        await recorder.shutdown();
+
+        const selections = writtenEvents(fs).filter(e => e.type === 'selectionChange');
+        assert.strictEqual(selections.length, 0);
+    });
+
+    test('session end flushes the pending payload into the ending session', async () => {
+        const { recorder, fs, hub } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(1);
+
+        hub.emit.selection.fire(selectionSignal('/w/F.java'));
+        await recorder.endSession(); // flushDebouncesForEnd, no 200ms wait
+
+        const events = writtenEvents(fs);
+        const selIdx = events.findIndex(e => e.type === 'selectionChange');
+        const endIdx = events.findIndex(e => e.type === 'sessionEnd');
+        assert.ok(selIdx !== -1, 'flushed selection must be recorded');
+        assert.ok(endIdx > selIdx, 'sessionEnd must come after the flushed payload');
+        await recorder.shutdown();
+    });
+
+    // Note on mechanism: the no-leak property here is enforced by
+    // flushDebouncesForEnd() cancelling all pending debounce timers at
+    // session end. The generation token (capturedGen in the registry's
+    // debounce callbacks) is defense-in-depth for asynchronous producers
+    // (snapshots, terminal output readers) and is not reachable through
+    // the synchronous selection path this test drives.
+    test('debounce payload from session A is flushed into A and never appears in session B', async () => {
+        const { recorder, fs, hub } = makeRecorder();
+        recorder.enable();
+        await recorder.startSession(1);
+        hub.emit.selection.fire(selectionSignal('/w/F.java'));
+        await recorder.endSession();   // flushes into session A
+        await recorder.startSession(2);
+        await sleep(300);              // stale timer (if any) would fire here
+        await recorder.endSession();
+        await recorder.shutdown();
+
+        const events = writtenEvents(fs);
+        const secondStart = events.findIndex(
+            e => e.type === 'sessionStart' && (e as { exerciseId?: number }).exerciseId === 2,
+        );
+        const beforeSecondStart = events.slice(0, secondStart).filter(e => e.type === 'selectionChange');
+        assert.strictEqual(beforeSecondStart.length, 1, 'flushed payload must land in session A');
+        const leaked = events.slice(secondStart).filter(e => e.type === 'selectionChange');
+        assert.strictEqual(leaked.length, 0);
+    });
+});


### PR DESCRIPTION
## What

Extracts a single sensing layer: `services/sensing/` now owns every VS Code event subscription and behavioral state read used by telemetry. The session recorder, the EQ pipeline, and the v1 inactivity/diagnostics services consume typed hub channels instead of subscribing to `vscode.*` themselves. Zero behavior change: recordings stay schema-v2 identical.

Design spec: `docs/superpowers/specs/2026-06-12-struggle-engine-v2-port.md` (PR 1 of the struggle-engine-v2 effort; all PRs of this effort target `feat/struggle-engine-v2`, not `dev`).

## How

- `SensorHub` interface + `VsCodeSensorHub`: one lazy relay per VS Code API. A channel subscribes to its source only while at least one consumer is attached, so consent-scoped consumers still produce consent-scoped VS Code listeners (the untouched `terminalShellExecution` test proves it). Per-listener error isolation, per-subscription refcounting, post-dispose inertness.
- Save-triggered diagnostics settle snapshot (500 ms LS settle, coalescing) moved from `CompileEquivalentEmitter` into `sensing/collectors/diagnosticsSettle.ts`. The emitter keeps the EQ pairing logic and now drops cross-session settles via a monotonic ordering token (`savedSeq`), reproducing v1's clear-timer-at-session-start semantics without same-millisecond ambiguity.
- All policy (phase gates, generation tokens, URI filters, debounces) stayed in the consumers; handler bodies are byte-identical, only the subscription expressions changed.
- Production wiring creates exactly one hub (`extension.ts`) and injects it everywhere; classes keep optional owned defaults so tests construct them standalone.
- `TestSensorHub` double for deterministic lifecycle tests.

## Equivalence proof

1. Existing suites pass unchanged: unit 1344/0, struggle 135, recorder-e2e 9, react/logic 865/0 (only test change: a construction site in the wiring test got the injected hub; assertions untouched).
2. New targeted lifecycle tests (`observationLifecycle.test.ts`): debounce coalescing, consent-downgrade discard, end-flush ordering, session isolation; plus EQ settle-path tests including the cross-session guard and pre-session v1 parity.
3. Clean bundle: `verify-clean-bundle.js` green on the openvsx variant (sensing is in, recorder/consent stay out).
4. Manual before/after recording field-diff: DONE (2026-06-13). Two comparable interactive dev-host sessions against the same exercise (19570), one on the base branch (pre-refactor recorder), one on this branch: open file, type, save 3-4x, select, scroll, terminal, file switches, end session. Result: schema v2 on both; the per-type field sets are IDENTICAL for every common event type (incl. `eqSnapshot`: `confidence/eq/source/timestamp/type`); both sessions bracket cleanly (`sessionStart` first, `sessionEnd` last); event counts per type are in the same range with differences fully explained by session content (the sessions were similar, not scripted identically; e.g. `viewNavigation` only occurred in the base session, `terminalCommand`/`textDocumentClose` only in the refactored one). The EQ settle path produced 3 `eqSnapshot` events in both sessions. `validate-recording` passes on both; the handful of timestamp-regression warnings appear on both sides and on a pre-refactor recording from 2026-06-02 (debounce design: payload stamped at trigger, written later), so they are pre-existing, not refactor drift.

## Notes for later PRs

- `sensing/collectors/diagnosticsSettle.ts` imports `shouldRecordUri` from `services/telemetry/uriFilter`; when `services/telemetry` dissolves (PR 2/PR 5), `uriFilter` should move to a neutral location.
- The known micro-difference (documented in the plan's decision log): the `struggleDetection.enabled` gate for the EQ save path moved from save-time to settle-time; only observable when the setting flips inside the 500 ms settle window.
