### PR TITLE
fix(openvsx): make clean-bundle verifier fail-closed for telemetry subtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **Local Dev Server Preset**: The "Local Development" server option now targets `localhost:8080` (the Artemis server) instead of `localhost:9000`.
 
+### Internal
+
+- **Open VSX Bundle Verifier**: `verify-clean-bundle.js` now denies the entire telemetry subtree by default (fail-closed) instead of a hand-picked denylist, so any new telemetry/recorder file is kept out of the clean build automatically.
+
 ## [0.4.6] - 2026-06-18
 
 ### Added

--- a/extension/scripts/verify-clean-bundle.js
+++ b/extension/scripts/verify-clean-bundle.js
@@ -3,34 +3,39 @@
 const fs = require('fs');
 const path = require('path');
 
+// The whole telemetry-engine subtree (struggle detection, metrics, intervention,
+// session recorder, replay, URI filtering) is excluded from the clean Open VSX
+// build via the @telemetry seam. Deny the entire subtree by DEFAULT (fail-closed):
+// any file under it is forbidden unless explicitly allowlisted. This replaces an
+// earlier hand-picked denylist that silently let unlisted files (e.g. uriFilter.ts)
+// through if they were ever pulled into the clean bundle.
+const TELEMETRY_SUBTREE = 'src/extension/services/telemetry/';
+const TELEMETRY_ALLOWED = [
+    // Shared type + config declarations only (no engine/recorder/consent logic).
+    'src/extension/services/telemetry/types.ts',
+];
+
+// Excluded code that lives OUTSIDE the telemetry subtree.
 const FORBIDDEN = [
-    'src/extension/services/telemetry/recording/',
-    'src/extension/services/telemetry/replay/',
     'src/extension/services/auth/consentService.ts',
     'src/extension/activation/sessionRecorderWiring.ts',
-    // Struggle-detection webview view — excluded from the clean webview build via @struggleView alias.
-    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target in openvsx).
+    // Struggle-detection webview view, excluded via the @struggleView alias.
+    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target).
     'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
     'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
-    // Struggle-detection engine — excluded from the clean build via @telemetry/noop.
-    'src/extension/services/telemetry/telemetryManager.ts',
-    'src/extension/services/telemetry/metrics/',
-    'src/extension/services/telemetry/eventPipeline/',
-    'src/extension/services/telemetry/decision/',
-    'src/extension/services/telemetry/intervention/',
-    'src/extension/services/telemetry/interventionService.ts',
-    'src/extension/services/telemetry/interventionFilter.ts',
-    'src/extension/services/telemetry/buildResultTracker.ts',
-    'src/extension/services/telemetry/inactivityService.ts',
-    'src/extension/services/telemetry/diagnosticPersistenceService.ts',
-    'src/extension/services/telemetry/debugDashboard.ts',
-    'src/extension/services/telemetry/buildResultGuard.ts',
 ];
+
+function isForbiddenInput(input) {
+    const p = input.replace(/\\/g, '/');
+    if (p.includes(TELEMETRY_SUBTREE)) {
+        return !TELEMETRY_ALLOWED.some(allowed => p.includes(allowed));
+    }
+    return FORBIDDEN.some(f => p.includes(f));
+}
 
 function forbiddenInputs(metafilePath) {
     const meta = JSON.parse(fs.readFileSync(metafilePath, 'utf8'));
-    return Object.keys(meta.inputs || {})
-        .filter(input => FORBIDDEN.some(f => input.replace(/\\/g, '/').includes(f)));
+    return Object.keys(meta.inputs || {}).filter(isForbiddenInput);
 }
 
 function main() {

--- a/extension/test/logic/scripts/verifyCleanBundle.test.ts
+++ b/extension/test/logic/scripts/verifyCleanBundle.test.ts
@@ -54,4 +54,16 @@ describe('verify-clean-bundle', () => {
         ]);
         expect(forbiddenInputs(f)).toHaveLength(2);
     });
+
+    it('is fail-closed: flags unlisted telemetry-subtree files, allows only types.ts', () => {
+        const f = metaWith([
+            'src/extension/services/telemetry/uriFilter.ts', // recorder util, never explicitly listed
+            'src/extension/services/telemetry/someNewFile.ts', // any future addition
+            'src/extension/services/telemetry/types.ts', // allowlisted exception
+        ]);
+        expect(forbiddenInputs(f)).toEqual([
+            'src/extension/services/telemetry/uriFilter.ts',
+            'src/extension/services/telemetry/someNewFile.ts',
+        ]);
+    });
 });


### PR DESCRIPTION
## What

Makes the Open VSX clean-bundle verifier (`scripts/verify-clean-bundle.js`) **fail-closed** for the telemetry subtree.

## Why

The verifier used a hand-picked denylist of `src/extension/services/telemetry/**` paths. That is allow-by-omission: any file under the subtree that was not explicitly listed would pass even if it leaked into the clean build. The concrete gap was `uriFilter.ts` (session-recorder code) and any future file added under the subtree.

## How

- Deny the entire `src/extension/services/telemetry/` subtree by default.
- Allowlist only the shared type/config declarations (`types.ts`), matching the existing test intent.
- Keep the explicit forbidden paths that live outside the subtree (consent flow, recorder wiring, struggle-detection webview view).
- Add a unit test asserting unlisted subtree files (e.g. `uriFilter.ts`) are now flagged while `types.ts` stays allowed.

This is a follow-up to #310 (post-merge review finding). No change to the shipped bundle: the clean build is byte-identical; only the verification is stricter.

## Verification

- `verifyCleanBundle.test.ts`: 5/5 pass (incl. new fail-closed case).
- Real verifier against a fresh `--variant=openvsx` build: `OK`.
- `lint` + `check-types` clean.
