### PR TITLE
chore(renovate): target dev branch for dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "dev"
   ]
 }


### PR DESCRIPTION
## Problem

Renovate has no `baseBranches` configured, so it falls back to the repository default branch (`main`) and opens every dependency PR against `main`. That bypasses the project workflow, where all PRs branch off and merge into `dev` (and only `dev` is merged into `main`).

This is also why the renovate behaviour changed: earlier dependency PRs (#82–#87) targeted `dev` while `dev` was the default branch; after the default branch was switched to `main`, Renovate followed.

## Fix

Pin `baseBranches` to `dev` in `renovate.json`.

```json
"baseBranches": ["dev"]
```

## Why this PR targets `main`

Renovate always reads its config (`renovate.json`) from the repository **default branch** (`main`), regardless of `baseBranches`. So the config change must land on `main` to take effect. This is a config-only change.

## After merge

Renovate detects the base-branch change and recreates the existing `main`-targeted PRs against `dev` (closing the old ones). No manual cleanup needed.