### PR TITLE
fix(codelens): keep build-error CodeLens anchored to code on edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Intervention Block Reasons**: Withheld interventions record the real gate; `recent-progress`/`last-dismissed` no longer logged as `warmup`.
 - **Test Results With Hidden Names**: The "See test results" overview now lists results for exercises that hide test names from students (`showTestNamesToStudents` disabled), instead of showing "No test results available".
 - **Submission Git Locks**: Submitting is now guarded against a double-click, and a busy or stale Git index lock surfaces an actionable message instead of raw git output or a misleading "No local changes detected".
+- **Build Error CodeLens Position**: Build-error CodeLenses now shift with your edits instead of staying stuck at the originally reported line.
 
 ### Internal
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -70,6 +70,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const websocketStatusBarService = new WebSocketStatusBarService(artemisWebsocketService);
 
 	context.subscriptions.push(
+		buildErrorCodeLensProvider,
 		vscode.languages.registerCodeLensProvider({ scheme: 'file' }, buildErrorCodeLensProvider)
 	);
 

--- a/extension/src/extension/provider/buildErrorCodeLensProvider.ts
+++ b/extension/src/extension/provider/buildErrorCodeLensProvider.ts
@@ -3,6 +3,12 @@ import * as vscode from 'vscode';
 import type { ParsedBuildError } from '@extension/types';
 import { normalizeRelativePath } from '@extension/utils';
 
+interface TrackedBuildError {
+    readonly error: ParsedBuildError;
+    /** Live 1-based line, kept in sync with document edits. */
+    line: number;
+}
+
 /**
  * CodeLens provider for displaying build errors above the affected line
  * Shows errors in the style of "X references" or "Run Test"
@@ -11,7 +17,7 @@ export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
 
-    private buildErrors: Map<string, ParsedBuildError[]> = new Map();
+    private buildErrors: Map<string, TrackedBuildError[]> = new Map();
 
     /**
      * Set build errors for a specific file
@@ -23,7 +29,10 @@ export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
         if (!normalizedPath) {
             return;
         }
-        this.buildErrors.set(normalizedPath, errors);
+        this.buildErrors.set(
+            normalizedPath,
+            errors.map((error) => ({ error, line: error.line }))
+        );
         this._onDidChangeCodeLenses.fire();
     }
 
@@ -82,14 +91,14 @@ export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         // Create a CodeLens for each error
-        for (const error of errors) {
-            const line = Math.max(0, error.line - 1); // Convert to 0-based
+        for (const tracked of errors) {
+            const line = Math.max(0, tracked.line - 1); // Convert to 0-based
             const range = new vscode.Range(line, 0, line, 0);
 
             const codeLens = new vscode.CodeLens(range, {
-                title: `❌ Artemis Build Error: ${error.message}`,
+                title: `❌ Artemis Build Error: ${tracked.error.message}`,
                 command: 'artemis.goToSourceError',
-                arguments: [error.filePath, error.line, error.column, error.message]
+                arguments: [tracked.error.filePath, tracked.line, tracked.error.column, tracked.error.message]
             });
 
             codeLenses.push(codeLens);

--- a/extension/src/extension/provider/buildErrorCodeLensProvider.ts
+++ b/extension/src/extension/provider/buildErrorCodeLensProvider.ts
@@ -4,6 +4,11 @@ import type { ParsedBuildError } from '@extension/types';
 import { normalizeRelativePath } from '@extension/utils';
 
 interface TrackedBuildError {
+    /**
+     * Immutable build-result snapshot. Its `.line` is the original build-time
+     * line and goes stale after edits — use the outer `line` field for the
+     * current position.
+     */
     readonly error: ParsedBuildError;
     /** Live 1-based line, kept in sync with document edits. */
     line: number;
@@ -13,11 +18,18 @@ interface TrackedBuildError {
  * CodeLens provider for displaying build errors above the affected line
  * Shows errors in the style of "X references" or "Run Test"
  */
-export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
+export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
 
     private buildErrors: Map<string, TrackedBuildError[]> = new Map();
+    private readonly _changeSubscription: vscode.Disposable;
+
+    constructor() {
+        this._changeSubscription = vscode.workspace.onDidChangeTextDocument((e) =>
+            this.handleDocumentChange(e.document, e.contentChanges)
+        );
+    }
 
     /**
      * Set build errors for a specific file
@@ -108,6 +120,43 @@ export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     /**
+     * Shift tracked error lines so CodeLenses follow the code they point at
+     * when the user inserts or removes lines.
+     */
+    public handleDocumentChange(
+        document: vscode.TextDocument,
+        changes: readonly vscode.TextDocumentContentChangeEvent[]
+    ): void {
+        if (changes.length === 0) {
+            return;
+        }
+        const relativePath = this.getRelativePath(document);
+        if (!relativePath) {
+            return;
+        }
+        const errors = this.buildErrors.get(relativePath);
+        if (!errors || errors.length === 0) {
+            return;
+        }
+
+        const maxLine = Math.max(0, document.lineCount - 1);
+        let changed = false;
+        for (const tracked of errors) {
+            const shifted = shiftAnchorLine(tracked.line - 1, changes); // 0-based math
+            const clamped = Math.min(Math.max(0, shifted), maxLine);
+            const newLine = clamped + 1; // back to 1-based
+            if (newLine !== tracked.line) {
+                tracked.line = newLine;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            this._onDidChangeCodeLenses.fire();
+        }
+    }
+
+    /**
      * Resolve a CodeLens (optional, we provide everything in provideCodeLenses)
      */
     public resolveCodeLens?(
@@ -116,4 +165,62 @@ export class BuildErrorCodeLensProvider implements vscode.CodeLensProvider {
     ): vscode.CodeLens | Thenable<vscode.CodeLens> {
         return codeLens;
     }
+
+    public dispose(): void {
+        this._changeSubscription.dispose();
+        this._onDidChangeCodeLenses.dispose();
+    }
+}
+
+/**
+ * Compute the new 0-based line of an error anchored at column 0, given all the
+ * content changes of a single document-change event.
+ *
+ * The changes of one VS Code change event are non-overlapping and expressed in
+ * the coordinates of the document *before* the event (Monaco's model). That
+ * makes the result order-independent, so we accumulate over the array without
+ * sorting or sequential re-coordinating:
+ *   - a change strictly containing the anchor line (start < anchor < end, end
+ *     exclusive) deletes/replaces that line  -> clamp the anchor to start.line;
+ *   - any change entirely above the anchor (end <= anchor) shifts it by the
+ *     change's net line delta;
+ *   - changes at or below the anchor are ignored.
+ * The clamp target is itself shifted by the above-changes, which is correct
+ * because those changes lie above the clamp start too (non-overlapping).
+ *
+ * Scope: line-level only. An edit on the error's own line after column 0 (e.g.
+ * splitting the line) does not move the column-0 anchor. That is acceptable for
+ * a line-anchored CodeLens; the bug being fixed is line insertion/removal.
+ */
+function shiftAnchorLine(
+    line: number,
+    changes: readonly vscode.TextDocumentContentChangeEvent[]
+): number {
+    const anchor = new vscode.Position(line, 0);
+    let clampLine: number | null = null;
+    let shift = 0;
+
+    for (const change of changes) {
+        const start = change.range.start;
+        const end = change.range.end;
+        const delta = countNewlines(change.text) - (end.line - start.line);
+
+        if (start.isBefore(anchor) && anchor.isBefore(end)) {
+            clampLine = start.line; // anchor line is inside the replaced region
+        } else if (end.isBeforeOrEqual(anchor)) {
+            shift += delta; // change is entirely above the anchor (end exclusive)
+        }
+    }
+
+    return (clampLine ?? line) + shift;
+}
+
+function countNewlines(text: string): number {
+    let count = 0;
+    for (let i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === 10 /* \n */) {
+            count++;
+        }
+    }
+    return count;
 }

--- a/extension/test/unit/services/buildErrorCodeLensProvider.test.ts
+++ b/extension/test/unit/services/buildErrorCodeLensProvider.test.ts
@@ -11,8 +11,6 @@ class TestableBuildErrorCodeLensProvider extends BuildErrorCodeLensProvider {
     protected getRelativePath(document: vscode.TextDocument): string | null {
         return document.fileName;
     }
-
-    // Expose for testing if needed, but we override the caller
 }
 
 suite('BuildErrorCodeLensProvider Test Suite', () => {
@@ -164,5 +162,22 @@ suite('BuildErrorCodeLensProvider Test Suite', () => {
             change(8, 0, 11, 0, '')
         ]);
         assert.strictEqual(lineOf(provider, 'src/Main.java'), 9); // same as non-reversed
+    });
+
+    test('an edit on the error line after column 0 does not move the lens (line-level scope)', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        // Splitting the error's own line at column 5 leaves the column-0 anchor on line 9.
+        provider.handleDocumentChange(doc, [change(9, 5, 9, 5, '\n')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 9); // unchanged
+    });
+
+    test('a shift past the end of the document clamps to the last line', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        doc.lineCount = 12; // maxLine = 11
+        // Insert 5 lines at the top: error at 0-based 9 would go to 14, clamped to 11.
+        provider.handleDocumentChange(doc, [change(0, 0, 0, 0, '\n\n\n\n\n')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 11); // clamped to last line
     });
 });

--- a/extension/test/unit/services/buildErrorCodeLensProvider.test.ts
+++ b/extension/test/unit/services/buildErrorCodeLensProvider.test.ts
@@ -22,6 +22,10 @@ suite('BuildErrorCodeLensProvider Test Suite', () => {
         provider = new TestableBuildErrorCodeLensProvider();
     });
 
+    teardown(() => {
+        provider.dispose();
+    });
+
     test('should set and retrieve errors for file', () => {
         const errors: ParsedBuildError[] = [
             { filePath: 'src/Main.java', line: 10, message: 'Syntax error' }
@@ -85,5 +89,80 @@ suite('BuildErrorCodeLensProvider Test Suite', () => {
         provider.setErrors('', [{ filePath: '', line: 1, message: 'Error' }]);
         provider.clearFileErrors('');
         // Should not throw
+    });
+
+    function change(
+        startLine: number,
+        startChar: number,
+        endLine: number,
+        endChar: number,
+        text: string
+    ): vscode.TextDocumentContentChangeEvent {
+        const range = new vscode.Range(startLine, startChar, endLine, endChar);
+        return { range, rangeOffset: 0, rangeLength: 0, text };
+    }
+
+    function lineOf(p: TestableBuildErrorCodeLensProvider, fileName: string): number {
+        const doc = new MockTextDocument(vscode.Uri.file(`/workspace/${fileName}`), fileName);
+        const lenses = p.provideCodeLenses(doc, {} as vscode.CancellationToken) as vscode.CodeLens[];
+        return lenses[0].range.start.line; // 0-based
+    }
+
+    test('inserting a line above the error shifts the lens down', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        provider.handleDocumentChange(doc, [change(1, 0, 1, 0, '\n')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 10); // was 9, now 10
+    });
+
+    test('inserting a line below the error does not move the lens', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        provider.handleDocumentChange(doc, [change(20, 0, 20, 0, '\n')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 9); // unchanged
+    });
+
+    test('deleting a line above the error shifts the lens up', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        provider.handleDocumentChange(doc, [change(1, 0, 2, 0, '')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 8); // was 9, now 8
+    });
+
+    test('a deletion spanning the error line clamps to the edit start', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        // Half-open (7,0)..(11,0) removes 0-based lines 7,8,9,10; error at 9 is inside -> clamp to 7.
+        provider.handleDocumentChange(doc, [change(7, 0, 11, 0, '')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 7);
+    });
+
+    test('replacing the line directly above with extra lines shifts down (exclusive end)', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        // Replace 0-based line 8 (half-open (8,0)..(9,0)) with two lines; end==anchor, exclusive -> above -> +1.
+        provider.handleDocumentChange(doc, [change(8, 0, 9, 0, 'x\ny\n')]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 10); // was 9, now 10
+    });
+
+    test('multi-change edit composes order-independently (spanning delete + top insert)', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        // (8,0)..(11,0) deletes lines 8,9,10 -> error at 9 inside -> clamp 8; (0,0) insert "\n" -> above -> +1 => 9.
+        provider.handleDocumentChange(doc, [
+            change(8, 0, 11, 0, ''),
+            change(0, 0, 0, 0, '\n')
+        ]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 9);
+    });
+
+    test('multi-change result is identical when the array order is reversed', () => {
+        provider.setErrors('src/Main.java', [{ filePath: 'src/Main.java', line: 10, message: 'E' }]);
+        const doc = new MockTextDocument(vscode.Uri.file('/workspace/src/Main.java'), 'src/Main.java');
+        provider.handleDocumentChange(doc, [
+            change(0, 0, 0, 0, '\n'),
+            change(8, 0, 11, 0, '')
+        ]);
+        assert.strictEqual(lineOf(provider, 'src/Main.java'), 9); // same as non-reversed
     });
 });


### PR DESCRIPTION
## Problem

The build-error CodeLens stored the line number parsed from the build log statically and rebuilt its range from that number on every query. There was no `onDidChangeTextDocument` tracking, so inserting or removing lines above an error left the lens frozen at the original line. It then pointed at the wrong code.

## Fix

- The provider now keeps a live line per error (`TrackedBuildError`) and shifts it on document edits.
- `shiftAnchorLine` is an order-independent transform over a change event's `contentChanges` (changes are non-overlapping and in pre-event coordinates):
  - a change spanning the error line (`start < anchor < end`, end exclusive) clamps the anchor to the edit start;
  - a change entirely above the anchor (`end <= anchor`) shifts it by the change's net line delta;
  - changes on or below the line are ignored.
- The result is clamped to the document bounds; the CodeLens refresh only fires when a line actually moved.
- The provider implements `Disposable` (workspace listener + emitter) and is added to `context.subscriptions`.

Scope is line-level: an edit on the error's own line after column 0 does not move the column-0 anchor. Errors are repositioned, never dropped, on edit.

## Test Plan

- [x] `npm run test:unit` — 1697 pass, 0 failures (9 new tests for the provider).
- [x] New tests cover: insert above, insert below, delete above, deletion spanning the line (clamp), replacement directly above with extra lines (exclusive-end boundary), multi-change composition and order-independence, line-level scope, end-of-document clamp.
- [x] `npm run compile` and `npm run lint` clean.