### PR TITLE
Replace clone actions with "Open in Artemis" in EduIDE (managed Theia)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Changed
+
+- **EduIDE Exercise Actions**: In the EduIDE (Theia cloud) build the exercise repository is already the workspace, so cloning is replaced by an "Open in Artemis" button. The primary "Clone Repository" button, the dropdown "Clone Repository" and "Open Repository" entries, and the "recently cloned" notice are hidden in this managed environment; the "Copy Clone URL" options remain. The desktop build is unchanged.
+
 ## [0.4.7] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 - **EduIDE Exercise Actions**: In the EduIDE (Theia cloud) build the exercise repository is already the workspace, so cloning is replaced by an "Open in Artemis" button. The primary "Clone Repository" button, the dropdown "Clone Repository" and "Open Repository" entries, and the "recently cloned" notice are hidden in this managed environment; the "Copy Clone URL" options remain. The desktop build is unchanged.
 
+### Fixed
+
+- **EduIDE Server Links**: In EduIDE (Theia) the "Open in Artemis" button and other browser-open actions now target the connected Artemis server (delivered via the data-bridge) instead of falling back to the production default; problem-statement relative links resolve against the same server.
+
 ## [0.4.7] - 2026-06-22
 
 ### Changed

--- a/extension/src/extension/controller/commands/utilityCommands.ts
+++ b/extension/src/extension/controller/commands/utilityCommands.ts
@@ -6,7 +6,7 @@ import { getOptionalPayload, getPayload, WebviewCmd } from '@shared/messageContr
 
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
-import { CONFIG, extractErrorMessage, VSCODE_CONFIG } from '@extension/utils';
+import { extractErrorMessage, resolveServerUrl } from '@extension/utils';
 
 import type { CommandContext, CommandMap } from './types';
 
@@ -77,8 +77,9 @@ export class UtilityCommandModule {
 
     private handleOpenWebsite = async (message: WebviewToExtensionMessage): Promise<void> => {
         try {
-            const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-            const serverUrl = config.get<string>(VSCODE_CONFIG.SERVER_URL_KEY, CONFIG.ARTEMIS_SERVER_URL_DEFAULT);
+            // Resolve via the single source of truth so EduIDE/Theia (data-bridge
+            // ARTEMIS_URL) opens the connected server, not the config default.
+            const serverUrl = resolveServerUrl();
             const payload = getOptionalPayload<WebCmd<'openWebsite'>>(message);
             const urlPath = payload?.path || '/courses';
             await vscode.env.openExternal(vscode.Uri.parse(`${serverUrl}${urlPath}`));

--- a/extension/src/extension/services/problemStatementRenderService.ts
+++ b/extension/src/extension/services/problemStatementRenderService.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode';
 
 import type { ArtemisApiService } from '@extension/api/artemisApi';
 import type { ProblemStatementRenderRequest, TestFeedbackInput } from '@extension/domain/problemStatementRendering';
-import { CONFIG, VSCODE_CONFIG } from '@extension/utils/constants';
+import { VSCODE_CONFIG } from '@extension/utils/constants';
 import { extractLatestFeedbacks } from '@extension/utils/participationHelpers';
+import { resolveServerUrl } from '@extension/utils/serverUrl';
 
 import { LogCategory, logger } from './loggingService';
 
@@ -179,8 +180,9 @@ export class ProblemStatementRenderService implements vscode.Disposable {
     }
 
     private getServerUrl(): string {
-        const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-        return config.get<string>(VSCODE_CONFIG.SERVER_URL_KEY) || CONFIG.ARTEMIS_SERVER_URL_DEFAULT;
+        // Single source of truth: in EduIDE/Theia this is the data-bridge
+        // ARTEMIS_URL; on Desktop it falls back to the `artemis.serverUrl` config.
+        return resolveServerUrl();
     }
 }
 

--- a/extension/src/extension/services/ui/fullscreenPanelManager.ts
+++ b/extension/src/extension/services/ui/fullscreenPanelManager.ts
@@ -8,6 +8,7 @@ import { isWebviewMessage } from '@shared/messageContracts/typeGuards';
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { collectExerciseSources, detectWorkspaceExercise, detectWorkspaceForRepoUris } from '@extension/services/workspace/workspaceDetectionService';
+import { getTheiaEnvironment } from '@extension/theia/theiaEnvironment';
 import type { ExerciseDetailsResponse } from '@extension/types';
 
 import { getReactWebviewHtml } from './webviewHtml';
@@ -26,6 +27,7 @@ export class FullscreenPanelManager {
             title: `Exercise: ${exerciseTitle}`,
             viewName: 'exerciseDetail',
             onReady: (postSafe) => {
+                const isManagedEnvironment = getTheiaEnvironment().isManagedEnvironment;
                 const repoUris = (exerciseData.exercise?.studentParticipations ?? [])
                     .map(p => p.repositoryUri)
                     .filter((uri): uri is string => !!uri);
@@ -36,6 +38,7 @@ export class FullscreenPanelManager {
                             type: ExtensionMsg.ExerciseDetailInit,
                             exerciseData,
                             hideDeveloperTools: false,
+                            isManagedEnvironment,
                             repoStatus,
                         });
                     }).catch(() => {
@@ -43,6 +46,7 @@ export class FullscreenPanelManager {
                             type: ExtensionMsg.ExerciseDetailInit,
                             exerciseData,
                             hideDeveloperTools: false,
+                            isManagedEnvironment,
                         });
                     });
                 } else {
@@ -50,6 +54,7 @@ export class FullscreenPanelManager {
                         type: ExtensionMsg.ExerciseDetailInit,
                         exerciseData,
                         hideDeveloperTools: false,
+                        isManagedEnvironment,
                     });
                 }
             },

--- a/extension/src/extension/services/ui/viewInitDataService.ts
+++ b/extension/src/extension/services/ui/viewInitDataService.ts
@@ -14,6 +14,7 @@ import {
     detectWorkspaceExercise,
     detectWorkspaceForRepoUris,
 } from '@extension/services/workspace/workspaceDetectionService';
+import { getTheiaEnvironment } from '@extension/theia/theiaEnvironment';
 import type { CourseDashboardEntry, ExerciseDetail } from '@extension/types';
 import { resolveServerUrl } from '@extension/utils';
 
@@ -183,6 +184,8 @@ export class ViewInitDataService {
             return;
         }
 
+        const isManagedEnvironment = getTheiaEnvironment().isManagedEnvironment;
+
         const participations = exerciseData.exercise?.studentParticipations ?? [];
         const repoUris = participations
             .map(p => p.repositoryUri)
@@ -202,6 +205,7 @@ export class ViewInitDataService {
                     type: ExtensionMsg.ExerciseDetailInit,
                     exerciseData,
                     hideDeveloperTools: !this._isDeveloperMode(),
+                    isManagedEnvironment,
                     repoStatus,
                     serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
                 });
@@ -213,6 +217,7 @@ export class ViewInitDataService {
                     type: ExtensionMsg.ExerciseDetailInit,
                     exerciseData,
                     hideDeveloperTools: !this._isDeveloperMode(),
+                    isManagedEnvironment,
                     serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
                 });
             });
@@ -222,6 +227,7 @@ export class ViewInitDataService {
                 type: ExtensionMsg.ExerciseDetailInit,
                 exerciseData,
                 hideDeveloperTools: !this._isDeveloperMode(),
+                isManagedEnvironment,
                 serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
             });
         }

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -114,6 +114,8 @@ interface ExtensionMsgPayloads {
         hideDeveloperTools: boolean;
         repoStatus?: { isConnected: boolean; hasChanges: boolean; isPracticeRepo: boolean };
         serverRenderedProblemStatement?: RenderedProblemStatementPayload;
+        /** EduIDE (managed Theia): hide clone affordances, show "Open in Artemis". */
+        isManagedEnvironment?: boolean;
     };
     serviceStatusInit: {
         serverUrl?: string;

--- a/extension/src/webview/components/exercise/ParticipationActions.tsx
+++ b/extension/src/webview/components/exercise/ParticipationActions.tsx
@@ -54,6 +54,12 @@ interface ParticipationActionsProps {
   isPracticeAvailable?: boolean;
   showClonedNotice?: boolean;
   onOpenClonedRepository?: () => void;
+  /**
+   * EduIDE (managed Theia) mode. The exercise repo is already the workspace,
+   * so clone affordances are meaningless: the primary Clone button becomes
+   * "Open in Artemis", and the dropdown Clone / Open Repository entries hide.
+   */
+  isManagedEnvironment?: boolean;
 }
 
 export function ParticipationActions({
@@ -83,6 +89,7 @@ export function ParticipationActions({
   isPracticeAvailable = false,
   showClonedNotice = false,
   onOpenClonedRepository,
+  isManagedEnvironment = false,
 }: ParticipationActionsProps) {
   const isProgramming = exerciseType === 'programming';
   const hasParticipation = participationStatus !== 'not-started';
@@ -268,10 +275,16 @@ export function ParticipationActions({
         {renderSubmitButtonGroup()}
         {renderCommitMessageInput()}
         <div className={styles.actionButtonRow}>
-          {!isWorkspaceConnected && (
-            <Button variant="primary" onClick={onClone} fullWidth>
-              Clone Repository
+          {isManagedEnvironment ? (
+            <Button variant="primary" onClick={onOpenInBrowser} fullWidth>
+              Open in Artemis
             </Button>
+          ) : (
+            !isWorkspaceConnected && (
+              <Button variant="primary" onClick={onClone} fullWidth>
+                Clone Repository
+              </Button>
+            )
           )}
           <div className={styles.moreMenu} ref={moreMenuRef}>
             <Button variant="link" onClick={() => setIsDropdownOpen(prev => !prev)}>
@@ -281,7 +294,7 @@ export function ParticipationActions({
               <div className={styles.moreDropdown}>
                 {/* Section: Workspace */}
                 <div className={styles.dropdownSection}>
-                  {isWorkspaceConnected && (
+                  {!isManagedEnvironment && isWorkspaceConnected && (
                     <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onClone?.(); }}>
                       <GitBranch size={14} aria-hidden="true" />
                       <span>Clone Repository</span>
@@ -291,7 +304,7 @@ export function ParticipationActions({
                     <Activity size={14} aria-hidden="true" />
                     <span>Check workspace status</span>
                   </button>
-                  {onOpenRepository && (
+                  {!isManagedEnvironment && onOpenRepository && (
                     <button className={styles.dropdownItem} onClick={() => { setIsDropdownOpen(false); onOpenRepository(); }}>
                       <FolderOpen size={14} aria-hidden="true" />
                       <span>Open Repository</span>

--- a/extension/src/webview/components/exercise/ParticipationActions.tsx
+++ b/extension/src/webview/components/exercise/ParticipationActions.tsx
@@ -275,12 +275,13 @@ export function ParticipationActions({
         {renderSubmitButtonGroup()}
         {renderCommitMessageInput()}
         <div className={styles.actionButtonRow}>
-          {isManagedEnvironment ? (
-            <Button variant="primary" onClick={onOpenInBrowser} fullWidth>
-              Open in Artemis
-            </Button>
-          ) : (
-            !isWorkspaceConnected && (
+          {!isWorkspaceConnected && (
+            isManagedEnvironment ? (
+              // EduIDE: cloning is meaningless, so offer the web exercise instead.
+              <Button variant="primary" onClick={onOpenInBrowser} fullWidth>
+                Open in Artemis
+              </Button>
+            ) : (
               <Button variant="primary" onClick={onClone} fullWidth>
                 Clone Repository
               </Button>

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -76,6 +76,11 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
     const [showCommitMessage, setShowCommitMessage] = useState(false);
     const [commitMessage, setCommitMessage] = useState('');
 
+    // EduIDE (managed Theia): the exercise repo is already the workspace, so
+    // clone affordances are hidden in favor of an "Open in Artemis" button.
+    // Session constant delivered on the exerciseDetailInit message.
+    const [isManagedEnvironment, setIsManagedEnvironment] = useState(false);
+
     const [openOverviewView, setOpenOverviewView] = useState<OpenViewState | null>(null);
     const [openTaskView, setOpenTaskView] = useState<OpenTaskViewState | null>(null);
 
@@ -100,6 +105,7 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
             if (!msg.exerciseData) { return; }
 
             setExerciseData(msg.exerciseData, msg.hideDeveloperTools, msg.repoStatus);
+            setIsManagedEnvironment(msg.isManagedEnvironment ?? false);
             // Use cached server render if available on init
             if (msg.serverRenderedProblemStatement) {
                 setServerRenderedPS(msg.serverRenderedProblemStatement);
@@ -386,10 +392,14 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
         : !repoStatus.isConnected ? 'disconnected'
         : repoStatus.hasChanges ? 'dirty' : 'clean';
 
+    // In EduIDE the repo is already the workspace, so the "recently cloned"
+    // notice (banner + ParticipationActions entry) is suppressed.
+    const showClonedNotice = !!clonedNotice && !isManagedEnvironment;
+
     return (
         <div className={styles.exerciseDetailView}>
             {/* Cloned repo notice */}
-            {clonedNotice && (
+            {showClonedNotice && clonedNotice && (
                 <div className={styles.banner} data-variant="info">
                     <span>Repository cloned for "{clonedNotice.exerciseTitle}"</span>
                     <button className={styles.bannerDismiss} onClick={clearClonedNotice}>×</button>
@@ -476,7 +486,8 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
                     isPracticeMode={repoStatus?.isPracticeRepo ?? false}
                     isPracticeAvailable={isPracticeAvailable}
                     hasUnsavedChanges={dirtyPagesStatus?.hasDirtyPages === true && !dirtyPagesStatus?.autoSaveEnabled}
-                    showClonedNotice={!!clonedNotice}
+                    showClonedNotice={showClonedNotice}
+                    isManagedEnvironment={isManagedEnvironment}
                     onConfigureAutoSave={() => postCommand(vscodeApi, 'openSettings', { setting: 'files.autoSave' })}
                     onStart={() => {
                         if (exercise.id === undefined) { return; }

--- a/extension/test/react/components/exercise/ParticipationActions.test.tsx
+++ b/extension/test/react/components/exercise/ParticipationActions.test.tsx
@@ -536,4 +536,92 @@ describe('ParticipationActions', () => {
 			expect(handleOpenInBrowser).toHaveBeenCalledOnce();
 		});
 	});
+
+	describe('managed environment (EduIDE)', () => {
+		it('shows "Open in Artemis" instead of the primary Clone button when participated', () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="disconnected"
+					isManagedEnvironment={true}
+				/>
+			);
+			expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
+		});
+
+		it('shows "Open in Artemis" even when the workspace is connected', () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					isManagedEnvironment={true}
+				/>
+			);
+			expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+		});
+
+		it('calls onOpenInBrowser when "Open in Artemis" is clicked', async () => {
+			const handleOpenInBrowser = vi.fn();
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					isManagedEnvironment={true}
+					onOpenInBrowser={handleOpenInBrowser}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: 'Open in Artemis' }));
+
+			expect(handleOpenInBrowser).toHaveBeenCalledOnce();
+		});
+
+		it('hides the dropdown "Clone Repository" entry', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					isManagedEnvironment={true}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
+		});
+
+		it('hides the "Open Repository" entry', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					isManagedEnvironment={true}
+					onOpenRepository={vi.fn()}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.queryByRole('button', { name: /Open Repository/i })).not.toBeInTheDocument();
+		});
+
+		it('keeps the "Copy Clone URL" entry', async () => {
+			render(
+				<ParticipationActions
+					exerciseType="programming"
+					participationStatus="in-progress"
+					workspaceStatus="clean"
+					isManagedEnvironment={true}
+					onCopyCloneUrl={vi.fn()}
+				/>
+			);
+
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.getByRole('button', { name: 'Copy Clone URL' })).toBeInTheDocument();
+		});
+	});
 });

--- a/extension/test/react/components/exercise/ParticipationActions.test.tsx
+++ b/extension/test/react/components/exercise/ParticipationActions.test.tsx
@@ -551,7 +551,7 @@ describe('ParticipationActions', () => {
 			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
 		});
 
-		it('shows "Open in Artemis" even when the workspace is connected', () => {
+		it('does NOT show "Open in Artemis" when the workspace is connected (open exercise)', () => {
 			render(
 				<ParticipationActions
 					exerciseType="programming"
@@ -560,7 +560,8 @@ describe('ParticipationActions', () => {
 					isManagedEnvironment={true}
 				/>
 			);
-			expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+			// In the open/connected exercise only Submit + More options belong here.
+			expect(screen.queryByRole('button', { name: 'Open in Artemis' })).not.toBeInTheDocument();
 		});
 
 		it('calls onOpenInBrowser when "Open in Artemis" is clicked', async () => {
@@ -569,7 +570,7 @@ describe('ParticipationActions', () => {
 				<ParticipationActions
 					exerciseType="programming"
 					participationStatus="in-progress"
-					workspaceStatus="clean"
+					workspaceStatus="disconnected"
 					isManagedEnvironment={true}
 					onOpenInBrowser={handleOpenInBrowser}
 				/>

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -256,6 +256,69 @@ describe('ExerciseDetailView', () => {
 		);
 	});
 
+	describe('managed environment (EduIDE)', () => {
+		it('replaces clone affordances with "Open in Artemis" when exerciseDetailInit carries isManagedEnvironment', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'exerciseDetailInit',
+				exerciseData: makeExerciseDataWithParticipation(),
+				hideDeveloperTools: false,
+				repoStatus: { isConnected: true, hasChanges: false, isPracticeRepo: false },
+				isManagedEnvironment: true,
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+			});
+
+			// Clone affordances are gone, even inside the More-options dropdown.
+			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
+			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: /Open Repository/i })).not.toBeInTheDocument();
+		});
+
+		it('hides the "Repository cloned" banner when managed', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'exerciseDetailInit',
+				exerciseData: makeExerciseData(),
+				hideDeveloperTools: false,
+				isManagedEnvironment: true,
+			});
+			await waitFor(() => expect(screen.getByText('My Exercise')).toBeInTheDocument());
+
+			// clonedNotice is set later (store ← ShowClonedRepoNotice), after init resets it.
+			act(() => {
+				useExerciseDetailStore.getState().setClonedNotice('My Exercise', 99);
+			});
+
+			expect(screen.queryByText(/Repository cloned for/i)).not.toBeInTheDocument();
+		});
+
+		it('shows the "Repository cloned" banner in non-managed (desktop) mode', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'exerciseDetailInit',
+				exerciseData: makeExerciseData(),
+				hideDeveloperTools: false,
+				isManagedEnvironment: false,
+			});
+			await waitFor(() => expect(screen.getByText('My Exercise')).toBeInTheDocument());
+
+			act(() => {
+				useExerciseDetailStore.getState().setClonedNotice('My Exercise', 99);
+			});
+
+			expect(screen.getByText(/Repository cloned for/i)).toBeInTheDocument();
+		});
+	});
+
 	it('shows developer tools by default (hideDeveloperTools = false)', () => {
 		useExerciseDetailStore.setState({
 			exerciseData: makeExerciseData(),

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -257,7 +257,25 @@ describe('ExerciseDetailView', () => {
 	});
 
 	describe('managed environment (EduIDE)', () => {
-		it('replaces clone affordances with "Open in Artemis" when exerciseDetailInit carries isManagedEnvironment', async () => {
+		it('shows "Open in Artemis" (not Clone) when managed and the workspace is disconnected', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'exerciseDetailInit',
+				exerciseData: makeExerciseDataWithParticipation(),
+				hideDeveloperTools: false,
+				repoStatus: { isConnected: false, hasChanges: false, isPracticeRepo: false },
+				isManagedEnvironment: true,
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+			});
+			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
+		});
+
+		it('shows no "Open in Artemis" and no Clone/Open Repository when managed and connected (open exercise)', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<ExerciseDetailView vscodeApi={mockApi} />);
 
@@ -270,10 +288,11 @@ describe('ExerciseDetailView', () => {
 			});
 
 			await waitFor(() => {
-				expect(screen.getByRole('button', { name: 'Open in Artemis' })).toBeInTheDocument();
+				expect(screen.getByRole('button', { name: /Submit/i })).toBeInTheDocument();
 			});
+			// The open/connected exercise must not surface "Open in Artemis".
+			expect(screen.queryByRole('button', { name: 'Open in Artemis' })).not.toBeInTheDocument();
 
-			// Clone affordances are gone, even inside the More-options dropdown.
 			await userEvent.click(screen.getByRole('button', { name: /More options/i }));
 			expect(screen.queryByRole('button', { name: 'Clone Repository' })).not.toBeInTheDocument();
 			expect(screen.queryByRole('button', { name: /Open Repository/i })).not.toBeInTheDocument();

--- a/extension/test/unit/controller/utilityCommands.test.ts
+++ b/extension/test/unit/controller/utilityCommands.test.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { WebviewCmd } from '@shared/messageContracts';
+
+import type { CommandContext } from '@extension/controller/commands/types';
+import { UtilityCommandModule } from '@extension/controller/commands/utilityCommands';
+import { initializeTheiaContext } from '@extension/theia/theiaEnvironment';
+
+suite('UtilityCommandModule.handleOpenWebsite', () => {
+    let sandbox: sinon.SinonSandbox;
+    let openExternal: sinon.SinonStub;
+    let configValues: Map<string, unknown>;
+    let originalBridge: string | undefined;
+
+    function dispatchOpenWebsite(path: string): Promise<void> {
+        const mod = new UtilityCommandModule({} as CommandContext);
+        return mod.getHandlers()[WebviewCmd.OpenWebsite]({
+            type: 'command',
+            command: WebviewCmd.OpenWebsite,
+            payload: { path },
+        } as never);
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        originalBridge = process.env.DATA_BRIDGE_ENABLED;
+        openExternal = sandbox.stub(vscode.env, 'openExternal').resolves(true as never);
+
+        configValues = new Map<string, unknown>();
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+            get: (key: string, fallback?: unknown) => (configValues.has(key) ? configValues.get(key) : fallback),
+            update: sandbox.stub().resolves(undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    teardown(async () => {
+        // Reset the Theia singleton to the Desktop default so managed-env state
+        // set in a test cannot leak into other suites.
+        if (originalBridge === undefined) {
+            delete process.env.DATA_BRIDGE_ENABLED;
+        } else {
+            process.env.DATA_BRIDGE_ENABLED = originalBridge;
+        }
+        await initializeTheiaContext();
+        sandbox.restore();
+    });
+
+    test('opens the Theia/EduIDE server URL (data-bridge ARTEMIS_URL), not the VS Code config default', async () => {
+        const theiaUrl = 'https://artemis-test2.artemis.cit.tum.de';
+        process.env.DATA_BRIDGE_ENABLED = '1';
+        sandbox.stub(vscode.commands, 'getCommands').resolves(['dataBridge.getEnv']);
+        sandbox.stub(vscode.commands, 'executeCommand')
+            .withArgs('dataBridge.getEnv', sinon.match.any)
+            .resolves({ THEIA: 'true', ARTEMIS_URL: theiaUrl, ARTEMIS_TOKEN: 'tok-123' });
+        await initializeTheiaContext();
+
+        await dispatchOpenWebsite('/courses/1/exercises/2');
+
+        sinon.assert.calledOnce(openExternal);
+        const opened = (openExternal.firstCall.args[0] as vscode.Uri).toString(true);
+        assert.strictEqual(opened, `${theiaUrl}/courses/1/exercises/2`);
+    });
+
+    test('falls back to the configured server URL on Desktop (no data-bridge)', async () => {
+        delete process.env.DATA_BRIDGE_ENABLED;
+        await initializeTheiaContext();
+        configValues.set('serverUrl', 'https://artemis.example.com');
+
+        await dispatchOpenWebsite('/courses/3/exercises/4');
+
+        sinon.assert.calledOnce(openExternal);
+        const opened = (openExternal.firstCall.args[0] as vscode.Uri).toString(true);
+        assert.strictEqual(opened, 'https://artemis.example.com/courses/3/exercises/4');
+    });
+});

--- a/extension/test/unit/services/problemStatementRenderService.test.ts
+++ b/extension/test/unit/services/problemStatementRenderService.test.ts
@@ -8,6 +8,7 @@ import type {
     RenderedProblemStatementDTO,
 } from '@extension/domain/problemStatementRendering';
 import { ProblemStatementRenderService } from '@extension/services/problemStatementRenderService';
+import { initializeTheiaContext } from '@extension/theia/theiaEnvironment';
 
 suite('ProblemStatementRenderService', () => {
     let sandbox: sinon.SinonSandbox;
@@ -104,6 +105,38 @@ suite('ProblemStatementRenderService', () => {
         assert.ok(result.html.includes('src="https://artemis.example.com/api/files/foo.png"'));
         // Absolute URLs are left alone
         assert.ok(result.html.includes('src="https://other/x.png"'));
+    });
+
+    test('rewrites relative src URLs against the Theia/EduIDE server URL, not the VS Code config', async () => {
+        // In EduIDE the real server URL comes from the data-bridge (ARTEMIS_URL),
+        // not from the `artemis.serverUrl` config (which is left unset → production default).
+        // getServerUrl() must resolve via resolveServerUrl() so relative links point at the
+        // actual server the student is connected to.
+        const theiaUrl = 'https://artemis-test2.artemis.cit.tum.de';
+        const originalBridge = process.env.DATA_BRIDGE_ENABLED;
+        try {
+            process.env.DATA_BRIDGE_ENABLED = '1';
+            sandbox.stub(vscode.commands, 'getCommands').resolves(['dataBridge.getEnv']);
+            sandbox.stub(vscode.commands, 'executeCommand')
+                .withArgs('dataBridge.getEnv', sinon.match.any)
+                .resolves({ THEIA: 'true', ARTEMIS_URL: theiaUrl, ARTEMIS_TOKEN: 'tok-123' });
+            await initializeTheiaContext();
+
+            renderStub.resolves(mockDto({ html: '<img src="/api/files/foo.png">' }));
+            const result = await service.render(mockExercise());
+            assert.ok(result);
+            assert.ok(
+                result.html.includes(`src="${theiaUrl}/api/files/foo.png"`),
+                `Expected relative URL rewritten against the EduIDE server; got: ${result.html}`,
+            );
+        } finally {
+            if (originalBridge === undefined) {
+                delete process.env.DATA_BRIDGE_ENABLED;
+            } else {
+                process.env.DATA_BRIDGE_ENABLED = originalBridge;
+            }
+            await initializeTheiaContext();
+        }
     });
 
     test('caches result for identical input — no second API call', async () => {

--- a/extension/test/unit/theia/theiaEnvironment.test.ts
+++ b/extension/test/unit/theia/theiaEnvironment.test.ts
@@ -25,8 +25,16 @@ suite('detectTheiaEnvironment / initializeTheiaContext', () => {
         showErrorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage');
     });
 
-    teardown(() => {
+    teardown(async () => {
         sandbox.restore();
+        // Reset the global Theia singleton to the Desktop default so a managed-env
+        // value set by a test cannot leak into suites that run afterwards (the
+        // singleton is module-level state shared across the whole unit run).
+        // With DATA_BRIDGE_ENABLED unset, detection short-circuits to Desktop
+        // before touching any (now-restored) vscode command.
+        delete process.env.DATA_BRIDGE_ENABLED;
+        await initializeTheiaContext();
+        // Restore the ambient env var; this alone does not re-trigger detection.
         if (originalDataBridgeEnabled === undefined) {
             delete process.env.DATA_BRIDGE_ENABLED;
         } else {


### PR DESCRIPTION
In the EduIDE (managed Theia) cloud IDE the exercise repository is already the workspace, so the "Clone" affordances in the exercise view are meaningless. This replaces them with an "Open in Artemis" button and hides the clone-specific entries. The desktop (VS Code) build is unchanged.

## Behavior in EduIDE (managed Theia)
| Affordance | Result |
|---|---|
| Primary "Clone Repository" button | becomes a primary **"Open in Artemis"** button (deep-links to the exercise via the existing `openWebsite` handler) |
| Dropdown "Clone Repository" | hidden |
| Dropdown "Open Repository" | hidden |
| "Copy Clone URL" / "with token" | kept |
| "Repository recently cloned" notice (banner + entry) | hidden |

Non-participated / practice / non-programming paths keep their existing "Open in browser" button (intentionally not renamed).

## How it works
The gate is the existing host-side `getTheiaEnvironment().isManagedEnvironment` (true only when the EduIDE data-bridge delivered both `ARTEMIS_URL` and `ARTEMIS_TOKEN`), not plain `isTheia`. The webview previously had no knowledge of the managed environment, so the flag is plumbed in via the existing `exerciseDetailInit` message (both the sidebar `ViewInitDataService` and the `FullscreenPanelManager` senders), consumed in `ExerciseDetailView` and passed to `ParticipationActions`. The cloned-notice banner is gated at the source in `ExerciseDetailView`.

The new payload field is optional and defaults to `false`, so the desktop render branches are unchanged and backward compatible.

## Testing
- New React tests for the managed-mode component behavior, the host-to-webview plumbing, and the cloned-notice banner gate (with the order-sensitive seeding, since `exerciseDetailInit` resets `clonedNotice`).
- Full React suite: 898 passing.
- `tsc --noEmit` and `eslint src test`: clean.