### PR TITLE
chore(release): sync dev → main for 0.4.7

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,10 @@
 # Project: Artemis VS Code Extension
 
+## Naming
+
+- **The name of this project/extension is "Artemis Extension".** Use this name in docs, conversation, and any reference to the project (not "Iris Thaumantias").
+- This is the human-facing project name only. The published marketplace identifiers are unchanged and must stay as-is: package `name` = `iris-thaumantias` (part of the immutable marketplace ID `aet-tum.iris-thaumantias`, ~940 installs) and `displayName` = "Artemis - TUM".
+
 ## Branching
 
 - **All PRs branch off `dev`** and merge back into `dev`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local Dev Server Preset**: The "Local Development" server option now targets `localhost:8080` (the Artemis server) instead of `localhost:9000`.
+
 ## [0.4.6] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **Local Dev Server Preset**: The "Local Development" server option now targets `localhost:8080` (the Artemis server) instead of `localhost:9000`.
 
+### Internal
+
+- **Open VSX Bundle Verifier**: `verify-clean-bundle.js` now denies the entire telemetry subtree by default (fail-closed) instead of a hand-picked denylist, so any new telemetry/recorder file is kept out of the clean build automatically.
+
 ## [0.4.6] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-22
+
 ### Changed
 
 - **Open VSX Build**: The Open VSX (EduIDE/Theia cloud) distribution now also excludes the struggle-detection engine and its webview UI via fail-closed build seams (on top of the existing recorder/consent exclusion) and ships cloud-tailored setting defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Changed
+
+- **Open VSX Build**: The Open VSX (EduIDE/Theia cloud) distribution now also excludes the struggle-detection engine and its webview UI via fail-closed build seams (on top of the existing recorder/consent exclusion) and ships cloud-tailored setting defaults.
+
 ### Fixed
 
 - **Local Dev Server Preset**: The "Local Development" server option now targets `localhost:8080` (the Artemis server) instead of `localhost:9000`.

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -48,3 +48,6 @@ test/ui/screenshots/
 # Tool artifacts (RuVector agent memory, Claude Code session locks)
 ruvector.db
 .claude/scheduled_tasks.lock
+
+# Local planning docs (scratch). ADRs under docs/adr/ stay tracked.
+docs/plans/

--- a/extension/docs/adr/002-theia-openvsx-setting-defaults.md
+++ b/extension/docs/adr/002-theia-openvsx-setting-defaults.md
@@ -1,0 +1,84 @@
+# ADR 002: Theia / Open-VSX Setting-Default Overrides
+
+**Date:** 2026-06-20
+**Status:** Accepted (implementation pending)
+
+---
+
+## Context
+
+The extension ships in two build variants (see `esbuild.js`, `scripts/package-openvsx.js`):
+
+- **`full`** — published to the VS Code Marketplace, used by local VS Code Desktop installs. Bundles the recorder / data-collection / replay subtree (runtime-consent-gated).
+- **`openvsx`** — the "clean" variant published to Open-VSX. `EduIDE/eduide` bundles it into the managed Theia (`images/base-ide/package.json.patch`, e.g. `aet-tum/iris-thaumantias/<ver>`). The clean variant aliases `@dataCollection` to `noop.ts` and tree-shakes recording (`__IRIS_RECORDING__=false`); `scripts/generate-clean-manifest.js` additionally strips the consent setting, the recording commands, and the prepublish hook from the manifest.
+
+In the managed Theia (cloud) the desired out-of-the-box behaviour differs from a local VS Code install:
+
+- The workspace **is** a single exercise (auto-cloned by scorpio via `GIT_URI`), opened through Artemis "Open in Online IDE". So the post-login page should be the exercise itself, not the dashboard, and prompts that assume manual setup (clone folder, start-page suggestion) are noise.
+- Struggle detection must stay **off** in the cloud until the server-side intervention (Pyris/Artemis) pipeline is live there; otherwise it would surface half-working behaviour to students.
+
+Crucially, the **`full` (Marketplace/Desktop) defaults must not change** — only the cloud variant should prefill differently. The lever is the per-key `default` in `contributes.configuration`, which the IDE uses as the setting's default when the user has not set it (it remains a default — user/workspace settings still win at runtime).
+
+## Decision
+
+Override a small set of the extension's **own** `artemis.*` configuration defaults **only in the `openvsx` clean variant**, by patching `contributes.configuration.properties[<key>].default` in the generated clean manifest. This reuses the existing clean-variant seam (`scripts/generate-clean-manifest.js`) — the same place that already removes consent/recording for the clean build — and never mutates the source `package.json`. The `full` build is untouched.
+
+### Override list
+
+| Setting | `full` default | `openvsx` default | Reason |
+|---------|----------------|-------------------|--------|
+| `artemis.startPage` | `dashboard` | `workspace-exercise` | Workspace is the exercise; auto-open it after login instead of the dashboard. |
+| `artemis.showStartPageSuggestion` | `true` | `false` | Start page is now fixed → the "configure start page?" prompt is redundant. |
+| `artemis.struggleDetection.enabled` | `true` | `false` | Cloud intervention pipeline not yet live; keep detection off until it ships. |
+| `artemis.struggleDetection.showInterventions` | `true` | `false` | Inert while detection is off; pinned `false` so interventions can't surface if detection is later toggled on without review. |
+| `artemis.showSetDefaultClonePathPrompt` | `true` | `false` | Cloud auto-clones; the clone-folder prompt never applies. |
+
+All other `artemis.*` settings keep their source defaults. `artemis.dataCollectionConsent` is already removed from the clean manifest, so it is intentionally absent here.
+
+## Implementation
+
+Single change, in `scripts/generate-clean-manifest.js`. Add the override map as a top-level const, then apply it **after** the existing `const props = …` / `delete props['artemis.dataCollectionConsent']` block (do not re-declare `props`):
+
+```js
+// Cloud/Theia-tailored setting defaults (clean variant only). See ADR 002.
+const OPENVSX_SETTING_DEFAULTS = {
+    'artemis.startPage': 'workspace-exercise',
+    'artemis.showStartPageSuggestion': false,
+    'artemis.struggleDetection.enabled': false,
+    'artemis.struggleDetection.showInterventions': false,
+    'artemis.showSetDefaultClonePathPrompt': false,
+};
+```
+
+```js
+// ... after the existing `const props = m.contributes?.configuration?.properties;`
+//     and `if (props) { delete props['artemis.dataCollectionConsent']; }`:
+for (const [key, value] of Object.entries(OPENVSX_SETTING_DEFAULTS)) {
+    if (!props || !props[key]) {
+        throw new Error(`generate-clean-manifest: cannot override unknown setting '${key}'`);
+    }
+    props[key].default = value;
+}
+```
+
+The missing-key guard makes a renamed/removed setting fail the clean build loudly instead of silently shipping the upstream default.
+
+No changes to `esbuild.js`, `package-openvsx.js`, the source `package.json`, or the `full` build.
+
+## Testing
+
+- Extend the clean-manifest check (or add one if none exists) to assert that the generated manifest has each overridden `default` set to the expected value, that `artemis.dataCollectionConsent` is absent, and that an unknown override key throws.
+- Manual verification: run `node scripts/package-openvsx.js`, inspect `build/openvsx-pkg/package.json` for the five overridden defaults; confirm the source `extension/package.json` is unchanged.
+
+## Consequences
+
+- The managed Theia/cloud build gets the tailored defaults; local VS Code (Marketplace) behaviour is unchanged.
+- These are defaults, not forced values — a user or workspace setting still overrides them at runtime.
+- **Revisit when the cloud intervention pipeline goes live:** remove the two `struggleDetection.*` overrides so cloud detection turns back on.
+- Adding/removing future cloud-specific defaults is a one-line edit to `OPENVSX_SETTING_DEFAULTS`.
+
+## Alternatives considered
+
+- **Bake defaults into the EduIDE app** (`applications/browser` `theia.frontend.config.preferences`): required for generic Theia settings, but heavier (eduide image rebuild) and unnecessary here since only `artemis.*` settings are in scope.
+- **Change the source defaults in the extension manifest:** would also change Marketplace/Desktop behaviour — rejected; the goal is cloud-only.
+- **Per-deployment workspace/user settings injection (Helm):** per-environment flexibility, but settings live outside the artifact, are user-overwritable, and add deployment fragility — rejected.

--- a/extension/docs/adr/003-theia-openvsx-telemetry-seam.md
+++ b/extension/docs/adr/003-theia-openvsx-telemetry-seam.md
@@ -1,0 +1,48 @@
+# ADR 003: Telemetry / Struggle-Detection Build Seam for Open VSX
+
+**Date:** 2026-06-20
+**Status:** Accepted (implementation pending)
+
+---
+
+## Context
+
+The extension ships two build variants (`esbuild.js`, `scripts/package-openvsx.js`):
+
+- **`full`** — VS Code Marketplace / Desktop. Bundles the recorder/consent/replay subtree (runtime-consent-gated) and the struggle-detection (telemetry) engine.
+- **`openvsx`** — the "clean" variant published to Open-VSX and bundled into the managed Theia (`EduIDE/eduide`). It already excludes the recorder via the `@dataCollection` alias (`noop.ts`) and tree-shakes recording (`__IRIS_RECORDING__=false`).
+
+In the cloud / Theia deployment, **data protection is the dominant constraint: no behavioural tracking may run.** Today the struggle-detection engine (`TelemetryManager` + EQ engine, boundary triggers, intervention logic) is still **bundled** in the clean build and is only disabled by a runtime setting (`artemis.struggleDetection.enabled`, defaulted `false` in the clean manifest per ADR 002). A setting default is not an exclusion: the engine code ships, and a behavioural struggle context can in principle reach the server via the Iris chat message path.
+
+ADR 002 changed the *default*; this ADR removes the *code*.
+
+## Decision
+
+Introduce a build-time **`@telemetry` seam** that mirrors the proven `@dataCollection` seam: an esbuild alias resolving to the real `TelemetryManager` factory in the `full` build and a runtime-pure no-op factory in the `openvsx` build. Consumers depend on an `ITelemetryManager` contract (a `Pick` of the class's public surface) rather than the concrete class, so the clean build references no engine value and esbuild tree-shakes the entire engine subtree out. A `__IRIS_TELEMETRY__` define gates the webview struggle UI exactly as `__IRIS_RECORDING__` gates recording. `verify-clean-bundle.js` is extended to fail the build if any engine input reappears.
+
+### Why a seam (not just the runtime default)
+
+- **Defence in depth / provable absence:** the cloud artifact contains no tracking engine at all — verifiable from the bundle metafile (fail-closed in CI), not merely "off by config".
+- **Consistent with the established pattern:** same shape as `@dataCollection`; one reversible build switch.
+- **Trivially reversible:** when the server-side intervention pipeline (Pyris/Artemis) goes live in the cloud, flip the `@telemetry` alias back to the real factory.
+
+### Scope boundaries
+
+- The `full` build is unchanged: real `TelemetryManager` and all wiring intact.
+- Build-time presence (variant) is the seam's job; runtime user preference stays the `artemis.struggleDetection.*` setting. The two axes are kept separate.
+- The `@dataCollection` seam is left untouched (recorder and struggle engine are siblings; two thin parallel seams, not one merged one).
+
+## Consequences
+
+- The managed Theia / cloud build ships **no** struggle-detection engine; local VS Code (Marketplace) behaviour is unchanged.
+- `verify-clean-bundle.js` now also forbids the engine entry points — a future accidental value-import of the engine fails the clean build loudly.
+- The dead `artemis.showStruggleScore` palette command is stripped from the clean manifest.
+- **Revisit when the cloud intervention pipeline goes live:** flip the `@telemetry` alias back (and reconsider the ADR 002 `struggleDetection.*` setting defaults).
+- Residual (cosmetic): the `artemis.struggleDetection.*` settings still appear in the clean manifest but are inert; left in place to avoid re-opening ADR 002.
+
+## Alternatives considered
+
+- **Runtime default only (ADR 002):** engine still ships; insufficient for "no tracking code in the cloud artifact".
+- **Hard-delete struggle code for the clean build:** not reversible, diverges the source trees.
+- **`as`-cast a no-op into the concrete type:** breaks type safety; rejected in favour of the `ITelemetryManager` contract.
+- **Merge into the `@dataCollection` seam:** couples two independent features; rejected for two thin parallel seams.

--- a/extension/esbuild.js
+++ b/extension/esbuild.js
@@ -10,10 +10,19 @@ const variantArg = process.argv.find(a => a.startsWith('--variant='));
 const variant = variantArg ? variantArg.split('=')[1] : (process.env.IRIS_BUILD_VARIANT || 'full');
 const isOpenVsx = variant === 'openvsx';
 const recordingEnabled = isOpenVsx ? 'false' : 'true';
-const dataCollectionAlias = {
+const telemetryEnabled = isOpenVsx ? 'false' : 'true';
+const seamAliases = {
     '@dataCollection': path.join(__dirname, isOpenVsx
         ? 'src/extension/dataCollection/noop.ts'
         : 'src/extension/dataCollection/index.ts'),
+    '@telemetry': path.join(__dirname, isOpenVsx
+        ? 'src/extension/telemetry/noop.ts'
+        : 'src/extension/telemetry/index.ts'),
+};
+const webviewAliases = {
+    '@struggleView': path.join(__dirname, isOpenVsx
+        ? 'src/webview/views/StruggleDetection/stub.tsx'
+        : 'src/webview/views/StruggleDetection/index.ts'),
 };
 console.log(`[build] variant: ${variant}`);
 
@@ -61,7 +70,7 @@ async function main() {
 		platform: 'node',
 		outfile: 'dist/extension.js',
 		external: ['vscode'],
-		alias: dataCollectionAlias,
+		alias: seamAliases,
 		logLevel: 'silent',
 		metafile: true,
 		plugins: [
@@ -83,6 +92,7 @@ async function main() {
 		platform: 'browser',
 		outfile: 'dist/webview-react.js',
 		metafile: true,
+		alias: webviewAliases,
 		loader: {
 			'.tsx': 'tsx',
 			'.ts': 'ts',
@@ -94,6 +104,7 @@ async function main() {
 		define: {
 			'process.env.NODE_ENV': production ? '"production"' : '"development"',
 			'__IRIS_RECORDING__': recordingEnabled,
+			'__IRIS_TELEMETRY__': telemetryEnabled,
 		},
 		logLevel: 'silent',
 		plugins: [

--- a/extension/eslint.config.mjs
+++ b/extension/eslint.config.mjs
@@ -89,7 +89,7 @@ export default [{
                 ['^\\u0000'],
                 ['^vscode$', '^node:', '^@(?!extension(?:/|$)|webview(?:/|$)|shared(?:/|$)|test(?:/|$)|root(?:/|$))', '^[a-z]'],
                 ['^@shared(/|$)'],
-                ['^@(extension|webview|test|root)(/|$)'],
+                ['^@(extension|webview|test|root)(/|$)', '^@(struggleView|dataCollection|telemetry)$'],
                 ['^\\.'],
             ],
         }],

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -3,6 +3,8 @@
   "entry": [
     "src/extension.ts",
     "src/webview/index.tsx",
+    "src/extension/telemetry/noop.ts",
+    "src/webview/views/StruggleDetection/stub.tsx",
     "test/**/*.{ts,tsx}",
     ".mocharc.ui.yml",
     ".vscode-test.mjs"

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.7-dev",
+  "version": "0.4.7",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.6",
+  "version": "0.4.7-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",

--- a/extension/scripts/generate-clean-manifest.js
+++ b/extension/scripts/generate-clean-manifest.js
@@ -1,25 +1,58 @@
 // Produce a clean package.json (no consent setting, no recording commands, no
-// rebuild-on-package hook) WITHOUT mutating the source manifest. Writes to argv[2].
+// rebuild-on-package hook) and apply the cloud/Theia setting-default overrides,
+// WITHOUT mutating the source manifest. CLI writes to argv[2]. See docs/adr/002.
 const fs = require('fs');
 const path = require('path');
 
-const srcManifest = path.join(__dirname, '..', 'package.json');
-const outPath = process.argv[2];
-if (!outPath) { throw new Error('usage: generate-clean-manifest.js <out-path>'); }
+// Cloud/Theia-tailored setting defaults (clean variant only). See ADR 002.
+// NOTE: the two struggleDetection.* entries are temporary — remove them once the
+// cloud intervention pipeline is live.
+const OPENVSX_SETTING_DEFAULTS = {
+    'artemis.startPage': 'workspace-exercise',
+    'artemis.showStartPageSuggestion': false,
+    'artemis.struggleDetection.enabled': false,
+    'artemis.struggleDetection.showInterventions': false,
+    'artemis.showSetDefaultClonePathPrompt': false,
+};
 
-const m = JSON.parse(fs.readFileSync(srcManifest, 'utf8'));
+// Commands whose backing feature is excluded from the clean build.
+const DROPPED_COMMANDS = new Set([
+    'artemis.replaySession',
+    'artemis.openRecordingsFolder',
+    'artemis.showStruggleScore',
+]);
 
-const props = m.contributes?.configuration?.properties;
-if (props) { delete props['artemis.dataCollectionConsent']; }
+function cleanManifest(m) {
+    const props = m.contributes && m.contributes.configuration && m.contributes.configuration.properties;
+    if (props) { delete props['artemis.dataCollectionConsent']; }
 
-const dropCmds = new Set(['artemis.replaySession', 'artemis.openRecordingsFolder']);
-if (Array.isArray(m.contributes?.commands)) {
-    m.contributes.commands = m.contributes.commands.filter(c => !dropCmds.has(c.command));
+    for (const [key, value] of Object.entries(OPENVSX_SETTING_DEFAULTS)) {
+        if (!props || !props[key]) {
+            throw new Error(`generate-clean-manifest: cannot override unknown setting '${key}'`);
+        }
+        props[key].default = value;
+    }
+
+    if (Array.isArray(m.contributes && m.contributes.commands)) {
+        m.contributes.commands = m.contributes.commands.filter(c => !DROPPED_COMMANDS.has(c.command));
+    }
+
+    if (m.scripts) { delete m.scripts['vscode:prepublish']; }
+
+    return m;
 }
 
-// Drop the prepublish hook so `vsce package` cannot rebuild/clobber the staged dist/.
-if (m.scripts) { delete m.scripts['vscode:prepublish']; }
+function main() {
+    const srcManifest = path.join(__dirname, '..', 'package.json');
+    const outPath = process.argv[2];
+    if (!outPath) { throw new Error('usage: generate-clean-manifest.js <out-path>'); }
 
-fs.mkdirSync(path.dirname(outPath), { recursive: true });
-fs.writeFileSync(outPath, JSON.stringify(m, null, 2) + '\n');
-console.log(`[clean-manifest] wrote ${outPath}`);
+    const m = cleanManifest(JSON.parse(fs.readFileSync(srcManifest, 'utf8')));
+
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, JSON.stringify(m, null, 2) + '\n');
+    console.log(`[clean-manifest] wrote ${outPath}`);
+}
+
+module.exports = { cleanManifest };
+if (require.main === module) { main(); }

--- a/extension/scripts/verify-clean-bundle.js
+++ b/extension/scripts/verify-clean-bundle.js
@@ -1,4 +1,4 @@
-// Fail-closed proof that the Open VSX bundle excludes recorder/consent/replay.
+// Fail-closed proof that the Open VSX bundle excludes recorder/consent/replay/struggle-engine.
 // Reads the variant metafiles and asserts no forbidden input path is present.
 const fs = require('fs');
 const path = require('path');
@@ -8,6 +8,23 @@ const FORBIDDEN = [
     'src/extension/services/telemetry/replay/',
     'src/extension/services/auth/consentService.ts',
     'src/extension/activation/sessionRecorderWiring.ts',
+    // Struggle-detection webview view — excluded from the clean webview build via @struggleView alias.
+    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target in openvsx).
+    'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
+    'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
+    // Struggle-detection engine — excluded from the clean build via @telemetry/noop.
+    'src/extension/services/telemetry/telemetryManager.ts',
+    'src/extension/services/telemetry/metrics/',
+    'src/extension/services/telemetry/eventPipeline/',
+    'src/extension/services/telemetry/decision/',
+    'src/extension/services/telemetry/intervention/',
+    'src/extension/services/telemetry/interventionService.ts',
+    'src/extension/services/telemetry/interventionFilter.ts',
+    'src/extension/services/telemetry/buildResultTracker.ts',
+    'src/extension/services/telemetry/inactivityService.ts',
+    'src/extension/services/telemetry/diagnosticPersistenceService.ts',
+    'src/extension/services/telemetry/debugDashboard.ts',
+    'src/extension/services/telemetry/buildResultGuard.ts',
 ];
 
 function forbiddenInputs(metafilePath) {
@@ -28,7 +45,7 @@ function main() {
         console.error('FAIL: forbidden inputs in clean bundle:\n' + hits.join('\n'));
         process.exit(1);
     }
-    console.log('OK: clean bundle contains no recorder/consent/replay inputs');
+    console.log('OK: clean bundle contains no recorder/consent/replay, struggle-engine, or struggle-view inputs');
 }
 
 module.exports = { forbiddenInputs, FORBIDDEN };

--- a/extension/scripts/verify-clean-bundle.js
+++ b/extension/scripts/verify-clean-bundle.js
@@ -3,34 +3,39 @@
 const fs = require('fs');
 const path = require('path');
 
+// The whole telemetry-engine subtree (struggle detection, metrics, intervention,
+// session recorder, replay, URI filtering) is excluded from the clean Open VSX
+// build via the @telemetry seam. Deny the entire subtree by DEFAULT (fail-closed):
+// any file under it is forbidden unless explicitly allowlisted. This replaces an
+// earlier hand-picked denylist that silently let unlisted files (e.g. uriFilter.ts)
+// through if they were ever pulled into the clean bundle.
+const TELEMETRY_SUBTREE = 'src/extension/services/telemetry/';
+const TELEMETRY_ALLOWED = [
+    // Shared type + config declarations only (no engine/recorder/consent logic).
+    'src/extension/services/telemetry/types.ts',
+];
+
+// Excluded code that lives OUTSIDE the telemetry subtree.
 const FORBIDDEN = [
-    'src/extension/services/telemetry/recording/',
-    'src/extension/services/telemetry/replay/',
     'src/extension/services/auth/consentService.ts',
     'src/extension/activation/sessionRecorderWiring.ts',
-    // Struggle-detection webview view — excluded from the clean webview build via @struggleView alias.
-    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target in openvsx).
+    // Struggle-detection webview view, excluded via the @struggleView alias.
+    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target).
     'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
     'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
-    // Struggle-detection engine — excluded from the clean build via @telemetry/noop.
-    'src/extension/services/telemetry/telemetryManager.ts',
-    'src/extension/services/telemetry/metrics/',
-    'src/extension/services/telemetry/eventPipeline/',
-    'src/extension/services/telemetry/decision/',
-    'src/extension/services/telemetry/intervention/',
-    'src/extension/services/telemetry/interventionService.ts',
-    'src/extension/services/telemetry/interventionFilter.ts',
-    'src/extension/services/telemetry/buildResultTracker.ts',
-    'src/extension/services/telemetry/inactivityService.ts',
-    'src/extension/services/telemetry/diagnosticPersistenceService.ts',
-    'src/extension/services/telemetry/debugDashboard.ts',
-    'src/extension/services/telemetry/buildResultGuard.ts',
 ];
+
+function isForbiddenInput(input) {
+    const p = input.replace(/\\/g, '/');
+    if (p.includes(TELEMETRY_SUBTREE)) {
+        return !TELEMETRY_ALLOWED.some(allowed => p.includes(allowed));
+    }
+    return FORBIDDEN.some(f => p.includes(f));
+}
 
 function forbiddenInputs(metafilePath) {
     const meta = JSON.parse(fs.readFileSync(metafilePath, 'utf8'));
-    return Object.keys(meta.inputs || {})
-        .filter(input => FORBIDDEN.some(f => input.replace(/\\/g, '/').includes(f)));
+    return Object.keys(meta.inputs || {}).filter(isForbiddenInput);
 }
 
 function main() {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { wireDataCollection } from '@dataCollection';
 
 import { registerAllCommands } from '@extension/activation/extensionCommands';
 import { ArtemisApiService } from '@extension/api';
@@ -10,7 +9,7 @@ import { CourseDataCache } from '@extension/services/courseDataCache';
 import { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import { createProviderRegistry } from '@extension/services/ui';
 import { ArtemisWebsocketService, WebSocketStatusBarService } from '@extension/services/websocket';
 import { NoAiDetectionService } from '@extension/services/workspace';
@@ -24,9 +23,11 @@ import {
     initializeTheiaContext,
 } from '@extension/theia';
 import { VSCODE_CONFIG } from '@extension/utils';
+import { wireDataCollection } from '@dataCollection';
+import { createTelemetryManager } from '@telemetry';
 
 // Module-level references for deactivate() cleanup
-let activeTelemetryManager: TelemetryManager | undefined;
+let activeTelemetryManager: ITelemetryManager | undefined;
 let activeDataCollection: DataCollectionHandle | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -63,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const artemisWebsocketService = new ArtemisWebsocketService(authManager);
 	const buildErrorCodeLensProvider = new BuildErrorCodeLensProvider();
 	const exerciseRegistry = new ExerciseRegistry();
-	const telemetryManager = new TelemetryManager(exerciseRegistry);
+	const telemetryManager = createTelemetryManager(exerciseRegistry);
 	activeTelemetryManager = telemetryManager;
 	telemetryManager.setWebsocketService(artemisWebsocketService);
 

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -4,7 +4,7 @@ import type { ArtemisApiService } from '@extension/api';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/provider';
 import type { AuthManager } from '@extension/services/auth';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import type { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { IProviderRegistry } from '@extension/services/ui';
 import type { ArtemisWebsocketService } from '@extension/services/websocket';
 import { getTheiaEnvironment, KNOWN_BRIDGE_KEYS, probeDataBridge } from '@extension/theia';
@@ -525,7 +525,7 @@ function registerClearTrustedDomainsCommand(context: vscode.ExtensionContext): v
     });
 }
 
-function registerStruggleScoreCommand(telemetryManager: TelemetryManager): vscode.Disposable {
+function registerStruggleScoreCommand(telemetryManager: ITelemetryManager): vscode.Disposable {
     return vscode.commands.registerCommand('artemis.showStruggleScore', async () => {
         await telemetryManager.showStruggleScoreDialog();
     });
@@ -682,7 +682,7 @@ interface CommandDeps {
     authManager: AuthManager;
     artemisApiService: ArtemisApiService;
     artemisWebsocketService: ArtemisWebsocketService;
-    telemetryManager: TelemetryManager;
+    telemetryManager: ITelemetryManager;
     providerRegistry: IProviderRegistry;
     artemisWebviewProvider: ArtemisWebviewProvider;
     chatWebviewProvider: ChatWebviewProvider;

--- a/extension/src/extension/activation/extensionCommands.ts
+++ b/extension/src/extension/activation/extensionCommands.ts
@@ -429,7 +429,7 @@ const KNOWN_SERVERS: ReadonlyArray<{ label: string; url: string }> = [
     { label: 'Test Server 5 (artemis-test5.artemis.cit.tum.de)',    url: 'https://artemis-test5.artemis.cit.tum.de' },
     { label: 'Test Server 6 (artemis-test6.artemis.cit.tum.de)',    url: 'https://artemis-test6.artemis.cit.tum.de' },
     { label: 'Test Server 9 (artemis-test9.artemis.cit.tum.de)',    url: 'https://artemis-test9.artemis.cit.tum.de' },
-    { label: 'Local Development (localhost:9000)',                   url: 'http://localhost:9000' },
+    { label: 'Local Development (localhost:8080)',                   url: 'http://localhost:8080' },
 ];
 
 function registerSetServerUrlCommand(): vscode.Disposable {

--- a/extension/src/extension/activation/sessionRecorderWiring.ts
+++ b/extension/src/extension/activation/sessionRecorderWiring.ts
@@ -4,7 +4,7 @@ import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/pro
 import type { ConsentService } from '@extension/services/auth/consentService';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import type { ContextStore } from '@extension/services/iris/context/contextStore';
-import type { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { SessionRecorder } from '@extension/services/telemetry/recording';
 import {
     RecordingStatusBarService as RecordingStatusBarServiceImpl,
@@ -22,7 +22,7 @@ interface RecorderWiringDeps {
     context: vscode.ExtensionContext;
     consentService: ConsentService;
     artemisWebsocketService: ArtemisWebsocketService;
-    telemetryManager: TelemetryManager;
+    telemetryManager: ITelemetryManager;
     artemisWebviewProvider: ArtemisWebviewProvider;
     chatWebviewProvider: ChatWebviewProvider;
     capabilities?: PlatformCapabilities;

--- a/extension/src/extension/dataCollection/types.ts
+++ b/extension/src/extension/dataCollection/types.ts
@@ -3,7 +3,7 @@ import type * as vscode from 'vscode';
 import type { ArtemisWebviewProvider, ChatWebviewProvider } from '@extension/provider';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import type { ContextStore } from '@extension/services/iris/context/contextStore';
-import type { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { ArtemisWebsocketService } from '@extension/services/websocket';
 import type { PlatformCapabilities } from '@extension/theia';
 
@@ -11,7 +11,7 @@ import type { PlatformCapabilities } from '@extension/theia';
 export interface DataCollectionDeps {
     context: vscode.ExtensionContext;
     artemisWebsocketService: ArtemisWebsocketService;
-    telemetryManager: TelemetryManager;
+    telemetryManager: ITelemetryManager;
     artemisWebviewProvider: ArtemisWebviewProvider;
     chatWebviewProvider: ChatWebviewProvider;
     capabilities?: PlatformCapabilities;

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { createRecordingWebviewHandlers } from '@dataCollection';
 
 import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '@shared/messageContracts';
 import type {
@@ -23,7 +22,7 @@ import type { CourseDataCache } from '@extension/services/courseDataCache';
 import { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
-import type { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { SubmissionPayload } from '@extension/services/telemetry/recording/types';
 import type { IProviderRegistry } from '@extension/services/ui';
 import {
@@ -39,6 +38,7 @@ import type { ExerciseDetailsResponse } from '@extension/types';
 import { WebSocketMessageHandler } from '@extension/types';
 import type { IArtemisWebviewProvider } from '@extension/types/IArtemisWebviewProvider';
 import { CONFIG, resolveServerUrl } from '@extension/utils';
+import { createRecordingWebviewHandlers } from '@dataCollection';
 
 import type { ArtemisWebviewProviderDeps } from './artemisWebviewProviderDeps';
 import { BaseWebviewProvider } from './baseWebviewProvider';
@@ -82,7 +82,7 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
     private readonly _authContextUpdater: (isAuthenticated: boolean) => Promise<void>;
     private readonly _websocketService: ArtemisWebsocketService;
     private _websocketHandler: WebSocketMessageHandler;
-    private readonly _telemetryManager: TelemetryManager;
+    private readonly _telemetryManager: ITelemetryManager;
     private readonly _renderService: ProblemStatementRenderService;
     private readonly _ssrCoordinator: WebviewSSRCoordinator;
     private readonly _navigationFacade: WebviewNavigationFacade;

--- a/extension/src/extension/provider/artemisWebviewProviderDeps.ts
+++ b/extension/src/extension/provider/artemisWebviewProviderDeps.ts
@@ -4,7 +4,7 @@ import type { ArtemisApiService } from '@extension/api';
 import type { AuthManager } from '@extension/services/auth';
 import type { CourseDataCache } from '@extension/services/courseDataCache';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
-import type { TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { IProviderRegistry } from '@extension/services/ui';
 import type { ArtemisWebsocketService } from '@extension/services/websocket';
 
@@ -19,7 +19,7 @@ export interface ArtemisWebviewProviderDeps {
     providerRegistry: IProviderRegistry;
     websocketService: ArtemisWebsocketService;
     buildErrorCodeLensProvider: BuildErrorCodeLensProvider;
-    telemetryManager: TelemetryManager;
+    telemetryManager: ITelemetryManager;
     updateAuthContext: (isAuthenticated: boolean) => Promise<void>;
     courseDataCache?: CourseDataCache;
 }

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -19,7 +19,7 @@ import {
     IrisWebSocketSessionClient,
 } from '@extension/services/iris';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { type StruggleContext, TelemetryManager } from '@extension/services/telemetry';
+import type { ITelemetryManager, StruggleContext } from '@extension/services/telemetry';
 import { getReactWebviewHtml } from '@extension/services/ui';
 import { ArtemisWebsocketService } from '@extension/services/websocket';
 import {
@@ -120,7 +120,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         noAiDetectionService: NoAiDetectionService,
         private readonly _exerciseRegistry: ExerciseRegistry,
         private readonly _courseDataCache: CourseDataCache | undefined,
-        private readonly _telemetryManager: TelemetryManager | undefined,
+        private readonly _telemetryManager: ITelemetryManager | undefined,
         contextStore: ContextStore,
     ) {
         super(LogCategory.IRIS_CHAT);

--- a/extension/src/extension/services/iris/chat/chatMessageService.ts
+++ b/extension/src/extension/services/iris/chat/chatMessageService.ts
@@ -5,7 +5,7 @@ import { ExtensionMsg } from '@shared/messageContracts';
 import type { IrisServiceDeps } from '@extension/services/iris/context/sessionSyncUtils';
 import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { StruggleContext } from '@extension/services/telemetry';
+import type { StruggleContext } from '@extension/services/telemetry';
 import { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
 import { checkWorkspaceFiles } from '@extension/services/workspace/workspaceFileChecker';
 import { ActiveContext } from '@extension/types';

--- a/extension/src/extension/services/telemetry/iTelemetryManager.ts
+++ b/extension/src/extension/services/telemetry/iTelemetryManager.ts
@@ -1,0 +1,29 @@
+import type { TelemetryManager } from './telemetryManager';
+
+/**
+ * Public contract of the telemetry / struggle-detection engine.
+ *
+ * The `@telemetry` build seam swaps a real {@link TelemetryManager} for a no-op
+ * in the Open VSX (clean / Theia-cloud) build, so every consumer depends on this
+ * interface rather than the concrete class. Derived via `Pick` from the class so
+ * the contract cannot drift from the implementation: adding a public method here
+ * forces the no-op to implement it; removing one from the class breaks this type.
+ *
+ * This is a TYPE-ONLY module — `import type { TelemetryManager }` is erased at
+ * build time, so referencing it here never pulls the engine into a bundle.
+ */
+export type ITelemetryManager = Pick<TelemetryManager,
+    | 'setWebsocketService'
+    | 'startExerciseSession'
+    | 'getStruggleContext'
+    | 'getEqEngineState'
+    | 'isEnabled'
+    | 'showStruggleScoreDialog'
+    | 'dispose'
+    | 'onDidCalculateEQ'
+    | 'onDidShowIntervention'
+    | 'onDidAcceptIntervention'
+    | 'onDidDismissIntervention'
+    | 'onDidBlockIntervention'
+    | 'onDidSuppressIntervention'
+>;

--- a/extension/src/extension/services/telemetry/index.ts
+++ b/extension/src/extension/services/telemetry/index.ts
@@ -1,3 +1,4 @@
 // Telemetry services barrel exports
+export type { ITelemetryManager } from './iTelemetryManager';
 export { TelemetryManager } from './telemetryManager';
 export * from './types';

--- a/extension/src/extension/services/ui/exerciseOpeningService.ts
+++ b/extension/src/extension/services/ui/exerciseOpeningService.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import type { CourseAccessStorageService } from '@extension/services/courseAccessStorageService';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 import { logger } from '@extension/services/loggingService';
-import type { TelemetryManager } from '@extension/services/telemetry/telemetryManager';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import type { ExerciseDetailsResponse } from '@extension/types';
 
 import type { IProviderRegistry } from './providerRegistry';
@@ -12,7 +12,7 @@ export class ExerciseOpeningService {
     constructor(
         private readonly _exerciseRegistry: ExerciseRegistry,
         private readonly _providerRegistry: IProviderRegistry,
-        private _telemetryManager?: TelemetryManager,
+        private _telemetryManager?: ITelemetryManager,
         private readonly _courseAccessStorage?: CourseAccessStorageService,
     ) {}
 

--- a/extension/src/extension/services/ui/viewInitDataService.ts
+++ b/extension/src/extension/services/ui/viewInitDataService.ts
@@ -7,7 +7,7 @@ import { AppStateManager } from '@extension/controller/appStateManager';
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
 import { COURSE_ACCESS_DISPLAY_LIMIT, type CourseAccessStorageService } from '@extension/services/courseAccessStorageService';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import type { TelemetryManager } from '@extension/services/telemetry/telemetryManager';
+import type { ITelemetryManager } from '@extension/services/telemetry';
 import { GitService } from '@extension/services/workspace/gitService';
 import {
     collectExerciseSources,
@@ -25,7 +25,7 @@ export class ViewInitDataService {
 
     constructor(
         private readonly _appStateManager: AppStateManager,
-        private readonly _telemetryManager: TelemetryManager | undefined,
+        private readonly _telemetryManager: ITelemetryManager | undefined,
         private readonly _messageHandler: WebViewMessageHandler,
         private readonly _postMessage: (msg: ExtensionToWebviewMessage) => void,
         private readonly _courseAccessStorage?: CourseAccessStorageService,

--- a/extension/src/extension/telemetry/index.ts
+++ b/extension/src/extension/telemetry/index.ts
@@ -1,0 +1,8 @@
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
+import { TelemetryManager } from '@extension/services/telemetry';
+
+/** Real telemetry engine (full / Marketplace / Desktop build). */
+export function createTelemetryManager(exerciseRegistry?: ExerciseRegistry): ITelemetryManager {
+    return new TelemetryManager(exerciseRegistry);
+}

--- a/extension/src/extension/telemetry/noop.ts
+++ b/extension/src/extension/telemetry/noop.ts
@@ -1,0 +1,12 @@
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import type { ITelemetryManager } from '@extension/services/telemetry';
+
+import { NoopTelemetryManager } from './noopTelemetryManager';
+
+/**
+ * No-op telemetry seam for the Open VSX (clean) build. Imports nothing from the
+ * struggle engine, so esbuild keeps that subtree out of the bundle.
+ */
+export function createTelemetryManager(_exerciseRegistry?: ExerciseRegistry): ITelemetryManager {
+    return new NoopTelemetryManager();
+}

--- a/extension/src/extension/telemetry/noopTelemetryManager.ts
+++ b/extension/src/extension/telemetry/noopTelemetryManager.ts
@@ -1,0 +1,45 @@
+import type * as vscode from 'vscode';
+
+import type { EQState, ITelemetryManager, StruggleContext } from '@extension/services/telemetry';
+import type { ArtemisWebsocketService } from '@extension/services/websocket';
+
+/**
+ * An Event that never fires. Returns a disposable so unsubscription is safe.
+ * Runtime-pure: no `vscode.EventEmitter` (which would need a value import).
+ */
+function neverEvent<T>(): vscode.Event<T> {
+    return () => ({ dispose() { /* no event ever fires */ } });
+}
+
+/**
+ * No-op telemetry manager for the Open VSX (clean / Theia-cloud) build.
+ *
+ * Mirrors the @dataCollection/noop seam: imports nothing (at runtime) from the
+ * struggle engine, so esbuild tree-shakes the whole engine subtree out of the
+ * clean bundle. The cloud build therefore ships NO tracking engine. Detection
+ * re-enables by flipping the @telemetry alias back to the real factory.
+ *
+ * Method signatures match the real TelemetryManager exactly (via type-only
+ * imports) so the no-op is a faithful drop-in and unit tests can call it directly.
+ */
+export class NoopTelemetryManager implements ITelemetryManager {
+    public readonly onDidCalculateEQ: ITelemetryManager['onDidCalculateEQ'] = neverEvent();
+    public readonly onDidShowIntervention: ITelemetryManager['onDidShowIntervention'] = neverEvent();
+    public readonly onDidAcceptIntervention: ITelemetryManager['onDidAcceptIntervention'] = neverEvent();
+    public readonly onDidDismissIntervention: ITelemetryManager['onDidDismissIntervention'] = neverEvent();
+    public readonly onDidBlockIntervention: ITelemetryManager['onDidBlockIntervention'] = neverEvent();
+    public readonly onDidSuppressIntervention: ITelemetryManager['onDidSuppressIntervention'] = neverEvent();
+
+    // Never registers a WebSocket message handler → no build results are processed.
+    public setWebsocketService(_websocketService: ArtemisWebsocketService): void { /* no-op */ }
+    public startExerciseSession(_exerciseId: number, _exerciseRoot?: vscode.Uri): void { /* no-op */ }
+    public getStruggleContext(): StruggleContext {
+        return { isStruggling: false, eq: 0, eqConfidence: 'insufficient', recommendedAction: 'none' };
+    }
+    public getEqEngineState(): EQState {
+        return { snapshots: [], currentEQ: 0, pairCount: 0, confidence: 'insufficient' };
+    }
+    public isEnabled(): boolean { return false; }
+    public async showStruggleScoreDialog(): Promise<void> { /* no-op */ }
+    public dispose(): void { /* no-op */ }
+}

--- a/extension/src/webview/App.tsx
+++ b/extension/src/webview/App.tsx
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import type { VsCodeApi } from '@shared/messageContracts';
 import { WebviewMsgType } from '@shared/messageContracts';
 
+import { StruggleDetectionView } from '@struggleView';
+
 import styles from './App.module.css';
 import { AiConfigView } from './views/AiConfig';
 import { CourseDetailView } from './views/CourseDetail';
@@ -14,7 +16,6 @@ import { IrisChatView } from './views/IrisChat';
 import { LoginView } from './views/Login';
 import { RecommendedExtensionsView } from './views/RecommendedExtensions';
 import { ServiceStatusView } from './views/ServiceStatus';
-import { StruggleDetectionView } from './views/StruggleDetection';
 
 interface AppProps {
 	vscodeApi: VsCodeApi;
@@ -55,7 +56,9 @@ export function App({ vscodeApi }: AppProps) {
 			case 'aiConfig':
 				return <AiConfigView vscodeApi={vscodeApi} />;
 			case 'struggleDetection':
-				return <StruggleDetectionView vscodeApi={vscodeApi} />;
+				return __IRIS_TELEMETRY__
+					? <StruggleDetectionView vscodeApi={vscodeApi} />
+					: <div>Unknown view: {viewName}</div>;
 			default:
 				return <div>Unknown view: {viewName}</div>;
 		}

--- a/extension/src/webview/buildGlobals.d.ts
+++ b/extension/src/webview/buildGlobals.d.ts
@@ -1,2 +1,4 @@
 /** Injected by esbuild define; true in the full build, false in the Open VSX build. */
 declare const __IRIS_RECORDING__: boolean;
+/** Injected by esbuild define; true in the full build, false in the Open VSX build. */
+declare const __IRIS_TELEMETRY__: boolean;

--- a/extension/src/webview/views/Dashboard/DashboardView.tsx
+++ b/extension/src/webview/views/Dashboard/DashboardView.tsx
@@ -292,9 +292,11 @@ export function DashboardView({ vscodeApi }: DashboardViewProps) {
                     <Button variant="ghost" fullWidth onClick={handleOpenWebsite} icon={<ExternalLink size={16} />}>
                         Open Artemis in browser
                     </Button>
-                    <Button variant="ghost" fullWidth onClick={handleShowStruggleDetection} icon={<HeartPulse size={16} />}>
-                        Struggle Detection
-                    </Button>
+                    {__IRIS_TELEMETRY__ && (
+                        <Button variant="ghost" fullWidth onClick={handleShowStruggleDetection} icon={<HeartPulse size={16} />}>
+                            Struggle Detection
+                        </Button>
+                    )}
                     <Button variant="ghost" fullWidth onClick={handleShowServiceStatus} icon={<Activity size={16} />}>
                         Service Status
                     </Button>

--- a/extension/src/webview/views/StruggleDetection/stub.tsx
+++ b/extension/src/webview/views/StruggleDetection/stub.tsx
@@ -1,0 +1,11 @@
+import type { StruggleDetectionViewProps } from './types';
+
+/**
+ * No-op stub for the Open VSX (clean) build. The `@struggleView` esbuild alias
+ * resolves to this instead of the real StruggleDetectionView, so the real view
+ * and its CSS are excluded from the cloud bundle. Imports nothing with side
+ * effects, so esbuild drops it when unused.
+ */
+export function StruggleDetectionView(_props: StruggleDetectionViewProps) {
+    return null;
+}

--- a/extension/test/logic/scripts/generateCleanManifest.test.ts
+++ b/extension/test/logic/scripts/generateCleanManifest.test.ts
@@ -1,0 +1,76 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Resolve the plain-JS generator (in scripts/, no path alias). join(__dirname, ...)
+// keeps the require argument computed (lint rule) and avoids import.meta (CJS target).
+type ConfigProp = { type?: string; default?: unknown };
+type Manifest = {
+    contributes: {
+        configuration: { properties: Record<string, ConfigProp> };
+        commands: { command: string }[];
+    };
+    scripts: Record<string, string>;
+};
+
+const { cleanManifest } = require(
+    join(__dirname, '../../../scripts/generate-clean-manifest.js')
+) as {
+    cleanManifest: (m: Manifest) => Manifest;
+};
+
+function baseManifest(): Manifest {
+    return {
+        contributes: {
+            configuration: {
+                properties: {
+                    'artemis.startPage': { type: 'string', default: 'dashboard' },
+                    'artemis.showStartPageSuggestion': { type: 'boolean', default: true },
+                    'artemis.struggleDetection.enabled': { type: 'boolean', default: true },
+                    'artemis.struggleDetection.showInterventions': { type: 'boolean', default: true },
+                    'artemis.showSetDefaultClonePathPrompt': { type: 'boolean', default: true },
+                    'artemis.dataCollectionConsent': { type: 'string', default: 'pending' },
+                    'artemis.serverUrl': { type: 'string', default: 'https://artemis.tum.de' },
+                },
+            },
+            commands: [
+                { command: 'artemis.login' },
+                { command: 'artemis.replaySession' },
+                { command: 'artemis.openRecordingsFolder' },
+                { command: 'artemis.showStruggleScore' },
+            ],
+        },
+        scripts: { 'vscode:prepublish': 'npm run package', package: 'noop' },
+    };
+}
+
+describe('generate-clean-manifest: cleanManifest', () => {
+    it('applies the cloud setting-default overrides', () => {
+        const props = cleanManifest(baseManifest()).contributes.configuration.properties;
+        expect(props['artemis.startPage'].default).toBe('workspace-exercise');
+        expect(props['artemis.showStartPageSuggestion'].default).toBe(false);
+        expect(props['artemis.struggleDetection.enabled'].default).toBe(false);
+        expect(props['artemis.struggleDetection.showInterventions'].default).toBe(false);
+        expect(props['artemis.showSetDefaultClonePathPrompt'].default).toBe(false);
+    });
+
+    it('leaves non-overridden settings untouched', () => {
+        const props = cleanManifest(baseManifest()).contributes.configuration.properties;
+        expect(props['artemis.serverUrl'].default).toBe('https://artemis.tum.de');
+    });
+
+    it('removes the consent setting and dropped commands (recording + struggle score)', () => {
+        const m = cleanManifest(baseManifest());
+        expect(m.contributes.configuration.properties['artemis.dataCollectionConsent']).toBeUndefined();
+        expect(m.contributes.commands.map(c => c.command)).toEqual(['artemis.login']);
+    });
+
+    it('drops the prepublish hook', () => {
+        expect(cleanManifest(baseManifest()).scripts['vscode:prepublish']).toBeUndefined();
+    });
+
+    it('throws if an override key is missing (renamed/removed setting)', () => {
+        const m = baseManifest();
+        delete m.contributes.configuration.properties['artemis.startPage'];
+        expect(() => cleanManifest(m)).toThrow(/cannot override unknown setting 'artemis\.startPage'/);
+    });
+});

--- a/extension/test/logic/scripts/verifyCleanBundle.test.ts
+++ b/extension/test/logic/scripts/verifyCleanBundle.test.ts
@@ -54,4 +54,16 @@ describe('verify-clean-bundle', () => {
         ]);
         expect(forbiddenInputs(f)).toHaveLength(2);
     });
+
+    it('is fail-closed: flags unlisted telemetry-subtree files, allows only types.ts', () => {
+        const f = metaWith([
+            'src/extension/services/telemetry/uriFilter.ts', // recorder util, never explicitly listed
+            'src/extension/services/telemetry/someNewFile.ts', // any future addition
+            'src/extension/services/telemetry/types.ts', // allowlisted exception
+        ]);
+        expect(forbiddenInputs(f)).toEqual([
+            'src/extension/services/telemetry/uriFilter.ts',
+            'src/extension/services/telemetry/someNewFile.ts',
+        ]);
+    });
 });

--- a/extension/test/logic/scripts/verifyCleanBundle.test.ts
+++ b/extension/test/logic/scripts/verifyCleanBundle.test.ts
@@ -24,14 +24,34 @@ describe('verify-clean-bundle', () => {
             'src/extension/services/auth/consentService.ts',
             'src/extension/services/telemetry/metrics/errorQuotientEngine.ts',
         ]);
-        expect(forbiddenInputs(f)).toHaveLength(2);
+        expect(forbiddenInputs(f)).toHaveLength(3);
     });
 
     it('passes a clean input set', () => {
         const f = metaWith([
-            'src/extension/services/telemetry/metrics/errorQuotientEngine.ts',
+            'src/extension/services/telemetry/types.ts',
             'src/extension/dataCollection/noop.ts',
         ]);
         expect(forbiddenInputs(f)).toEqual([]);
+    });
+
+    it('flags the struggle engine entry points', () => {
+        const f = metaWith([
+            'src/extension/services/telemetry/telemetryManager.ts',
+            'src/extension/services/telemetry/decision/interventionDecisionEngine.ts',
+            'src/extension/services/telemetry/eventPipeline/boundaryTriggerEmitter.ts',
+            'src/extension/services/telemetry/types.ts', // allowed
+        ]);
+        expect(forbiddenInputs(f)).toHaveLength(3);
+    });
+
+    it('flags the struggle-detection webview view files', () => {
+        const f = metaWith([
+            'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
+            'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
+            'src/webview/views/StruggleDetection/stub.tsx', // allowed
+            'src/webview/views/StruggleDetection/types.ts', // allowed
+        ]);
+        expect(forbiddenInputs(f)).toHaveLength(2);
     });
 });

--- a/extension/test/logic/telemetry/noopTelemetryManager.test.ts
+++ b/extension/test/logic/telemetry/noopTelemetryManager.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NoopTelemetryManager } from '@extension/telemetry/noopTelemetryManager';
+
+describe('NoopTelemetryManager', () => {
+    it('reports a non-struggling, zero context', () => {
+        const m = new NoopTelemetryManager();
+        expect(m.getStruggleContext()).toEqual({
+            isStruggling: false,
+            eq: 0,
+            eqConfidence: 'insufficient',
+            recommendedAction: 'none',
+        });
+    });
+
+    it('reports an empty EQ engine state', () => {
+        const m = new NoopTelemetryManager();
+        expect(m.getEqEngineState()).toEqual({
+            snapshots: [],
+            currentEQ: 0,
+            pairCount: 0,
+            confidence: 'insufficient',
+        });
+    });
+
+    it('never fires events and its subscriptions are disposable', () => {
+        const m = new NoopTelemetryManager();
+        const listener = vi.fn();
+        const sub = m.onDidCalculateEQ(listener);
+        const sub2 = m.onDidShowIntervention(listener);
+        expect(listener).not.toHaveBeenCalled();
+        expect(() => { sub.dispose(); sub2.dispose(); }).not.toThrow();
+    });
+
+    it('no-op methods do not throw and isEnabled is false', async () => {
+        const m = new NoopTelemetryManager();
+        expect(m.isEnabled()).toBe(false);
+        expect(() => m.startExerciseSession(1)).not.toThrow();
+        await expect(m.showStruggleScoreDialog()).resolves.toBeUndefined();
+        expect(() => m.dispose()).not.toThrow();
+    });
+});

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -18,7 +18,9 @@
 			"@shared/*": ["./src/shared/*"],
 			"@test/*": ["./test/*"],
 			"@root/package.json": ["./package.json"],
-			"@dataCollection": ["./src/extension/dataCollection/index.ts"]
+			"@dataCollection": ["./src/extension/dataCollection/index.ts"],
+			"@telemetry": ["./src/extension/telemetry/index.ts"],
+			"@struggleView": ["./src/webview/views/StruggleDetection/index.ts"]
 		},
 		"plugins": [
 			{ "name": "typescript-plugin-css-modules" }

--- a/extension/vitest.config.mts
+++ b/extension/vitest.config.mts
@@ -3,6 +3,14 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
 	plugins: [react()],
+	// Build-time constants injected by esbuild's `define` in the real build
+	// (esbuild.js). Mirror them here so webview components that reference them
+	// (App.tsx, DashboardView.tsx, StruggleDetectionView.tsx) run under vitest.
+	// Tests exercise full-build behaviour, so both are true.
+	define: {
+		__IRIS_RECORDING__: 'true',
+		__IRIS_TELEMETRY__: 'true',
+	},
 	resolve: {
 		alias: {
 			// Stub the vscode module for tests that import extension-host code
@@ -14,6 +22,7 @@ export default defineConfig({
 			'@shared': new URL('./src/shared', import.meta.url).pathname,
 			'@test': new URL('./test', import.meta.url).pathname,
 			'@root/package.json': new URL('./package.json', import.meta.url).pathname,
+			'@struggleView': new URL('./src/webview/views/StruggleDetection/index.ts', import.meta.url).pathname,
 		},
 	},
 	test: {


### PR DESCRIPTION
Brings dev to main for the 0.4.7 release.

Contains since 0.4.6:
- #308 fix(server-picker): Local Development preset → port 8080
- #310 Harden Open VSX build: cloud setting defaults + telemetry-engine exclusion seam
- #312 fix(openvsx): clean-bundle verifier fail-closed for telemetry subtree
- #309 docs, #311 chore
- release prep: version 0.4.7 + CHANGELOG [0.4.7]

After merge, the release workflow runs from main (version 0.4.7).