### PR TITLE
chore(release): prepare 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-22
+
 ### Changed
 
 - **Open VSX Build**: The Open VSX (EduIDE/Theia cloud) distribution now also excludes the struggle-detection engine and its webview UI via fail-closed build seams (on top of the existing recorder/consent exclusion) and ships cloud-tailored setting defaults.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.7-dev",
+  "version": "0.4.7",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Release prep for 0.4.7 (cut from `dev`):

- `extension/package.json`: `0.4.7-dev` → `0.4.7`
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.4.7] - 2026-06-22` (fresh empty `[Unreleased]` kept on top)

Satisfies the release workflow's prepare gates (exact-version match + single `## [0.4.7]` changelog section). After this merges, `dev` → `main` sync follows, then the release runs from `main`.