### PR TITLE
PR 3: Engine v2 golden-replay verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Internal
 
+- **Engine v2 golden-replay verification**: a local (non-CI) harness replays recorded
+  sessions through the Engine v2 TS port and checks it tick-for-tick against the frozen
+  Python reference (exact engine-math fidelity; causal-mode divergence from the three
+  declared live deviations is characterized locally). Study data and per-session results
+  stay local; only the harness and methodology are in the repo.
 - **Struggle Engine v2 live (switchover)**: the v1 EQ decision path (boundary triggers,
   adaptive cadence, intervention filter/decision engine, inactivity/build-result/diagnostic
   trackers, debug dashboard, TelemetryManager) is removed; Engine v2 now drives a single-level

--- a/docs/struggle/golden-replay-verification.md
+++ b/docs/struggle/golden-replay-verification.md
@@ -58,9 +58,12 @@ The harness asserts up front (failing loud rather than producing silently-wrong 
 
    Without `IRIS_STUDY_DATA`/`GOLDEN_DIR` set, the dataset suite skips (the harness unit tests still run), so the target is safe on any machine.
 
-## Outcome
+## Pass criteria (what the harness checks)
 
-Exact mode passes for every replayed session: the port reproduces the reference engine's per-tick severity, dynamics, boundaries, and alerts with no divergence (6-decimal numeric tolerance; exact boundary/alert match). Causal mode shows the expected, bounded divergence attributable to the three declared deviations, with the live engine's intervention behavior matching the reference; the per-session figures are recorded locally for the thesis evaluation and are not committed here.
+- **exact mode passes** when every replayed session matches the reference with no divergence: per-tick `S`/`V`/`S_base`/features within a 6-decimal tolerance, and boundaries plus alerts (times, pre-gate/gated types, primary, path, warmup/grace flags) exactly equal.
+- **causal mode is informational**: it records, per session, the divergence attributable to the three declared deviations — per-tick `S`/`V` deltas, `f_a8`/`f_n2`/N1-boundary disagreement tick counts, and alert-time/primary/path parity.
+
+All per-session figures are written to the local run output (console + the local goldens directory) for the thesis evaluation and are intentionally not committed to this repository. Run the command above to produce them.
 
 ## Code map
 

--- a/docs/struggle/golden-replay-verification.md
+++ b/docs/struggle/golden-replay-verification.md
@@ -40,7 +40,7 @@ Because `V(t)` carries decay memory, a deviation that shifts `S` at one tick con
 The harness asserts up front (failing loud rather than producing silently-wrong output):
 - the golden's `theta`/`graceS` match the TS `SPEC` constants (within float tolerance for `graceS`, whose derivation carries IEEE noise below any gating granularity);
 - every `taskFeedbackView` close has a matching prior open (mirrors the reference);
-- every `textChange` URI has a prior `fileSnapshot`/`textDocumentOpen` baseline.
+- every `textChange` URI has a `fileSnapshot` somewhere in the stream — a `textDocumentOpen` carries no text, so a snapshot is required (membership, not stream order, since the recorder can write a snapshot's event after an early edit).
 
 ## Reproduce locally
 

--- a/docs/struggle/golden-replay-verification.md
+++ b/docs/struggle/golden-replay-verification.md
@@ -1,0 +1,69 @@
+# Engine v2 Golden-Replay Verification
+
+A **local** verification that the TypeScript Engine v2 port (`extension/src/extension/services/struggle/`) faithfully reproduces the frozen Python reference engine, by replaying recorded study sessions through the TS engine and comparing the per-tick output tick-for-tick.
+
+This is **not** a CI gate, and **no study-derived data is committed** to this repository. Only the harness, the runner, and this methodology document live here. The session recordings, the generated goldens, and all per-session numbers stay local (the local output directory is gitignored).
+
+## Why
+
+PR 2b ported the data-derived engine from the Python reference; PR 2c switched it live. Component tests proved each piece in isolation. This verification closes the loop end-to-end: it confirms that, fed the same inputs, the ported engine produces the same severity curve, dynamics, boundaries, gates, and alerts as the reference — on real sessions, not synthetic fixtures.
+
+## The two reference sides
+
+| | Python reference (frozen, never edited) | TS engine (under test) |
+|---|---|---|
+| Location | `IrisStudyData/analysis/lib/engine_v2.py` | `extension/src/extension/services/struggle/` |
+| Entry | `run_pipeline(pid, …)` + `full_alerts(…)` | `StruggleEngine` driven by a `SensorHub`, ticked via `advanceTo` |
+| Per-tick output | `feat` rows + `run_state_machine` audit | `TickRecord` / `AlertRecord` |
+
+The recorded `events.jsonl` is the same format the extension's session recorder writes, so the TS side replays exactly the stream the recorder produced.
+
+## The three declared deviations
+
+The reference consumes whole-session, retrospective artifacts for three signals; the live TS engine derives them causally (online, no look-ahead). These are the spec's declared deviations:
+
+1. **A8** (`f_a8`, region-persistence severity bonus) — reference canonicalizes transient method names over the whole session; live canonicalizes session-so-far.
+2. **N2** (`f_n2`, distant-active-error bonus) — reference uses each error's last-seen time and eventual-resolution flag (look-ahead); live is active-until-removal.
+3. **N1** (paste boundary) — reference uses the recorded v1 paste-trigger set; live uses the deterministic paste heuristic.
+
+Everything else (base severity `f_typing`/`f_gap`/`f_n4`, the `FM`/`FM_PLUS`/`E4`/`STATE` boundaries, the decay `V(t)`, the gates, and the alert state machine) is deviation-free.
+
+## Two comparison modes
+
+Because `V(t)` carries decay memory, a deviation that shifts `S` at one tick contaminates `V` onward, so end-to-end exactness can only be asserted when the deviation-affected signals are held identical. Hence two modes:
+
+- **exact** — proves the ported *math*. The Python generator exports, per tick, the reference's `f_a8`/`f_n2` and the reference's paste event times; the harness drives the engine with scripted A8/N2 trackers and injected paste (causal paste derivation suppressed), while base features, builds, terminal, decay, gates, and the state machine are derived by the TS engine from the recorded events. Every quantity must match: `S`/`V`/`S_base`/features to 6 decimals; boundaries and alerts (incl. pre-gate types, primary, path, warmup/grace flags) exactly.
+- **causal** — characterizes the *live* engine. The TS engine derives A8/N2/paste online; the harness reports (does not assert) the divergence from the offline reference. This quantifies the real-world impact of the three deviations. Its numbers are produced locally and intentionally not committed.
+
+## Guarded invariants
+
+The harness asserts up front (failing loud rather than producing silently-wrong output):
+- the golden's `theta`/`graceS` match the TS `SPEC` constants (within float tolerance for `graceS`, whose derivation carries IEEE noise below any gating granularity);
+- every `taskFeedbackView` close has a matching prior open (mirrors the reference);
+- every `textChange` URI has a prior `fileSnapshot`/`textDocumentOpen` baseline.
+
+## Reproduce locally
+
+1. Generate the goldens from the frozen reference (in the analysis repo, with its venv):
+
+   ```
+   IrisStudyData/analysis/.venv/bin/python IrisStudyData/analysis/scripts/26_export_ts_goldens.py --out <local-goldens-dir>
+   ```
+
+2. Run the verification (from `extension/`), pointing at the study data root and the goldens:
+
+   ```
+   IRIS_STUDY_DATA=<study-data-root> GOLDEN_DIR=<local-goldens-dir> npm run test:golden-replay
+   ```
+
+   Without `IRIS_STUDY_DATA`/`GOLDEN_DIR` set, the dataset suite skips (the harness unit tests still run), so the target is safe on any machine.
+
+## Outcome
+
+Exact mode passes for every replayed session: the port reproduces the reference engine's per-tick severity, dynamics, boundaries, and alerts with no divergence (6-decimal numeric tolerance; exact boundary/alert match). Causal mode shows the expected, bounded divergence attributable to the three declared deviations, with the live engine's intervention behavior matching the reference; the per-session figures are recorded locally for the thesis evaluation and are not committed here.
+
+## Code map
+
+- `extension/test/golden-replay/` — harness (replay sensor hub, text reconstruction, build-result rehydration, scripted trackers), comparator, invariants, schema, and the dataset suite. Test-tree only; never shipped.
+- `extension/vitest.golden-replay.config.mts` + `npm run test:golden-replay` — the dedicated local target (excluded from the default `test:react` run).
+- `IrisStudyData/analysis/scripts/26_export_ts_goldens.py` — the golden generator (lives with the data; not in this repo).

--- a/docs/superpowers/plans/2026-06-13-pr3-golden-replay.md
+++ b/docs/superpowers/plans/2026-06-13-pr3-golden-replay.md
@@ -146,9 +146,11 @@ git commit -m "feat(struggle): injectable A8/N2 trackers for replay verification
 
 ---
 
-## Task 2: Golden schema + parser + invariants
+## Task 2: Dedicated Vitest target + golden schema + parser + invariants
 
-**Files:** Create `extension/test/golden-replay/goldenTypes.ts`, `invariants.ts`; Test `goldenTypes.unit.test.ts`.
+**Files:** Create `extension/vitest.golden-replay.config.mts`, `extension/test/golden-replay/goldenTypes.ts`, `invariants.ts`; Test `goldenTypes.unit.test.ts`; Modify `extension/package.json`.
+
+> The default Vitest `include` is `test/react/**` + `test/logic/**` only — it does NOT collect `test/golden-replay/**`. So create the dedicated target up front (not in Task 7) so every golden-replay task (2-6) can run its unit tests. Config: copy the alias/stub/`setupFiles` block from `vitest.config.mts`, set `include: ['test/golden-replay/**/*.test.{ts,tsx}']`. Add npm script `"test:golden-replay": "vitest run --config vitest.golden-replay.config.mts"`. The default `vitest.config.mts` stays unchanged (never collects golden-replay; the dataset suite is fully isolated in this target). `check-types` (whole test tree) and `knip` still cover the golden-replay code in CI.
 
 - [ ] **Step 1: Write failing test** — `parseGoldenSession` accepts a minimal well-formed golden, rejects a malformed one; `assertSpecConstants(golden)` throws when `golden.theta !== SPEC.THETA_FULL` or `golden.graceS !== SPEC.GRACE_S`.
 - [ ] **Step 2: Run → FAIL.**
@@ -236,11 +238,11 @@ Deterministic injected clock (no real timers). `ticksFor(durationS)` mirrors Pyt
 
 ---
 
-## Task 7: Vitest target + Python generator + the verification run
+## Task 7: Dataset suite + Python generator + the verification run
 
-**Files:** Create `vitest.golden-replay.config.mts`, `goldenReplay.test.ts`; Modify `package.json`, `vitest.config.mts`, `.gitignore`; Create (local, NOT committed) `IrisStudyData/analysis/scripts/26_export_ts_goldens.py`.
+**Files:** Create `goldenReplay.test.ts`; Modify `.gitignore`; Create (local, NOT committed) `IrisStudyData/analysis/scripts/26_export_ts_goldens.py`. (The dedicated Vitest target `vitest.golden-replay.config.mts` + `test:golden-replay` script already exist from Task 2.)
 
-- [ ] **Step 1: Dedicated Vitest target.** `vitest.golden-replay.config.mts` includes only `test/golden-replay/**`, same `vscode` alias as the default config. Add `"test:golden-replay"` script. Exclude `test/golden-replay/**` from the default `vitest.config.mts` include so the normal `test:react` run never collects it.
+- [ ] **Step 1: (config already exists from Task 2)** — the dataset suite below is collected by the existing `test:golden-replay` target; the default `test:react` never collects `test/golden-replay/**`.
 - [ ] **Step 2: The local suite `goldenReplay.test.ts`** — `describe.skipIf(!process.env.IRIS_STUDY_DATA)`. Resolve sessions dir + goldens dir from env (`IRIS_STUDY_DATA`, `GOLDEN_DIR`). Per pid: read `events.jsonl` + metadata (durationS), parse golden, `assertSpecConstants`; run exact (assert `compareExact.ok`, surfacing the first divergence) + causal (collect `summarizeCausal`, log a table). When the env is unset, the whole suite is skipped — proving CI-safety.
 - [ ] **Step 3: Python generator (local).** Implement `26_export_ts_goldens.py`: for each pid P1..P10 (golden replay is fidelity, not eval — all 10 usable, no labels touched), load the four artifacts filtered to pid, `pipe = ev2.run_pipeline(...)`, `theta = params['v2_theta_full']`, `grace_s = params['grace_s']`, `res = ev2.full_alerts(pipe, theta, grace_s)`. Emit `GoldenSession` JSON: per-tick from `pipe['feat']` (round floats to 6 decimals), boundaries from `pipe['boundaries']['flags']` (BOUNDARY priority order), alerts from `res['audit']`, `inject` = per-tick `f_a8`/`f_n2` arrays + paste **event times** (`inputs['paste_t']`). Write to a local `$OUT` dir. NEVER edit the frozen lib.
 - [ ] **Step 4: Run the generator locally; sanity-check** tick counts per pid against the `24_engine_v2.py` console output / `RESULTS_v2_freeze.md`.

--- a/docs/superpowers/plans/2026-06-13-pr3-golden-replay.md
+++ b/docs/superpowers/plans/2026-06-13-pr3-golden-replay.md
@@ -1,0 +1,288 @@
+# PR 3 — Engine v2 Golden-Replay Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the TypeScript Engine v2 port reproduces the frozen Python reference (`IrisStudyData/analysis/lib/engine_v2.py`) by replaying the 10 real study sessions through the TS engine and comparing tick-for-tick — as a **local-only** verification (deliberately NOT a CI gate, per Liam's decision), with no study-derived data committed to the repo.
+
+**Architecture:** All replay/harness/runner code lives in the **test tree** (`extension/test/golden-replay/`) and runs as a **dedicated local Vitest target** (`npm run test:golden-replay`, excluded from the default test run, additionally guarded by `skipIf(!IRIS_STUDY_DATA)`). It never enters the shipped import graph, so the Open-VSX clean bundle is unaffected by construction. A `ReplaySensorHub` reconstructs file text + signals from a recorded session's `events.jsonl` and drives the existing `StruggleEngine`. A Python generator (in IrisStudyData, where the data is) exports the reference engine's per-tick output as JSON goldens. Comparison runs in two modes: **exact** (engine-math fidelity, tolerance 0 / 6-decimal, with the reference's `f_a8`/`f_n2`/paste signals injected) and **causal** (honest end-to-end characterization of the 3 declared live deviations). Only harness/runner/methodology code is committed; goldens, sessions, and per-session results stay local + gitignored.
+
+**Tech Stack:** TypeScript (strict, `@extension/*` aliases), Vitest (with an extended `vscode` stub), Python 3 + pandas/numpy/pyarrow (reference, read-only — frozen, never modified).
+
+**Codex review:** plan reviewed across 3 rounds; all critical/high findings folded in (test-tree+Vitest target, injectable trackers seam, full text reconstruction, ResultDTO rehydration, no-study-data, schema/ordering/invariant fixes) before approval.
+
+---
+
+## Context for the implementer
+
+Engine v2 (the struggle-detection engine) was ported from a frozen Python reference into `extension/src/extension/services/struggle/` in PR 2b and switched live in PR 2c. This PR adds an **offline verification** that the port is faithful to the reference on real study data.
+
+**Branch:** All work happens on a new branch `feat/struggle-golden-replay` cut from the integration branch `feat/struggle-engine-v2` (NOT from `dev`). It merges back into `feat/struggle-engine-v2` via squash PR. `dev` stays untouched.
+
+**The two sides being compared:**
+
+| | Python reference (FROZEN) | TS engine (under test) |
+|---|---|---|
+| Location | `/Users/liamberger/Documents/private/IrisStudyData/analysis/lib/engine_v2.py` | `extension/src/extension/services/struggle/` |
+| Entry | `run_pipeline(pid, builds, pastes, emm, errors)` + `full_alerts(pipe, theta, grace_s)` | `StruggleEngine` driven by a `SensorHub`, ticked via `advanceTo` |
+| Per-tick output | `feat` DataFrame rows + `run_state_machine` audit rows | `TickRecord` (+ `AlertRecord`) on `onDidTick`/`onDidAlert` |
+
+**Field correspondence (verified against both sources):**
+
+| Python `feat` column (engine_v2.py:350-369) | TS `TickRecord` field |
+|---|---|
+| `t` | `t` |
+| `effective_window_s` | `features.effectiveWindowS` |
+| `n_1char_inserts` | `features.nOneCharInserts` *(confirm exact field name when reading FeatureVector)* |
+| `scroll_events` | `features.scrollEvents` *(confirm)* |
+| `typing_rate`, `n4_ratio`, `longest_gap_s` | `features.typingRate`, `n4Ratio`, `longestGapS` |
+| `f_typing`, `f_gap`, `f_n4` | `features.fTyping`, `fGap`, `fN4` |
+| `f_fb`, `f_a8`, `f_n2` | `features.fFb`, `fA8`, `fN2` |
+| `S_base`, `S`, `V`, `fast_decay` | `sBase`, `s`, `v`, `fastDecay` |
+| `ts_state`, `n4_state` | `features.tsState`, `n4State` *(confirm)* |
+| boundary flags `FM/FM_PLUS/E4/N1/STATE` | `boundariesPreGate` |
+
+| Python `run_state_machine` audit (engine_v2.py:592-602) | TS `AlertRecord` |
+|---|---|
+| `t`, `v` | `t`, `v` |
+| `types_pre_gate`, `types`, `primary` | `typesPreGate`, `types`, `primary` |
+| `path` (`armed`/`e6`), `in_warmup`, `in_grace` | `path`, `inWarmup`, `inGrace` |
+
+> **Implementer:** before Task 2, READ `services/struggle/types.ts` (the `FeatureVector` interface) to confirm the exact field names for the 1-char-insert count, scroll count, `tsState`, `n4State`. Use the real names; the table above marks the uncertain ones.
+
+**Session format (`IrisStudyData/VSCode Recorded Data/P{n}-Name-.../`):** `metadata.json` (`startTime`, `endTime`, `eventCount` in epoch-ms) + `events.jsonl` (one JSON event per line, `{type, timestamp, ...payload}`). Time base = seconds since `metadata.startTime`. This is the exact format the recorder writes (`RecordedEvent`). All 10 sessions have startup `fileSnapshot` events (verified).
+
+---
+
+## THE CENTRAL DESIGN DECISION: the declared causal deviations
+
+The Python reference consumes **retrospective, whole-session artifacts** for three signals; the live TS engine derives them **causally (online, no look-ahead)**. These are the declared deviations from the spec (`ENGINE_V2_SPEC.md`; port memory). Located precisely:
+
+1. **A8 (`f_a8`, +0.15 severity)** — Python `_canonical_method_map` (engine_v2.py:93) maps transient method names to the *most frequent name over the whole session*. Live TS canonicalizes session-so-far. (`signals/regionPersistence.ts` + `signals/javaMethods.ts`.)
+2. **N2 (`f_n2`, +0.10)** — Python `active = (e_first <= t) & ((t <= e_last) | ~resolved)` (engine_v2.py:328) needs look-ahead (`e_last`, `resolved`). Live TS is active-until-removal. (`signals/errorDistance.ts`.)
+3. **N1 (paste boundary)** — Python `paste_t` from `paste_events.parquet` (recorded v1 paste-trigger union). Live TS uses the deterministic paste rule. (`sensing/` paste channel → `onPasteDetected`.)
+
+Everything else (`f_typing`/`f_gap`/`f_n4`/`S_base`, `typing_rate`/`longest_gap_s`/`n4_ratio`, the `FM`/`FM_PLUS`/`E4`/`STATE` boundaries, decay `V(t)`, gates, state machine) is **deviation-free**: it depends only on events both sides observe identically.
+
+`V(t)` has cross-tick memory (decay), so a deviation that flips `S` at tick *i* contaminates `V` at tick *i* and onward until it re-converges. Therefore end-to-end `V`/alert exactness **cannot** be asserted in the presence of any deviation disagreement — which is why the exact claim requires injecting the reference's deviation-affected signals.
+
+### Two comparison modes (both local)
+
+- **Mode `exact` — engine-math fidelity (the rigorous tolerance-0 claim).** Feed the TS engine the *same* deviation-affected signals the reference used: the Python generator exports, per tick, the reference's `f_a8`/`f_n2` (0/1) and the reference's paste **event times**; the harness drives the engine with scripted A8/N2 tracker doubles (returning the golden's `f_a8`/`f_n2`) and fires `onPasteDetected` at the golden's paste event times **with causal paste derivation suppressed** (no double N1). Everything else (`f_typing`/`f_gap`/`f_n4`, builds, terminal, decay, gates, state machine) is derived by the TS engine from the recorded events. Then **every** quantity must match: `S_base`/`S`/`V`/`f_*`/`typing_rate`/`longest_gap_s`/`n4_ratio` to 6 decimals, all boundaries + all alerts (`t`, `typesPreGate`, `types`, `primary`, `path`, `inWarmup`, `inGrace`) **exactly**. This isolates and proves the ported *math* on real-session inputs, independent of the sensing layer.
+- **Mode `causal` — honest end-to-end characterization.** The TS engine derives everything causally (no injection, real paste derivation); compare to the Python retrospective goldens and **report** the divergence (per-tick `S`/`V` deltas, alert count/timing diffs, deviation-disagreement tick counts). NOT asserted exact; documents what the *live extension* does versus the offline reference, and quantifies deviation impact (thesis Ch. 6/8). Results stay local.
+
+**Rejected alternatives (for the record):** (A) *causal adapters in Python* — duplicates causal logic in a second language, fragile, and the duplicate would itself be unverified. (B) *partitioned no-injection assertion* — cannot prove `V`/alert exactness end-to-end because of decay memory.
+
+### Engine seam (the ONLY production change): injectable A8/N2 trackers
+
+Exact mode needs scripted A8/N2. The cleanest seam is **dependency injection of the trackers** (not a replay-mode branch in `_runTick`). N1 needs no engine change (it is already a hub channel, `onPasteDetected` at struggleEngine.ts:266).
+
+In `StruggleEngine`:
+- Define narrow interfaces matching today's trackers' used surface, e.g.
+  ```ts
+  export interface A8TrackerLike { recordChange(tS: number, uriKey: string, method: string | null): void; activeAt(tS: number): boolean; reset(): void; }
+  export interface N2TrackerLike { ingestSelection(tS: number, uriKey: string, endLine: number): void; ingestSnapshot(tS: number, uriKey: string, errors: ...): void; activeAt(tS: number): boolean; reset(): void; }
+  ```
+  (Read `regionPersistence.ts`/`errorDistance.ts` for the exact method set; the interfaces must be the engine-used subset.)
+- Add an optional ctor option `trackers?: { a8?: () => A8TrackerLike; n2?: () => N2TrackerLike }`; `_resetState()` uses `this._opts.trackers?.a8?.() ?? new A8Tracker()` (same for n2). Default path byte-identical to today.
+- The harness's **exact** mode passes factories returning scripted doubles seeded from the golden's per-tick `f_a8`/`f_n2`. Its **causal** mode passes nothing (real trackers).
+
+If the implementer finds a method on the concrete tracker the engine calls that the interface misses, widen the interface — do not cast.
+
+---
+
+## File Structure
+
+**New — committed (all under the TEST TREE, never ships):**
+- `extension/test/golden-replay/goldenTypes.ts` — golden JSON schema + strict `parseGoldenSession` validator + the injection-signal shape.
+- `extension/test/golden-replay/textReconstruction.ts` — per-URI text state from `fileSnapshot` + `textChange` deltas (reuse the algorithm in `extension/scripts/roundtrip-recording.ts`; extract a shared helper if clean, else port faithfully).
+- `extension/test/golden-replay/fakeVscode.ts` — minimal `Uri` (valid `scheme`/`fsPath`/`toString`), `TextDocument` (`uri`, `getText`), `TextEditor` (`document.uri`, `selections[].end.line`, `visibleRanges`) shims for replay.
+- `extension/test/golden-replay/replaySensorHub.ts` — `RecordedEvent[]` → `SensorHub` signals (with text reconstruction, diagnostics map, ResultDTO rehydration, paste derive|inject).
+- `extension/test/golden-replay/buildResultRehydrate.ts` — recorded `buildResult` event → minimal `ResultDTO`.
+- `extension/test/golden-replay/scriptedTrackers.ts` — `A8TrackerLike`/`N2TrackerLike` doubles backed by a per-tick lookup from the golden.
+- `extension/test/golden-replay/struggleReplay.ts` — the harness: drive `StruggleEngine` over the grid, return `{ durationS, ticks, alerts }`; modes exact|causal.
+- `extension/test/golden-replay/goldenCompare.ts` — `compareExact` + `summarizeCausal`, structured diff (first divergence, max delta, counts).
+- `extension/test/golden-replay/invariants.ts` — up-front guards (feedbackView matched-close; every `textChange` URI has reconstructed text state — from a startup `fileSnapshot` or a prior open — before its first change; `golden.theta===SPEC.THETA_FULL && golden.graceS===SPEC.GRACE_S`).
+- `extension/test/golden-replay/goldenReplay.test.ts` — the local Vitest suite: `describe.skipIf(!process.env.IRIS_STUDY_DATA)`, loops the 10 sessions, exact (assert) + causal (report).
+- `extension/test/golden-replay/*.unit.test.ts` — fast unit tests for the harness pieces (synthetic data only; run in the dedicated target).
+- `extension/vitest.golden-replay.config.mts` — dedicated config including ONLY `test/golden-replay/**`.
+- `docs/struggle/golden-replay-verification.md` — methodology + reproduction steps ONLY (no per-pid numbers).
+
+**New — local, NOT committed (outside the repo):**
+- `/Users/liamberger/Documents/private/IrisStudyData/analysis/scripts/26_export_ts_goldens.py` — per session: `run_pipeline` + `full_alerts` → golden JSON (incl. per-tick `f_a8`/`f_n2` + paste event times). Writes to a local dir.
+
+**Modified — committed:**
+- `extension/src/extension/services/struggle/struggleEngine.ts` — injectable-tracker ctor option (the only `src/` change).
+- `extension/test/react/__helpers__/vscode.stub.ts` (or the shared stub the configs use) — extend additively with a working `EventEmitter` + minimal `Disposable` (the engine constructs real `vscode.EventEmitter`s; today's stub only has `DiagnosticSeverity` + `Uri.parse`). Additive → safe for existing suites.
+- `extension/package.json` — `"test:golden-replay": "vitest run --config vitest.golden-replay.config.mts"`; ensure the default `test:react`/vitest include does NOT pick up `test/golden-replay/**`.
+- `extension/vitest.config.mts` — exclude `test/golden-replay/**` from the default include.
+- `.gitignore` — ignore the local goldens/output dir (e.g. `extension/.golden-replay/`).
+- `CHANGELOG.md` — generic Internal entry (no baked-in numbers).
+
+---
+
+## Task 0: Branch + plan
+
+- [ ] **Step 1:** `cd /Users/liamberger/Documents/private/MA/artemis-extension && git status && git branch --show-current` → branch `feat/struggle-engine-v2`, clean tree.
+- [ ] **Step 2:** `git checkout -b feat/struggle-golden-replay`
+- [ ] **Step 3:** `git add docs/superpowers/plans/2026-06-13-pr3-golden-replay.md && git commit -m "docs(struggle): PR3 golden-replay verification plan"`
+
+---
+
+## Task 1: Engine seam — injectable A8/N2 trackers (only production change)
+
+**Files:** Modify `extension/src/extension/services/struggle/struggleEngine.ts`; Test `extension/test/logic/struggle/engineTrackerInjection.test.ts` (vitest logic; needs the extended vscode stub from Task 2 Step 0 — do Task 2 Step 0 first, or co-locate the stub extension here).
+
+- [ ] **Step 0 (prereq): extend the shared vscode stub** with a real-enough `EventEmitter` (subscribe/fire/dispose) + minimal `Disposable`. Run an existing engine-touching logic test to confirm no regression.
+- [ ] **Step 1: Write failing test** — construct `StruggleEngine` with injected scripted A8 (`activeAt(t)=t>=100`) + N2 (`activeAt=false`) via the new ctor option, drive a synthetic idle session, assert `TickRecord.features.fA8===1` for `t>=100` regardless of edits, and assert the default (no option) path is unchanged on an existing scenario expectation.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the `A8TrackerLike`/`N2TrackerLike` interfaces (engine-used subset, read the concrete trackers) + the `trackers?` ctor option used in `_resetState`. Default byte-identical.
+- [ ] **Step 4: Run → PASS.** Also run the full vitest logic suite + (compile-tests) unit label to confirm no regression.
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/extension/services/struggle/struggleEngine.ts extension/test/react/__helpers__/vscode.stub.ts extension/test/logic/struggle/engineTrackerInjection.test.ts
+git commit -m "feat(struggle): injectable A8/N2 trackers for replay verification"
+```
+
+---
+
+## Task 2: Golden schema + parser + invariants
+
+**Files:** Create `extension/test/golden-replay/goldenTypes.ts`, `invariants.ts`; Test `goldenTypes.unit.test.ts`.
+
+- [ ] **Step 1: Write failing test** — `parseGoldenSession` accepts a minimal well-formed golden, rejects a malformed one; `assertSpecConstants(golden)` throws when `golden.theta !== SPEC.THETA_FULL` or `golden.graceS !== SPEC.GRACE_S`.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `GoldenTick` (all fields incl. `nOneCharInserts`, `scrollEvents`, `tsState`, `n4State`), `GoldenAlert` (incl. `typesPreGate`), `GoldenInject` `{ fA8: [number, 0|1][]; fN2: [number, 0|1][]; pasteEventTimes: number[] }`, `GoldenSession`. Import `BoundaryType` from `@extension/services/struggle/constants`. Strict validator (no unchecked casts). In `invariants.ts`: `assertSpecConstants`, `assertFeedbackViewMatched(events)`, `assertSnapshotBeforeChange(events)`.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** `feat(struggle): golden-replay schema, parser, invariants`.
+
+---
+
+## Task 3: Text reconstruction + fake vscode shims
+
+**Files:** Create `textReconstruction.ts`, `fakeVscode.ts`; Test `textReconstruction.unit.test.ts`.
+
+- [ ] **Step 1: Read `extension/scripts/roundtrip-recording.ts`** — it already replays `fileSnapshot` + `textChange` to reconstruct file text. Extract/port its reconstruction into `textReconstruction.ts` (`class FileTextState { seedSnapshot(uri, text); applyChanges(uri, changes[]): void; getText(uri): string | undefined }`). If a clean shared extraction from the script is possible without coupling, prefer it; else port faithfully and note the shared origin.
+- [ ] **Step 2: Write failing test** — seed a snapshot, apply a couple of `textChange` change arrays (VS Code semantics: offsets vs the pre-event state, descending application), assert reconstructed text. Mirror the Python `apply_event_changes` validation order.
+- [ ] **Step 3: Run → FAIL → implement → PASS.**
+- [ ] **Step 4: Implement `fakeVscode.ts`** — `makeUri(recordedUriString)` producing `{ scheme, fsPath, path, toString() }` that satisfies `shouldRecordUri()` (uriFilter.ts:57 uses `scheme` + `fsPath`); `makeDocument(uri, getText)`; `makeEditor(uri, selections, visibleRanges)`. Unit-test that `shouldRecordUri(makeUri(<a recorded session uri>))` is true.
+- [ ] **Step 5: Commit** `feat(struggle): replay text reconstruction + fake vscode shims`.
+
+---
+
+## Task 4: ReplaySensorHub + buildResult rehydration
+
+**Files:** Create `replaySensorHub.ts`, `buildResultRehydrate.ts`; Test `replaySensorHub.unit.test.ts`, `buildResultRehydrate.unit.test.ts`.
+
+- [ ] **Step 1: Read** `services/recording/types.ts` (the `textChange`, `diagnostics`, `selectionChange`, `visibleRangeChange`, `terminalCommand`, `buildResult`, `taskFeedbackView`, `fileSnapshot` member shapes), `services/recording/eventCollectors.ts` (how `buildResult` was recorded), `services/struggle/signals/buildDelta.ts` (which `ResultDTO` fields it consumes: `submission.buildFailed`, `feedbacks[].detailText`/positive — confirm), `services/sensing/sensorHub.ts` (the `SensorHub` interface + signal payload shapes).
+- [ ] **Step 2: buildResult rehydration (TDD).** Write failing parity tests: a rehydrated `ResultDTO` from a recorded `buildResult` event, fed to `buildDelta.ingest`, classifies as the expected delta across all six classes — `compile-error`, `first`, `identical-set`, `improved`, `worse`, `same-count` — asserted against the **TS build-delta contract** (synthetic expected values, not "Python by implication"). Implement `buildResultRehydrate.ts` → PASS.
+- [ ] **Step 3: ReplaySensorHub (TDD).** Write failing tests on a small synthetic `RecordedEvent[]` (sessionStart + fileSnapshot + 2 textChanges + diagnostics + terminalCommand + buildResult + taskFeedbackView): subscribe to each engine-consumed channel, `pumpUpTo`, assert each fires once with the mapped payload at the correct session-relative time; `readDiagnostics(uri)` reflects state-at-pump; `readTextDocuments()` returns startup-snapshot docs.
+- [ ] **Step 4: Implement `ReplaySensorHub`.** Back each channel with a `vscode.EventEmitter`. `constructor(events, { pasteMode: 'derive' | 'inject'; injectedPasteEventTimes?: number[] })`. Maintain `FileTextState`; fake docs return reconstructed text. Map:
+
+| RecordedEvent | Hub signal |
+|---|---|
+| `fileSnapshot` | seed `FileTextState`; contribute to `readTextDocuments()` startup set |
+| `textDocumentOpen` | `onDidOpenTextDocument` (fake doc with reconstructed text) |
+| `textChange` | apply to `FileTextState`; fire `onDidChangeTextDocument` (fake doc `getText()` = post-change text; `contentChanges` carry `range.start.line`, `rangeLength`, `text`) |
+| `selectionChange` | `onDidChangeTextEditorSelection` (fake editor; `selections[0].end.line`) |
+| `visibleRangeChange` | `onDidChangeTextEditorVisibleRanges` |
+| `diagnostics` | update diagnostics map; `onDidChangeDiagnostics` |
+| `terminalCommand` | `onDidEndTerminalShellExecution` |
+| `buildResult` | rehydrate → `onBuildResult({ result })` |
+| `taskFeedbackView` | `onTaskFeedbackView` |
+| paste | `pasteMode==='derive'`: detect from `textChange` via the live paste heuristic (reuse `sensing/` paste detector) and fire `onPasteDetected`; `pasteMode==='inject'`: fire `onPasteDetected` at each `injectedPasteEventTimes` and DERIVE NOTHING (no double N1) |
+
+`pumpUpTo(tS)` fires all not-yet-fired signals with session-relative time ≤ `tS`, **preserving original event order for equal timestamps**, and enqueues a derived/injected paste **immediately after its parent/scheduled time** so the engine's stable queue-drain order matches.
+- [ ] **Step 5: Run → PASS. Commit** `feat(struggle): replay sensor hub + buildResult rehydration`.
+
+---
+
+## Task 5: Replay harness
+
+**Files:** Create `struggleReplay.ts`, `scriptedTrackers.ts`; Test `struggleReplay.unit.test.ts`.
+
+- [ ] **Step 1: Write failing tests** — `scriptedTrackers`: an `A8TrackerLike` built from `[[t, v]]` returns `v` at `activeAt(t)` and `false` elsewhere. `replaySession(events, { mode: 'causal' })`: a synthetic idle session yields ticks `[10,20,...]` and a `STATE` alert (mirror `struggleCoordinator.test.ts`'s idle case). `replaySession(events, { mode: 'exact', inject })`: with injected `fA8`/`fN2`/paste, the resulting tick features equal the injected values.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement `struggleReplay.ts`**
+
+```ts
+export interface ReplayResult { durationS: number; ticks: TickRecord[]; alerts: AlertRecord[]; }
+export function replaySession(events: RecordedEvent[], opts: { mode: 'exact'; inject: GoldenInject } | { mode: 'causal' }): ReplayResult {
+    // assert invariants (feedbackView matched-close, snapshot-before-change)
+    // sessionStartMs + durationS from metadata (passed in) / sessionStart
+    // hub = new ReplaySensorHub(events, opts.mode==='exact'
+    //         ? { pasteMode: 'inject', injectedPasteEventTimes: opts.inject.pasteEventTimes }
+    //         : { pasteMode: 'derive' })
+    // trackers = opts.mode==='exact' ? { a8: () => scriptedA8(opts.inject.fA8), n2: () => scriptedN2(opts.inject.fN2) } : undefined
+    // engine = new StruggleEngine(hub, fixedClock, { preDebouncedIntake: true, trackers })
+    // collect onDidTick/onDidAlert; engine.start({ sessionStartMs })
+    // for tS of ticksFor(durationS): hub.pumpUpTo(tS); engine.advanceTo(sessionStartMs + tS*1000)
+    // engine.stop(); return { durationS, ticks, alerts }
+}
+```
+Deterministic injected clock (no real timers). `ticksFor(durationS)` mirrors Python `ticks_for`.
+- [ ] **Step 4: Run → PASS. Commit** `feat(struggle): replay harness (exact + causal)`.
+
+---
+
+## Task 6: Comparator
+
+**Files:** Create `goldenCompare.ts`; Test `goldenCompare.unit.test.ts`.
+
+- [ ] **Step 1: Write failing tests** — `compareExact`: identical → ok; `v` perturbed 1e-7 → ok (6-dec tol); 1e-5 → not ok with first-diverging tick; flipped `primary` or differing `typesPreGate` → not ok. `summarizeCausal`: returns counts (ticks compared, `fA8`/`fN2`/paste-disagreement ticks, max abs `S`/`V` delta, alert count delta) without throwing.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `const TOL = 1e-6;` `compareExact` (tick count; every numeric field within TOL incl. `nOneCharInserts`/`scrollEvents`/`typingRate`/`n4Ratio`/`longestGapS`/`sBase`/`s`/`v`/`f*`; `tsState`/`n4State` exact; boundaries deep-equal; alerts deep-equal on `t`/`typesPreGate`/`types`/`primary`/`path`/`inWarmup`/`inGrace`). Report the FIRST divergence with full context. `summarizeCausal` partitions by deviation-signal agreement, asserts nothing.
+- [ ] **Step 4: Run → PASS. Commit** `feat(struggle): golden comparison (exact + causal report)`.
+
+---
+
+## Task 7: Vitest target + Python generator + the verification run
+
+**Files:** Create `vitest.golden-replay.config.mts`, `goldenReplay.test.ts`; Modify `package.json`, `vitest.config.mts`, `.gitignore`; Create (local, NOT committed) `IrisStudyData/analysis/scripts/26_export_ts_goldens.py`.
+
+- [ ] **Step 1: Dedicated Vitest target.** `vitest.golden-replay.config.mts` includes only `test/golden-replay/**`, same `vscode` alias as the default config. Add `"test:golden-replay"` script. Exclude `test/golden-replay/**` from the default `vitest.config.mts` include so the normal `test:react` run never collects it.
+- [ ] **Step 2: The local suite `goldenReplay.test.ts`** — `describe.skipIf(!process.env.IRIS_STUDY_DATA)`. Resolve sessions dir + goldens dir from env (`IRIS_STUDY_DATA`, `GOLDEN_DIR`). Per pid: read `events.jsonl` + metadata (durationS), parse golden, `assertSpecConstants`; run exact (assert `compareExact.ok`, surfacing the first divergence) + causal (collect `summarizeCausal`, log a table). When the env is unset, the whole suite is skipped — proving CI-safety.
+- [ ] **Step 3: Python generator (local).** Implement `26_export_ts_goldens.py`: for each pid P1..P10 (golden replay is fidelity, not eval — all 10 usable, no labels touched), load the four artifacts filtered to pid, `pipe = ev2.run_pipeline(...)`, `theta = params['v2_theta_full']`, `grace_s = params['grace_s']`, `res = ev2.full_alerts(pipe, theta, grace_s)`. Emit `GoldenSession` JSON: per-tick from `pipe['feat']` (round floats to 6 decimals), boundaries from `pipe['boundaries']['flags']` (BOUNDARY priority order), alerts from `res['audit']`, `inject` = per-tick `f_a8`/`f_n2` arrays + paste **event times** (`inputs['paste_t']`). Write to a local `$OUT` dir. NEVER edit the frozen lib.
+- [ ] **Step 4: Run the generator locally; sanity-check** tick counts per pid against the `24_engine_v2.py` console output / `RESULTS_v2_freeze.md`.
+- [ ] **Step 5: Run the verification locally over all 10 sessions.**
+  - `cd extension && IRIS_STUDY_DATA="/Users/liamberger/Documents/private/IrisStudyData" GOLDEN_DIR="<local-out>" npm run test:golden-replay`
+  - **Exact mode is the moment of truth.** Any mismatch is a real port/harness/mapping bug — diagnose via the first-divergence report and fix the ROOT CAUSE (engine, harness, mapping; never the frozen Python, never the golden, never the tolerance). If a divergence is a genuine justified port choice, document it and get sign-off; do not loosen tolerance.
+  - Record causal-mode numbers **locally** for the report (do not commit them).
+- [ ] **Step 6: `.gitignore`** the local out dir. **Commit** the target + suite (NOT data):
+
+```bash
+git add extension/vitest.golden-replay.config.mts extension/vitest.config.mts extension/package.json extension/test/golden-replay/goldenReplay.test.ts .gitignore
+git commit -m "feat(struggle): local golden-replay vitest target"
+```
+
+---
+
+## Task 8: Report + finalize
+
+**Files:** Create `docs/struggle/golden-replay-verification.md`; Modify `CHANGELOG.md`.
+
+- [ ] **Step 1: Report — methodology + reproduction ONLY.** Describe the two modes, the injection rationale, the declared deviations + the guarded invariants, and the exact steps to reproduce locally (generator script path + invocation + the `test:golden-replay` command with env vars). State the exact-mode pass criterion (6-dec S/V, exact boundaries/alerts) and that causal-mode numbers are produced locally and intentionally not committed. **No per-pid results, no study-derived numbers/conclusions.**
+- [ ] **Step 2: CHANGELOG** — generic Internal entry, no baked-in numbers, e.g.: "Added a local (non-CI) golden-replay verification that replays recorded sessions through the Engine v2 TS port and checks engine-math fidelity against the frozen reference; study data and per-session results stay local."
+- [ ] **Step 3: Commit** `docs(struggle): golden-replay verification methodology`.
+
+---
+
+## Final gates (before the PR)
+
+- [ ] `cd extension && npm run check-types` → exit 0
+- [ ] `npm run lint` → exit 0
+- [ ] `npm run knip` → exit 0 (the golden-replay test modules are exercised by their unit tests + the suite; if knip flags any, prefer wiring; an ignore must be justified in `knip.json`)
+- [ ] `npm run test:react` (vitest default) → green AND confirm it did NOT collect `test/golden-replay/**`
+- [ ] `npm run test:golden-replay` with NO `IRIS_STUDY_DATA` → suite skipped, exit 0 (CI-safety proof); with the dataset → exact mode passes
+- [ ] `npm run compile-tests && npx vscode-test --label unit` → 0 failures (engine seam didn't regress)
+- [ ] `node esbuild.js --production && node esbuild.js --production --variant=openvsx && node scripts/verify-clean-bundle.js` → **clean bundle still green** (replay code is in `test/`, never bundled; the engine seam adds no recording import). Confirm.
+
+## Out of scope (raised at plan review)
+
+Task #8's title mentions "Review-Panel." This plan delivers the verification only. A new panel is out of scope because the recording-viewer already renders schema-v3 `struggleScore`/`alert` events (PR 2c), so replay output can be inspected there if needed (optional later `--emit-recording` from the harness), and "local-only" argues against shipping new UI. Confirm this satisfies the "Review-Panel" intent.
+
+## Invariants
+- Frozen reference: never edit `engine_v2.py`, `replay.py`, `features.py`, or any IrisStudyData artifact. Read-only.
+- No study-derived data in the repo: goldens, sessions, runner output, and per-pid numbers stay local + gitignored. Only harness/runner/methodology code is committed.
+- No re-tuning, no tolerance-loosening: a mismatch is fixed in the port or harness, never by changing constants or tolerances.
+- Eval-set burn (P1/P3/P7/P9) is irrelevant — golden replay touches no labels.

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -25,6 +25,10 @@ dist/*.html
 test/struggle-detection/reports/
 reports/
 
+# Golden-replay local artifacts (study-derived; never committed — the goldens and
+# any runner output stay local, generated from IrisStudyData via 26_export_ts_goldens.py)
+.golden-replay/
+
 # IDE
 .vscode-test/
 *.swp

--- a/extension/package.json
+++ b/extension/package.json
@@ -276,6 +276,7 @@
     "lint:src": "eslint src",
     "test:unit": "vscode-test --label unit",
     "test:unit:coverage": "vscode-test --label unit --coverage",
+    "test:golden-replay": "vitest run --config vitest.golden-replay.config.mts",
     "test:react": "vitest run",
     "test:react:watch": "vitest",
     "test:react:coverage": "vitest run --coverage",

--- a/extension/src/extension/services/struggle/struggleEngine.ts
+++ b/extension/src/extension/services/struggle/struggleEngine.ts
@@ -46,6 +46,21 @@ const DEFAULT_CLOCK: EngineClock = {
 
 interface QueuedEvent { tsS: number; apply: () => void }
 
+/** The A8-tracker subset the engine drives. Lets golden-replay (PR 3) inject a
+ *  scripted A8 signal in exact mode instead of deriving it online. Widen this
+ *  if the engine ever calls another A8Tracker method. */
+export type A8TrackerLike = Pick<A8Tracker, 'recordChange' | 'activeAt'>;
+/** The N2-tracker subset the engine drives (see A8TrackerLike). */
+export type N2TrackerLike = Pick<N2Tracker, 'ingestSelection' | 'ingestSnapshot' | 'activeAt'>;
+
+interface StruggleEngineOptions {
+    /** Replay feeds already-debounced recorded streams (Decision 5). */
+    preDebouncedIntake?: boolean;
+    /** Factories for scripted A8/N2 trackers (golden-replay exact mode, PR 3).
+     *  Omitted factories fall back to the real online trackers. */
+    trackers?: { a8?: () => A8TrackerLike; n2?: () => N2TrackerLike };
+}
+
 export class StruggleEngine implements vscode.Disposable {
     private readonly _hub: SensorHub;
     private readonly _clock: EngineClock;
@@ -66,8 +81,8 @@ export class StruggleEngine implements vscode.Disposable {
     private _features = new FeatureWindowTracker();
     private _feedback = new FeedbackViewTracker();
     private _shadow = new DocumentShadowTracker();
-    private _a8 = new A8Tracker();
-    private _n2 = new N2Tracker();
+    private _a8: A8TrackerLike = new A8Tracker();
+    private _n2: N2TrackerLike = new N2Tracker();
     private _buildDelta = new BuildDeltaTracker();
     private _fastDecay = new FastDecayTracker();
     private _v = new VTracker();
@@ -77,14 +92,16 @@ export class StruggleEngine implements vscode.Disposable {
     private _scrollDebounce: TrailingDebouncer<number> | undefined;
     /** Replay feeds already-debounced recorded streams (Decision 5). */
     private readonly _preDebounced: boolean;
+    private readonly _opts: StruggleEngineOptions | undefined;
 
     constructor(
         hub: SensorHub,
         clock: EngineClock = DEFAULT_CLOCK,
-        options?: { preDebouncedIntake?: boolean },
+        options?: StruggleEngineOptions,
     ) {
         this._hub = hub;
         this._clock = clock;
+        this._opts = options;
         this._preDebounced = options?.preDebouncedIntake ?? false;
     }
 
@@ -356,8 +373,8 @@ export class StruggleEngine implements vscode.Disposable {
         this._features = new FeatureWindowTracker();
         this._feedback = new FeedbackViewTracker();
         this._shadow = new DocumentShadowTracker();
-        this._a8 = new A8Tracker();
-        this._n2 = new N2Tracker();
+        this._a8 = this._opts?.trackers?.a8?.() ?? new A8Tracker();
+        this._n2 = this._opts?.trackers?.n2?.() ?? new N2Tracker();
         this._buildDelta = new BuildDeltaTracker();
         this._fastDecay = new FastDecayTracker();
         this._v = new VTracker();

--- a/extension/test/golden-replay/buildResultRehydrate.ts
+++ b/extension/test/golden-replay/buildResultRehydrate.ts
@@ -1,0 +1,34 @@
+/**
+ * Inverse of `recording/eventCollectors.ts#collectBuildResult`: rebuild the
+ * minimal `ResultDTO` that the engine's build-delta classifier consumes from a
+ * recorded `buildResult` event.
+ *
+ * The classifier (`services/struggle/signals/buildDelta.ts`) reads ONLY:
+ *   - `result.submission?.buildFailed`  → compile-error vs test-build branch
+ *   - `result.feedbacks[]` where `positive === false` → the failed-test SET,
+ *     keyed on `detailText` (the exact string the frozen reference diffed).
+ *
+ * The recorder derives the failed set from `fb.positive === false → detailText`
+ * and persists it as `failedTestDetails[].detail` (with `testName`). We invert
+ * that mapping: one failed feedback per recorded detail. Every other ResultDTO
+ * field is left undefined except the required `id` (the parser/DTO contract
+ * marks it non-optional); buildDelta never reads it, so a constant is fine.
+ */
+import type { ArtemisFeedback } from '@extension/domain/core';
+import type { ResultDTO } from '@extension/domain/submissions';
+import type { BuildResultEvent } from '@extension/services/recording/types';
+
+export function rehydrateResultDTO(event: BuildResultEvent): ResultDTO {
+    // Prefer the structured details (testName + detail); fall back to the legacy
+    // flat `failedTests` list of detailText strings when details are absent.
+    const failedFeedbacks: ArtemisFeedback[] = event.failedTestDetails
+        ? event.failedTestDetails.map(d => ({ positive: false, detailText: d.detail, text: d.testName }))
+        : event.failedTests.map(detail => ({ positive: false, detailText: detail }));
+
+    return {
+        id: event.submissionId ?? 0,
+        successful: event.successful,
+        feedbacks: failedFeedbacks,
+        submission: { id: event.submissionId, buildFailed: event.buildFailed },
+    };
+}

--- a/extension/test/golden-replay/buildResultRehydrate.unit.test.ts
+++ b/extension/test/golden-replay/buildResultRehydrate.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BuildResultEvent } from '@extension/services/recording/types';
+import { BuildDeltaTracker } from '@extension/services/struggle/signals/buildDelta';
+
+import { rehydrateResultDTO } from './buildResultRehydrate';
+
+/**
+ * Build a minimal recorded buildResult event. The fields the rehydration (and
+ * therefore buildDelta) cares about are `buildFailed` and `failedTestDetails`
+ * (detail = the recorded detailText that the failed-set diff keys on). The
+ * other recorded fields are filled with consistent-but-irrelevant values.
+ */
+function buildResultEvent(opts: {
+    timestamp?: number;
+    buildFailed: boolean;
+    failedDetails?: string[];
+}): BuildResultEvent {
+    const details = opts.failedDetails ?? [];
+    return {
+        type: 'buildResult',
+        timestamp: opts.timestamp ?? 0,
+        successful: !opts.buildFailed && details.length === 0,
+        errorCount: details.length,
+        failedTests: details,
+        buildFailed: opts.buildFailed,
+        failedTestDetails: details.length > 0
+            ? details.map((detail, i) => ({ testName: `test${i}`, detail }))
+            : undefined,
+    };
+}
+
+describe('rehydrateResultDTO + buildDelta classification', () => {
+    it('classifies a compile-error build (buildFailed=true)', () => {
+        const tracker = new BuildDeltaTracker();
+        const c = tracker.ingest(1, rehydrateResultDTO(buildResultEvent({ buildFailed: true })));
+        expect(c.delta).toBe('compile-error');
+        expect(c.failedCount).toBeNull();
+        expect(c.isFM).toBe(true);
+    });
+
+    it('classifies the FIRST build with tests', () => {
+        const tracker = new BuildDeltaTracker();
+        const c = tracker.ingest(1, rehydrateResultDTO(buildResultEvent({
+            buildFailed: false,
+            failedDetails: ['a', 'b'],
+        })));
+        expect(c.delta).toBe('first');
+        expect(c.failedCount).toBe(2);
+    });
+
+    it('classifies an IDENTICAL-SET re-run of the same failures', () => {
+        const tracker = new BuildDeltaTracker();
+        tracker.ingest(1, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'b'] })));
+        const c = tracker.ingest(2, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'b'] })));
+        expect(c.delta).toBe('identical-set');
+        expect(c.failedCount).toBe(2);
+    });
+
+    it('classifies an IMPROVED build (fewer failures)', () => {
+        const tracker = new BuildDeltaTracker();
+        tracker.ingest(1, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'b'] })));
+        const c = tracker.ingest(2, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a'] })));
+        expect(c.delta).toBe('improved');
+        expect(c.improved).toBe(true);
+        expect(c.isFMPlus).toBe(true); // improved AND still has a failure
+    });
+
+    it('classifies a WORSE build (more failures)', () => {
+        const tracker = new BuildDeltaTracker();
+        tracker.ingest(1, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a'] })));
+        const c = tracker.ingest(2, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'b'] })));
+        expect(c.delta).toBe('worse');
+        expect(c.failedCount).toBe(2);
+    });
+
+    it('classifies a SAME-COUNT build (different set, equal size)', () => {
+        const tracker = new BuildDeltaTracker();
+        tracker.ingest(1, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'b'] })));
+        const c = tracker.ingest(2, rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['a', 'c'] })));
+        expect(c.delta).toBe('same-count');
+        expect(c.failedCount).toBe(2);
+    });
+
+    it('populates only buildDelta-relevant fields (buildFailed + failed feedbacks)', () => {
+        const dto = rehydrateResultDTO(buildResultEvent({ buildFailed: false, failedDetails: ['x', 'y'] }));
+        expect(dto.submission?.buildFailed).toBe(false);
+        expect((dto.feedbacks ?? []).filter(f => f.positive === false).map(f => f.detailText))
+            .toEqual(['x', 'y']);
+    });
+});

--- a/extension/test/golden-replay/fakeVscode.ts
+++ b/extension/test/golden-replay/fakeVscode.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal `vscode` object shims for the golden-replay harness.
+ *
+ * The replay harness drives the struggle engine off recorded events. The engine
+ * (and the shared uriFilter) only read a tiny surface of the VS Code object
+ * graph, so these factories build just that surface rather than full mocks:
+ *
+ *   - uriFilter.shouldRecordUri reads `uri.scheme` and `uri.fsPath`.
+ *   - The engine's onDidChangeTextDocument reads `document.uri` (+ `.toString()`
+ *     for the shadow key), `document.getText()`, and per-change `rangeLength` /
+ *     `text` / `range.start.line`.
+ *   - onDidOpenTextDocument reads `document.uri` and `document.getText()`.
+ *   - onDidChangeTextEditorSelection / VisibleRanges read
+ *     `textEditor.document.uri` and `selections[0].end.line`.
+ *
+ * Recorded URIs are standard `vscode.Uri.toString()` strings such as
+ * "file:///Users/x/exercise/src/Foo.java". `makeUri` reuses the test vscode
+ * stub's `Uri.parse`, which derives `scheme` from the protocol, `path`/`fsPath`
+ * from the decoded pathname, and preserves the original string via toString().
+ *
+ * Casts to the real vscode types are localized here and deliberate: these are
+ * structural test shims, and the real interfaces carry far more members than
+ * the engine ever touches.
+ */
+import * as vscode from 'vscode';
+
+/**
+ * Build a `vscode.Uri` from a recorded URI string. Round-trips scheme/path/
+ * fsPath and toString() such that `shouldRecordUri` treats a normal workspace
+ * file:// URI as recordable.
+ */
+export function makeUri(recordedUriString: string): vscode.Uri {
+    return vscode.Uri.parse(recordedUriString) as unknown as vscode.Uri;
+}
+
+/** Build a minimal `vscode.TextDocument` exposing `uri` and `getText()`. */
+export function makeDocument(uri: vscode.Uri, getText: () => string): vscode.TextDocument {
+    return { uri, getText } as unknown as vscode.TextDocument;
+}
+
+/**
+ * Build a minimal `vscode.TextEditor` exposing `document.uri`, `selections`
+ * (the engine reads `selections[0].end.line`) and `visibleRanges`.
+ */
+export function makeEditor(
+    uri: vscode.Uri,
+    selections: { end: { line: number } }[],
+    visibleRanges?: { start: { line: number }; end: { line: number } }[],
+): vscode.TextEditor {
+    return {
+        document: { uri },
+        selections,
+        visibleRanges: visibleRanges ?? [],
+    } as unknown as vscode.TextEditor;
+}

--- a/extension/test/golden-replay/fakeVscode.unit.test.ts
+++ b/extension/test/golden-replay/fakeVscode.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRecordUri } from '@extension/services/sensing/uriFilter';
+
+import { makeDocument, makeEditor, makeUri } from './fakeVscode';
+
+const FILE_URI = 'file:///Users/x/exercise/src/Foo.java';
+
+describe('makeUri', () => {
+    it('produces a URI that passes shouldRecordUri for a normal workspace file', () => {
+        expect(shouldRecordUri(makeUri(FILE_URI))).toBe(true);
+    });
+
+    it('round-trips scheme, fsPath, path and toString sensibly', () => {
+        const uri = makeUri(FILE_URI);
+        expect(uri.scheme).toBe('file');
+        expect(uri.path).toBe('/Users/x/exercise/src/Foo.java');
+        expect(uri.fsPath).toBe('/Users/x/exercise/src/Foo.java');
+        expect(uri.toString()).toBe(FILE_URI);
+    });
+
+    it('respects exerciseRoot scoping through shouldRecordUri', () => {
+        const root = makeUri('file:///Users/x/exercise');
+        expect(shouldRecordUri(makeUri(FILE_URI), root)).toBe(true);
+        // Prefix-bug guard: /exercise10 must not match root /exercise.
+        expect(shouldRecordUri(makeUri('file:///Users/x/exercise10/Foo.java'), root)).toBe(false);
+    });
+
+    it('rejects non-file schemes via shouldRecordUri', () => {
+        expect(shouldRecordUri(makeUri('git:///Users/x/exercise/src/Foo.java'))).toBe(false);
+    });
+});
+
+describe('makeDocument', () => {
+    it('exposes the uri and a getText() returning the supplied text', () => {
+        const uri = makeUri(FILE_URI);
+        const doc = makeDocument(uri, () => 'hello world');
+        expect(doc.uri).toBe(uri);
+        expect(doc.getText()).toBe('hello world');
+    });
+
+    it('reflects later text changes through the getText closure', () => {
+        const uri = makeUri(FILE_URI);
+        let text = 'before';
+        const doc = makeDocument(uri, () => text);
+        expect(doc.getText()).toBe('before');
+        text = 'after';
+        expect(doc.getText()).toBe('after');
+    });
+});
+
+describe('makeEditor', () => {
+    it('exposes document.uri and selection end lines', () => {
+        const uri = makeUri(FILE_URI);
+        const editor = makeEditor(uri, [{ end: { line: 7 } }]);
+        expect(editor.document.uri).toBe(uri);
+        expect(editor.selections[0].end.line).toBe(7);
+        expect(editor.visibleRanges).toEqual([]);
+    });
+
+    it('carries supplied visibleRanges', () => {
+        const uri = makeUri(FILE_URI);
+        const editor = makeEditor(uri, [{ end: { line: 0 } }], [{ start: { line: 2 }, end: { line: 40 } }]);
+        expect(editor.visibleRanges[0].start.line).toBe(2);
+        expect(editor.visibleRanges[0].end.line).toBe(40);
+    });
+});

--- a/extension/test/golden-replay/goldenCompare.ts
+++ b/extension/test/golden-replay/goldenCompare.ts
@@ -31,6 +31,12 @@ export interface CausalReport {
     readonly alertCountReplay: number;
     readonly alertCountGolden: number;
     readonly alertCountDelta: number;
+    /** Alert tick-times present in the replay but not the reference. */
+    readonly alertTimesOnlyInReplay: number;
+    /** Alert tick-times present in the reference but not the replay. */
+    readonly alertTimesOnlyInGolden: number;
+    /** Alerts at a shared tick-time that differ in primary boundary or path. */
+    readonly alertSharedTimeFieldMismatches: number;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -356,6 +362,22 @@ export function summarizeCausal(replay: ReplayResult, golden: GoldenSession): Ca
     const alertCountReplay = replay.alerts.length;
     const alertCountGolden = golden.alerts.length;
 
+    // Alerts fire at most once per integer tick-time, so compare by tick-time:
+    // does the same alert fire at the same time, with the same primary + path?
+    const replayByT = new Map(replay.alerts.map(a => [a.t, a]));
+    const goldenByT = new Map(golden.alerts.map(a => [a.t, a]));
+    let alertTimesOnlyInReplay = 0;
+    let alertTimesOnlyInGolden = 0;
+    let alertSharedTimeFieldMismatches = 0;
+    for (const [t, ra] of replayByT) {
+        const ga = goldenByT.get(t);
+        if (ga === undefined) { alertTimesOnlyInReplay++; }
+        else if (ra.primary !== ga.primary || ra.path !== ga.path) { alertSharedTimeFieldMismatches++; }
+    }
+    for (const t of goldenByT.keys()) {
+        if (!replayByT.has(t)) { alertTimesOnlyInGolden++; }
+    }
+
     return {
         ticksCompared,
         tickCountDelta,
@@ -367,5 +389,8 @@ export function summarizeCausal(replay: ReplayResult, golden: GoldenSession): Ca
         alertCountReplay,
         alertCountGolden,
         alertCountDelta: alertCountReplay - alertCountGolden,
+        alertTimesOnlyInReplay,
+        alertTimesOnlyInGolden,
+        alertSharedTimeFieldMismatches,
     };
 }

--- a/extension/test/golden-replay/goldenCompare.ts
+++ b/extension/test/golden-replay/goldenCompare.ts
@@ -1,0 +1,371 @@
+import type { AlertRecord, TickRecord } from '@extension/services/struggle/types';
+
+import type { GoldenAlert, GoldenSession, GoldenTick } from './goldenTypes';
+import type { ReplayResult } from './struggleReplay';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ExactDivergence {
+    readonly kind: 'tickCount' | 'tickField' | 'alertCount' | 'alertField';
+    readonly t?: number;
+    readonly index?: number;
+    readonly field?: string;
+    readonly replay?: unknown;
+    readonly golden?: unknown;
+    readonly message: string;
+}
+
+export interface ExactReport {
+    readonly ok: boolean;
+    readonly firstDivergence?: ExactDivergence;
+}
+
+export interface CausalReport {
+    readonly ticksCompared: number;
+    readonly tickCountDelta: number;
+    readonly fA8DisagreeTicks: number;
+    readonly fN2DisagreeTicks: number;
+    readonly pasteBoundaryDisagreeTicks: number;
+    readonly maxAbsSDelta: number;
+    readonly maxAbsVDelta: number;
+    readonly alertCountReplay: number;
+    readonly alertCountGolden: number;
+    readonly alertCountDelta: number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TOL = 1e-6;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function approxEq(a: number, b: number): boolean {
+    return Math.abs(a - b) <= TOL;
+}
+
+function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+    if (a.length !== b.length) {return false;}
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {return false;}
+    }
+    return true;
+}
+
+// ── compareExact ──────────────────────────────────────────────────────────────
+
+function compareTickFields(
+    rt: TickRecord,
+    gt: GoldenTick,
+    index: number,
+): ExactDivergence | null {
+    const t = gt.t;
+
+    const numericFields: Array<{ field: string; replay: number; golden: number }> = [
+        { field: 'effectiveWindowS', replay: rt.features.effectiveWindowS, golden: gt.effectiveWindowS },
+        { field: 'nOneCharInserts', replay: rt.features.nOneCharInserts, golden: gt.nOneCharInserts },
+        { field: 'scrollEvents', replay: rt.features.scrollEvents, golden: gt.scrollEvents },
+        { field: 'typingRate', replay: rt.features.typingRate, golden: gt.typingRate },
+        { field: 'n4Ratio', replay: rt.features.n4Ratio, golden: gt.n4Ratio },
+        { field: 'longestGapS', replay: rt.features.longestGapS, golden: gt.longestGapS },
+        { field: 'fTyping', replay: rt.features.fTyping, golden: gt.fTyping },
+        { field: 'fGap', replay: rt.features.fGap, golden: gt.fGap },
+        { field: 'fN4', replay: rt.features.fN4, golden: gt.fN4 },
+        { field: 'fFb', replay: rt.features.fFb, golden: gt.fFb },
+        { field: 'fA8', replay: rt.features.fA8, golden: gt.fA8 },
+        { field: 'fN2', replay: rt.features.fN2, golden: gt.fN2 },
+        { field: 'sBase', replay: rt.sBase, golden: gt.sBase },
+        { field: 's', replay: rt.s, golden: gt.s },
+        { field: 'v', replay: rt.v, golden: gt.v },
+    ];
+
+    for (const { field, replay, golden } of numericFields) {
+        if (!approxEq(replay, golden)) {
+            return {
+                kind: 'tickField',
+                t,
+                index,
+                field,
+                replay,
+                golden,
+                message: `tick[${index}] t=${t}: field "${field}" diverged (replay=${replay}, golden=${golden}, diff=${Math.abs(replay - golden)})`,
+            };
+        }
+    }
+
+    if (rt.features.tsState !== gt.tsState) {
+        return {
+            kind: 'tickField',
+            t,
+            index,
+            field: 'tsState',
+            replay: rt.features.tsState,
+            golden: gt.tsState,
+            message: `tick[${index}] t=${t}: field "tsState" diverged (replay=${rt.features.tsState}, golden=${gt.tsState})`,
+        };
+    }
+
+    if (rt.features.n4State !== gt.n4State) {
+        return {
+            kind: 'tickField',
+            t,
+            index,
+            field: 'n4State',
+            replay: rt.features.n4State,
+            golden: gt.n4State,
+            message: `tick[${index}] t=${t}: field "n4State" diverged (replay=${rt.features.n4State}, golden=${gt.n4State})`,
+        };
+    }
+
+    if (rt.fastDecay !== gt.fastDecay) {
+        return {
+            kind: 'tickField',
+            t,
+            index,
+            field: 'fastDecay',
+            replay: rt.fastDecay,
+            golden: gt.fastDecay,
+            message: `tick[${index}] t=${t}: field "fastDecay" diverged (replay=${rt.fastDecay}, golden=${gt.fastDecay})`,
+        };
+    }
+
+    if (!arraysEqual(rt.boundariesPreGate, gt.boundaries)) {
+        return {
+            kind: 'tickField',
+            t,
+            index,
+            field: 'boundariesPreGate',
+            replay: [...rt.boundariesPreGate],
+            golden: [...gt.boundaries],
+            message: `tick[${index}] t=${t}: field "boundariesPreGate" diverged (replay=${JSON.stringify(rt.boundariesPreGate)}, golden=${JSON.stringify(gt.boundaries)})`,
+        };
+    }
+
+    return null;
+}
+
+function compareAlertFields(
+    ra: AlertRecord,
+    ga: GoldenAlert,
+    index: number,
+): ExactDivergence | null {
+    const t = ga.t;
+
+    if (!approxEq(ra.v, ga.v)) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'v',
+            replay: ra.v,
+            golden: ga.v,
+            message: `alert[${index}] t=${t}: field "v" diverged (replay=${ra.v}, golden=${ga.v})`,
+        };
+    }
+
+    if (!arraysEqual(ra.typesPreGate, ga.typesPreGate)) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'typesPreGate',
+            replay: [...ra.typesPreGate],
+            golden: [...ga.typesPreGate],
+            message: `alert[${index}] t=${t}: field "typesPreGate" diverged`,
+        };
+    }
+
+    if (!arraysEqual(ra.types, ga.types)) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'types',
+            replay: [...ra.types],
+            golden: [...ga.types],
+            message: `alert[${index}] t=${t}: field "types" diverged`,
+        };
+    }
+
+    if (ra.primary !== ga.primary) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'primary',
+            replay: ra.primary,
+            golden: ga.primary,
+            message: `alert[${index}] t=${t}: field "primary" diverged (replay=${ra.primary}, golden=${ga.primary})`,
+        };
+    }
+
+    if (ra.path !== ga.path) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'path',
+            replay: ra.path,
+            golden: ga.path,
+            message: `alert[${index}] t=${t}: field "path" diverged (replay=${ra.path}, golden=${ga.path})`,
+        };
+    }
+
+    if (ra.inWarmup !== ga.inWarmup) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'inWarmup',
+            replay: ra.inWarmup,
+            golden: ga.inWarmup,
+            message: `alert[${index}] t=${t}: field "inWarmup" diverged`,
+        };
+    }
+
+    if (ra.inGrace !== ga.inGrace) {
+        return {
+            kind: 'alertField',
+            t,
+            index,
+            field: 'inGrace',
+            replay: ra.inGrace,
+            golden: ga.inGrace,
+            message: `alert[${index}] t=${t}: field "inGrace" diverged`,
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Tick-for-tick exact comparison of a replay result against a golden session.
+ * Returns on the first divergence with full context.
+ */
+export function compareExact(replay: ReplayResult, golden: GoldenSession): ExactReport {
+    if (replay.ticks.length !== golden.ticks.length) {
+        return {
+            ok: false,
+            firstDivergence: {
+                kind: 'tickCount',
+                replay: replay.ticks.length,
+                golden: golden.ticks.length,
+                message: `tick count mismatch: replay has ${replay.ticks.length}, golden has ${golden.ticks.length}`,
+            },
+        };
+    }
+
+    for (let i = 0; i < golden.ticks.length; i++) {
+        const gt = golden.ticks[i];
+        const rt = replay.ticks[i];
+
+        if (rt.t !== gt.t) {
+            return {
+                ok: false,
+                firstDivergence: {
+                    kind: 'tickField',
+                    t: gt.t,
+                    index: i,
+                    field: 't',
+                    replay: rt.t,
+                    golden: gt.t,
+                    message: `tick[${i}]: time mismatch (replay t=${rt.t}, golden t=${gt.t})`,
+                },
+            };
+        }
+
+        const div = compareTickFields(rt, gt, i);
+        if (div !== null) {
+            return { ok: false, firstDivergence: div };
+        }
+    }
+
+    if (replay.alerts.length !== golden.alerts.length) {
+        return {
+            ok: false,
+            firstDivergence: {
+                kind: 'alertCount',
+                replay: replay.alerts.length,
+                golden: golden.alerts.length,
+                message: `alert count mismatch: replay has ${replay.alerts.length}, golden has ${golden.alerts.length}`,
+            },
+        };
+    }
+
+    for (let i = 0; i < golden.alerts.length; i++) {
+        const ga = golden.alerts[i];
+        const ra = replay.alerts[i];
+
+        if (ra.t !== ga.t) {
+            return {
+                ok: false,
+                firstDivergence: {
+                    kind: 'alertField',
+                    t: ga.t,
+                    index: i,
+                    field: 't',
+                    replay: ra.t,
+                    golden: ga.t,
+                    message: `alert[${i}]: time mismatch (replay t=${ra.t}, golden t=${ga.t})`,
+                },
+            };
+        }
+
+        const div = compareAlertFields(ra, ga, i);
+        if (div !== null) {
+            return { ok: false, firstDivergence: div };
+        }
+    }
+
+    return { ok: true };
+}
+
+// ── summarizeCausal ───────────────────────────────────────────────────────────
+
+/**
+ * Measurement-only comparison: counts disagreements and deltas without asserting.
+ * Useful for diagnosing causal-mode divergence at the feature level.
+ */
+export function summarizeCausal(replay: ReplayResult, golden: GoldenSession): CausalReport {
+    const ticksCompared = Math.min(replay.ticks.length, golden.ticks.length);
+    const tickCountDelta = replay.ticks.length - golden.ticks.length;
+
+    let fA8DisagreeTicks = 0;
+    let fN2DisagreeTicks = 0;
+    let pasteBoundaryDisagreeTicks = 0;
+    let maxAbsSDelta = 0;
+    let maxAbsVDelta = 0;
+
+    for (let i = 0; i < ticksCompared; i++) {
+        const rt = replay.ticks[i];
+        const gt = golden.ticks[i];
+
+        if (rt.features.fA8 !== gt.fA8) {fA8DisagreeTicks++;}
+        if (rt.features.fN2 !== gt.fN2) {fN2DisagreeTicks++;}
+
+        const replayHasN1 = rt.boundariesPreGate.includes('N1');
+        const goldenHasN1 = gt.boundaries.includes('N1');
+        if (replayHasN1 !== goldenHasN1) {pasteBoundaryDisagreeTicks++;}
+
+        const sDelta = Math.abs(rt.s - gt.s);
+        if (sDelta > maxAbsSDelta) {maxAbsSDelta = sDelta;}
+
+        const vDelta = Math.abs(rt.v - gt.v);
+        if (vDelta > maxAbsVDelta) {maxAbsVDelta = vDelta;}
+    }
+
+    const alertCountReplay = replay.alerts.length;
+    const alertCountGolden = golden.alerts.length;
+
+    return {
+        ticksCompared,
+        tickCountDelta,
+        fA8DisagreeTicks,
+        fN2DisagreeTicks,
+        pasteBoundaryDisagreeTicks,
+        maxAbsSDelta,
+        maxAbsVDelta,
+        alertCountReplay,
+        alertCountGolden,
+        alertCountDelta: alertCountReplay - alertCountGolden,
+    };
+}

--- a/extension/test/golden-replay/goldenCompare.unit.test.ts
+++ b/extension/test/golden-replay/goldenCompare.unit.test.ts
@@ -246,4 +246,26 @@ describe('summarizeCausal', () => {
         const report = summarizeCausal(replay, golden);
         expect(report.pasteBoundaryDisagreeTicks).toBe(1);
     });
+
+    it('reports alert-time parity by tick-time', () => {
+        const golden = makeGolden({
+            ticks: [makeTick({ t: 10 })],
+            alerts: [
+                makeAlert({ t: 10, primary: 'STATE', path: 'armed' }),
+                makeAlert({ t: 130, primary: 'STATE', path: 'e6' }),
+            ],
+        });
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(makeTick({ t: 10 }))],
+            alerts: [
+                makeReplayAlert(makeAlert({ t: 10, primary: 'FM', path: 'armed' })), // shared t, primary differs
+                makeReplayAlert(makeAlert({ t: 250, primary: 'STATE', path: 'armed' })), // only in replay
+            ],
+        };
+        const report = summarizeCausal(replay, golden);
+        expect(report.alertTimesOnlyInReplay).toBe(1); // t=250
+        expect(report.alertTimesOnlyInGolden).toBe(1); // t=130
+        expect(report.alertSharedTimeFieldMismatches).toBe(1); // t=10 FM vs STATE
+    });
 });

--- a/extension/test/golden-replay/goldenCompare.unit.test.ts
+++ b/extension/test/golden-replay/goldenCompare.unit.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AlertRecord, TickRecord } from '@extension/services/struggle/types';
+
+import { compareExact, summarizeCausal } from './goldenCompare';
+import type { GoldenAlert, GoldenSession, GoldenTick } from './goldenTypes';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTick(overrides: Partial<GoldenTick> = {}): GoldenTick {
+    return {
+        t: 10,
+        effectiveWindowS: 10,
+        nOneCharInserts: 0,
+        scrollEvents: 0,
+        typingRate: 5,
+        n4Ratio: 0,
+        longestGapS: 0,
+        fTyping: 0.75,
+        fGap: 0,
+        fN4: 0,
+        fFb: 0,
+        fA8: 0,
+        fN2: 0,
+        tsState: false,
+        n4State: false,
+        sBase: 0.1,
+        s: 0.2,
+        v: 0.5,
+        fastDecay: false,
+        boundaries: [],
+        ...overrides,
+    };
+}
+
+function makeAlert(overrides: Partial<GoldenAlert> = {}): GoldenAlert {
+    return {
+        t: 10,
+        v: 0.65,
+        typesPreGate: ['FM'],
+        types: ['FM'],
+        primary: 'FM',
+        path: 'armed',
+        inWarmup: false,
+        inGrace: false,
+        ...overrides,
+    };
+}
+
+function makeGolden(overrides: { ticks?: GoldenTick[]; alerts?: GoldenAlert[] } = {}): GoldenSession {
+    return {
+        pid: 'P1',
+        durationS: 600,
+        theta: 0.6,
+        graceS: 30,
+        ticks: overrides.ticks ?? [makeTick()],
+        alerts: overrides.alerts ?? [],
+        inject: { fA8: [], fN2: [], pasteEventTimes: [] },
+    };
+}
+
+/** Build a TickRecord matching a GoldenTick. */
+function makeReplayTick(gt: GoldenTick): TickRecord {
+    return {
+        t: gt.t,
+        ts: gt.t * 1000,
+        features: {
+            t: gt.t,
+            effectiveWindowS: gt.effectiveWindowS,
+            nOneCharInserts: gt.nOneCharInserts,
+            scrollEvents: gt.scrollEvents,
+            typingRate: gt.typingRate,
+            n4Ratio: gt.n4Ratio,
+            longestGapS: gt.longestGapS,
+            fTyping: gt.fTyping,
+            fGap: gt.fGap,
+            fN4: gt.fN4,
+            fFb: gt.fFb,
+            fA8: gt.fA8,
+            fN2: gt.fN2,
+            tsState: gt.tsState,
+            n4State: gt.n4State,
+        },
+        sBase: gt.sBase,
+        s: gt.s,
+        v: gt.v,
+        fastDecay: gt.fastDecay,
+        boundariesPreGate: [...gt.boundaries],
+        alert: null,
+    };
+}
+
+/** Build an AlertRecord matching a GoldenAlert. */
+function makeReplayAlert(ga: GoldenAlert): AlertRecord {
+    return {
+        t: ga.t,
+        ts: ga.t * 1000,
+        v: ga.v,
+        typesPreGate: [...ga.typesPreGate],
+        types: [...ga.types],
+        primary: ga.primary,
+        path: ga.path,
+        inWarmup: ga.inWarmup,
+        inGrace: ga.inGrace,
+    };
+}
+
+// ── compareExact ──────────────────────────────────────────────────────────────
+
+describe('compareExact', () => {
+    it('returns ok:true when replay exactly matches golden', () => {
+        const gt = makeTick();
+        const golden = makeGolden({ ticks: [gt] });
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(gt)],
+            alerts: [],
+        };
+        expect(compareExact(replay, golden)).toEqual({ ok: true });
+    });
+
+    it('returns ok:true when numeric difference is within TOL (1e-7)', () => {
+        const gt = makeTick({ v: 0.5 });
+        const golden = makeGolden({ ticks: [gt] });
+        const replayTick = makeReplayTick(gt);
+        // perturb v by 1e-7, which is within TOL=1e-6
+        const replay = {
+            durationS: 600,
+            ticks: [{ ...replayTick, v: replayTick.v + 1e-7 }],
+            alerts: [],
+        };
+        expect(compareExact(replay, golden)).toEqual({ ok: true });
+    });
+
+    it('returns ok:false with tickField divergence when v differs by 1e-5', () => {
+        const gt = makeTick({ v: 0.5 });
+        const golden = makeGolden({ ticks: [gt] });
+        const replayTick = makeReplayTick(gt);
+        const replay = {
+            durationS: 600,
+            ticks: [{ ...replayTick, v: replayTick.v + 1e-5 }],
+            alerts: [],
+        };
+        const result = compareExact(replay, golden);
+        expect(result.ok).toBe(false);
+        expect(result.firstDivergence?.kind).toBe('tickField');
+        expect(result.firstDivergence?.t).toBe(10);
+        expect(result.firstDivergence?.field).toBe('v');
+    });
+
+    it('returns ok:false with tickCount divergence when tick counts differ', () => {
+        const gt = makeTick();
+        const golden = makeGolden({ ticks: [gt, makeTick({ t: 20 })] });
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(gt)],
+            alerts: [],
+        };
+        const result = compareExact(replay, golden);
+        expect(result.ok).toBe(false);
+        expect(result.firstDivergence?.kind).toBe('tickCount');
+    });
+
+    it('returns ok:false with alertField divergence when alert primary differs', () => {
+        const ga = makeAlert({ primary: 'FM' });
+        const golden = makeGolden({ ticks: [makeTick()], alerts: [ga] });
+        const replayAlert = makeReplayAlert(ga);
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(makeTick())],
+            alerts: [{ ...replayAlert, primary: 'N1' as const }],
+        };
+        const result = compareExact(replay, golden);
+        expect(result.ok).toBe(false);
+        expect(result.firstDivergence?.kind).toBe('alertField');
+        expect(result.firstDivergence?.field).toBe('primary');
+    });
+
+    it('returns ok:false when typesPreGate arrays differ', () => {
+        const ga = makeAlert({ typesPreGate: ['FM'] });
+        const golden = makeGolden({ ticks: [makeTick()], alerts: [ga] });
+        const replayAlert = makeReplayAlert(ga);
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(makeTick())],
+            alerts: [{ ...replayAlert, typesPreGate: ['N1'] as const }],
+        };
+        const result = compareExact(replay, golden);
+        expect(result.ok).toBe(false);
+        expect(result.firstDivergence?.kind).toBe('alertField');
+        expect(result.firstDivergence?.field).toBe('typesPreGate');
+    });
+
+    it('returns ok:false with alertCount when alert counts differ', () => {
+        const ga = makeAlert();
+        const golden = makeGolden({ ticks: [makeTick()], alerts: [ga] });
+        const replay = {
+            durationS: 600,
+            ticks: [makeReplayTick(makeTick())],
+            alerts: [],
+        };
+        const result = compareExact(replay, golden);
+        expect(result.ok).toBe(false);
+        expect(result.firstDivergence?.kind).toBe('alertCount');
+    });
+});
+
+// ── summarizeCausal ───────────────────────────────────────────────────────────
+
+describe('summarizeCausal', () => {
+    it('returns correct counts and maxAbsSDelta without throwing', () => {
+        const gt1 = makeTick({ t: 10, fA8: 0, s: 0.2, v: 0.5 });
+        const gt2 = makeTick({ t: 20, fA8: 1, s: 0.4, v: 0.6 });
+        const golden = makeGolden({ ticks: [gt1, gt2] });
+
+        // replay: fA8 disagrees at t=20, s differs by 0.1 at t=20
+        const rt1 = makeReplayTick(gt1);
+        const rt2: TickRecord = {
+            ...makeReplayTick(gt2),
+            features: { ...makeReplayTick(gt2).features, fA8: 0 }, // disagrees
+            s: 0.3, // delta = 0.1
+        };
+        const replay = { durationS: 600, ticks: [rt1, rt2], alerts: [] };
+
+        const report = summarizeCausal(replay, golden);
+        expect(report.ticksCompared).toBe(2);
+        expect(report.tickCountDelta).toBe(0);
+        expect(report.fA8DisagreeTicks).toBe(1);
+        expect(report.fN2DisagreeTicks).toBe(0);
+        expect(report.maxAbsSDelta).toBeCloseTo(0.1, 10);
+        expect(report.alertCountReplay).toBe(0);
+        expect(report.alertCountGolden).toBe(0);
+        expect(report.alertCountDelta).toBe(0);
+    });
+
+    it('reports pasteBoundaryDisagreeTicks correctly', () => {
+        // golden boundaries has N1; replay does not
+        const gt = makeTick({ t: 10, boundaries: ['N1'] });
+        const golden = makeGolden({ ticks: [gt] });
+        const rt: TickRecord = {
+            ...makeReplayTick(gt),
+            boundariesPreGate: [], // N1 absent
+        };
+        const replay = { durationS: 600, ticks: [rt], alerts: [] };
+
+        const report = summarizeCausal(replay, golden);
+        expect(report.pasteBoundaryDisagreeTicks).toBe(1);
+    });
+});

--- a/extension/test/golden-replay/goldenReplay.test.ts
+++ b/extension/test/golden-replay/goldenReplay.test.ts
@@ -49,9 +49,15 @@ function readEvents(eventsPath: string): RecordedEvent[] {
         .map(l => JSON.parse(l) as RecordedEvent);
 }
 
-describe.skipIf(!DATA_ROOT || !GOLDEN_DIR)('golden replay (local, study dataset)', () => {
-    const sessionsDir = path.join(DATA_ROOT as string, 'VSCode Recorded Data');
-    const goldenFiles = fs.readdirSync(GOLDEN_DIR as string)
+describe('golden replay (local, study dataset)', () => {
+    // Skip cleanly with no filesystem I/O when the dataset/goldens are absent
+    // (describe.skipIf still evaluates the body, so the readdir must be guarded).
+    if (!DATA_ROOT || !GOLDEN_DIR) {
+        it.skip('skipped: set IRIS_STUDY_DATA and GOLDEN_DIR to run the dataset verification', () => { /* no dataset available */ });
+        return;
+    }
+    const sessionsDir = path.join(DATA_ROOT, 'VSCode Recorded Data');
+    const goldenFiles = fs.readdirSync(GOLDEN_DIR)
         .filter(f => f.endsWith('.json'))
         .sort();
     const causalSummaries: { pid: string; summary: CausalReport }[] = [];
@@ -61,7 +67,7 @@ describe.skipIf(!DATA_ROOT || !GOLDEN_DIR)('golden replay (local, study dataset)
 
         it(`${pid}: exact-mode tick-for-tick match against the Python reference`, () => {
             const golden = parseGoldenSession(
-                JSON.parse(fs.readFileSync(path.join(GOLDEN_DIR as string, file), 'utf8')),
+                JSON.parse(fs.readFileSync(path.join(GOLDEN_DIR, file), 'utf8')),
             );
             assertSpecConstants(golden);
 

--- a/extension/test/golden-replay/goldenReplay.test.ts
+++ b/extension/test/golden-replay/goldenReplay.test.ts
@@ -24,8 +24,8 @@ import {
     summarizeCausal,
 } from './index';
 import {
+    assertEveryChangeHasSnapshot,
     assertFeedbackViewMatched,
-    assertSnapshotBeforeChange,
     assertSpecConstants,
 } from './invariants';
 
@@ -79,7 +79,7 @@ describe('golden replay (local, study dataset)', () => {
 
             // Invariants the harness depends on (fail loud, not silently wrong).
             assertFeedbackViewMatched(events);
-            assertSnapshotBeforeChange(events);
+            assertEveryChangeHasSnapshot(events);
 
             const resolveSnapshotText = (snapshotPath: string): string => {
                 let text = fs.readFileSync(path.join(folder, snapshotPath), 'utf8');
@@ -121,7 +121,9 @@ describe('golden replay (local, study dataset)', () => {
                 `fA8≠ ${summary.fA8DisagreeTicks} fN2≠ ${summary.fN2DisagreeTicks} ` +
                 `N1≠ ${summary.pasteBoundaryDisagreeTicks} ` +
                 `maxΔS ${summary.maxAbsSDelta.toFixed(4)} maxΔV ${summary.maxAbsVDelta.toFixed(4)} ` +
-                `alerts ts=${summary.alertCountReplay}/ref=${summary.alertCountGolden} (Δ ${summary.alertCountDelta})`,
+                `alerts ts=${summary.alertCountReplay}/ref=${summary.alertCountGolden} (Δ ${summary.alertCountDelta}) ` +
+                `alert-only ts/ref ${summary.alertTimesOnlyInReplay}/${summary.alertTimesOnlyInGolden} ` +
+                `fieldΔ ${summary.alertSharedTimeFieldMismatches}`,
             );
         }
     });

--- a/extension/test/golden-replay/goldenReplay.test.ts
+++ b/extension/test/golden-replay/goldenReplay.test.ts
@@ -1,0 +1,122 @@
+// Local golden-replay verification (NOT a CI gate). Skipped unless both
+// IRIS_STUDY_DATA (the study data root containing "VSCode Recorded Data/") and
+// GOLDEN_DIR (the Python-exported goldens from 26_export_ts_goldens.py) are set.
+//
+// exact mode: replays each recorded session through the TS engine with the
+// reference's f_a8/f_n2/paste injected, and asserts tick-for-tick equality with
+// the frozen Python reference (6-decimal S/V, exact boundaries/alerts).
+//
+// causal mode: replays with the TS engine deriving everything online, and
+// REPORTS (does not assert) the divergence from the offline reference — the
+// magnitude of the three declared live deviations (A8/N2/N1). Numbers are
+// printed locally and intentionally never committed.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import type { RecordedEvent } from '@extension/services/recording/types';
+
+import {
+    type CausalReport,
+    compareExact,
+    parseGoldenSession,
+    replaySession,
+    summarizeCausal,
+} from './index';
+import {
+    assertFeedbackViewMatched,
+    assertSnapshotBeforeChange,
+    assertSpecConstants,
+} from './invariants';
+
+const DATA_ROOT = process.env.IRIS_STUDY_DATA;
+const GOLDEN_DIR = process.env.GOLDEN_DIR;
+const TRUNCATED_TRAILER = '\n[TRUNCATED at 1MB]';
+
+function findSessionFolder(sessionsDir: string, pid: string): string {
+    const match = fs.readdirSync(sessionsDir).find(d => d.startsWith(`${pid}-`));
+    if (!match) {
+        throw new Error(`no session folder for ${pid} under ${sessionsDir}`);
+    }
+    return path.join(sessionsDir, match);
+}
+
+function readEvents(eventsPath: string): RecordedEvent[] {
+    return fs.readFileSync(eventsPath, 'utf8')
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0)
+        .map(l => JSON.parse(l) as RecordedEvent);
+}
+
+describe.skipIf(!DATA_ROOT || !GOLDEN_DIR)('golden replay (local, study dataset)', () => {
+    const sessionsDir = path.join(DATA_ROOT as string, 'VSCode Recorded Data');
+    const goldenFiles = fs.readdirSync(GOLDEN_DIR as string)
+        .filter(f => f.endsWith('.json'))
+        .sort();
+    const causalSummaries: { pid: string; summary: CausalReport }[] = [];
+
+    for (const file of goldenFiles) {
+        const pid = path.basename(file, '.json');
+
+        it(`${pid}: exact-mode tick-for-tick match against the Python reference`, () => {
+            const golden = parseGoldenSession(
+                JSON.parse(fs.readFileSync(path.join(GOLDEN_DIR as string, file), 'utf8')),
+            );
+            assertSpecConstants(golden);
+
+            const folder = findSessionFolder(sessionsDir, pid);
+            const meta = JSON.parse(fs.readFileSync(path.join(folder, 'metadata.json'), 'utf8'));
+            const sessionStartMs: number = meta.startTime;
+            const durationS = (meta.endTime - meta.startTime) / 1000;
+            const events = readEvents(path.join(folder, 'events.jsonl'));
+
+            // Invariants the harness depends on (fail loud, not silently wrong).
+            assertFeedbackViewMatched(events);
+            assertSnapshotBeforeChange(events);
+
+            const resolveSnapshotText = (snapshotPath: string): string => {
+                let text = fs.readFileSync(path.join(folder, snapshotPath), 'utf8');
+                if (text.endsWith(TRUNCATED_TRAILER)) {
+                    text = text.slice(0, -TRUNCATED_TRAILER.length);
+                }
+                return text;
+            };
+
+            // exact: inject the reference's f_a8/f_n2/paste; the engine math must match.
+            const exact = replaySession(events, {
+                mode: 'exact', inject: golden.inject, sessionStartMs, durationS, resolveSnapshotText,
+            });
+            const report = compareExact(exact, golden);
+            if (!report.ok) {
+                throw new Error(`${pid} exact-mode divergence: ${JSON.stringify(report.firstDivergence)}`);
+            }
+            expect(report.ok).toBe(true);
+
+            // causal: TS derives A8/N2/paste online; report (do not assert) the divergence.
+            const causal = replaySession(events, {
+                mode: 'causal', sessionStartMs, durationS, resolveSnapshotText,
+            });
+            const summary = summarizeCausal(causal, golden);
+            causalSummaries.push({ pid, summary });
+             
+            console.log(`[causal ${pid}] ${JSON.stringify(summary)}`);
+        });
+    }
+
+    afterAll(() => {
+        if (causalSummaries.length === 0) { return; }
+         
+        console.log('\n=== causal-mode divergence (live-vs-reference, local only) ===');
+        for (const { pid, summary } of causalSummaries) {
+             
+            console.log(
+                `${pid}: ticks=${summary.ticksCompared} (Δcount ${summary.tickCountDelta}) ` +
+                `fA8≠ ${summary.fA8DisagreeTicks} fN2≠ ${summary.fN2DisagreeTicks} ` +
+                `N1≠ ${summary.pasteBoundaryDisagreeTicks} ` +
+                `maxΔS ${summary.maxAbsSDelta.toFixed(4)} maxΔV ${summary.maxAbsVDelta.toFixed(4)} ` +
+                `alerts ts=${summary.alertCountReplay}/ref=${summary.alertCountGolden} (Δ ${summary.alertCountDelta})`,
+            );
+        }
+    });
+});

--- a/extension/test/golden-replay/goldenTypes.ts
+++ b/extension/test/golden-replay/goldenTypes.ts
@@ -1,0 +1,225 @@
+import type { BoundaryType } from '@extension/services/struggle/constants';
+import { BOUNDARY_PRIORITY } from '@extension/services/struggle/constants';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface GoldenTick {
+    readonly t: number;
+    readonly effectiveWindowS: number;
+    readonly nOneCharInserts: number;
+    readonly scrollEvents: number;
+    readonly typingRate: number;
+    readonly n4Ratio: number;
+    readonly longestGapS: number;
+    readonly fTyping: number;
+    readonly fGap: number;
+    readonly fN4: number;
+    readonly fFb: 0 | 1;
+    readonly fA8: 0 | 1;
+    readonly fN2: 0 | 1;
+    readonly tsState: boolean;
+    readonly n4State: boolean;
+    readonly sBase: number;
+    readonly s: number;
+    readonly v: number;
+    readonly fastDecay: boolean;
+    /** Boundary types pre-gate, in audit priority order. */
+    readonly boundaries: BoundaryType[];
+}
+
+export interface GoldenAlert {
+    readonly t: number;
+    readonly v: number;
+    readonly typesPreGate: BoundaryType[];
+    readonly types: BoundaryType[];
+    readonly primary: BoundaryType;
+    readonly path: 'armed' | 'e6';
+    readonly inWarmup: boolean;
+    readonly inGrace: boolean;
+}
+
+export interface GoldenInject {
+    /** [tickTime, value] pairs for the fA8 binary signal. */
+    readonly fA8: [number, 0 | 1][];
+    /** [tickTime, value] pairs for the fN2 binary signal. */
+    readonly fN2: [number, 0 | 1][];
+    /** Session-relative seconds where the reference fired an N1 paste. */
+    readonly pasteEventTimes: number[];
+}
+
+export interface GoldenSession {
+    readonly pid: string;
+    readonly durationS: number;
+    readonly theta: number;
+    readonly graceS: number;
+    readonly ticks: GoldenTick[];
+    readonly alerts: GoldenAlert[];
+    readonly inject: GoldenInject;
+}
+
+// ── Validator helpers ─────────────────────────────────────────────────────────
+
+const VALID_BOUNDARY_TYPES = new Set<string>(BOUNDARY_PRIORITY);
+const VALID_PATHS = new Set<string>(['armed', 'e6']);
+
+function isBoundaryType(v: unknown): v is BoundaryType {
+    return typeof v === 'string' && VALID_BOUNDARY_TYPES.has(v);
+}
+
+function assertNumber(v: unknown, field: string): number {
+    if (typeof v !== 'number' || !isFinite(v)) {
+        throw new Error(`parseGoldenSession: field "${field}" must be a finite number, got ${JSON.stringify(v)}`);
+    }
+    return v;
+}
+
+function assertBoolean(v: unknown, field: string): boolean {
+    if (typeof v !== 'boolean') {
+        throw new Error(`parseGoldenSession: field "${field}" must be a boolean, got ${JSON.stringify(v)}`);
+    }
+    return v;
+}
+
+function assertString(v: unknown, field: string): string {
+    if (typeof v !== 'string') {
+        throw new Error(`parseGoldenSession: field "${field}" must be a string, got ${JSON.stringify(v)}`);
+    }
+    return v;
+}
+
+function assertBit(v: unknown, field: string): 0 | 1 {
+    if (v !== 0 && v !== 1) {
+        throw new Error(`parseGoldenSession: field "${field}" must be 0 or 1, got ${JSON.stringify(v)}`);
+    }
+    return v;
+}
+
+function assertArray(v: unknown, field: string): unknown[] {
+    if (!Array.isArray(v)) {
+        throw new Error(`parseGoldenSession: field "${field}" must be an array, got ${JSON.stringify(v)}`);
+    }
+    return v;
+}
+
+function assertObject(v: unknown, context: string): Record<string, unknown> {
+    if (v === null || typeof v !== 'object' || Array.isArray(v)) {
+        throw new Error(`parseGoldenSession: ${context} must be a plain object, got ${JSON.stringify(v)}`);
+    }
+    return v as Record<string, unknown>;
+}
+
+function parseTick(raw: unknown, idx: number): GoldenTick {
+    const r = assertObject(raw, `ticks[${idx}]`);
+    const prefix = `ticks[${idx}]`;
+    const boundaries = assertArray(r['boundaries'], `${prefix}.boundaries`).map((b, bi) => {
+        if (!isBoundaryType(b)) {
+            throw new Error(`parseGoldenSession: ${prefix}.boundaries[${bi}] is not a valid BoundaryType: ${JSON.stringify(b)}`);
+        }
+        return b;
+    });
+    return {
+        t: assertNumber(r['t'], `${prefix}.t`),
+        effectiveWindowS: assertNumber(r['effectiveWindowS'], `${prefix}.effectiveWindowS`),
+        nOneCharInserts: assertNumber(r['nOneCharInserts'], `${prefix}.nOneCharInserts`),
+        scrollEvents: assertNumber(r['scrollEvents'], `${prefix}.scrollEvents`),
+        typingRate: assertNumber(r['typingRate'], `${prefix}.typingRate`),
+        n4Ratio: assertNumber(r['n4Ratio'], `${prefix}.n4Ratio`),
+        longestGapS: assertNumber(r['longestGapS'], `${prefix}.longestGapS`),
+        fTyping: assertNumber(r['fTyping'], `${prefix}.fTyping`),
+        fGap: assertNumber(r['fGap'], `${prefix}.fGap`),
+        fN4: assertNumber(r['fN4'], `${prefix}.fN4`),
+        fFb: assertBit(r['fFb'], `${prefix}.fFb`),
+        fA8: assertBit(r['fA8'], `${prefix}.fA8`),
+        fN2: assertBit(r['fN2'], `${prefix}.fN2`),
+        tsState: assertBoolean(r['tsState'], `${prefix}.tsState`),
+        n4State: assertBoolean(r['n4State'], `${prefix}.n4State`),
+        sBase: assertNumber(r['sBase'], `${prefix}.sBase`),
+        s: assertNumber(r['s'], `${prefix}.s`),
+        v: assertNumber(r['v'], `${prefix}.v`),
+        fastDecay: assertBoolean(r['fastDecay'], `${prefix}.fastDecay`),
+        boundaries,
+    };
+}
+
+function parseBoundaryArray(raw: unknown, field: string): BoundaryType[] {
+    return assertArray(raw, field).map((b, bi) => {
+        if (!isBoundaryType(b)) {
+            throw new Error(`parseGoldenSession: ${field}[${bi}] is not a valid BoundaryType: ${JSON.stringify(b)}`);
+        }
+        return b;
+    });
+}
+
+function parseAlert(raw: unknown, idx: number): GoldenAlert {
+    const r = assertObject(raw, `alerts[${idx}]`);
+    const prefix = `alerts[${idx}]`;
+    const path = assertString(r['path'], `${prefix}.path`);
+    if (!VALID_PATHS.has(path)) {
+        throw new Error(`parseGoldenSession: ${prefix}.path must be 'armed' or 'e6', got ${JSON.stringify(path)}`);
+    }
+    const primary = r['primary'];
+    if (!isBoundaryType(primary)) {
+        throw new Error(`parseGoldenSession: ${prefix}.primary is not a valid BoundaryType: ${JSON.stringify(primary)}`);
+    }
+    return {
+        t: assertNumber(r['t'], `${prefix}.t`),
+        v: assertNumber(r['v'], `${prefix}.v`),
+        typesPreGate: parseBoundaryArray(r['typesPreGate'], `${prefix}.typesPreGate`),
+        types: parseBoundaryArray(r['types'], `${prefix}.types`),
+        primary,
+        path: path as 'armed' | 'e6',
+        inWarmup: assertBoolean(r['inWarmup'], `${prefix}.inWarmup`),
+        inGrace: assertBoolean(r['inGrace'], `${prefix}.inGrace`),
+    };
+}
+
+function parseBitTupleArray(raw: unknown, field: string): [number, 0 | 1][] {
+    return assertArray(raw, field).map((item, i) => {
+        if (!Array.isArray(item) || item.length !== 2) {
+            throw new Error(`parseGoldenSession: ${field}[${i}] must be a [number, 0|1] tuple, got ${JSON.stringify(item)}`);
+        }
+        const t = item[0];
+        const v = item[1];
+        if (typeof t !== 'number' || !isFinite(t)) {
+            throw new Error(`parseGoldenSession: ${field}[${i}][0] must be a finite number, got ${JSON.stringify(t)}`);
+        }
+        if (v !== 0 && v !== 1) {
+            throw new Error(`parseGoldenSession: ${field}[${i}][1] must be 0 or 1, got ${JSON.stringify(v)}`);
+        }
+        return [t, v] as [number, 0 | 1];
+    });
+}
+
+function parseInject(raw: unknown): GoldenInject {
+    const r = assertObject(raw, 'inject');
+    return {
+        fA8: parseBitTupleArray(r['fA8'], 'inject.fA8'),
+        fN2: parseBitTupleArray(r['fN2'], 'inject.fN2'),
+        pasteEventTimes: assertArray(r['pasteEventTimes'], 'inject.pasteEventTimes').map((v, i) =>
+            assertNumber(v, `inject.pasteEventTimes[${i}]`)
+        ),
+    };
+}
+
+// ── Public parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Strict runtime validator for golden session JSON. Throws a descriptive Error
+ * on any schema mismatch. Never uses unchecked `as` casts of the input.
+ */
+export function parseGoldenSession(raw: unknown): GoldenSession {
+    const r = assertObject(raw, 'GoldenSession');
+    const pid = r['pid'];
+    if (typeof pid !== 'string') {
+        throw new Error(`parseGoldenSession: field "pid" must be a string, got ${JSON.stringify(pid)}`);
+    }
+    return {
+        pid,
+        durationS: assertNumber(r['durationS'], 'durationS'),
+        theta: assertNumber(r['theta'], 'theta'),
+        graceS: assertNumber(r['graceS'], 'graceS'),
+        ticks: assertArray(r['ticks'], 'ticks').map((t, i) => parseTick(t, i)),
+        alerts: assertArray(r['alerts'], 'alerts').map((a, i) => parseAlert(a, i)),
+        inject: parseInject(r['inject']),
+    };
+}

--- a/extension/test/golden-replay/goldenTypes.unit.test.ts
+++ b/extension/test/golden-replay/goldenTypes.unit.test.ts
@@ -4,7 +4,7 @@ import type { RecordedEvent } from '@extension/services/recording/types';
 import { SPEC } from '@extension/services/struggle/constants';
 
 import { parseGoldenSession } from './goldenTypes';
-import { assertFeedbackViewMatched, assertSnapshotBeforeChange, assertSpecConstants } from './invariants';
+import { assertEveryChangeHasSnapshot, assertFeedbackViewMatched, assertSpecConstants } from './invariants';
 
 // ── Minimal valid fixture ─────────────────────────────────────────────────────
 
@@ -175,41 +175,51 @@ describe('assertFeedbackViewMatched', () => {
     });
 });
 
-// ── assertSnapshotBeforeChange ────────────────────────────────────────────────
+// ── assertEveryChangeHasSnapshot ──────────────────────────────────────────────
 
-describe('assertSnapshotBeforeChange', () => {
+describe('assertEveryChangeHasSnapshot', () => {
     it('passes for an empty event stream', () => {
-        expect(() => assertSnapshotBeforeChange([])).not.toThrow();
+        expect(() => assertEveryChangeHasSnapshot([])).not.toThrow();
     });
 
-    it('passes when textChange is preceded by a fileSnapshot for the same URI', () => {
+    it('passes when a changed URI has a fileSnapshot for the same URI', () => {
         const events: RecordedEvent[] = [
             { type: 'fileSnapshot', timestamp: 500, uri: 'file:///a.java', snapshotPath: '/tmp/snap' },
             { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
         ];
-        expect(() => assertSnapshotBeforeChange(events)).not.toThrow();
+        expect(() => assertEveryChangeHasSnapshot(events)).not.toThrow();
     });
 
-    it('passes when textChange is preceded by a textDocumentOpen for the same URI', () => {
+    it('passes by membership when the fileSnapshot lands AFTER the textChange (async I/O)', () => {
+        const events: RecordedEvent[] = [
+            { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
+            { type: 'fileSnapshot', timestamp: 1100, uri: 'file:///a.java', snapshotPath: '/tmp/snap' },
+        ];
+        expect(() => assertEveryChangeHasSnapshot(events)).not.toThrow();
+    });
+
+    it('throws when a changed URI has only a textDocumentOpen and no fileSnapshot', () => {
+        // A textDocumentOpen carries no text, so the replay would reconstruct
+        // against an empty document — a fileSnapshot is required.
         const events: RecordedEvent[] = [
             { type: 'textDocumentOpen', timestamp: 500, uri: 'file:///a.java' },
             { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
         ];
-        expect(() => assertSnapshotBeforeChange(events)).not.toThrow();
+        expect(() => assertEveryChangeHasSnapshot(events)).toThrow(/file:\/\/\/a\.java/);
     });
 
-    it('throws on a textChange whose URI never had a prior snapshot or open', () => {
+    it('throws on a changed URI with no fileSnapshot anywhere', () => {
         const events: RecordedEvent[] = [
             { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
         ];
-        expect(() => assertSnapshotBeforeChange(events)).toThrow(/file:\/\/\/a\.java/);
+        expect(() => assertEveryChangeHasSnapshot(events)).toThrow(/file:\/\/\/a\.java/);
     });
 
-    it('throws when snapshot is for a different URI', () => {
+    it('throws when the only snapshot is for a different URI', () => {
         const events: RecordedEvent[] = [
             { type: 'fileSnapshot', timestamp: 500, uri: 'file:///b.java', snapshotPath: '/tmp/snap' },
             { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
         ];
-        expect(() => assertSnapshotBeforeChange(events)).toThrow(/file:\/\/\/a\.java/);
+        expect(() => assertEveryChangeHasSnapshot(events)).toThrow(/file:\/\/\/a\.java/);
     });
 });

--- a/extension/test/golden-replay/goldenTypes.unit.test.ts
+++ b/extension/test/golden-replay/goldenTypes.unit.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RecordedEvent } from '@extension/services/recording/types';
+import { SPEC } from '@extension/services/struggle/constants';
+
+import { parseGoldenSession } from './goldenTypes';
+import { assertFeedbackViewMatched, assertSnapshotBeforeChange, assertSpecConstants } from './invariants';
+
+// ── Minimal valid fixture ─────────────────────────────────────────────────────
+
+const MINIMAL_TICK = {
+    t: 10,
+    effectiveWindowS: 10,
+    nOneCharInserts: 0,
+    scrollEvents: 0,
+    typingRate: 5,
+    n4Ratio: 0,
+    longestGapS: 0,
+    fTyping: 0.75,
+    fGap: 0,
+    fN4: 0,
+    fFb: 0 as 0 | 1,
+    fA8: 0 as 0 | 1,
+    fN2: 0 as 0 | 1,
+    tsState: false,
+    n4State: false,
+    sBase: 0.1,
+    s: 0.1,
+    v: 0.05,
+    fastDecay: false,
+    boundaries: [],
+};
+
+const MINIMAL_ALERT = {
+    t: 10,
+    v: 0.65,
+    typesPreGate: ['FM'] as const,
+    types: ['FM'] as const,
+    primary: 'FM' as const,
+    path: 'armed' as const,
+    inWarmup: false,
+    inGrace: false,
+};
+
+const MINIMAL_SESSION = {
+    pid: 'P1',
+    durationS: 600,
+    theta: 0.6,
+    graceS: 32.94,
+    ticks: [MINIMAL_TICK],
+    alerts: [MINIMAL_ALERT],
+    inject: {
+        fA8: [[10, 0]] as [number, 0 | 1][],
+        fN2: [] as [number, 0 | 1][],
+        pasteEventTimes: [],
+    },
+};
+
+// ── parseGoldenSession ────────────────────────────────────────────────────────
+
+describe('parseGoldenSession', () => {
+    it('accepts a minimal well-formed GoldenSession and returns pid intact', () => {
+        const result = parseGoldenSession(MINIMAL_SESSION);
+        expect(result.pid).toBe('P1');
+        expect(result.ticks).toHaveLength(1);
+        expect(result.alerts).toHaveLength(1);
+    });
+
+    it('rejects an object missing required fields', () => {
+        expect(() => parseGoldenSession({})).toThrow();
+    });
+
+    it('rejects when pid is missing', () => {
+        const bad = { ...MINIMAL_SESSION, pid: undefined };
+        expect(() => parseGoldenSession(bad)).toThrow(/pid/);
+    });
+
+    it('rejects a boundaries entry that is not a valid BoundaryType', () => {
+        const bad = {
+            ...MINIMAL_SESSION,
+            ticks: [{ ...MINIMAL_TICK, boundaries: ['INVALID_TYPE'] }],
+        };
+        expect(() => parseGoldenSession(bad)).toThrow();
+    });
+
+    it('rejects fFb value that is not 0 or 1', () => {
+        const bad = {
+            ...MINIMAL_SESSION,
+            ticks: [{ ...MINIMAL_TICK, fFb: 2 }],
+        };
+        expect(() => parseGoldenSession(bad)).toThrow(/fFb/);
+    });
+
+    it('rejects alert path that is not armed or e6', () => {
+        const bad = {
+            ...MINIMAL_SESSION,
+            alerts: [{ ...MINIMAL_ALERT, path: 'unknown' }],
+        };
+        expect(() => parseGoldenSession(bad)).toThrow(/path/);
+    });
+
+    it('rejects alert primary that is not a valid BoundaryType', () => {
+        const bad = {
+            ...MINIMAL_SESSION,
+            alerts: [{ ...MINIMAL_ALERT, primary: 'BOGUS' }],
+        };
+        expect(() => parseGoldenSession(bad)).toThrow();
+    });
+
+    it('rejects inject.fA8 tuple with wrong value', () => {
+        const bad = {
+            ...MINIMAL_SESSION,
+            inject: { ...MINIMAL_SESSION.inject, fA8: [[10, 5]] },
+        };
+        expect(() => parseGoldenSession(bad)).toThrow();
+    });
+});
+
+// ── assertSpecConstants ───────────────────────────────────────────────────────
+
+describe('assertSpecConstants', () => {
+    it('passes for theta=0.6 and graceS=32.94', () => {
+        const session = parseGoldenSession(MINIMAL_SESSION);
+        expect(() => assertSpecConstants(session)).not.toThrow();
+    });
+
+    it('throws when theta differs from SPEC.THETA_FULL', () => {
+        const session = parseGoldenSession({ ...MINIMAL_SESSION, theta: 0.5 });
+        expect(() => assertSpecConstants(session)).toThrow(/theta/);
+    });
+
+    it('throws when graceS differs from SPEC.GRACE_S', () => {
+        const session = parseGoldenSession({ ...MINIMAL_SESSION, graceS: 30 });
+        expect(() => assertSpecConstants(session)).toThrow(/graceS/);
+    });
+
+    it('confirms SPEC.THETA_FULL === 0.6', () => {
+        expect(SPEC.THETA_FULL).toBe(0.6);
+    });
+
+    it('confirms SPEC.GRACE_S === 32.94', () => {
+        expect(SPEC.GRACE_S).toBe(32.94);
+    });
+});
+
+// ── assertFeedbackViewMatched ─────────────────────────────────────────────────
+
+describe('assertFeedbackViewMatched', () => {
+    it('passes for an empty event stream', () => {
+        expect(() => assertFeedbackViewMatched([])).not.toThrow();
+    });
+
+    it('passes for a properly matched open/close pair', () => {
+        const events: RecordedEvent[] = [
+            { type: 'taskFeedbackView', action: 'opened', timestamp: 1000, viewId: 'v1', exerciseId: 1, taskName: 'task1', testIds: [], totalTests: 1, passedTests: 0, failedTests: 1 },
+            { type: 'taskFeedbackView', action: 'closed', timestamp: 2000, viewId: 'v1', exerciseId: 1, taskName: 'task1', durationMs: 1000, closeReason: 'button' },
+        ];
+        expect(() => assertFeedbackViewMatched(events)).not.toThrow();
+    });
+
+    it('throws on a closed event with no prior opened for that viewId', () => {
+        const events: RecordedEvent[] = [
+            { type: 'taskFeedbackView', action: 'closed', timestamp: 2000, viewId: 'v1', exerciseId: 1, taskName: 'task1', durationMs: 1000, closeReason: 'button' },
+        ];
+        expect(() => assertFeedbackViewMatched(events)).toThrow();
+    });
+
+    it('throws when closing a viewId that was already closed', () => {
+        const events: RecordedEvent[] = [
+            { type: 'taskFeedbackView', action: 'opened', timestamp: 1000, viewId: 'v1', exerciseId: 1, taskName: 'task1', testIds: [], totalTests: 1, passedTests: 0, failedTests: 1 },
+            { type: 'taskFeedbackView', action: 'closed', timestamp: 2000, viewId: 'v1', exerciseId: 1, taskName: 'task1', durationMs: 1000, closeReason: 'button' },
+            { type: 'taskFeedbackView', action: 'closed', timestamp: 3000, viewId: 'v1', exerciseId: 1, taskName: 'task1', durationMs: 2000, closeReason: 'escape' },
+        ];
+        expect(() => assertFeedbackViewMatched(events)).toThrow();
+    });
+});
+
+// ── assertSnapshotBeforeChange ────────────────────────────────────────────────
+
+describe('assertSnapshotBeforeChange', () => {
+    it('passes for an empty event stream', () => {
+        expect(() => assertSnapshotBeforeChange([])).not.toThrow();
+    });
+
+    it('passes when textChange is preceded by a fileSnapshot for the same URI', () => {
+        const events: RecordedEvent[] = [
+            { type: 'fileSnapshot', timestamp: 500, uri: 'file:///a.java', snapshotPath: '/tmp/snap' },
+            { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
+        ];
+        expect(() => assertSnapshotBeforeChange(events)).not.toThrow();
+    });
+
+    it('passes when textChange is preceded by a textDocumentOpen for the same URI', () => {
+        const events: RecordedEvent[] = [
+            { type: 'textDocumentOpen', timestamp: 500, uri: 'file:///a.java' },
+            { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
+        ];
+        expect(() => assertSnapshotBeforeChange(events)).not.toThrow();
+    });
+
+    it('throws on a textChange whose URI never had a prior snapshot or open', () => {
+        const events: RecordedEvent[] = [
+            { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
+        ];
+        expect(() => assertSnapshotBeforeChange(events)).toThrow(/file:\/\/\/a\.java/);
+    });
+
+    it('throws when snapshot is for a different URI', () => {
+        const events: RecordedEvent[] = [
+            { type: 'fileSnapshot', timestamp: 500, uri: 'file:///b.java', snapshotPath: '/tmp/snap' },
+            { type: 'textChange', timestamp: 1000, uri: 'file:///a.java', changes: [] },
+        ];
+        expect(() => assertSnapshotBeforeChange(events)).toThrow(/file:\/\/\/a\.java/);
+    });
+});

--- a/extension/test/golden-replay/index.ts
+++ b/extension/test/golden-replay/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Public surface of the golden-replay harness, consumed by the dataset suite and
+ * the tick/alert comparator (later tasks).
+ */
+export type {
+    GoldenAlert, GoldenInject, GoldenSession, GoldenTick,
+} from './goldenTypes';
+export { parseGoldenSession } from './goldenTypes';
+export { assertSpecConstants } from './invariants';
+export type { ReplayOpts, ReplayResult } from './struggleReplay';
+export { replaySession } from './struggleReplay';

--- a/extension/test/golden-replay/index.ts
+++ b/extension/test/golden-replay/index.ts
@@ -2,6 +2,8 @@
  * Public surface of the golden-replay harness, consumed by the dataset suite and
  * the tick/alert comparator (later tasks).
  */
+export type { CausalReport, ExactReport } from './goldenCompare';
+export { compareExact, summarizeCausal } from './goldenCompare';
 export type {
     GoldenAlert, GoldenInject, GoldenSession, GoldenTick,
 } from './goldenTypes';

--- a/extension/test/golden-replay/invariants.ts
+++ b/extension/test/golden-replay/invariants.ts
@@ -56,23 +56,27 @@ export function assertFeedbackViewMatched(events: readonly RecordedEvent[]): voi
 }
 
 /**
- * Asserts that every textChange event in the stream is preceded by either a
- * fileSnapshot or a textDocumentOpen for the same URI. A textChange with no
- * prior baseline means the replaying engine cannot reconstruct starting state.
+ * Asserts that every URI with a textChange also has a fileSnapshot somewhere in
+ * the stream. A fileSnapshot is REQUIRED (a textDocumentOpen carries no text, so
+ * the replay would reconstruct against an empty document and silently mis-derive
+ * causal A8). Membership — not stream order — is the contract: the recorder
+ * writes a snapshot's event only after async I/O, so it can legitimately land
+ * after an early edit, and the replay hub pre-seeds FileTextState from ALL
+ * fileSnapshots up front regardless of position.
  */
-export function assertSnapshotBeforeChange(events: readonly RecordedEvent[]): void {
-    const baselinedUris = new Set<string>();
+export function assertEveryChangeHasSnapshot(events: readonly RecordedEvent[]): void {
+    const snapshotUris = new Set<string>();
     for (const event of events) {
-        if (event.type === 'fileSnapshot' || event.type === 'textDocumentOpen') {
-            baselinedUris.add(event.uri);
-        } else if (event.type === 'textChange') {
-            if (!baselinedUris.has(event.uri)) {
-                throw new Error(
-                    `invariant: textChange for URI "${event.uri}" ` +
-                    'at timestamp ' + event.timestamp + ' has no prior fileSnapshot or ' +
-                    'textDocumentOpen for that URI. The event stream is missing baseline state.'
-                );
-            }
+        if (event.type === 'fileSnapshot') {
+            snapshotUris.add(event.uri);
+        }
+    }
+    for (const event of events) {
+        if (event.type === 'textChange' && !snapshotUris.has(event.uri)) {
+            throw new Error(
+                `invariant: textChange for URI "${event.uri}" at timestamp ${event.timestamp} ` +
+                'has no fileSnapshot in the stream; the replay cannot reconstruct its baseline text.'
+            );
         }
     }
 }

--- a/extension/test/golden-replay/invariants.ts
+++ b/extension/test/golden-replay/invariants.ts
@@ -14,10 +14,16 @@ export function assertSpecConstants(g: GoldenSession): void {
             'Golden was generated with different constants and is incomparable.'
         );
     }
-    if (g.graceS !== SPEC.GRACE_S) {
+    // grace_s comes from the F3 derivation as a full-precision double
+    // (32.940000000000055); the TS SPEC froze the human value 32.94. The ~5e-14
+    // gap never flips grace gating at the 10s tick / event-time granularities,
+    // so tolerate float noise here rather than reject every golden. A real
+    // constant mismatch (different derived value) is orders of magnitude larger.
+    const GRACE_TOL = 1e-9;
+    if (Math.abs(g.graceS - SPEC.GRACE_S) > GRACE_TOL) {
         throw new Error(
-            `invariant: golden graceS ${g.graceS} !== SPEC.GRACE_S ${SPEC.GRACE_S}. ` +
-            'Golden was generated with different constants and is incomparable.'
+            `invariant: golden graceS ${g.graceS} differs from SPEC.GRACE_S ${SPEC.GRACE_S} ` +
+            `by more than ${GRACE_TOL}. Golden was generated with different constants and is incomparable.`
         );
     }
 }

--- a/extension/test/golden-replay/invariants.ts
+++ b/extension/test/golden-replay/invariants.ts
@@ -1,0 +1,72 @@
+import type { RecordedEvent } from '@extension/services/recording/types';
+import { SPEC } from '@extension/services/struggle/constants';
+
+import type { GoldenSession } from './goldenTypes';
+
+/**
+ * Asserts that the golden was generated with the frozen engine constants.
+ * A golden built with different theta or graceS is incomparable to the TS engine.
+ */
+export function assertSpecConstants(g: GoldenSession): void {
+    if (g.theta !== SPEC.THETA_FULL) {
+        throw new Error(
+            `invariant: golden theta ${g.theta} !== SPEC.THETA_FULL ${SPEC.THETA_FULL}. ` +
+            'Golden was generated with different constants and is incomparable.'
+        );
+    }
+    if (g.graceS !== SPEC.GRACE_S) {
+        throw new Error(
+            `invariant: golden graceS ${g.graceS} !== SPEC.GRACE_S ${SPEC.GRACE_S}. ` +
+            'Golden was generated with different constants and is incomparable.'
+        );
+    }
+}
+
+/**
+ * Scans taskFeedbackView events and throws if a 'closed' event is encountered
+ * for a viewId with no prior 'opened' (or that was already closed).
+ * Mirrors engine_v2.py behaviour which raises on close-without-open.
+ */
+export function assertFeedbackViewMatched(events: readonly RecordedEvent[]): void {
+    const openViewIds = new Set<string>();
+    for (const event of events) {
+        if (event.type !== 'taskFeedbackView') {
+            continue;
+        }
+        if (event.action === 'opened') {
+            openViewIds.add(event.viewId);
+        } else {
+            // action === 'closed'
+            if (!openViewIds.has(event.viewId)) {
+                throw new Error(
+                    `invariant: taskFeedbackView 'closed' for viewId "${event.viewId}" ` +
+                    'at timestamp ' + event.timestamp + ' has no prior opened event. ' +
+                    'Close-without-open indicates a corrupt or truncated event stream.'
+                );
+            }
+            openViewIds.delete(event.viewId);
+        }
+    }
+}
+
+/**
+ * Asserts that every textChange event in the stream is preceded by either a
+ * fileSnapshot or a textDocumentOpen for the same URI. A textChange with no
+ * prior baseline means the replaying engine cannot reconstruct starting state.
+ */
+export function assertSnapshotBeforeChange(events: readonly RecordedEvent[]): void {
+    const baselinedUris = new Set<string>();
+    for (const event of events) {
+        if (event.type === 'fileSnapshot' || event.type === 'textDocumentOpen') {
+            baselinedUris.add(event.uri);
+        } else if (event.type === 'textChange') {
+            if (!baselinedUris.has(event.uri)) {
+                throw new Error(
+                    `invariant: textChange for URI "${event.uri}" ` +
+                    'at timestamp ' + event.timestamp + ' has no prior fileSnapshot or ' +
+                    'textDocumentOpen for that URI. The event stream is missing baseline state.'
+                );
+            }
+        }
+    }
+}

--- a/extension/test/golden-replay/replaySensorHub.ts
+++ b/extension/test/golden-replay/replaySensorHub.ts
@@ -116,9 +116,9 @@ export class ReplaySensorHub implements SensorHub {
     // ── replay state ────────────────────────────────────────────────────
     private readonly _opts: ReplaySensorHubOptions;
     private readonly _fileText = new FileTextState();
-    /** URIs whose fileSnapshot precedes startupPhaseComplete; readTextDocuments()
-     *  returns exactly these (the docs the engine treats as already-open). */
-    private readonly _startupUris: string[] = [];
+    /** Every URI with a recorded fileSnapshot (insertion order). readTextDocuments()
+     *  returns these as already-open docs, and injected pastes anchor to one. */
+    private readonly _snapshotUris: string[] = [];
     /** Current diagnostics, by URI string, as of the last pumped diagnostics event. */
     private readonly _diagByUri = new Map<string, vscode.Diagnostic[]>();
     private readonly _queue: QueuedSignal[];
@@ -133,12 +133,12 @@ export class ReplaySensorHub implements SensorHub {
         if (
             opts.pasteMode === 'inject'
             && (opts.injectedPasteEventTimes?.length ?? 0) > 0
-            && this._startupUris.length === 0
+            && this._snapshotUris.length === 0
         ) {
             // Injected pastes must attach to a real in-root URI or the engine's
             // shouldRecordUri filter silently drops every N1. Fail loud rather
             // than fabricate an out-of-root URI.
-            throw new Error('ReplaySensorHub: injected pastes require at least one startup file snapshot to anchor the URI');
+            throw new Error('ReplaySensorHub: injected pastes require at least one recorded fileSnapshot to anchor the URI');
         }
         this._queue = this._buildQueue(events);
     }
@@ -150,8 +150,7 @@ export class ReplaySensorHub implements SensorHub {
     }
 
     /**
-     * Seed FileTextState from EVERY recorded fileSnapshot up front, and record
-     * which URIs are "startup" (snapshotted before startupPhaseComplete).
+     * Seed FileTextState from EVERY recorded fileSnapshot up front.
      *
      * fileSnapshot is not a runtime mutation in the recorder: each URI is
      * snapshotted at most once per session (snapshotManager gates on
@@ -164,33 +163,19 @@ export class ReplaySensorHub implements SensorHub {
      * (b) makes a mid-stream rollback impossible. Snapshots are never re-applied
      * from the pump queue.
      *
-     * The recorder writes sessionStart, THEN the startup fileSnapshots (with
-     * Date.now() > sessionStartTs, i.e. relS > 0), THEN one startupPhaseComplete
-     * marker — its documented "seed state vs runtime events" cut-point. Snapshots
-     * before that marker are the already-open docs the engine seeds in start().
-     * Fallback when no marker exists (truncated recording): treat snapshots
-     * before the first textChange as startup.
+     * The recorder snapshots files LAZILY on first open/switch — observed AFTER
+     * the startupPhaseComplete marker, not before it — so a "snapshots before the
+     * marker" notion is empty in practice. We therefore treat every snapshotted
+     * URI as an already-open doc for readTextDocuments(): the engine's shadow only
+     * feeds A8, and A8 reads `before` at the first textChange, where the seeded
+     * baseline is the snapshot content either way. Any snapshot URI is also a
+     * valid in-root anchor for an injected N1 paste.
      */
     private _seedSnapshots(events: RecordedEvent[]): void {
-        // Cut-point: the index of the first startupPhaseComplete marker; snapshots
-        // before it are startup. Authoritative when the marker exists. Fallback
-        // for marker-less (truncated) recordings: the first textChange index, or
-        // the end of the stream if neither marker nor textChange exists.
-        const markerIdx = events.findIndex(e => e.type === 'startupPhaseComplete');
-        const firstChangeIdx = events.findIndex(e => e.type === 'textChange');
-        let startupCutIdx: number;
-        if (markerIdx >= 0) {
-            startupCutIdx = markerIdx;
-        } else if (firstChangeIdx >= 0) {
-            startupCutIdx = firstChangeIdx;
-        } else {
-            startupCutIdx = events.length;
-        }
-
         const seeded = new Set<string>();
-        events.forEach((ev, idx) => {
+        for (const ev of events) {
             if (ev.type !== 'fileSnapshot') {
-                return;
+                continue;
             }
             if (seeded.has(ev.uri)) {
                 // Enforce the one-snapshot-per-URI recorder contract: a second
@@ -199,10 +184,8 @@ export class ReplaySensorHub implements SensorHub {
             }
             this._fileText.seedSnapshot(ev.uri, this._opts.resolveSnapshotText(ev.snapshotPath));
             seeded.add(ev.uri);
-            if (idx < startupCutIdx) {
-                this._startupUris.push(ev.uri);
-            }
-        });
+            this._snapshotUris.push(ev.uri);
+        }
     }
 
     // ── queue construction ──────────────────────────────────────────────
@@ -262,9 +245,9 @@ export class ReplaySensorHub implements SensorHub {
         }
 
         if (this._opts.pasteMode === 'inject') {
-            // The constructor guarantees a startup URI exists whenever there are
-            // injected paste times, so _startupUris[0] is always defined here.
-            const uriKey = this._startupUris[0];
+            // The constructor guarantees a snapshot URI exists whenever there are
+            // injected paste times, so _snapshotUris[0] is always defined here.
+            const uriKey = this._snapshotUris[0];
             for (const t of this._opts.injectedPasteEventTimes ?? []) {
                 const tsMs = this._opts.sessionStartMs + t * 1000;
                 // chars/lines are unused by the engine — it reads only ts + uri for
@@ -394,7 +377,7 @@ export class ReplaySensorHub implements SensorHub {
     // ── state reads ─────────────────────────────────────────────────────
 
     readTextDocuments(): readonly vscode.TextDocument[] {
-        return this._startupUris.map(uri =>
+        return this._snapshotUris.map(uri =>
             makeDocument(makeUri(uri), () => this._fileText.getText(uri) ?? ''),
         );
     }

--- a/extension/test/golden-replay/replaySensorHub.ts
+++ b/extension/test/golden-replay/replaySensorHub.ts
@@ -1,0 +1,425 @@
+/**
+ * A `SensorHub` that replays a recorded session into the struggle engine.
+ *
+ * The engine has ONE intake path for live and replay (struggleEngine.ts §5): it
+ * subscribes to the hub channels and reads the hub's state methods. This class
+ * turns a `RecordedEvent[]` into exactly those channel signals, reconstructing
+ * file text (recorded textDocumentOpen/textChange carry no text) and diagnostics
+ * state along the way.
+ *
+ * Determinism: every recorded event is mapped to a queue entry stamped with its
+ * session-relative time and its ORIGINAL index. `pumpUpTo(tS)` fires all
+ * not-yet-fired entries with time <= tS, sorted by (time, originalIndex) so
+ * equal timestamps preserve recording order (the engine's own intake queue is
+ * stable-sorted the same way — struggleEngine.ts#_drainUpTo).
+ *
+ * Signal `ts` convention: the engine computes `relS(ts) = (ts - sessionStartMs)
+ * / 1000`, so every fired signal carries `ts = sessionStartMs + tSeconds * 1000`.
+ * Recorded events store absolute `timestamp` already on that clock, so we reuse
+ * it verbatim; injected pastes are stamped `sessionStartMs + t * 1000`.
+ *
+ * Read methods the engine never calls in replay throw rather than return fake
+ * data: a silent fake would mask an engine change that starts reading them.
+ */
+import * as vscode from 'vscode';
+
+import type { RecordedEvent } from '@extension/services/recording/types';
+import { detectPastes } from '@extension/services/sensing/collectors/paste';
+import type { SensorHub } from '@extension/services/sensing/sensorHub';
+import type {
+    ActiveEditorSignal, BreakpointsSignal, BuildResultSignal, DebugSessionSignal,
+    DiagnosticsChangeSignal, DiagnosticsSettledSignal, FileRenameSignal, FileSetSignal,
+    PasteSignal, SaveSignal, SelectionSignal, ShellExecutionEndSignal, ShellExecutionStartSignal,
+    TaskFeedbackViewSignal, TerminalSignal, TextChangeSignal, TextDocumentSignal,
+    VisibleRangesSignal, WindowStateSignal,
+} from '@extension/services/sensing/types';
+
+import { rehydrateResultDTO } from './buildResultRehydrate';
+import { makeDocument, makeEditor, makeUri } from './fakeVscode';
+import { FileTextState } from './textReconstruction';
+
+export interface ReplaySensorHubOptions {
+    /** Resolve a recorded snapshot path to its text. Injected to keep the hub
+     *  disk-free and unit-testable. */
+    readonly resolveSnapshotText: (snapshotPath: string) => string;
+    /** 'derive' runs each textChange through the live paste heuristic; 'inject'
+     *  derives nothing and instead fires pastes at `injectedPasteEventTimes`. */
+    readonly pasteMode: 'derive' | 'inject';
+    /** Session-relative seconds for injected pastes. Required in 'inject' mode. */
+    readonly injectedPasteEventTimes?: number[];
+    /** Absolute ms of session start; signal ts = sessionStartMs + tSeconds*1000. */
+    readonly sessionStartMs: number;
+}
+
+/** One queued signal: its session-relative time, recording index (tie-break),
+ *  and the side effect that fires it. */
+interface QueuedSignal {
+    readonly tS: number;
+    readonly seq: number;
+    readonly fire: () => void;
+}
+
+export class ReplaySensorHub implements SensorHub {
+    // ── channel emitters ────────────────────────────────────────────────
+    // Engine-consumed channels get fired; the remaining interface members are
+    // backed by idle emitters that never fire (the engine never subscribes).
+    private readonly _textChange = new vscode.EventEmitter<TextChangeSignal>();
+    private readonly _save = new vscode.EventEmitter<SaveSignal>();
+    private readonly _activeEditor = new vscode.EventEmitter<ActiveEditorSignal>();
+    private readonly _diagnostics = new vscode.EventEmitter<DiagnosticsChangeSignal>();
+    private readonly _diagnosticsSettled = new vscode.EventEmitter<DiagnosticsSettledSignal>();
+    private readonly _windowState = new vscode.EventEmitter<WindowStateSignal>();
+    private readonly _selection = new vscode.EventEmitter<SelectionSignal>();
+    private readonly _visibleRanges = new vscode.EventEmitter<VisibleRangesSignal>();
+    private readonly _terminalOpen = new vscode.EventEmitter<TerminalSignal>();
+    private readonly _terminalClose = new vscode.EventEmitter<TerminalSignal>();
+    private readonly _fileCreate = new vscode.EventEmitter<FileSetSignal>();
+    private readonly _fileDelete = new vscode.EventEmitter<FileSetSignal>();
+    private readonly _fileRename = new vscode.EventEmitter<FileRenameSignal>();
+    private readonly _docOpen = new vscode.EventEmitter<TextDocumentSignal>();
+    private readonly _docClose = new vscode.EventEmitter<TextDocumentSignal>();
+    private readonly _debugStart = new vscode.EventEmitter<DebugSessionSignal>();
+    private readonly _debugTerminate = new vscode.EventEmitter<DebugSessionSignal>();
+    private readonly _debugActive = new vscode.EventEmitter<DebugSessionSignal>();
+    private readonly _breakpoints = new vscode.EventEmitter<BreakpointsSignal>();
+    private readonly _shellStart = new vscode.EventEmitter<ShellExecutionStartSignal>();
+    private readonly _shellEnd = new vscode.EventEmitter<ShellExecutionEndSignal>();
+    private readonly _buildResult = new vscode.EventEmitter<BuildResultSignal>();
+    private readonly _taskFeedbackView = new vscode.EventEmitter<TaskFeedbackViewSignal>();
+    private readonly _pasteDetected = new vscode.EventEmitter<PasteSignal>();
+
+    readonly onDidChangeTextDocument = this._textChange.event;
+    readonly onDidSaveTextDocument = this._save.event;
+    readonly onDidChangeActiveTextEditor = this._activeEditor.event;
+    readonly onDidChangeDiagnostics = this._diagnostics.event;
+    readonly onDiagnosticsSettled = this._diagnosticsSettled.event;
+    readonly onDidChangeWindowState = this._windowState.event;
+    readonly onDidChangeTextEditorSelection = this._selection.event;
+    readonly onDidChangeTextEditorVisibleRanges = this._visibleRanges.event;
+    readonly onDidOpenTerminal = this._terminalOpen.event;
+    readonly onDidCloseTerminal = this._terminalClose.event;
+    readonly onDidCreateFiles = this._fileCreate.event;
+    readonly onDidDeleteFiles = this._fileDelete.event;
+    readonly onDidRenameFiles = this._fileRename.event;
+    readonly onDidOpenTextDocument = this._docOpen.event;
+    readonly onDidCloseTextDocument = this._docClose.event;
+    readonly onDidStartDebugSession = this._debugStart.event;
+    readonly onDidTerminateDebugSession = this._debugTerminate.event;
+    readonly onDidChangeActiveDebugSession = this._debugActive.event;
+    readonly onDidChangeBreakpoints = this._breakpoints.event;
+    readonly onDidStartTerminalShellExecution = this._shellStart.event;
+    readonly onDidEndTerminalShellExecution = this._shellEnd.event;
+    readonly onBuildResult = this._buildResult.event;
+    readonly onTaskFeedbackView = this._taskFeedbackView.event;
+    readonly onPasteDetected = this._pasteDetected.event;
+
+    // ── replay state ────────────────────────────────────────────────────
+    private readonly _opts: ReplaySensorHubOptions;
+    private readonly _fileText = new FileTextState();
+    /** URIs whose fileSnapshot precedes startupPhaseComplete; readTextDocuments()
+     *  returns exactly these (the docs the engine treats as already-open). */
+    private readonly _startupUris: string[] = [];
+    /** Current diagnostics, by URI string, as of the last pumped diagnostics event. */
+    private readonly _diagByUri = new Map<string, vscode.Diagnostic[]>();
+    private readonly _queue: QueuedSignal[];
+    private _cursor = 0;
+
+    constructor(events: RecordedEvent[], opts: ReplaySensorHubOptions) {
+        this._opts = opts;
+        if (opts.pasteMode === 'inject' && opts.injectedPasteEventTimes === undefined) {
+            throw new Error("ReplaySensorHub: pasteMode 'inject' requires injectedPasteEventTimes");
+        }
+        this._seedSnapshots(events);
+        if (
+            opts.pasteMode === 'inject'
+            && (opts.injectedPasteEventTimes?.length ?? 0) > 0
+            && this._startupUris.length === 0
+        ) {
+            // Injected pastes must attach to a real in-root URI or the engine's
+            // shouldRecordUri filter silently drops every N1. Fail loud rather
+            // than fabricate an out-of-root URI.
+            throw new Error('ReplaySensorHub: injected pastes require at least one startup file snapshot to anchor the URI');
+        }
+        this._queue = this._buildQueue(events);
+    }
+
+    // ── startup seeding ─────────────────────────────────────────────────
+
+    private _relS(timestampMs: number): number {
+        return (timestampMs - this._opts.sessionStartMs) / 1000;
+    }
+
+    /**
+     * Seed FileTextState from EVERY recorded fileSnapshot up front, and record
+     * which URIs are "startup" (snapshotted before startupPhaseComplete).
+     *
+     * fileSnapshot is not a runtime mutation in the recorder: each URI is
+     * snapshotted at most once per session (snapshotManager gates on
+     * _snapshotedUris), the content is captured synchronously at open/switch
+     * time, and all of that URI's textChange offsets are relative to that single
+     * baseline (exactly like roundtrip-recording.ts). Installing every baseline
+     * before any pump therefore (a) guarantees the baseline exists before the
+     * first textChange regardless of recording order (the snapshot event is
+     * written only after async I/O, so it can land AFTER an early edit), and
+     * (b) makes a mid-stream rollback impossible. Snapshots are never re-applied
+     * from the pump queue.
+     *
+     * The recorder writes sessionStart, THEN the startup fileSnapshots (with
+     * Date.now() > sessionStartTs, i.e. relS > 0), THEN one startupPhaseComplete
+     * marker — its documented "seed state vs runtime events" cut-point. Snapshots
+     * before that marker are the already-open docs the engine seeds in start().
+     * Fallback when no marker exists (truncated recording): treat snapshots
+     * before the first textChange as startup.
+     */
+    private _seedSnapshots(events: RecordedEvent[]): void {
+        // Cut-point: the index of the first startupPhaseComplete marker; snapshots
+        // before it are startup. Authoritative when the marker exists. Fallback
+        // for marker-less (truncated) recordings: the first textChange index, or
+        // the end of the stream if neither marker nor textChange exists.
+        const markerIdx = events.findIndex(e => e.type === 'startupPhaseComplete');
+        const firstChangeIdx = events.findIndex(e => e.type === 'textChange');
+        let startupCutIdx: number;
+        if (markerIdx >= 0) {
+            startupCutIdx = markerIdx;
+        } else if (firstChangeIdx >= 0) {
+            startupCutIdx = firstChangeIdx;
+        } else {
+            startupCutIdx = events.length;
+        }
+
+        const seeded = new Set<string>();
+        events.forEach((ev, idx) => {
+            if (ev.type !== 'fileSnapshot') {
+                return;
+            }
+            if (seeded.has(ev.uri)) {
+                // Enforce the one-snapshot-per-URI recorder contract: a second
+                // snapshot for a URI would make the single-baseline model unsafe.
+                throw new Error(`ReplaySensorHub: duplicate fileSnapshot for URI "${ev.uri}"`);
+            }
+            this._fileText.seedSnapshot(ev.uri, this._opts.resolveSnapshotText(ev.snapshotPath));
+            seeded.add(ev.uri);
+            if (idx < startupCutIdx) {
+                this._startupUris.push(ev.uri);
+            }
+        });
+    }
+
+    // ── queue construction ──────────────────────────────────────────────
+
+    /** Map every recorded event (and injected pastes) to a queued signal. */
+    private _buildQueue(events: RecordedEvent[]): QueuedSignal[] {
+        const queue: QueuedSignal[] = [];
+        let seq = 0;
+        const push = (tS: number, fire: () => void): void => {
+            queue.push({ tS, seq: seq++, fire });
+        };
+
+        for (const ev of events) {
+            const tS = this._relS(ev.timestamp);
+            switch (ev.type) {
+                case 'fileSnapshot':
+                    // All snapshots are pre-seeded into FileTextState at construction
+                    // (see _seedSnapshots); they are baselines, never pumped mutations.
+                    break;
+                case 'textDocumentOpen':
+                    push(tS, () => this._fireDocOpen(ev.uri, ev.timestamp));
+                    break;
+                case 'textChange': {
+                    const { uri, changes } = ev;
+                    // Paste derivation (derive mode) rides the SAME queue entry as
+                    // its textChange (inside _fireTextChange), so it can never be
+                    // reordered relative to the change that produced it.
+                    push(tS, () => this._fireTextChange(uri, changes, ev.timestamp));
+                    break;
+                }
+                case 'selectionChange':
+                    push(tS, () => this._fireSelection(ev.uri, ev.selections, ev.timestamp));
+                    break;
+                case 'visibleRangeChange':
+                    push(tS, () => this._fireVisibleRanges(ev.uri, ev.visibleRanges, ev.timestamp));
+                    break;
+                case 'diagnostics':
+                    push(tS, () => this._fireDiagnostics(ev.uri, ev.diagnostics, ev.timestamp));
+                    break;
+                case 'terminalCommand':
+                    push(tS, () => this._shellEnd.fire(
+                        { ts: ev.timestamp, event: {} as vscode.TerminalShellExecutionEndEvent },
+                    ));
+                    break;
+                case 'buildResult':
+                    push(tS, () => this._buildResult.fire({ ts: ev.timestamp, result: rehydrateResultDTO(ev) }));
+                    break;
+                case 'taskFeedbackView':
+                    push(tS, () => this._taskFeedbackView.fire(
+                        { ts: ev.timestamp, action: ev.action, viewId: ev.viewId },
+                    ));
+                    break;
+                default:
+                    // Every other recorded event type is not consumed by the engine.
+                    break;
+            }
+        }
+
+        if (this._opts.pasteMode === 'inject') {
+            // The constructor guarantees a startup URI exists whenever there are
+            // injected paste times, so _startupUris[0] is always defined here.
+            const uriKey = this._startupUris[0];
+            for (const t of this._opts.injectedPasteEventTimes ?? []) {
+                const tsMs = this._opts.sessionStartMs + t * 1000;
+                // chars/lines are unused by the engine — it reads only ts + uri for
+                // the N1 boundary — so they carry placeholder values.
+                push(t, () => this._pasteDetected.fire(
+                    { ts: tsMs, uri: makeUri(uriKey), chars: 0, lines: 1 },
+                ));
+            }
+        }
+
+        queue.sort((a, b) => (a.tS - b.tS) || (a.seq - b.seq));
+        return queue;
+    }
+
+    // ── fire helpers ────────────────────────────────────────────────────
+
+    private _fireDocOpen(uri: string, tsMs: number): void {
+        if (!this._fileText.has(uri)) {
+            // textDocumentOpen carries no text; without a prior snapshot there is
+            // nothing to reconstruct. Seed empty so getText() never returns undefined.
+            this._fileText.seedSnapshot(uri, '');
+        }
+        const text = this._fileText.getText(uri) ?? '';
+        this._docOpen.fire({ ts: tsMs, document: makeDocument(makeUri(uri), () => text) });
+    }
+
+    private _fireTextChange(
+        uri: string,
+        changes: {
+            range: { startLine: number; endLine: number };
+            rangeOffset: number;
+            rangeLength: number;
+            text: string;
+        }[],
+        tsMs: number,
+    ): void {
+        this._fileText.applyChanges(uri, changes);
+        // Snapshot the post-change text NOW: the engine reads document.getText()
+        // synchronously in its handler, but tests may capture the signal and read
+        // it later, after further changes have mutated FileTextState.
+        const postText = this._fileText.getText(uri) ?? '';
+        const contentChanges = changes.map(c => ({
+            range: {
+                start: { line: c.range.startLine },
+                // Paste heuristic reads range.isEmpty / range.isSingleLine; derive
+                // both from the recorded range (rangeLength==0 ⇒ pure insert).
+                isEmpty: c.rangeLength === 0,
+                isSingleLine: c.range.startLine === c.range.endLine,
+            },
+            rangeOffset: c.rangeOffset,
+            rangeLength: c.rangeLength,
+            text: c.text,
+        }));
+        const signal: TextChangeSignal = {
+            ts: tsMs,
+            event: {
+                document: makeDocument(makeUri(uri), () => postText),
+                contentChanges,
+            } as unknown as vscode.TextDocumentChangeEvent,
+        };
+        this._textChange.fire(signal);
+
+        if (this._opts.pasteMode === 'derive') {
+            for (const paste of detectPastes(signal)) {
+                this._pasteDetected.fire(paste);
+            }
+        }
+    }
+
+    private _fireSelection(uri: string, selections: { endLine: number }[], tsMs: number): void {
+        const editor = makeEditor(makeUri(uri), selections.map(s => ({ end: { line: s.endLine } })));
+        this._selection.fire({
+            ts: tsMs,
+            event: { textEditor: editor, selections: editor.selections } as unknown as vscode.TextEditorSelectionChangeEvent,
+        });
+    }
+
+    private _fireVisibleRanges(
+        uri: string,
+        visibleRanges: { startLine: number; endLine: number }[],
+        tsMs: number,
+    ): void {
+        const editor = makeEditor(
+            makeUri(uri), [],
+            visibleRanges.map(r => ({ start: { line: r.startLine }, end: { line: r.endLine } })),
+        );
+        this._visibleRanges.fire({
+            ts: tsMs,
+            event: { textEditor: editor, visibleRanges: editor.visibleRanges } as unknown as vscode.TextEditorVisibleRangesChangeEvent,
+        });
+    }
+
+    private _fireDiagnostics(
+        uri: string,
+        diagnostics: { code: string | number | undefined; message: string; severity: number; range: { startLine: number } }[],
+        tsMs: number,
+    ): void {
+        const rehydrated = diagnostics.map(d => ({
+            severity: d.severity === 0 ? vscode.DiagnosticSeverity.Error : (d.severity as vscode.DiagnosticSeverity),
+            range: { start: { line: d.range.startLine } },
+            code: d.code,
+            message: d.message,
+        } as unknown as vscode.Diagnostic));
+        this._diagByUri.set(uri, rehydrated);
+        this._diagnostics.fire({ ts: tsMs, uris: [makeUri(uri)] });
+    }
+
+    // ── pump ────────────────────────────────────────────────────────────
+
+    /** Fire all not-yet-fired signals with session-relative time <= tS. */
+    pumpUpTo(tS: number): void {
+        while (this._cursor < this._queue.length && this._queue[this._cursor].tS <= tS) {
+            this._queue[this._cursor].fire();
+            this._cursor++;
+        }
+    }
+
+    // ── internal sources (engine never pushes these in replay) ──────────
+
+    emitBuildResult(): void {
+        throw new Error('not supported in replay: emitBuildResult (use recorded buildResult events)');
+    }
+    emitTaskFeedbackView(): void {
+        throw new Error('not supported in replay: emitTaskFeedbackView (use recorded taskFeedbackView events)');
+    }
+
+    // ── state reads ─────────────────────────────────────────────────────
+
+    readTextDocuments(): readonly vscode.TextDocument[] {
+        return this._startupUris.map(uri =>
+            makeDocument(makeUri(uri), () => this._fileText.getText(uri) ?? ''),
+        );
+    }
+    readDiagnostics(uri: vscode.Uri): readonly vscode.Diagnostic[] {
+        return this._diagByUri.get(uri.toString()) ?? [];
+    }
+    readAllDiagnostics(): ReadonlyArray<[vscode.Uri, vscode.Diagnostic[]]> {
+        return [...this._diagByUri.entries()].map(([uri, ds]) => [makeUri(uri), ds]);
+    }
+    readWindowFocused(): boolean { throw new Error('not supported in replay: readWindowFocused'); }
+    readVisibleTextEditors(): readonly vscode.TextEditor[] { throw new Error('not supported in replay: readVisibleTextEditors'); }
+    readActiveTextEditor(): vscode.TextEditor | undefined { throw new Error('not supported in replay: readActiveTextEditor'); }
+    readTerminals(): readonly vscode.Terminal[] { throw new Error('not supported in replay: readTerminals'); }
+    readBreakpoints(): readonly vscode.Breakpoint[] { throw new Error('not supported in replay: readBreakpoints'); }
+
+    dispose(): void {
+        for (const emitter of [
+            this._textChange, this._save, this._activeEditor, this._diagnostics,
+            this._diagnosticsSettled, this._windowState, this._selection, this._visibleRanges,
+            this._terminalOpen, this._terminalClose, this._fileCreate, this._fileDelete,
+            this._fileRename, this._docOpen, this._docClose, this._debugStart,
+            this._debugTerminate, this._debugActive, this._breakpoints, this._shellStart,
+            this._shellEnd, this._buildResult, this._taskFeedbackView, this._pasteDetected,
+        ]) {
+            emitter.dispose();
+        }
+    }
+}

--- a/extension/test/golden-replay/replaySensorHub.unit.test.ts
+++ b/extension/test/golden-replay/replaySensorHub.unit.test.ts
@@ -234,9 +234,10 @@ describe('ReplaySensorHub — channel mapping + state reads', () => {
         expect(() => hub.readTerminals()).toThrow(/not supported in replay/);
     });
 
-    it('classifies a snapshot before startupPhaseComplete as startup even though relS>0', () => {
-        // The real recorder writes startup snapshots with Date.now() > sessionStartMs;
-        // the startupPhaseComplete marker — not a t<=0 test — is the cut-point.
+    it('returns every snapshot URI from readTextDocuments() (relS and marker irrelevant)', () => {
+        // The real recorder writes snapshots lazily on first open/switch, with
+        // Date.now() > sessionStartMs and AFTER startupPhaseComplete. Every
+        // snapshotted URI is treated as an already-open doc; the marker is not used.
         const hub = new ReplaySensorHub(buildEvents(), {
             resolveSnapshotText, pasteMode: 'derive', sessionStartMs: SESSION_START_MS,
         });
@@ -245,7 +246,7 @@ describe('ReplaySensorHub — channel mapping + state reads', () => {
         expect(docs[0].getText()).toBe('hello');
     });
 
-    it('treats a post-startup snapshot as a pre-seeded baseline, not a startup doc', () => {
+    it('returns a post-marker snapshot from readTextDocuments() and pre-seeds its baseline', () => {
         const OTHER = 'file:///Users/x/exercise/src/Bar.java';
         const events = buildEvents();
         // A file opened mid-session: its (single) snapshot lands after the marker.
@@ -262,9 +263,9 @@ describe('ReplaySensorHub — channel mapping + state reads', () => {
             resolveSnapshotText: resolve, pasteMode: 'inject', injectedPasteEventTimes: [],
             sessionStartMs: SESSION_START_MS,
         });
-        // Bar is NOT a startup doc (snapshot is post-marker)…
-        expect(hub.readTextDocuments().map(d => d.uri.toString())).toEqual([URI]);
-        // …yet its baseline was pre-seeded, so the post-startup textChange applies
+        // Both snapshotted URIs are returned (insertion order); the marker is ignored.
+        expect(hub.readTextDocuments().map(d => d.uri.toString())).toEqual([URI, OTHER]);
+        // Bar's baseline was pre-seeded, so the post-marker textChange applies
         // against 'bar' (no unseeded-apply throw) and reconstructs correctly.
         const seen: { uri: string; text: string }[] = [];
         hub.onDidChangeTextDocument(s => seen.push({ uri: s.event.document.uri.toString(), text: s.event.document.getText() }));
@@ -282,11 +283,11 @@ describe('ReplaySensorHub — channel mapping + state reads', () => {
         })).toThrow(/duplicate fileSnapshot/);
     });
 
-    it('fails loud when inject pastes have no startup URI to anchor', () => {
+    it('fails loud when inject pastes have no snapshot URI to anchor', () => {
         const events: RecordedEvent[] = [
             { type: 'sessionStart', timestamp: SESSION_START_MS, exerciseId: 1, participantId: 'P1' },
             { type: 'startupPhaseComplete', timestamp: SESSION_START_MS + 50 },
-            // no startup fileSnapshot
+            // no fileSnapshot at all
         ];
         expect(() => new ReplaySensorHub(events, {
             resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [2],

--- a/extension/test/golden-replay/replaySensorHub.unit.test.ts
+++ b/extension/test/golden-replay/replaySensorHub.unit.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RecordedEvent, SerializedRange } from '@extension/services/recording/types';
+import type {
+    BuildResultSignal, DiagnosticsChangeSignal, PasteSignal, SelectionSignal,
+    ShellExecutionEndSignal, TaskFeedbackViewSignal, TextChangeSignal, TextDocumentSignal,
+    VisibleRangesSignal,
+} from '@extension/services/sensing/types';
+
+import { ReplaySensorHub } from './replaySensorHub';
+
+const URI = 'file:///Users/x/exercise/src/Foo.java';
+const SNAPSHOT_PATH = 'snapshots/Foo.java.0.txt';
+const SESSION_START_MS = 1_000_000_000_000;
+
+function range(startLine: number): SerializedRange {
+    return { startLine, startCharacter: 0, endLine: startLine, endCharacter: 0 };
+}
+
+/** Build the synthetic recorded stream the harness will drive.
+ *  Mirrors real recorder ordering: sessionStart, then startup fileSnapshot with
+ *  a timestamp STRICTLY AFTER sessionStart (the recorder uses Date.now() for the
+ *  snapshot, captured after the async open-file capture), then the
+ *  startupPhaseComplete marker, then runtime events. */
+function buildEvents(): RecordedEvent[] {
+    return [
+        { type: 'sessionStart', timestamp: SESSION_START_MS, exerciseId: 1, participantId: 'P1' },
+        // startup snapshot at +20ms (relS > 0, yet still a startup doc because it
+        // precedes startupPhaseComplete): seeds FileTextState + readTextDocuments()
+        { type: 'fileSnapshot', timestamp: SESSION_START_MS + 20, uri: URI, snapshotPath: SNAPSHOT_PATH },
+        { type: 'startupPhaseComplete', timestamp: SESSION_START_MS + 50 },
+        // textChange #1 at t=1s: append "X" at offset 5 (one-char insert)
+        {
+            type: 'textChange', timestamp: SESSION_START_MS + 1000, uri: URI,
+            changes: [{ range: range(0), rangeOffset: 5, rangeLength: 0, text: 'X' }],
+        },
+        // textChange #2 at t=2s: append "YY" at offset 6
+        {
+            type: 'textChange', timestamp: SESSION_START_MS + 2000, uri: URI,
+            changes: [{ range: range(0), rangeOffset: 6, rangeLength: 0, text: 'YY' }],
+        },
+        // diagnostics at t=3s
+        {
+            type: 'diagnostics', timestamp: SESSION_START_MS + 3000, uri: URI,
+            diagnostics: [{ code: 'E1', message: 'boom', severity: 0, range: range(7), source: 'javac' }],
+        },
+        // terminal command at t=4s
+        {
+            type: 'terminalCommand', timestamp: SESSION_START_MS + 4000, command: 'gradle test',
+            exitCode: 0, output: '', outputTruncated: false, cwd: undefined,
+            terminalName: 'bash', durationMs: 10,
+        },
+        // build result at t=5s (one failed test)
+        {
+            type: 'buildResult', timestamp: SESSION_START_MS + 5000, successful: false,
+            errorCount: 1, failedTests: ['fail-detail'], buildFailed: false,
+            failedTestDetails: [{ testName: 'testA', detail: 'fail-detail' }],
+        },
+        // task feedback view opened at t=6s
+        {
+            type: 'taskFeedbackView', action: 'opened', timestamp: SESSION_START_MS + 6000,
+            viewId: 'view-1', exerciseId: 1, taskName: 'Task 1',
+            testIds: [1], totalTests: 1, passedTests: 0, failedTests: 1,
+        },
+    ];
+}
+
+function resolveSnapshotText(path: string): string {
+    if (path === SNAPSHOT_PATH) {
+        return 'hello';
+    }
+    throw new Error(`unexpected snapshot path: ${path}`);
+}
+
+describe('ReplaySensorHub — channel mapping + state reads', () => {
+    it('seeds readTextDocuments() from startup snapshot before any pump', () => {
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'derive', sessionStartMs: SESSION_START_MS,
+        });
+        const docs = hub.readTextDocuments();
+        expect(docs).toHaveLength(1);
+        expect(docs[0].uri.toString()).toBe(URI);
+        expect(docs[0].getText()).toBe('hello');
+    });
+
+    it('fires every engine-consumed channel once, mapped, at the right time', () => {
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        });
+
+        const textChanges: TextChangeSignal[] = [];
+        const opens: TextDocumentSignal[] = [];
+        const selections: SelectionSignal[] = [];
+        const visibles: VisibleRangesSignal[] = [];
+        const diags: DiagnosticsChangeSignal[] = [];
+        const shells: ShellExecutionEndSignal[] = [];
+        const builds: BuildResultSignal[] = [];
+        const feedbacks: TaskFeedbackViewSignal[] = [];
+
+        hub.onDidChangeTextDocument(s => textChanges.push(s));
+        hub.onDidOpenTextDocument(s => opens.push(s));
+        hub.onDidChangeTextEditorSelection(s => selections.push(s));
+        hub.onDidChangeTextEditorVisibleRanges(s => visibles.push(s));
+        hub.onDidChangeDiagnostics(s => diags.push(s));
+        hub.onDidEndTerminalShellExecution(s => shells.push(s));
+        hub.onBuildResult(s => builds.push(s));
+        hub.onTaskFeedbackView(s => feedbacks.push(s));
+
+        hub.pumpUpTo(10);
+
+        // textChange: two events, post-change text + mapped contentChanges
+        expect(textChanges).toHaveLength(2);
+        expect(textChanges[0].ts).toBe(SESSION_START_MS + 1000);
+        expect(textChanges[0].event.document.uri.toString()).toBe(URI);
+        expect(textChanges[0].event.document.getText()).toBe('helloX'); // post-change
+        expect(textChanges[0].event.contentChanges[0].text).toBe('X');
+        expect(textChanges[0].event.contentChanges[0].rangeLength).toBe(0);
+        expect(textChanges[0].event.contentChanges[0].range.start.line).toBe(0);
+        expect(textChanges[1].event.document.getText()).toBe('helloXYY'); // cumulative
+
+        // no open events in this stream
+        expect(opens).toHaveLength(0);
+        expect(selections).toHaveLength(0);
+        expect(visibles).toHaveLength(0);
+
+        // diagnostics channel fired once with the affected URI
+        expect(diags).toHaveLength(1);
+        expect(diags[0].uris.map(u => u.toString())).toEqual([URI]);
+        expect(diags[0].ts).toBe(SESSION_START_MS + 3000);
+
+        // terminal shell-execution end fired once
+        expect(shells).toHaveLength(1);
+        expect(shells[0].ts).toBe(SESSION_START_MS + 4000);
+
+        // build result: rehydrated DTO with one failed feedback, mapped ts
+        expect(builds).toHaveLength(1);
+        expect(builds[0].ts).toBe(SESSION_START_MS + 5000);
+        expect(builds[0].result.submission?.buildFailed).toBe(false);
+        expect((builds[0].result.feedbacks ?? []).map(f => f.detailText)).toEqual(['fail-detail']);
+
+        // task feedback view
+        expect(feedbacks).toHaveLength(1);
+        expect(feedbacks[0].action).toBe('opened');
+        expect(feedbacks[0].viewId).toBe('view-1');
+        expect(feedbacks[0].ts).toBe(SESSION_START_MS + 6000);
+    });
+
+    it('reflects pumped diagnostics through readDiagnostics()', () => {
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        });
+        const uri = hub.readTextDocuments()[0].uri;
+
+        // Before pumping past the diagnostics event, no diagnostics.
+        hub.pumpUpTo(2);
+        expect(hub.readDiagnostics(uri)).toHaveLength(0);
+
+        // After pumping past t=3s, the recorded error is reflected.
+        hub.pumpUpTo(3);
+        const ds = hub.readDiagnostics(uri);
+        expect(ds).toHaveLength(1);
+        expect(ds[0].severity).toBe(0); // DiagnosticSeverity.Error
+        expect(ds[0].range.start.line).toBe(7);
+        expect(ds[0].code).toBe('E1');
+        expect(ds[0].message).toBe('boom');
+        expect(hub.readAllDiagnostics().map(([u]) => u.toString())).toEqual([URI]);
+    });
+
+    it('inject-mode fires onPasteDetected at the injected times only', () => {
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [2],
+            sessionStartMs: SESSION_START_MS,
+        });
+        const pastes: PasteSignal[] = [];
+        hub.onPasteDetected(s => pastes.push(s));
+        hub.pumpUpTo(10);
+        // Exactly one injected paste at t=2s; the textChanges do NOT derive pastes.
+        expect(pastes).toHaveLength(1);
+        expect(pastes[0].ts).toBe(SESSION_START_MS + 2000);
+    });
+
+    it('derive-mode fires onPasteDetected from the paste heuristic (the >10-char insert)', () => {
+        // textChange #2 inserts "YY" (2 chars, single-line, non-empty range start):
+        // does NOT qualify. Add a long insert that DOES qualify under detectPastes.
+        const events = buildEvents();
+        events.push({
+            type: 'textChange', timestamp: SESSION_START_MS + 7000, uri: URI,
+            changes: [{ range: range(0), rangeOffset: 8, rangeLength: 0, text: 'this-is-a-long-paste' }],
+        });
+        const hub = new ReplaySensorHub(events, {
+            resolveSnapshotText, pasteMode: 'derive', sessionStartMs: SESSION_START_MS,
+        });
+        const pastes: PasteSignal[] = [];
+        hub.onPasteDetected(s => pastes.push(s));
+        hub.pumpUpTo(10);
+        // Only the long insert qualifies; the short "X"/"YY" inserts do not.
+        expect(pastes).toHaveLength(1);
+        expect(pastes[0].ts).toBe(SESSION_START_MS + 7000);
+        expect(pastes[0].chars).toBe('this-is-a-long-paste'.length);
+    });
+
+    it('preserves original event order for equal timestamps', () => {
+        const sameTs = SESSION_START_MS + 1500;
+        const events: RecordedEvent[] = [
+            { type: 'sessionStart', timestamp: SESSION_START_MS, exerciseId: 1, participantId: 'P1' },
+            { type: 'fileSnapshot', timestamp: SESSION_START_MS, uri: URI, snapshotPath: SNAPSHOT_PATH },
+            {
+                type: 'textChange', timestamp: sameTs, uri: URI,
+                changes: [{ range: range(0), rangeOffset: 5, rangeLength: 0, text: 'A' }],
+            },
+            {
+                type: 'textChange', timestamp: sameTs, uri: URI,
+                changes: [{ range: range(0), rangeOffset: 6, rangeLength: 0, text: 'B' }],
+            },
+        ];
+        const hub = new ReplaySensorHub(events, {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        });
+        const seen: string[] = [];
+        hub.onDidChangeTextDocument(s => seen.push(s.event.contentChanges[0].text));
+        hub.pumpUpTo(10);
+        expect(seen).toEqual(['A', 'B']); // A enqueued first, B second — stable on tie
+    });
+
+    it('throws a clear error for read methods not supported in replay', () => {
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        });
+        expect(() => hub.readActiveTextEditor()).toThrow(/not supported in replay/);
+        expect(() => hub.readTerminals()).toThrow(/not supported in replay/);
+    });
+
+    it('classifies a snapshot before startupPhaseComplete as startup even though relS>0', () => {
+        // The real recorder writes startup snapshots with Date.now() > sessionStartMs;
+        // the startupPhaseComplete marker — not a t<=0 test — is the cut-point.
+        const hub = new ReplaySensorHub(buildEvents(), {
+            resolveSnapshotText, pasteMode: 'derive', sessionStartMs: SESSION_START_MS,
+        });
+        const docs = hub.readTextDocuments();
+        expect(docs.map(d => d.uri.toString())).toEqual([URI]);
+        expect(docs[0].getText()).toBe('hello');
+    });
+
+    it('treats a post-startup snapshot as a pre-seeded baseline, not a startup doc', () => {
+        const OTHER = 'file:///Users/x/exercise/src/Bar.java';
+        const events = buildEvents();
+        // A file opened mid-session: its (single) snapshot lands after the marker.
+        events.push(
+            { type: 'fileSnapshot', timestamp: SESSION_START_MS + 7000, uri: OTHER, snapshotPath: 'snapshots/Bar.txt' },
+            {
+                type: 'textChange', timestamp: SESSION_START_MS + 8000, uri: OTHER,
+                changes: [{ range: range(0), rangeOffset: 3, rangeLength: 0, text: 'Z' }],
+            },
+        );
+        const resolve = (path: string): string =>
+            path === SNAPSHOT_PATH ? 'hello' : path === 'snapshots/Bar.txt' ? 'bar' : (() => { throw new Error(path); })();
+        const hub = new ReplaySensorHub(events, {
+            resolveSnapshotText: resolve, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        });
+        // Bar is NOT a startup doc (snapshot is post-marker)…
+        expect(hub.readTextDocuments().map(d => d.uri.toString())).toEqual([URI]);
+        // …yet its baseline was pre-seeded, so the post-startup textChange applies
+        // against 'bar' (no unseeded-apply throw) and reconstructs correctly.
+        const seen: { uri: string; text: string }[] = [];
+        hub.onDidChangeTextDocument(s => seen.push({ uri: s.event.document.uri.toString(), text: s.event.document.getText() }));
+        hub.pumpUpTo(10);
+        const barChange = seen.find(s => s.uri === OTHER)!;
+        expect(barChange.text).toBe('barZ');
+    });
+
+    it('throws on a duplicate fileSnapshot for the same URI (recorder contract)', () => {
+        const events = buildEvents();
+        events.push({ type: 'fileSnapshot', timestamp: SESSION_START_MS + 9000, uri: URI, snapshotPath: SNAPSHOT_PATH });
+        expect(() => new ReplaySensorHub(events, {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [],
+            sessionStartMs: SESSION_START_MS,
+        })).toThrow(/duplicate fileSnapshot/);
+    });
+
+    it('fails loud when inject pastes have no startup URI to anchor', () => {
+        const events: RecordedEvent[] = [
+            { type: 'sessionStart', timestamp: SESSION_START_MS, exerciseId: 1, participantId: 'P1' },
+            { type: 'startupPhaseComplete', timestamp: SESSION_START_MS + 50 },
+            // no startup fileSnapshot
+        ];
+        expect(() => new ReplaySensorHub(events, {
+            resolveSnapshotText, pasteMode: 'inject', injectedPasteEventTimes: [2],
+            sessionStartMs: SESSION_START_MS,
+        })).toThrow(/injected pastes require/);
+    });
+});

--- a/extension/test/golden-replay/scriptedTrackers.ts
+++ b/extension/test/golden-replay/scriptedTrackers.ts
@@ -1,0 +1,36 @@
+/**
+ * Scripted A8/N2 trackers for golden-replay EXACT mode.
+ *
+ * In exact mode the harness injects the golden's recorded binary fA8/fN2 streams
+ * verbatim instead of deriving them online, so the engine's severity and alerting
+ * are exercised against the exact feature inputs the reference used. Each tracker
+ * is backed by a `Map<tickTime, 0|1>`; `activeAt(tS)` returns the mapped boolean
+ * (defaulting to inactive for unmapped ticks), and every ingest method is a no-op
+ * (the scripted value, not the online derivation, is authoritative).
+ */
+import type {
+    A8TrackerLike, N2TrackerLike,
+} from '@extension/services/struggle/struggleEngine';
+
+function toMap(pairs: [number, 0 | 1][]): Map<number, 0 | 1> {
+    return new Map(pairs);
+}
+
+/** A8 tracker whose `activeAt` replays the scripted [tickTime, value] pairs. */
+export function scriptedA8(pairs: [number, 0 | 1][]): A8TrackerLike {
+    const map = toMap(pairs);
+    return {
+        recordChange(): void { /* no-op: scripted value is authoritative */ },
+        activeAt(tS: number): boolean { return (map.get(tS) ?? 0) === 1; },
+    };
+}
+
+/** N2 tracker whose `activeAt` replays the scripted [tickTime, value] pairs. */
+export function scriptedN2(pairs: [number, 0 | 1][]): N2TrackerLike {
+    const map = toMap(pairs);
+    return {
+        ingestSelection(): void { /* no-op: scripted value is authoritative */ },
+        ingestSnapshot(): void { /* no-op: scripted value is authoritative */ },
+        activeAt(tS: number): boolean { return (map.get(tS) ?? 0) === 1; },
+    };
+}

--- a/extension/test/golden-replay/scriptedTrackers.unit.test.ts
+++ b/extension/test/golden-replay/scriptedTrackers.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { scriptedA8, scriptedN2 } from './scriptedTrackers';
+
+describe('scriptedA8', () => {
+    it('returns the mapped boolean at mapped ticks and false elsewhere', () => {
+        const a8 = scriptedA8([[100, 1], [110, 0]]);
+        expect(a8.activeAt(100)).toBe(true);
+        expect(a8.activeAt(110)).toBe(false);
+        // unmapped tick defaults to inactive
+        expect(a8.activeAt(120)).toBe(false);
+    });
+
+    it('recordChange is a harmless no-op that does not change activeAt', () => {
+        const a8 = scriptedA8([[100, 1]]);
+        a8.recordChange(50, 'file:///x.java', 'foo');
+        a8.recordChange(100, 'file:///x.java', null);
+        expect(a8.activeAt(100)).toBe(true);
+        expect(a8.activeAt(50)).toBe(false);
+    });
+});
+
+describe('scriptedN2', () => {
+    it('returns the mapped boolean at mapped ticks and false elsewhere', () => {
+        const n2 = scriptedN2([[200, 1], [210, 0]]);
+        expect(n2.activeAt(200)).toBe(true);
+        expect(n2.activeAt(210)).toBe(false);
+        expect(n2.activeAt(220)).toBe(false);
+    });
+
+    it('ingestSelection / ingestSnapshot are harmless no-ops', () => {
+        const n2 = scriptedN2([[200, 1]]);
+        n2.ingestSelection(150, 'file:///x.java', 7);
+        n2.ingestSnapshot(150, 'file:///x.java', [{ line: 1, code: 'E', message: 'm' }]);
+        expect(n2.activeAt(200)).toBe(true);
+        expect(n2.activeAt(150)).toBe(false);
+    });
+});

--- a/extension/test/golden-replay/struggleReplay.ts
+++ b/extension/test/golden-replay/struggleReplay.ts
@@ -1,0 +1,113 @@
+/**
+ * Golden-replay harness: drive the StruggleEngine from a recorded session through
+ * a ReplaySensorHub, capturing every TickRecord and AlertRecord for comparison
+ * against the frozen Python reference.
+ *
+ * Two modes:
+ *   - 'exact'  — inject the golden's binary fA8/fN2 streams (scripted trackers)
+ *                and the golden's N1 paste times, so severity + alerting run on
+ *                exactly the reference's feature inputs.
+ *   - 'causal' — the engine derives A8/N2/paste online from the recorded events.
+ *
+ * Determinism (one intake path, struggleEngine.ts §5): per grid tick we (1)
+ * pump every hub signal with time <= tS so the engine ENQUEUES it, THEN (2)
+ * advanceTo(tS) which drains ts <= tS and computes the tick. Pump-then-advance
+ * is the contract — a signal at exactly a grid time must be enqueued before its
+ * own tick runs. The engine's live interval timer is disabled here: a fake clock
+ * whose setInterval never fires lets the harness own the clock.
+ */
+import * as vscode from 'vscode';
+
+import type { RecordedEvent } from '@extension/services/recording/types';
+import { SPEC } from '@extension/services/struggle/constants';
+import { StruggleEngine } from '@extension/services/struggle/struggleEngine';
+import type { AlertRecord, EngineClock, TickRecord } from '@extension/services/struggle/types';
+
+import type { GoldenInject } from './goldenTypes';
+import { assertFeedbackViewMatched, assertSnapshotBeforeChange } from './invariants';
+import { ReplaySensorHub } from './replaySensorHub';
+import { scriptedA8, scriptedN2 } from './scriptedTrackers';
+
+export interface ReplayResult {
+    readonly durationS: number;
+    readonly ticks: TickRecord[];
+    readonly alerts: AlertRecord[];
+}
+
+export type ReplayOpts =
+    | {
+        mode: 'exact';
+        inject: GoldenInject;
+        sessionStartMs: number;
+        durationS: number;
+        resolveSnapshotText: (snapshotPath: string) => string;
+    }
+    | {
+        mode: 'causal';
+        sessionStartMs: number;
+        durationS: number;
+        resolveSnapshotText: (snapshotPath: string) => string;
+    };
+
+/** Grid tick times for a session of length durationS: 10, 20, ... <= durationS.
+ *  First tick at +10s, never at 0 (mirrors Python ticks_for). */
+function ticksFor(durationS: number): number[] {
+    const out: number[] = [];
+    for (let t = SPEC.TICK_S; t <= durationS; t += SPEC.TICK_S) {
+        out.push(t);
+    }
+    return out;
+}
+
+export function replaySession(events: RecordedEvent[], opts: ReplayOpts): ReplayResult {
+    // Fail loud on a corrupt stream before driving the engine.
+    assertFeedbackViewMatched(events);
+    assertSnapshotBeforeChange(events);
+
+    const hub = new ReplaySensorHub(events, {
+        resolveSnapshotText: opts.resolveSnapshotText,
+        pasteMode: opts.mode === 'exact' ? 'inject' : 'derive',
+        injectedPasteEventTimes: opts.mode === 'exact' ? opts.inject.pasteEventTimes : undefined,
+        sessionStartMs: opts.sessionStartMs,
+    });
+
+    const trackers = opts.mode === 'exact'
+        ? { a8: () => scriptedA8(opts.inject.fA8), n2: () => scriptedN2(opts.inject.fN2) }
+        : undefined;
+
+    // Fake clock: the harness owns time. setInterval never fires (the engine's
+    // live auto-tick is disabled); advanceTo is driven manually below.
+    const DUMMY_HANDLE = Symbol('replay-timer');
+    let currentMs = opts.sessionStartMs;
+    const clock: EngineClock = {
+        now: () => currentMs,
+        setInterval: () => DUMMY_HANDLE,
+        clearInterval: () => { /* harness-driven */ },
+    };
+
+    const engine = new StruggleEngine(hub, clock, { preDebouncedIntake: true, trackers });
+    const ticks: TickRecord[] = [];
+    const alerts: AlertRecord[] = [];
+    const subs: vscode.Disposable[] = [
+        engine.onDidTick(t => ticks.push(t)),
+        engine.onDidAlert(a => alerts.push(a)),
+    ];
+
+    try {
+        engine.start({ sessionStartMs: opts.sessionStartMs });
+        for (const tS of ticksFor(opts.durationS)) {
+            hub.pumpUpTo(tS);
+            currentMs = opts.sessionStartMs + tS * 1000;
+            engine.advanceTo(currentMs);
+        }
+        engine.stop();
+    } finally {
+        for (const sub of subs) {
+            sub.dispose();
+        }
+        engine.dispose();
+        hub.dispose();
+    }
+
+    return { durationS: opts.durationS, ticks, alerts };
+}

--- a/extension/test/golden-replay/struggleReplay.ts
+++ b/extension/test/golden-replay/struggleReplay.ts
@@ -24,7 +24,7 @@ import { StruggleEngine } from '@extension/services/struggle/struggleEngine';
 import type { AlertRecord, EngineClock, TickRecord } from '@extension/services/struggle/types';
 
 import type { GoldenInject } from './goldenTypes';
-import { assertFeedbackViewMatched, assertSnapshotBeforeChange } from './invariants';
+import { assertEveryChangeHasSnapshot, assertFeedbackViewMatched } from './invariants';
 import { ReplaySensorHub } from './replaySensorHub';
 import { scriptedA8, scriptedN2 } from './scriptedTrackers';
 
@@ -62,7 +62,7 @@ function ticksFor(durationS: number): number[] {
 export function replaySession(events: RecordedEvent[], opts: ReplayOpts): ReplayResult {
     // Fail loud on a corrupt stream before driving the engine.
     assertFeedbackViewMatched(events);
-    assertSnapshotBeforeChange(events);
+    assertEveryChangeHasSnapshot(events);
 
     const hub = new ReplaySensorHub(events, {
         resolveSnapshotText: opts.resolveSnapshotText,

--- a/extension/test/golden-replay/struggleReplay.unit.test.ts
+++ b/extension/test/golden-replay/struggleReplay.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RecordedEvent } from '@extension/services/recording/types';
+
+import { replaySession } from './struggleReplay';
+
+const URI = 'file:///Users/x/exercise/src/Main.java';
+const SNAPSHOT_PATH = 'snapshots/Main.java.0.txt';
+const SESSION_START_MS = 1_000_000_000_000;
+const JAVA = 'class Main { void run() {} }';
+
+function resolveSnapshotText(path: string): string {
+    if (path === SNAPSHOT_PATH) {
+        return JAVA;
+    }
+    throw new Error(`unexpected snapshot path: ${path}`);
+}
+
+/** A minimal idle session: a startup snapshot for one URI, a sessionStart, and
+ *  nothing else. The engine should still tick the whole grid and (eventually)
+ *  alert on the idle STATE boundary. */
+function idleEvents(): RecordedEvent[] {
+    return [
+        { type: 'sessionStart', timestamp: SESSION_START_MS, exerciseId: 1, participantId: 'P1' },
+        { type: 'fileSnapshot', timestamp: SESSION_START_MS + 20, uri: URI, snapshotPath: SNAPSHOT_PATH },
+        { type: 'startupPhaseComplete', timestamp: SESSION_START_MS + 50 },
+    ];
+}
+
+describe('replaySession — causal mode', () => {
+    it('ticks the whole 10s grid and alerts STATE on a pure idle session', () => {
+        const result = replaySession(idleEvents(), {
+            mode: 'causal',
+            sessionStartMs: SESSION_START_MS,
+            durationS: 520,
+            resolveSnapshotText,
+        });
+
+        expect(result.durationS).toBe(520);
+        // First tick at +10s, never 0; one tick every 10s through durationS.
+        expect(result.ticks.map(t => t.t)).toEqual(
+            Array.from({ length: 52 }, (_, i) => (i + 1) * 10),
+        );
+        // The idle session crosses warmup (480s) with no typing -> STATE alert.
+        expect(result.alerts.length).toBeGreaterThanOrEqual(1);
+        expect(result.alerts[0].primary).toBe('STATE');
+    });
+});
+
+describe('replaySession — exact mode', () => {
+    it('injects the scripted fA8 at the mapped ticks regardless of (absent) edits', () => {
+        const result = replaySession(idleEvents(), {
+            mode: 'exact',
+            inject: { fA8: [[20, 1], [30, 1]], fN2: [], pasteEventTimes: [] },
+            sessionStartMs: SESSION_START_MS,
+            durationS: 60,
+            resolveSnapshotText,
+        });
+
+        const byT = new Map(result.ticks.map(t => [t.t, t]));
+        expect(byT.get(20)!.features.fA8).toBe(1);
+        expect(byT.get(30)!.features.fA8).toBe(1);
+        // Unmapped ticks stay inactive.
+        expect(byT.get(10)!.features.fA8).toBe(0);
+        expect(byT.get(40)!.features.fA8).toBe(0);
+    });
+
+    it('injects a paste producing an N1 boundary at the mapped tick', () => {
+        const result = replaySession(idleEvents(), {
+            mode: 'exact',
+            inject: { fA8: [], fN2: [], pasteEventTimes: [20] },
+            sessionStartMs: SESSION_START_MS,
+            durationS: 60,
+            resolveSnapshotText,
+        });
+
+        const byT = new Map(result.ticks.map(t => [t.t, t]));
+        expect(byT.get(20)!.boundariesPreGate).toContain('N1');
+        // No paste at other ticks.
+        expect(byT.get(10)!.boundariesPreGate).not.toContain('N1');
+        expect(byT.get(30)!.boundariesPreGate).not.toContain('N1');
+    });
+});

--- a/extension/test/golden-replay/textReconstruction.ts
+++ b/extension/test/golden-replay/textReconstruction.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure in-memory file-text reconstruction for the golden-replay harness.
+ *
+ * Recorded `textDocumentOpen` events carry no text, so the harness must
+ * rebuild each file's text from the startup `fileSnapshot` plus the applied
+ * `textChange` deltas. This class holds the per-URI current text and exposes
+ * the before/after text the struggle engine's onDidChangeTextDocument handler
+ * needs (before-text for A8 Java-method parsing, after-text for the shadow).
+ *
+ * The delta-application logic is ported from `scripts/roundtrip-recording.ts`
+ * (`replayUri`, the `content.slice(0, off) + text + content.slice(off + len)`
+ * loop): changes are applied in ARRAY ORDER, never sorted. VS Code delivers
+ * `contentChanges` pre-sorted (descending position), so array-order application
+ * reproduces exactly what the live engine/recorder observed. The Python
+ * reference sorts descending, which is equivalent for valid data, but we
+ * mirror the live VS Code behaviour.
+ *
+ * Unlike the script (which collects errors and continues so it can report on
+ * a whole recording), this class THROWS on a bad offset/range: the harness
+ * wants corruption surfaced immediately rather than silently skipped.
+ */
+export class FileTextState {
+    private readonly _texts = new Map<string, string>();
+
+    /** Initial content for a URI (the recorded fileSnapshot text). */
+    seedSnapshot(uriKey: string, text: string): void {
+        this._texts.set(uriKey, text);
+    }
+
+    /**
+     * Apply one textChange event's `changes[]` to the current text, in array
+     * order. Each change replaces `[rangeOffset, rangeOffset + rangeLength)`
+     * with `text`. Throws if the URI was never seeded or a change is out of
+     * bounds.
+     */
+    applyChanges(
+        uriKey: string,
+        changes: { rangeOffset: number; rangeLength: number; text: string }[],
+    ): void {
+        let content = this._texts.get(uriKey);
+        if (content === undefined) {
+            throw new Error(
+                `cannot apply changes to URI "${uriKey}": it was never seeded with a snapshot`,
+            );
+        }
+        for (let i = 0; i < changes.length; i++) {
+            const { rangeOffset: off, rangeLength: len, text } = changes[i];
+            if (off < 0) {
+                throw new Error(
+                    `textChange #${i} for URI "${uriKey}" has rangeOffset<0: ${off}`,
+                );
+            }
+            if (off + len > content.length) {
+                throw new Error(
+                    `textChange #${i} for URI "${uriKey}" range ${off}+${len}=${off + len} ` +
+                    `exceeds content length ${content.length}`,
+                );
+            }
+            content = content.slice(0, off) + text + content.slice(off + len);
+        }
+        this._texts.set(uriKey, content);
+    }
+
+    /** Current reconstructed text, or undefined if the URI was never seeded. */
+    getText(uriKey: string): string | undefined {
+        return this._texts.get(uriKey);
+    }
+
+    /** True if the URI has been seeded. */
+    has(uriKey: string): boolean {
+        return this._texts.has(uriKey);
+    }
+}

--- a/extension/test/golden-replay/textReconstruction.unit.test.ts
+++ b/extension/test/golden-replay/textReconstruction.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileTextState } from './textReconstruction';
+
+const URI = 'file:///Users/x/exercise/src/Foo.java';
+
+describe('FileTextState', () => {
+    it('returns undefined and has()===false for a URI that was never seeded', () => {
+        const state = new FileTextState();
+        expect(state.has(URI)).toBe(false);
+        expect(state.getText(URI)).toBeUndefined();
+    });
+
+    it('seeds a snapshot and reports it as current text', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        expect(state.has(URI)).toBe(true);
+        expect(state.getText(URI)).toBe('abc\ndef');
+    });
+
+    it('applies a single insert at a given rangeOffset', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        // Insert "XY" after "abc\n" (offset 4), inserting nothing replaced.
+        state.applyChanges(URI, [{ rangeOffset: 4, rangeLength: 0, text: 'XY' }]);
+        expect(state.getText(URI)).toBe('abc\nXYdef');
+    });
+
+    it('applies a single replace at a given rangeOffset', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        // Replace "abc" (offset 0, length 3) with "ZZZZ".
+        state.applyChanges(URI, [{ rangeOffset: 0, rangeLength: 3, text: 'ZZZZ' }]);
+        expect(state.getText(URI)).toBe('ZZZZ\ndef');
+    });
+
+    it('applies a multi-change event in ARRAY ORDER (VS Code descending-position delivery)', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        // VS Code delivers contentChanges sorted by DESCENDING position: the
+        // later array entry has the smaller offset. Applying in array order
+        // keeps earlier (higher-offset) edits from invalidating later ones.
+        //   entry 0: replace "def" (offset 4, len 3) -> "ghi"
+        //   entry 1: replace "abc" (offset 0, len 3) -> "AB"
+        state.applyChanges(URI, [
+            { rangeOffset: 4, rangeLength: 3, text: 'ghi' },
+            { rangeOffset: 0, rangeLength: 3, text: 'AB' },
+        ]);
+        expect(state.getText(URI)).toBe('AB\nghi');
+    });
+
+    it('accumulates across multiple applyChanges calls', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc');
+        state.applyChanges(URI, [{ rangeOffset: 3, rangeLength: 0, text: 'def' }]);
+        state.applyChanges(URI, [{ rangeOffset: 6, rangeLength: 0, text: 'ghi' }]);
+        expect(state.getText(URI)).toBe('abcdefghi');
+    });
+
+    it('throws on a negative rangeOffset', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        expect(() => state.applyChanges(URI, [{ rangeOffset: -1, rangeLength: 0, text: 'X' }]))
+            .toThrow(/rangeOffset/);
+    });
+
+    it('throws on a rangeOffset beyond the current length', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        // length is 7; offset 8 is out of bounds.
+        expect(() => state.applyChanges(URI, [{ rangeOffset: 8, rangeLength: 0, text: 'X' }]))
+            .toThrow(/exceeds/);
+    });
+
+    it('throws on a range that extends past the current length', () => {
+        const state = new FileTextState();
+        state.seedSnapshot(URI, 'abc\ndef');
+        // offset 5 + length 5 = 10 > 7.
+        expect(() => state.applyChanges(URI, [{ rangeOffset: 5, rangeLength: 5, text: 'X' }]))
+            .toThrow(/exceeds/);
+    });
+
+    it('throws when applying changes to a URI that was never seeded', () => {
+        const state = new FileTextState();
+        expect(() => state.applyChanges(URI, [{ rangeOffset: 0, rangeLength: 0, text: 'X' }]))
+            .toThrow(/never seeded|not seeded|seed/i);
+    });
+});

--- a/extension/test/logic/struggle/engineTrackerInjection.test.ts
+++ b/extension/test/logic/struggle/engineTrackerInjection.test.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+import { describe, expect, it } from 'vitest';
+
+import type {
+    A8TrackerLike, N2TrackerLike,
+} from '@extension/services/struggle/struggleEngine';
+import { StruggleEngine } from '@extension/services/struggle/struggleEngine';
+import type { AlertRecord, EngineClock, TickRecord } from '@extension/services/struggle/types';
+import { TestSensorHub } from '@test/__shared__/testSensorHub';
+
+const START = 1_000_000_000_000;
+
+/** Manual clock pinned at START: tests drive ticks via advanceTo() themselves
+ *  (so stop()/dispose drains never catch up against the real Date.now()). */
+function pinnedClock(): EngineClock {
+    return { now: () => START, setInterval: () => 0, clearInterval: () => { /* manual */ } };
+}
+
+/** Scripted A8: active iff the tick time is at or past 100 s, no matter what the
+ *  recorded changes are. recordChange is accepted and ignored. */
+function scriptedA8(): A8TrackerLike {
+    return {
+        recordChange: () => { /* scripted: input ignored */ },
+        activeAt: (tS: number) => tS >= 100,
+    };
+}
+
+/** Scripted N2: never active. */
+function scriptedN2(): N2TrackerLike {
+    return {
+        ingestSelection: () => { /* scripted: input ignored */ },
+        ingestSnapshot: () => { /* scripted: input ignored */ },
+        activeAt: () => false,
+    };
+}
+
+function fakeTextChange(uri: string, oneCharTexts: string[], fullText: string, ts: number): { ts: number; event: unknown } {
+    return {
+        ts,
+        event: {
+            document: { uri: vscode.Uri.parse(uri), getText: () => fullText },
+            contentChanges: oneCharTexts.map(text => ({
+                text,
+                rangeLength: 0,
+                range: { start: { line: 0 }, isEmpty: true, isSingleLine: true },
+            })),
+        },
+    };
+}
+
+describe('StruggleEngine — injectable A8/N2 trackers', () => {
+    it('feeds scripted A8/N2 signals regardless of edits (exact-replay seam)', () => {
+        const hub = new TestSensorHub();
+        const engine = new StruggleEngine(hub, pinnedClock(), {
+            trackers: { a8: scriptedA8, n2: scriptedN2 },
+        });
+        const ticks: TickRecord[] = [];
+        engine.onDidTick(t => ticks.push(t));
+        engine.start({ sessionStartMs: START });
+
+        // Fire edits that would NOT trip the real A8 tracker (too few, too
+        // sparse) — proves fA8 follows the injected script, not online derivation.
+        for (let s = 1; s <= 50; s++) {
+            hub.emit.textChange.fire(fakeTextChange('file:///ws/Main.java', ['a'], 'class A {}', START + s * 1000) as never);
+        }
+        engine.advanceTo(START + 200_000);
+
+        expect(ticks.map(t => t.t)).toEqual(
+            Array.from({ length: 20 }, (_, i) => (i + 1) * 10),
+        );
+        for (const tick of ticks) {
+            expect(tick.features.fA8).toBe(tick.t >= 100 ? 1 : 0);
+            expect(tick.features.fN2).toBe(0);
+        }
+
+        engine.dispose();
+    });
+
+    it('default path (no trackers option) is unchanged: idle session alerts STATE at t=490', () => {
+        const hub = new TestSensorHub();
+        const engine = new StruggleEngine(hub);
+        const ticks: TickRecord[] = [];
+        const alerts: AlertRecord[] = [];
+        engine.onDidTick(t => ticks.push(t));
+        engine.onDidAlert(a => alerts.push(a));
+        engine.start({ sessionStartMs: START });
+
+        engine.advanceTo(START + 520_000);
+
+        expect(alerts.map(a => a.t)).toEqual([490]);
+        expect(alerts[0].primary).toBe('STATE');
+        expect(alerts[0].path).toBe('armed');
+        const tick49 = ticks.find(t => t.t === 490)!;
+        expect(Math.abs(tick49.s - 0.7)).toBeLessThan(1e-9);
+        // Default real trackers: an idle session never trips A8 or N2.
+        for (const tick of ticks) {
+            expect(tick.features.fA8).toBe(0);
+            expect(tick.features.fN2).toBe(0);
+        }
+
+        engine.dispose();
+    });
+});

--- a/extension/test/react/__helpers__/vscode.stub.ts
+++ b/extension/test/react/__helpers__/vscode.stub.ts
@@ -21,3 +21,55 @@ export const Uri = {
         return { scheme: url.protocol.replace(':', ''), authority: url.host, path, fsPath: path, toString: () => value };
     },
 };
+
+/** Minimal disposable matching the vscode.Disposable shape. */
+export interface Disposable {
+    dispose(): void;
+}
+
+export const Disposable = {
+    from(...disposables: Disposable[]): Disposable {
+        return { dispose: () => { for (const d of disposables) { d.dispose(); } } };
+    },
+};
+
+type Listener<T> = (e: T) => void;
+
+/**
+ * Real-enough EventEmitter so extension-host code that constructs
+ * vscode.EventEmitter (e.g. StruggleEngine's onDidTick/onDidAlert, the test
+ * sensor hub) is constructable and behaves correctly under vitest. Mirrors the
+ * subset of the vscode.EventEmitter contract those consumers use: subscribe via
+ * `.event`, emit via `.fire(value)`, tear down via `.dispose()`.
+ */
+export class EventEmitter<T> {
+    private readonly _listeners = new Set<Listener<T>>();
+
+    readonly event = (listener: Listener<T>): Disposable => {
+        this._listeners.add(listener);
+        return { dispose: () => { this._listeners.delete(listener); } };
+    };
+
+    fire(data: T): void {
+        // Test-oriented: one listener throwing must not stop the others (the
+        // real event-bus property), but the first error is rethrown after all
+        // listeners run so assertions inside a listener stay visible under vitest.
+        let firstError: unknown;
+        for (const listener of [...this._listeners]) {
+            try {
+                listener(data);
+            } catch (err) {
+                if (firstError === undefined) {
+                    firstError = err;
+                }
+            }
+        }
+        if (firstError !== undefined) {
+            throw firstError;
+        }
+    }
+
+    dispose(): void {
+        this._listeners.clear();
+    }
+}

--- a/extension/vitest.golden-replay.config.mts
+++ b/extension/vitest.golden-replay.config.mts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+	plugins: [react()],
+	resolve: {
+		alias: {
+			// Stub the vscode module for tests that import extension-host code
+			vscode: new URL('./test/react/__helpers__/vscode.stub.ts', import.meta.url).pathname,
+			// Path aliases — kept in sync with tsconfig.json "paths".
+			'@extension': new URL('./src/extension', import.meta.url).pathname,
+			'@webview': new URL('./src/webview', import.meta.url).pathname,
+			'@shared': new URL('./src/shared', import.meta.url).pathname,
+			'@test': new URL('./test', import.meta.url).pathname,
+			'@root/package.json': new URL('./package.json', import.meta.url).pathname,
+		},
+	},
+	test: {
+		globals: true,
+		environment: 'happy-dom',
+		setupFiles: ['./test/react/__helpers__/vitest.setup.ts'],
+		include: ['test/golden-replay/**/*.test.{ts,tsx}'],
+	},
+});


### PR DESCRIPTION
## PR 3: Engine v2 golden-replay verification

Closes the loop on the Engine v2 port (PR 2b/2c): an **offline, local** verification that the TypeScript engine reproduces the frozen Python reference (`IrisStudyData/analysis/lib/engine_v2.py`) when replaying recorded study sessions through it.

This is a **local verification, not a CI gate** (deliberate), and **no study-derived data is committed** — the harness, runner, and a methodology doc live here; recordings, generated goldens, and per-session figures stay local.

### What it adds
- A test-tree harness (`extension/test/golden-replay/`): a `ReplaySensorHub` that reconstructs file text + signals from a session's `events.jsonl` and drives the real `StruggleEngine`, plus `buildResult` rehydration, scripted A8/N2 trackers, a strict golden schema/parser, up-front invariants, and a tick-for-tick comparator.
- A dedicated Vitest target `npm run test:golden-replay` (excluded from the default `test:react`), gated by `IRIS_STUDY_DATA` / `GOLDEN_DIR` so it skips cleanly anywhere the dataset is absent.
- The **only production change**: an injectable A8/N2 tracker seam in `struggleEngine.ts` (test/replay-only; default behavior byte-identical).
- Methodology: `docs/struggle/golden-replay-verification.md`. Generator (lives with the data, not in this repo): `IrisStudyData/analysis/scripts/26_export_ts_goldens.py`.

### Two comparison modes
- **exact** proves the ported math: the reference's `f_a8`/`f_n2`/paste are injected; everything else is derived by the TS engine. Per-tick `S`/`V`/features match to 6 decimals; boundaries and alerts match exactly.
- **causal** characterizes the live engine deriving the three declared deviations (A8/N2/N1) online, reporting (not asserting) the divergence locally.

Verified locally: exact mode matches the reference tick-for-tick across the study sessions. Per-session figures are kept local for the thesis evaluation.

### Gates
check-types, lint, knip: clean. `test:react`: 945. unit label: 1232/0. `test:golden-replay`: 86 with dataset / clean-skip without. Production std + Open VSX builds + clean-bundle: green (harness is test-tree only, never bundled).

### Notes
- Plan: `docs/superpowers/plans/2026-06-13-pr3-golden-replay.md` (reviewed across 3 rounds; implementation reviewed and approved).
- Per the integration-branch convention, this targets `feat/struggle-engine-v2`; `dev` is untouched.
