### PR TITLE
docs: record project name "Artemis Extension" in project guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,10 @@
 # Project: Artemis VS Code Extension
 
+## Naming
+
+- **The name of this project/extension is "Artemis Extension".** Use this name in docs, conversation, and any reference to the project (not "Iris Thaumantias").
+- This is the human-facing project name only. The published marketplace identifiers are unchanged and must stay as-is: package `name` = `iris-thaumantias` (part of the immutable marketplace ID `aet-tum.iris-thaumantias`, ~940 installs) and `displayName` = "Artemis - TUM".
+
 ## Branching
 
 - **All PRs branch off `dev`** and merge back into `dev`.


### PR DESCRIPTION
## What

Adds a **Naming** section to the repo-local project guidelines (`.claude/CLAUDE.md`) recording that the project/extension is called **"Artemis Extension"**.

## Why

Establishes a single canonical name for the project, replacing the older "Iris Thaumantias" wording. Explicitly notes that this is a human-facing name only: the published marketplace identifiers stay unchanged (package `name` = `iris-thaumantias`, part of the immutable ID `aet-tum.iris-thaumantias`; `displayName` = "Artemis - TUM").

Docs-only change. No code, no version bump.
