### PR TITLE
chore(gitignore): ignore local docs/plans scratch directory

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -48,3 +48,6 @@ test/ui/screenshots/
 # Tool artifacts (RuVector agent memory, Claude Code session locks)
 ruvector.db
 .claude/scheduled_tasks.lock
+
+# Local planning docs (scratch). ADRs under docs/adr/ stay tracked.
+docs/plans/


### PR DESCRIPTION
Ignores the local `extension/docs/plans/` scratch directory (dated planning notes). ADRs under `docs/adr/` stay tracked. Repo-hygiene only, no code change.