### PR TITLE
fix(webview): keep previous test feedback visible while a new build runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Test Results With Hidden Names**: The "See test results" overview now lists results for exercises that hide test names from students (`showTestNamesToStudents` disabled), instead of showing "No test results available".
 - **Submission Git Locks**: Submitting is now guarded against a double-click, and a busy or stale Git index lock surfaces an actionable message instead of raw git output or a misleading "No local changes detected".
 - **Build Error CodeLens Position**: Build-error CodeLenses now shift with your edits instead of staying stuck at the originally reported line.
+- **Feedback During Builds**: Build feedback now stays visible while a new build runs, with a banner, and updates automatically when results arrive.
 
 ### Internal
 

--- a/extension/src/webview/components/exercise/TestResultsOverlay.module.css
+++ b/extension/src/webview/components/exercise/TestResultsOverlay.module.css
@@ -241,3 +241,13 @@
   text-align: center;
   padding: 24px 12px;
 }
+
+/* Rebuild banner: a new build is running, modal shows the previous result */
+.rebuildBanner {
+  padding: 10px 20px;
+  font-size: 12px;
+  color: var(--vscode-foreground);
+  background: rgba(100, 149, 237, 0.10);
+  border-bottom: 1px solid var(--vscode-panel-border, #e0e0e0);
+  flex-shrink: 0;
+}

--- a/extension/src/webview/components/exercise/TestResultsOverlay.tsx
+++ b/extension/src/webview/components/exercise/TestResultsOverlay.tsx
@@ -19,6 +19,7 @@ interface TestResultsOverlayTaskProps {
     state: TaskTestState;
     taskName: string;
     loading?: boolean;
+    buildRunning?: boolean;
 }
 
 /** Global overview: unfiltered list of all test cases for the latest result. */
@@ -27,12 +28,13 @@ interface TestResultsOverlayOverviewProps {
     onClose: (reason: TestResultsOverlayCloseReason) => void;
     state: { kind: 'all'; testCases: TestCase[] };
     loading?: boolean;
+    buildRunning?: boolean;
 }
 
 type TestResultsOverlayProps = TestResultsOverlayTaskProps | TestResultsOverlayOverviewProps;
 
 export function TestResultsOverlay(props: TestResultsOverlayProps) {
-    const { open, onClose, loading = false } = props;
+    const { open, onClose, loading = false, buildRunning = false } = props;
 
     useEffect(() => {
         if (!open) { return; }
@@ -64,6 +66,12 @@ export function TestResultsOverlay(props: TestResultsOverlayProps) {
                     <div className={styles.title}>{title}</div>
                     <IconButton.Close onClick={() => onClose('button')} />
                 </div>
+
+                {buildRunning && (
+                    <div className={styles.rebuildBanner} role="status">
+                        A new build is running. Showing feedback from your previous submission. This will update automatically.
+                    </div>
+                )}
 
                 {loading ? (
                     <div className={styles.testList}>

--- a/extension/src/webview/utils/exerciseStatus.ts
+++ b/extension/src/webview/utils/exerciseStatus.ts
@@ -61,7 +61,7 @@ export function getLatestById<T extends { id?: number }>(
 /**
  * The result to DISPLAY for a participation: the latest result of the newest
  * submission that actually has one (submission-first, matching how the rest of
- * the codebase resolves "latest" — `ExerciseDetailView` lines 227-229,
+ * the codebase resolves "latest" (see `ExerciseDetailView` lines 227-229,
  * `participationHelpers.ts`).
  *
  * Differs from `getLatestById(latestSubmission?.results)` only during a build:
@@ -69,7 +69,7 @@ export function getLatestById<T extends { id?: number }>(
  * submission returns nothing and the previous result vanishes from the UI.
  * Walking submissions newest-first keeps the previous result visible until the
  * new one lands on the newest submission. When the newest submission has a
- * result, this returns exactly that result — identical to `latestResult`.
+ * result, this returns exactly that result, identical to `latestResult`.
  *
  * NOT a global "highest result id" scan: a re-evaluated older submission can
  * own a result with a higher id than the newest submission's, which must NOT

--- a/extension/src/webview/utils/exerciseStatus.ts
+++ b/extension/src/webview/utils/exerciseStatus.ts
@@ -58,6 +58,34 @@ export function getLatestById<T extends { id?: number }>(
     return [...items].sort((a, b) => (b.id ?? 0) - (a.id ?? 0))[0];
 }
 
+/**
+ * The result to DISPLAY for a participation: the latest result of the newest
+ * submission that actually has one (submission-first, matching how the rest of
+ * the codebase resolves "latest" — `ExerciseDetailView` lines 227-229,
+ * `participationHelpers.ts`).
+ *
+ * Differs from `getLatestById(latestSubmission?.results)` only during a build:
+ * a freshly-created submission has no results yet, so reading only the latest
+ * submission returns nothing and the previous result vanishes from the UI.
+ * Walking submissions newest-first keeps the previous result visible until the
+ * new one lands on the newest submission. When the newest submission has a
+ * result, this returns exactly that result — identical to `latestResult`.
+ *
+ * NOT a global "highest result id" scan: a re-evaluated older submission can
+ * own a result with a higher id than the newest submission's, which must NOT
+ * override the newest submission's result.
+ */
+export function getLatestResultAcrossSubmissions<R extends { id?: number }>(
+    submissions: ReadonlyArray<{ id?: number; results?: R[] }> | undefined,
+): R | undefined {
+    const newestFirst = [...(submissions ?? [])].sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+    for (const submission of newestFirst) {
+        const latest = getLatestById(submission.results);
+        if (latest) { return latest; }
+    }
+    return undefined;
+}
+
 interface TestCaseResult {
     name: string;
     passed: boolean;

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -245,7 +245,6 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     const buildFailed = latestSubmission?.buildFailed ?? false;
     const feedbacks = latestResult?.feedbacks ?? [];
     const testFeedbacks = feedbacks.filter(isTestCaseFeedback);
-    const testCases = transformFeedbacksToTestCases(feedbacks);
     const displayTestCases = transformFeedbacksToTestCases(displayResult?.feedbacks ?? []);
 
     // Use Artemis-provided test case counts when available, fall back to feedbacks

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -229,11 +229,15 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     // Results live on submission.results (not on participation directly)
     const latestResult = getLatestById(latestSubmission?.results);
 
-    // Feedback modals show the latest result across ALL submissions, so a fresh
-    // resultless submission created on submit does not blank the previous
-    // feedback. Card/status/score deliberately stay on `latestResult` (the main
-    // page is unchanged while building). See plan 2026-06-18.
-    const displayResult = getLatestResultAcrossSubmissions(participation?.submissions);
+    // Feedback modals show the previous result while a build is running, so a
+    // fresh resultless submission does not blank the feedback. The fallback to
+    // an earlier submission is gated on an ACTIVE pending build: without one, a
+    // resultless newest submission (e.g. a completed build-failed submission)
+    // must keep the existing `latestResult` behaviour and NOT resurface stale
+    // feedback from an older submission. Card/status/score stay on latestResult.
+    const displayResult = pendingSubmission !== null
+        ? getLatestResultAcrossSubmissions(participation?.submissions)
+        : latestResult;
 
     // Build test cases from feedbacks for detailed display. Test-case feedback
     // is identified by isTestCaseFeedback (Artemis parity); the test name may be

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -28,6 +28,7 @@ import {
     determineParticipationStatus,
     determineSubmissionStatus,
     getLatestById,
+    getLatestResultAcrossSubmissions,
     isTestCaseFeedback,
     transformFeedbacksToTestCases,
 } from '@webview/utils/exerciseStatus';
@@ -228,6 +229,12 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     // Results live on submission.results (not on participation directly)
     const latestResult = getLatestById(latestSubmission?.results);
 
+    // Feedback modals show the latest result across ALL submissions, so a fresh
+    // resultless submission created on submit does not blank the previous
+    // feedback. Card/status/score deliberately stay on `latestResult` (the main
+    // page is unchanged while building). See plan 2026-06-18.
+    const displayResult = getLatestResultAcrossSubmissions(participation?.submissions);
+
     // Build test cases from feedbacks for detailed display. Test-case feedback
     // is identified by isTestCaseFeedback (Artemis parity); the test name may be
     // hidden (showTestNamesToStudents=false) and is not required.
@@ -235,6 +242,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     const feedbacks = latestResult?.feedbacks ?? [];
     const testFeedbacks = feedbacks.filter(isTestCaseFeedback);
     const testCases = transformFeedbacksToTestCases(feedbacks);
+    const displayTestCases = transformFeedbacksToTestCases(displayResult?.feedbacks ?? []);
 
     // Use Artemis-provided test case counts when available, fall back to feedbacks
     const totalTests = latestResult?.testCaseCount || testFeedbacks.length;
@@ -273,9 +281,9 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
         const viewId = makeViewId();
         const openedAt = Date.now();
         const exerciseId = exerciseData.exercise.id;
-        const resultId = latestResult?.id;
-        const totalTestCount = testCases.length;
-        const passedTestCount = testCases.filter(t => t.passed).length;
+        const resultId = displayResult?.id;
+        const totalTestCount = displayTestCases.length;
+        const passedTestCount = displayTestCases.filter(t => t.passed).length;
         const failedTests = totalTestCount - passedTestCount;
         postCommand(vscodeApi, WebviewCmd.TestResultsOverviewOpened, {
             viewId, exerciseId, participationId, resultId,
@@ -290,7 +298,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
 
     const handleTaskOpen = ({ taskName, testIds }: { taskName: string; testIds: number[] }) => {
         if (!exerciseData?.exercise?.id) { return; }
-        const classification = classifyTaskTests(testIds, latestResult);
+        const classification = classifyTaskTests(testIds, displayResult);
         // Telemetry: keep existing totalTests/passedTests/failedTests semantics
         // (matched tests for this task). Add notExecutedTests as additive field.
         const { passedCount, failedCount, notExecutedCount } = countsForTelemetry(classification);
@@ -298,7 +306,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
         const viewId = makeViewId();
         const openedAt = Date.now();
         const exerciseId = exerciseData.exercise.id;
-        const resultId = latestResult?.id;
+        const resultId = displayResult?.id;
         postCommand(vscodeApi, WebviewCmd.TaskFeedbackOpened, {
             viewId, exerciseId, participationId, resultId,
             taskName, testIds,
@@ -316,6 +324,10 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
 
     // result.score is already a percentage (0-100) in Artemis
     const scorePercentage = latestResult?.score ?? 0;
+
+    // Banner only when we are actually substituting a previous result for the
+    // running build. No previous result -> no banner (first-build stays as-is).
+    const buildRunning = pendingSubmission !== null && displayResult !== undefined;
 
     // Determine submission status
     const submissionStatus = determineSubmissionStatus(pendingSubmission, latestResult, latestSubmission);
@@ -635,14 +647,16 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
             <TestResultsOverlay
                 open={openOverviewView !== null}
                 onClose={handleOverviewClose}
-                state={{ kind: 'all', testCases }}
+                buildRunning={buildRunning}
+                state={{ kind: 'all', testCases: displayTestCases }}
             />
 
             {openTaskView !== null && (
                 <TestResultsOverlay
                     open
                     onClose={handleTaskClose}
-                    state={classifyTaskTests(openTaskView.testIds, latestResult)}
+                    buildRunning={buildRunning}
+                    state={classifyTaskTests(openTaskView.testIds, displayResult)}
                     taskName={openTaskView.taskName}
                 />
             )}

--- a/extension/test/react/components/exercise/TestResultsOverlay.test.tsx
+++ b/extension/test/react/components/exercise/TestResultsOverlay.test.tsx
@@ -187,4 +187,37 @@ describe('TestResultsOverlay', () => {
         await userEvent.click(screen.getByText('testA'));
         expect(onClose).not.toHaveBeenCalled();
     });
+
+    // ── Rebuild banner ───────────────────────────────────────────────────
+    const BANNER_RE = /a new build is running/i;
+
+    it('shows the rebuild banner when buildRunning is true (task mode)', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                taskName="doOverlap"
+                buildRunning
+                state={{ kind: 'fail', failed: [{ id: 1, name: 'tA', passed: false }], passed: [], notExecutedIds: [] }}
+            />,
+        );
+        expect(screen.getByText(BANNER_RE)).toBeInTheDocument();
+    });
+
+    it('shows the rebuild banner when buildRunning is true (overview mode)', () => {
+        render(
+            <TestResultsOverlay
+                open
+                onClose={() => undefined}
+                buildRunning
+                state={{ kind: 'all', testCases }}
+            />,
+        );
+        expect(screen.getByText(BANNER_RE)).toBeInTheDocument();
+    });
+
+    it('does not show the rebuild banner when buildRunning is absent/false', () => {
+        render(<TestResultsOverlay open onClose={() => undefined} state={{ kind: 'all', testCases }} />);
+        expect(screen.queryByText(BANNER_RE)).not.toBeInTheDocument();
+    });
 });

--- a/extension/test/react/utils/exerciseStatus.test.ts
+++ b/extension/test/react/utils/exerciseStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { classifyTaskTests, countsForTelemetry, transformFeedbacksToTestCases } from '@webview/utils/exerciseStatus';
+import { classifyTaskTests, countsForTelemetry, getLatestResultAcrossSubmissions, transformFeedbacksToTestCases } from '@webview/utils/exerciseStatus';
 
 describe('classifyTaskTests', () => {
     it('returns no-result when latestResult is undefined', () => {
@@ -207,5 +207,42 @@ describe('countsForTelemetry', () => {
             passed: [{ id: 1, name: 'a', passed: true }],
             notExecutedIds: [2, 3],
         })).toEqual({ passedCount: 1, failedCount: 0, notExecutedCount: 2 });
+    });
+});
+
+describe('getLatestResultAcrossSubmissions', () => {
+    it('returns undefined for no submissions', () => {
+        expect(getLatestResultAcrossSubmissions(undefined)).toBeUndefined();
+        expect(getLatestResultAcrossSubmissions([])).toBeUndefined();
+    });
+
+    it('returns undefined when no submission has a result', () => {
+        expect(getLatestResultAcrossSubmissions([{ id: 1, results: [] }, { id: 2 }])).toBeUndefined();
+    });
+
+    it('returns the latest result (highest id) within a submission', () => {
+        const r = getLatestResultAcrossSubmissions([{ id: 1, results: [{ id: 10 }, { id: 11 }] }]);
+        expect(r?.id).toBe(11);
+    });
+
+    it('is submission-first: the newest submission with a result wins, even if an older submission has a higher result id', () => {
+        // Older submission (id 1) was re-evaluated → its result id (99) is higher
+        // than the newest submission's result (30). Submission-first must still
+        // return the newest submission's result, NOT the globally-highest id.
+        const r = getLatestResultAcrossSubmissions([
+            { id: 1, results: [{ id: 99 }] },
+            { id: 2, results: [{ id: 30 }] },
+        ]);
+        expect(r?.id).toBe(30);
+    });
+
+    it('keeps the previous result when the newest submission has no result yet', () => {
+        // Submission id 2 is newer but resultless (build running); id 1 holds the
+        // previous result. The helper must surface that previous result.
+        const r = getLatestResultAcrossSubmissions([
+            { id: 1, results: [{ id: 10 }] },
+            { id: 2, results: [] },
+        ]);
+        expect(r?.id).toBe(10);
     });
 });

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -545,6 +545,108 @@ describe('ExerciseDetailView', () => {
 		expect(screen.getByText('Passed (2)')).toBeInTheDocument();
 	});
 
+	// Participation with a PREVIOUS result (submission 1) and a newer RESULTLESS
+	// submission (submission 2), the exact state right after a submit while the
+	// new build is running. pendingSubmissionsByParticipationId is seeded as a
+	// sibling store field (it is NOT read from exerciseData).
+	function exerciseBuildingOverPreviousResult(): ExerciseDetailsResponse {
+		return makeExerciseData({
+			exercise: {
+				id: 42, title: 'My Exercise', type: 'programming',
+				maxPoints: 10, bonusPoints: 0, problemStatement: 'Solve.',
+				course: { id: 1, title: 'Test Course', shortName: 'TC' },
+				studentParticipations: [{
+					id: 99,
+					repositoryUri: 'https://git.example.com/repo',
+					submissions: [
+						{
+							id: 1,
+							submissionDate: '2025-01-01T00:00:00Z',
+							results: [{
+								id: 10, score: 50, successful: false,
+								completionDate: '2025-01-01T00:00:00Z',
+								feedbacks: [
+									{ testCase: { id: 1, testName: 'tA' }, positive: true },
+									{ testCase: { id: 2, testName: 'tB' }, positive: false, detailText: 'old fail' },
+								],
+							}],
+						},
+						{ id: 2, submissionDate: '2025-01-02T00:00:00Z', results: [] },
+					],
+				}],
+			},
+		});
+	}
+
+	it('task overlay shows the previous result plus the rebuild banner while a build is running', async () => {
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseBuildingOverPreviousResult(),
+			pendingSubmissionsByParticipationId: { 99: { participationId: 99, state: 'BUILDING' } },
+			isLoading: false,
+		});
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+
+		// Previous result is shown (NOT the no-result empty state)...
+		expect(screen.queryByText(/no build results yet/i)).not.toBeInTheDocument();
+		expect(screen.getByText('Failed (1)')).toBeInTheDocument();
+		expect(screen.getByText('Passed (1)')).toBeInTheDocument();
+		// ...with the rebuild banner.
+		expect(screen.getByText(/a new build is running/i)).toBeInTheDocument();
+	});
+
+	it('task overlay drops the banner and shows the new result when the build finishes', async () => {
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseBuildingOverPreviousResult(),
+			pendingSubmissionsByParticipationId: { 99: { participationId: 99, state: 'BUILDING' } },
+			isLoading: false,
+		});
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+		expect(screen.getByText(/a new build is running/i)).toBeInTheDocument();
+
+		// Build finishes: result attaches to the newest submission (id 2), pending
+		// cleared (single store mutation, mirrors the WS path).
+		act(() => {
+			useExerciseDetailStore.getState().updateBuildStatus({
+				id: 11,
+				participationId: 99,
+				score: 100,
+				successful: true,
+				feedbacks: [
+					{ testCase: { id: 1, testName: 'tA' }, positive: true },
+					{ testCase: { id: 2, testName: 'tB' }, positive: true },
+				],
+			});
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByText(/a new build is running/i)).not.toBeInTheDocument();
+		});
+		expect(screen.getByText('Passed (2)')).toBeInTheDocument();
+		expect(screen.queryByText(/^Failed/)).not.toBeInTheDocument();
+	});
+
+	it('taskFeedbackOpened reports the previous result id and counts while a build is running', async () => {
+		// Telemetry must reflect what the modal actually shows (the previous
+		// result), not undefined, when opened during a build.
+		useExerciseDetailStore.setState({
+			exerciseData: exerciseBuildingOverPreviousResult(),
+			pendingSubmissionsByParticipationId: { 99: { participationId: 99, state: 'BUILDING' } },
+			isLoading: false,
+		});
+		const mockApi = createMockVsCodeApi();
+		const postMessageMock = vi.mocked(mockApi.postMessage);
+		const { container } = render(<ExerciseDetailView vscodeApi={mockApi} />);
+		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html: taskHtml('1,2') });
+		await waitFor(() => expect(container.querySelector('.artemis-task[data-test-ids]')).not.toBeNull());
+		await userEvent.click(container.querySelector('.artemis-task[data-test-ids]')!);
+
+		const openedCall = postMessageMock.mock.calls.find(c => (c[0] as Record<string, unknown>).command === 'taskFeedbackOpened');
+		const payload = (openedCall![0] as Record<string, unknown>).payload as Record<string, unknown>;
+		expect(payload.resultId).toBe(10); // previous result, NOT undefined
+		expect(payload.passedTests).toBe(1);
+		expect(payload.failedTests).toBe(1);
+	});
+
 	describe('sticky build status strip', () => {
 		let observerCallback: IntersectionObserverCallback;
 

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -647,6 +647,44 @@ describe('ExerciseDetailView', () => {
 		expect(payload.failedTests).toBe(1);
 	});
 
+	it('task overlay shows no-result (not stale feedback) when the newest submission failed to build with no pending rebuild', async () => {
+		useExerciseDetailStore.setState({
+			exerciseData: makeExerciseData({
+				exercise: {
+					id: 42, title: 'My Exercise', type: 'programming',
+					maxPoints: 10, bonusPoints: 0, problemStatement: 'Solve.',
+					course: { id: 1, title: 'Test Course', shortName: 'TC' },
+					studentParticipations: [{
+						id: 99,
+						repositoryUri: 'https://git.example.com/repo',
+						submissions: [
+							{
+								id: 1, submissionDate: '2025-01-01T00:00:00Z',
+								results: [{
+									id: 10, score: 50, successful: false,
+									completionDate: '2025-01-01T00:00:00Z',
+									feedbacks: [
+										{ testCase: { id: 1, testName: 'tA' }, positive: true },
+										{ testCase: { id: 2, testName: 'tB' }, positive: false, detailText: 'old fail' },
+									],
+								}],
+							},
+							{ id: 2, submissionDate: '2025-01-02T00:00:00Z', buildFailed: true, results: [] },
+						],
+					}],
+				},
+			}),
+			// No pendingSubmissionsByParticipationId entry -> no active build.
+			isLoading: false,
+		});
+		await clickTaskAndOpenOverlay(taskHtml('1,2'));
+
+		expect(screen.getByText(/no build results yet/i)).toBeInTheDocument();
+		expect(screen.queryByText(/a new build is running/i)).not.toBeInTheDocument();
+		// Must NOT resurface the previous submission's feedback.
+		expect(screen.queryByText('Failed (1)')).not.toBeInTheDocument();
+	});
+
 	describe('sticky build status strip', () => {
 		let observerCallback: IntersectionObserverCallback;
 


### PR DESCRIPTION
## Problem

After submitting, Artemis creates a new submission that has no result yet. The exercise view derived the displayed result from the latest submission only (`getLatestById(latestSubmission?.results)`), so that fresh, resultless submission made `latestResult` undefined. The per-task and overview feedback modals then collapsed to "No build results yet. Submit your code to see test feedback.", discarding the result the student had a moment ago.

## Fix

The two feedback modals now use a separate `displayResult`: the latest result of the newest submission that actually has one (submission-first, matching how the rest of the codebase resolves "latest"). While a build is running, this keeps the previous result on screen, and it switches to the new result automatically once that result arrives (no extra wiring; it falls out of the existing live re-render). A banner inside the modal makes the state explicit: "A new build is running. Showing feedback from your previous submission. This will update automatically."

The fallback to an earlier submission is gated on an active pending build. Without one, a resultless newest submission (for example a completed build that failed without producing a result) keeps the existing empty-state behaviour and does not resurface stale feedback from an older submission.

The exercise status card, score, and sticky build strip deliberately stay on `latestResult`, so the main page is visually unchanged while building (it already shows its own build-progress UI).

## Scope

- New submission-first helper `getLatestResultAcrossSubmissions`.
- `TestResultsOverlay` gains an optional `buildRunning` prop that renders the banner (task and overview variants).
- `ExerciseDetailView` wires `displayResult` + `buildRunning` into both modals and their open-telemetry; the status card and all off-limits variables are untouched.

## Testing

- New unit, component, and integration tests cover: the submission-first helper (including the re-evaluation case where an older submission owns a higher result id), the banner shown/hidden, the previous result staying visible while building, the automatic switch to the new result, the open telemetry reporting the shown result, and the build-failed/no-pending terminal state correctly showing the empty state instead of stale feedback.
- Full webview test suite green (848 tests), lint clean.