### PR TITLE
chore: bump dev to 0.4.8-dev

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.7",
+  "version": "0.4.8-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Post-0.4.7-release housekeeping: open the next dev cycle. CHANGELOG already carries an empty [Unreleased] from the 0.4.7 prep.