### PR TITLE
ci(release): auto-notify EduIDE to bump bundled artemis-extension

### DIFF
--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -486,3 +486,34 @@ jobs:
               exit 1
             }
           done
+
+  notify_eduide:
+    name: Notify EduIDE (bump bundled extension)
+    needs: [prepare, publish_openvsx, release]
+    # Fire only after a real release whose Open VSX publish succeeded - EduIDE bundles
+    # the Open VSX (clean) build, so a marketplace-only release must NOT notify it.
+    if: |
+      !cancelled() && !inputs.dry_run && inputs.publish_openvsx &&
+      needs.publish_openvsx.result == 'success' &&
+      needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger EduIDE bundled-extension bump
+        env:
+          EDUIDE_DISPATCH_TOKEN: ${{ secrets.EDUIDE_DISPATCH_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # Fire the EduIDE auto-update workflow (workflow_dispatch via API). The token
+          # needs only Actions:read/write on EduIDE/EduIDE; the actual file bump + PR is
+          # done there by EduIDE's own GITHUB_TOKEN (least privilege for the cross-org token).
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${EDUIDE_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/EduIDE/EduIDE/actions/workflows/artemis_extension_auto_update.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"version\":\"${VERSION}\"}}"
+          echo "Dispatched EduIDE auto-update for $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Internal
+
+- **EduIDE Auto-Update**: A new release-pipeline job notifies the EduIDE (Theia cloud) repository after a successful Open VSX publish, which automatically opens a PR bumping the bundled extension version, replacing the previous manual version-pin step.
+
 ## [0.4.7] - 2026-06-22
 
 ### Changed


### PR DESCRIPTION
Adds a `notify_eduide` job to `release-openvsx.yml`. After a real (strict-semver) release whose **Open VSX** publish succeeded, it fires the EduIDE auto-update workflow (workflow_dispatch via API) with the released version, so EduIDE opens a PR bumping the bundled artemis-extension pin.

- Gated on `publish_openvsx == success && release == success` (a marketplace-only release does not notify EduIDE, which bundles the Open VSX clean build).
- Cross-org token is least-privilege: only `Actions:write` on EduIDE/EduIDE (to dispatch); the file bump + PR are done by EduIDE's own GITHUB_TOKEN.
- Pairs with EduIDE/EduIDE#163 (the receiving `artemis_extension_auto_update.yml`).

**Prerequisite before this is effective:** add repo secret `EDUIDE_DISPATCH_TOKEN` (fine-grained PAT scoped to EduIDE/EduIDE, Actions: read/write). Rollout order: merge EduIDE#163 to EduIDE `main` first, then this. Only fires for real semver releases; dev builds stay manual.