### PR TITLE
chore(release): 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-06-18
+
 ### Added
 
 - **Reading Telemetry**: The session recorder now captures problem-statement reading behavior (scrolling and text selections, with extended consent only).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.6-dev",
+  "version": "0.4.6",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Prepares the 0.4.6 release.

## Changes

- Bump `extension/package.json` from `0.4.6-dev` to `0.4.6`.
- Add the `## [0.4.6] - 2026-06-18` CHANGELOG section (the prior `## [Unreleased]` content), keeping an empty `## [Unreleased]` heading on top.

## What 0.4.6 ships

**Added**
- Reading Telemetry (problem-statement reading capture, extended consent only)
- Sticky Build Status (build progress + ETA strip while scrolling)

**Fixed**
- Replay Fidelity, Intervention Block Reasons, Test Results With Hidden Names, Submission Git Locks, Build Error CodeLens Position, Feedback During Builds

**Internal**
- Struggle-Detection Config, two Live Recording Viewer improvements, Recorder Test Coverage

## Not included

The Engine v2 work (sensing layer, telemetry dissolution, struggle engine, switchover, golden-replay) stays on `feat/struggle-engine-v2` and is intentionally not part of this release.

## After merge

Merge `dev` into `main`, then trigger the `release-openvsx.yml` workflow with version `0.4.6`. Adjust the changelog date if the release ships on a different day.