### PR TITLE
chore(release): prepare 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-06-24
+
 ### Changed
 
 - **EduIDE Exercise Actions**: In the EduIDE (Theia cloud) build the exercise repository is already the workspace, so cloning is replaced by an "Open in Artemis" button. The primary "Clone Repository" button, the dropdown "Clone Repository" and "Open Repository" entries, and the "recently cloned" notice are hidden in this managed environment; the "Copy Clone URL" options remain. The desktop build is unchanged.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.8-dev",
+  "version": "0.4.8",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Bumps `extension/package.json` to `0.4.8` and converts the `[Unreleased]` changelog section into `## [0.4.8] - 2026-06-24`.

Release contents (already merged to `dev`):
- #317 EduIDE Exercise Actions: "Open in Artemis" replaces clone in the Theia cloud build
- #317 EduIDE Server Links target the connected Artemis server
- #318 Release pipeline auto-notifies EduIDE to bump the bundled extension
- #319 Docs restructure (two root READMEs, single-sourced marketplace docs)

Follow-up: sync `dev` -> `main`, then dispatch the release workflow for `0.4.8` from `main`.