### PR TITLE
chore(renovate): sync baseBranches dev into dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "dev"
   ]
 }


### PR DESCRIPTION
Sync `renovate.json` so `dev` carries the same `baseBranches: ["dev"]` as `main`.

Renovate reads its config only from the default branch (`main`), where this is already active (#292). This PR keeps `dev` consistent so the config doesn't look divergent and isn't accidentally reverted on a future `dev` -> `main` merge. Config-only change.