### PR TITLE
fix(server-picker): point Local Development preset to Artemis server port 8080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local Dev Server Preset**: The "Local Development" server option now targets `localhost:8080` (the Artemis server) instead of `localhost:9000`.
+
 ## [0.4.6] - 2026-06-18
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.6",
+  "version": "0.4.7-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -429,7 +429,7 @@ const KNOWN_SERVERS: ReadonlyArray<{ label: string; url: string }> = [
     { label: 'Test Server 5 (artemis-test5.artemis.cit.tum.de)',    url: 'https://artemis-test5.artemis.cit.tum.de' },
     { label: 'Test Server 6 (artemis-test6.artemis.cit.tum.de)',    url: 'https://artemis-test6.artemis.cit.tum.de' },
     { label: 'Test Server 9 (artemis-test9.artemis.cit.tum.de)',    url: 'https://artemis-test9.artemis.cit.tum.de' },
-    { label: 'Local Development (localhost:9000)',                   url: 'http://localhost:9000' },
+    { label: 'Local Development (localhost:8080)',                   url: 'http://localhost:8080' },
 ];
 
 function registerSetServerUrlCommand(): vscode.Disposable {


### PR DESCRIPTION
## What

The "Local Development" entry in the Artemis server picker now points to the Artemis server at `http://localhost:8080` instead of the Angular client dev server at `http://localhost:9000`.

## Why

The extension talks to the Artemis REST and STOMP WebSocket API directly from the extension host (auth injects the JWT as a manual `Cookie:` header, so requests cannot run through the browser/webview). It does not need the Angular client at all.

- `localhost:8080` reaches the Artemis server directly and works whenever the server is up.
- `localhost:9000` only works while the Angular client dev server (`npm run serve`) is running and proxying `/api` + `/websocket` to 8080.

So 8080 is the robust target for the extension; the old 9000 preset was misleading and broke without the client running.

## Changes

- Point the "Local Development" preset to `localhost:8080`.
- Add a short `CHANGELOG.md` entry under `[Unreleased]`.
- Bump the dev version to `0.4.7-dev` to open the next cycle.

The production default (`artemis.serverUrl` = `https://artemis.tum.de`) is unchanged.
