### PR TITLE
Redesign WebSocket status bar: student-friendly by default, diagnostics in developer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Changed
 
+- **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **EduIDE Exercise Actions**: In the EduIDE (Theia cloud) build the exercise repository is already the workspace, so cloning is replaced by an "Open in Artemis" button. The primary "Clone Repository" button, the dropdown "Clone Repository" and "Open Repository" entries, and the "recently cloned" notice are hidden in this managed environment; the "Copy Clone URL" options remain. The desktop build is unchanged.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Configure the extension through VS Code settings (`Cmd+,` or `Ctrl+,`):
 - `artemis.showSetDefaultClonePathPrompt` - Ask to set a default clone folder on first clone
 - `artemis.startPage` - Which page to show after logging in
 - `artemis.showStartPageSuggestion` - Suggest configuring the start page when an exercise is detected
-- `artemis.showWebSocketStatusBar` - Show the WebSocket connection status in the status bar
-- `artemis.developerMode` - Enable developer mode (debug tools and extra diagnostics)
+- `artemis.developerMode` - Enable developer mode (debug tools, extra diagnostics, and an always-visible WebSocket status indicator)
 
 ## About Artemis
 

--- a/docs/superpowers/specs/2026-06-24-ws-statusbar-button-design.md
+++ b/docs/superpowers/specs/2026-06-24-ws-statusbar-button-design.md
@@ -1,0 +1,145 @@
+# WebSocket Status Bar Button Redesign
+
+**Issue:** #320 — Re-evaluate: does the WebSocket status-bar item need the `artemis.showWebSocketStatusBar` setting?
+**Date:** 2026-06-24
+**Branch:** `worktree-ws-statusbar-dev-hover` (off `dev`)
+**Status:** Approved design, pending implementation plan
+
+## Context
+
+The WebSocket connection-status item in the status bar
+(`extension/src/extension/services/websocket/websocketStatusBar.ts`,
+`WebSocketStatusBarService`) is currently gated by a user setting
+`artemis.showWebSocketStatusBar` (boolean, default `false`).
+
+Today's behavior:
+- On disconnect / reconnecting → item is **always shown** (red/yellow), setting ignored.
+- During connected operation → shown **only** when `showWebSocketStatusBar` is `true`.
+- Logged out → hidden unless the setting is `true`.
+- After reconnection with the setting off → 2s flash, then hidden.
+- Tooltip: a plain one-line string. Click: reset + reconnect (no-op while connecting/reconnecting).
+
+A previous, richer version (commit `ec5f6d0d`, before a 588→165 line simplification)
+had a Markdown hover tooltip with full debug info and a QuickPick action menu. That
+was stripped out. This redesign brings back a focused, audience-aware version of the
+hover info and resolves #320.
+
+#320 asks whether the dedicated setting earns its place. The genuinely useful signal
+(a connection problem) already surfaces automatically, independent of the setting. The
+only thing the setting adds is a permanent "connected" indicator during normal
+operation — niche, defaults off, and arguably clutter for students.
+
+## Goals
+
+- Remove the `artemis.showWebSocketStatusBar` configuration knob (resolves #320 as "remove").
+- Fold "always show the item" into the existing `artemis.developerMode` setting, which
+  already governs status-bar diagnostics (e.g. the live struggle-detection score).
+- Give students a clear, plain-language explanation when the connection fails (the only
+  moment a non-developer sees the item).
+- Give developers full WebSocket diagnostics on hover.
+
+## Non-Goals
+
+- No change to the click action (stays reset + reconnect).
+- No QuickPick / action-menu (Disconnect / Reset / Copy debug) — low value for a niche
+  diagnostic, not worth the surface. Reconnect is the one in-context action and is the click.
+- No auth diagnostics (Cookie / JWT presence) in the dev hover — `getDiagnostics()` does
+  not expose them today and they are not needed now (YAGNI). Can be added later if a
+  real debugging need arises.
+
+## Design
+
+### 1. Visibility
+
+`developerMode` replaces `showWebSocketStatusBar` 1:1 in the visibility logic:
+
+- **developerMode ON** → item always visible (including the connected steady state, and
+  while logged out — diagnostics).
+- **developerMode OFF** → visible only on problems (`disconnected` / `reconnecting`),
+  plus the existing 2s flash after a successful reconnect; otherwise hidden. Logged out → hidden.
+
+The "always show on problems" override and the logged-out gate are unchanged in shape;
+only the gating field switches from `_showStatusBar` to a developer-mode flag.
+
+### 2. Button text (mode-dependent)
+
+| State | Normal (student) | Developer |
+|-------|------------------|-----------|
+| connected | `$(plug) Artemis: connected` | `$(plug) WS Connected` |
+| connecting | `$(sync~spin) Artemis: connecting…` | `$(sync~spin) WS Connecting…` |
+| reconnecting | `$(sync~spin) Artemis: reconnecting (3/20)…` | `$(sync~spin) WS Reconnecting (3/20)…` |
+| disconnected | `$(debug-disconnect) Artemis: offline` | `$(debug-disconnect) WS Disconnected` |
+
+Background colors unchanged: error (red) when disconnected, warning (yellow) when reconnecting.
+
+### 3. Hover (tooltip) — three tiers
+
+- **Normal + connected:** simple one-liner (e.g. "Connected to Artemis. Click to reconnect.").
+  Rarely seen, since the item is hidden when connected in normal mode.
+- **Normal + reconnecting:**
+  > **Reconnecting to Artemis… (3/20)**
+  > Live updates are paused and will resume automatically.
+- **Normal + disconnected:**
+  > **Connection to Artemis lost**
+  > Live updates (build results, submission status, Iris) are paused.
+  > Click to reconnect. If it keeps failing, check your internet connection or sign in again.
+- **Developer (all states):** rich `MarkdownString` built from
+  `ArtemisWebsocketService.getDiagnostics()`:
+  status, `clientConnected` / `clientActive`, reconnect `(attempts/max)`,
+  `subscriptionCount` + subscription topics, `sessionId`, `serverUrl`, `websocketUrl`.
+
+### 4. Click action
+
+Unchanged: `resetConnectionState()` + `connect()`, no-op while `connecting` / `reconnecting`.
+Same in both modes.
+
+### 5. Setting removal (#320)
+
+Remove `artemis.showWebSocketStatusBar` everywhere:
+- `extension/package.json` — `contributes.configuration` entry (~line 179).
+- `extension/src/extension/utils/constants.ts` — `SHOW_WEBSOCKET_STATUS_BAR_KEY` (line 37).
+- `README.md` — the bullet listing the setting (line 106).
+- `websocketStatusBar.ts` — `_showStatusBar`, `_updateVisibilitySetting`, and the
+  config-change listener; switch the listener to watch `DEVELOPER_MODE_KEY`.
+- `CHANGELOG.md` — new entry under `## [Unreleased]` (do not rename that heading).
+
+CHANGELOG history (lines mentioning the setting in past releases) is left untouched.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `extension/src/extension/services/websocket/websocketStatusBar.ts` | Swap setting→developerMode; mode-dependent text; three-tier tooltip incl. dev diagnostics |
+| `extension/src/extension/utils/constants.ts` | Remove `SHOW_WEBSOCKET_STATUS_BAR_KEY` |
+| `extension/package.json` | Remove `artemis.showWebSocketStatusBar` config contribution |
+| `README.md` | Remove the setting's documentation bullet |
+| `CHANGELOG.md` | Add `[Unreleased]` entry |
+| `extension/test/unit/services/websocketStatusBar.test.ts` | Re-point setting tests to `developerMode`; add new tests |
+
+No change required to `ArtemisWebsocketService` — `getDiagnostics()` already provides the
+data for the dev hover.
+
+## Testing
+
+`extension/test/unit/services/websocketStatusBar.test.ts` (mocha/vscode-test):
+
+- Re-point existing `showWebSocketStatusBar`-based visibility tests to `developerMode`.
+- Keep: always-shown-on-problem, 2s reconnect flash, auth-gate, dispose tests.
+- Add:
+  - developerMode ON → item visible while connected (and while logged out).
+  - Dev hover tooltip contains diagnostics (e.g. `serverUrl`, subscription count).
+  - Normal-mode button text uses plain-language labels ("Artemis: offline", etc.).
+  - Normal-mode disconnected/reconnecting tooltip contains the friendly explanation.
+
+All `extension/` checks must pass before completion: `npm test`, `npm run lint`,
+`npm run check-types` (tsc --noEmit catches unused locals that lint misses).
+
+## Open Decisions
+
+- **Auth diagnostics in dev hover:** OUT (YAGNI). Revisit only on a concrete need.
+
+## Out of Scope / Future
+
+- QuickPick action menu (Disconnect / Reset / Copy debug / Show debug doc).
+- Clickable command links inside the hover tooltip.
+- Exposing auth (Cookie/JWT) state via `getDiagnostics()`.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.8-dev",
+  "version": "0.4.9-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",

--- a/extension/package.json
+++ b/extension/package.json
@@ -174,12 +174,7 @@
         "artemis.developerMode": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable developer mode to show debugging tools, including debug buttons in views and live struggle detection score in the status bar."
-        },
-        "artemis.showWebSocketStatusBar": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show the WebSocket connection status in the status bar during normal operation. When a connection failure occurs, the status bar item is always shown regardless of this setting."
+          "markdownDescription": "Enable developer mode to show debugging tools, including debug buttons in views, the live struggle detection score, and the WebSocket connection status (with diagnostics on hover) in the status bar."
         },
         "artemis.defaultCommitMessage": {
           "type": "string",

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -69,7 +69,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
     private _updateVisibilitySetting(): void {
         const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
         this._isDevMode = config.get<boolean>(VSCODE_CONFIG.DEVELOPER_MODE_KEY, false);
-        this._applyVisibility();
+        this._updateStatusBarItem();
     }
 
     private _refreshStatus(): void {

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -141,21 +141,18 @@ export class WebSocketStatusBarService implements vscode.Disposable {
                 this._statusBarItem.text = this._isDevMode
                     ? '$(plug) WS Connected'
                     : '$(plug) Artemis: connected';
-                this._statusBarItem.tooltip = 'WebSocket connected. Click to reconnect.';
                 this._statusBarItem.backgroundColor = undefined;
                 break;
             case 'reconnecting':
                 this._statusBarItem.text = this._isDevMode
                     ? `$(sync~spin) WS Reconnecting (${attempts}/20)...`
                     : `$(sync~spin) Artemis: reconnecting (${attempts}/20)...`;
-                this._statusBarItem.tooltip = 'WebSocket reconnecting...';
                 this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
                 break;
             case 'connecting':
                 this._statusBarItem.text = this._isDevMode
                     ? '$(sync~spin) WS Connecting...'
                     : '$(sync~spin) Artemis: connecting...';
-                this._statusBarItem.tooltip = 'WebSocket connecting...';
                 this._statusBarItem.backgroundColor = undefined;
                 break;
             case 'disconnected':
@@ -163,10 +160,63 @@ export class WebSocketStatusBarService implements vscode.Disposable {
                 this._statusBarItem.text = this._isDevMode
                     ? '$(debug-disconnect) WS Disconnected'
                     : '$(debug-disconnect) Artemis: offline';
-                this._statusBarItem.tooltip = 'WebSocket disconnected. Click to reconnect.';
                 this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
                 break;
         }
+
+        this._statusBarItem.tooltip = this._buildTooltip();
+    }
+
+    private _buildTooltip(): string | vscode.MarkdownString {
+        if (this._isDevMode) {
+            return this._buildDevTooltip();
+        }
+        switch (this._currentStatus) {
+            case 'reconnecting': {
+                const md = new vscode.MarkdownString();
+                const attempts = this._websocketService.reconnectAttempts;
+                md.appendMarkdown(
+                    `**Reconnecting to Artemis... (${attempts}/20)**\n\n`
+                    + `Live updates are paused and will resume automatically.`
+                );
+                return md;
+            }
+            case 'disconnected': {
+                const md = new vscode.MarkdownString();
+                md.appendMarkdown(
+                    `**Connection to Artemis lost**\n\n`
+                    + `Live updates (build results, submission status, Iris) are paused.\n\n`
+                    + `Click to reconnect. If it keeps failing, check your internet connection or sign in again.`
+                );
+                return md;
+            }
+            case 'connecting':
+                return 'Connecting to Artemis...';
+            case 'connected':
+            default:
+                return 'Connected to Artemis. Click to reconnect.';
+        }
+    }
+
+    private _buildDevTooltip(): vscode.MarkdownString {
+        const d = this._websocketService.getDiagnostics();
+        const md = new vscode.MarkdownString();
+        md.appendMarkdown(`## WebSocket (dev)\n\n`);
+        md.appendMarkdown(`**Status:** ${this._currentStatus}\n\n`);
+        md.appendMarkdown(`**Connection:**\n`);
+        md.appendMarkdown(`- clientConnected: ${d.clientConnected}\n`);
+        md.appendMarkdown(`- clientActive: ${d.clientActive}\n`);
+        md.appendMarkdown(`- reconnect: ${d.reconnectAttempts}/${d.maxReconnectAttempts}\n\n`);
+        md.appendMarkdown(`**Subscriptions (${d.subscriptionCount}):**\n`);
+        if (d.subscriptions.length > 0) {
+            d.subscriptions.forEach(s => md.appendMarkdown(`- \`${s}\`\n`));
+        } else {
+            md.appendMarkdown(`- *none*\n`);
+        }
+        md.appendMarkdown(`\n**Session:** \`${d.sessionId}\`\n\n`);
+        md.appendMarkdown(`**Server:** \`${d.serverUrl}\`\n`);
+        md.appendMarkdown(`**WebSocket:** \`${d.websocketUrl}\`\n`);
+        return md;
     }
 
     private _clickInFlight = false;

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -134,27 +134,35 @@ export class WebSocketStatusBarService implements vscode.Disposable {
     private _updateStatusBarItem(): void {
         this._applyVisibility();
 
+        const attempts = this._websocketService.reconnectAttempts;
+
         switch (this._currentStatus) {
             case 'connected':
-                this._statusBarItem.text = '$(plug) WS Connected';
+                this._statusBarItem.text = this._isDevMode
+                    ? '$(plug) WS Connected'
+                    : '$(plug) Artemis: connected';
                 this._statusBarItem.tooltip = 'WebSocket connected. Click to reconnect.';
                 this._statusBarItem.backgroundColor = undefined;
                 break;
-            case 'reconnecting': {
-                const attempts = this._websocketService.reconnectAttempts;
-                this._statusBarItem.text = `$(sync~spin) Reconnecting (${attempts}/20)...`;
+            case 'reconnecting':
+                this._statusBarItem.text = this._isDevMode
+                    ? `$(sync~spin) WS Reconnecting (${attempts}/20)...`
+                    : `$(sync~spin) Artemis: reconnecting (${attempts}/20)...`;
                 this._statusBarItem.tooltip = 'WebSocket reconnecting...';
                 this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
                 break;
-            }
             case 'connecting':
-                this._statusBarItem.text = '$(sync~spin) WS Connecting...';
+                this._statusBarItem.text = this._isDevMode
+                    ? '$(sync~spin) WS Connecting...'
+                    : '$(sync~spin) Artemis: connecting...';
                 this._statusBarItem.tooltip = 'WebSocket connecting...';
                 this._statusBarItem.backgroundColor = undefined;
                 break;
             case 'disconnected':
             default:
-                this._statusBarItem.text = '$(debug-disconnect) WS Disconnected';
+                this._statusBarItem.text = this._isDevMode
+                    ? '$(debug-disconnect) WS Disconnected'
+                    : '$(debug-disconnect) Artemis: offline';
                 this._statusBarItem.tooltip = 'WebSocket disconnected. Click to reconnect.';
                 this._statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
                 break;

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -214,7 +214,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
             md.appendMarkdown(`- *none*\n`);
         }
         md.appendMarkdown(`\n**Session:** \`${d.sessionId}\`\n\n`);
-        md.appendMarkdown(`**Server:** \`${d.serverUrl}\`\n`);
+        md.appendMarkdown(`**Server:** \`${d.serverUrl}\`\n\n`);
         md.appendMarkdown(`**WebSocket:** \`${d.websocketUrl}\`\n`);
         return md;
     }

--- a/extension/src/extension/services/websocket/websocketStatusBar.ts
+++ b/extension/src/extension/services/websocket/websocketStatusBar.ts
@@ -11,18 +11,15 @@ import { ArtemisWebsocketService } from './artemisWebsocketService';
  * StatusBar item showing WebSocket connection status.
  *
  * Visibility rules:
- * - When logged out: hidden unless `artemis.showWebSocketStatusBar` is true
- *   (no WebSocket exists, so the default "needs attention on disconnect" rule
- *   would surface a misleading red error indicator)
- * - When logged in:
- *   - ALWAYS shown when disconnected or reconnecting
- *   - Otherwise shown only when `artemis.showWebSocketStatusBar` is true
- *   - After reconnection with setting off: 2s flash then hidden
+ * - developerMode ON: always shown (any state, including connected and while
+ *   logged out) — diagnostics.
+ * - developerMode OFF:
+ *   - shown when disconnected or reconnecting (a problem the user can act on)
+ *   - 2s flash after a successful reconnect, then hidden
+ *   - otherwise hidden (incl. logged out)
  *
- * Auth state is supplied externally via {@link setAuthenticated}; the service
- * does not own auth lifecycle.
- *
- * Click action: always reconnect (reset + connect). No-op while connecting.
+ * Auth state is supplied externally via {@link setAuthenticated}.
+ * Click action: reset + reconnect. No-op while connecting/reconnecting.
  */
 export class WebSocketStatusBarService implements vscode.Disposable {
     private readonly _statusBarItem: vscode.StatusBarItem;
@@ -30,7 +27,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
     private readonly _disposables: vscode.Disposable[] = [];
     private _stateSubscription?: vscode.Disposable;
     private _currentStatus: WebSocketDisplayStatus = 'disconnected';
-    private _showStatusBar = false;
+    private _isDevMode = false;
     private _isAuthenticated = false;
     private _reconnectHideTimeout?: ReturnType<typeof setTimeout>;
 
@@ -56,7 +53,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
 
         this._disposables.push(
             vscode.workspace.onDidChangeConfiguration(event => {
-                if (event.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.SHOW_WEBSOCKET_STATUS_BAR_KEY}`)) {
+                if (event.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.DEVELOPER_MODE_KEY}`)) {
                     this._updateVisibilitySetting();
                 }
             })
@@ -71,7 +68,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
 
     private _updateVisibilitySetting(): void {
         const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-        this._showStatusBar = config.get<boolean>(VSCODE_CONFIG.SHOW_WEBSOCKET_STATUS_BAR_KEY, false);
+        this._isDevMode = config.get<boolean>(VSCODE_CONFIG.DEVELOPER_MODE_KEY, false);
         this._applyVisibility();
     }
 
@@ -82,7 +79,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
         if (
             this._currentStatus === 'connected'
             && previousStatus === 'reconnecting'
-            && !this._showStatusBar
+            && !this._isDevMode
         ) {
             if (this._reconnectHideTimeout) {
                 clearTimeout(this._reconnectHideTimeout);
@@ -110,10 +107,8 @@ export class WebSocketStatusBarService implements vscode.Disposable {
     }
 
     private _applyVisibility(): void {
-        // Logged out: there is no WebSocket to surface a state for. Honor the
-        // explicit "always show" setting for diagnostics, otherwise hide.
         if (!this._isAuthenticated) {
-            if (this._showStatusBar) {
+            if (this._isDevMode) {
                 this._statusBarItem.show();
             } else {
                 this._statusBarItem.hide();
@@ -127,7 +122,7 @@ export class WebSocketStatusBarService implements vscode.Disposable {
 
         if (needsAttention) {
             this._statusBarItem.show();
-        } else if (this._showStatusBar) {
+        } else if (this._isDevMode) {
             this._statusBarItem.show();
         } else if (this._reconnectHideTimeout) {
             this._statusBarItem.show();

--- a/extension/src/extension/utils/constants.ts
+++ b/extension/src/extension/utils/constants.ts
@@ -34,7 +34,6 @@ export const VSCODE_CONFIG = {
     DEFAULT_CLONE_PATH_KEY: 'defaultClonePath',
     SHOW_SET_DEFAULT_CLONE_PATH_PROMPT_KEY: 'showSetDefaultClonePathPrompt',
     DEVELOPER_MODE_KEY: 'developerMode',
-    SHOW_WEBSOCKET_STATUS_BAR_KEY: 'showWebSocketStatusBar',
     START_PAGE_KEY: 'startPage',
     SHOW_START_PAGE_SUGGESTION_KEY: 'showStartPageSuggestion',
     DATA_COLLECTION_CONSENT_KEY: 'dataCollectionConsent',

--- a/extension/test/unit/services/websocketStatusBar.test.ts
+++ b/extension/test/unit/services/websocketStatusBar.test.ts
@@ -101,6 +101,17 @@ suite('WebSocketStatusBarService', () => {
             disconnect: sandbox.stub().resolves(),
             resetConnectionState: sandbox.stub(),
             reconnectAttempts: 0,
+            getDiagnostics: sandbox.stub().returns({
+                clientConnected: false,
+                clientActive: false,
+                subscriptionCount: 2,
+                subscriptions: ['/user/topic/results', '/user/topic/submissions'],
+                reconnectAttempts: 0,
+                maxReconnectAttempts: 20,
+                sessionId: 'test-session-id',
+                serverUrl: 'https://artemis.test',
+                websocketUrl: 'wss://artemis.test/ws',
+            }),
         } as unknown as sinon.SinonStubbedInstance<ArtemisWebsocketService> & { reconnectAttempts: number };
 
         driveState = (status, isConnected = status === 'connected', wasEverConnected = status === 'reconnecting' || status === 'connected') => {
@@ -438,6 +449,50 @@ suite('WebSocketStatusBarService', () => {
                 !mockStatusBarItem.show.called && !mockStatusBarItem.hide.called,
                 'setAuthenticated with unchanged value must not trigger show/hide'
             );
+        });
+    });
+
+    suite('tooltip tiers', () => {
+        function tooltipValue(): string {
+            const t = mockStatusBarItem.tooltip;
+            return typeof t === 'string' ? t : (t?.value ?? '');
+        }
+
+        test('normal mode disconnected tooltip explains the impact', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('disconnected');
+            assert.ok(tooltipValue().includes('Connection to Artemis lost'), `got: ${tooltipValue()}`);
+            assert.ok(tooltipValue().includes('Live updates'), `got: ${tooltipValue()}`);
+        });
+
+        test('normal mode reconnecting tooltip reassures', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('reconnecting');
+            assert.ok(tooltipValue().includes('Reconnecting to Artemis'), `got: ${tooltipValue()}`);
+        });
+
+        test('normal mode connected tooltip is the simple one-liner', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('connected');
+            assert.ok(
+                tooltipValue().includes('Connected to Artemis. Click to reconnect.'),
+                `got: ${tooltipValue()}`
+            );
+        });
+
+        test('dev mode tooltip shows full diagnostics', () => {
+            configValues.developerMode = true;
+            createService();
+            driveState('connected');
+            const v = tooltipValue();
+            assert.ok(v.includes('artemis.test'), `serverUrl, got: ${v}`);
+            assert.ok(v.includes('wss://artemis.test/ws'), `websocketUrl, got: ${v}`);
+            assert.ok(v.includes('test-session-id'), `sessionId, got: ${v}`);
+            assert.ok(v.includes('/user/topic/results'), `subscription topic, got: ${v}`);
+            assert.ok(v.includes('0/20'), `reconnect counts, got: ${v}`);
         });
     });
 

--- a/extension/test/unit/services/websocketStatusBar.test.ts
+++ b/extension/test/unit/services/websocketStatusBar.test.ts
@@ -457,4 +457,41 @@ suite('WebSocketStatusBarService', () => {
             );
         });
     });
+
+    suite('normal mode labels', () => {
+        test('normal mode connected shows "Artemis: connected"', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('connected');
+            assert.ok(
+                mockStatusBarItem.text.includes('Artemis: connected'),
+                `Expected "Artemis: connected", got: ${mockStatusBarItem.text}`
+            );
+        });
+
+        test('normal mode disconnected shows "Artemis: offline"', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('disconnected');
+            assert.ok(
+                mockStatusBarItem.text.includes('Artemis: offline'),
+                `Expected "Artemis: offline", got: ${mockStatusBarItem.text}`
+            );
+        });
+
+        test('normal mode reconnecting shows "Artemis: reconnecting (N/20)"', () => {
+            configValues.developerMode = false;
+            mockWsService.reconnectAttempts = 2;
+            createService();
+            driveState('reconnecting');
+            assert.ok(
+                mockStatusBarItem.text.includes('Artemis: reconnecting'),
+                `Expected "Artemis: reconnecting", got: ${mockStatusBarItem.text}`
+            );
+            assert.ok(
+                mockStatusBarItem.text.includes('2/20'),
+                `Expected "2/20", got: ${mockStatusBarItem.text}`
+            );
+        });
+    });
 });

--- a/extension/test/unit/services/websocketStatusBar.test.ts
+++ b/extension/test/unit/services/websocketStatusBar.test.ts
@@ -209,6 +209,80 @@ suite('WebSocketStatusBarService', () => {
 
             assert.ok(mockStatusBarItem.show.called, 'enabling developerMode shows the item while connected');
         });
+
+        test('enabling developerMode while connected re-renders text and tooltip immediately (no driveState)', () => {
+            // Start in student mode + connected
+            configValues.developerMode = false;
+            createService();
+            driveState('connected');
+
+            // Verify student label is showing
+            assert.ok(
+                mockStatusBarItem.text.includes('Artemis: connected'),
+                `precondition: expected student label, got: ${mockStatusBarItem.text}`
+            );
+
+            // Toggle developerMode on via config change — no intervening driveState
+            configValues.developerMode = true;
+            capturedConfigCallback({
+                affectsConfiguration: (section: string) => section === 'artemis.developerMode',
+            } as vscode.ConfigurationChangeEvent);
+
+            // Text must switch to dev label immediately
+            assert.ok(
+                mockStatusBarItem.text.includes('WS Connected'),
+                `expected "WS Connected" after enabling devMode, got: ${mockStatusBarItem.text}`
+            );
+            assert.ok(
+                !mockStatusBarItem.text.includes('Artemis: connected'),
+                `student label must be gone after enabling devMode, got: ${mockStatusBarItem.text}`
+            );
+
+            // Tooltip must switch to dev diagnostics (MarkdownString with serverUrl)
+            const tooltip = mockStatusBarItem.tooltip;
+            const tooltipText = typeof tooltip === 'string' ? tooltip : (tooltip?.value ?? '');
+            assert.ok(
+                tooltipText.includes('artemis.test'),
+                `expected dev tooltip with serverUrl after enabling devMode, got: ${tooltipText}`
+            );
+        });
+
+        test('disabling developerMode while disconnected re-renders text and tooltip immediately (no driveState)', () => {
+            // Start in dev mode + disconnected
+            configValues.developerMode = true;
+            createService();
+            driveState('disconnected');
+
+            // Verify dev label is showing
+            assert.ok(
+                mockStatusBarItem.text.includes('WS Disconnected'),
+                `precondition: expected dev label, got: ${mockStatusBarItem.text}`
+            );
+
+            // Toggle developerMode off via config change — no intervening driveState
+            configValues.developerMode = false;
+            capturedConfigCallback({
+                affectsConfiguration: (section: string) => section === 'artemis.developerMode',
+            } as vscode.ConfigurationChangeEvent);
+
+            // Text must switch to student label immediately
+            assert.ok(
+                mockStatusBarItem.text.includes('Artemis: offline'),
+                `expected "Artemis: offline" after disabling devMode, got: ${mockStatusBarItem.text}`
+            );
+            assert.ok(
+                !mockStatusBarItem.text.includes('WS Disconnected'),
+                `dev label must be gone after disabling devMode, got: ${mockStatusBarItem.text}`
+            );
+
+            // Tooltip must switch to student disconnected message
+            const tooltip = mockStatusBarItem.tooltip;
+            const tooltipText = typeof tooltip === 'string' ? tooltip : (tooltip?.value ?? '');
+            assert.ok(
+                tooltipText.includes('Connection to Artemis lost'),
+                `expected student tooltip after disabling devMode, got: ${tooltipText}`
+            );
+        });
     });
 
     suite('status text', () => {
@@ -493,6 +567,32 @@ suite('WebSocketStatusBarService', () => {
             assert.ok(v.includes('test-session-id'), `sessionId, got: ${v}`);
             assert.ok(v.includes('/user/topic/results'), `subscription topic, got: ${v}`);
             assert.ok(v.includes('0/20'), `reconnect counts, got: ${v}`);
+        });
+
+        test('dev mode tooltip with zero subscriptions shows "Subscriptions (0)" and "none"', () => {
+            configValues.developerMode = true;
+            (mockWsService.getDiagnostics as sinon.SinonStub).returns({
+                clientConnected: false,
+                clientActive: false,
+                subscriptionCount: 0,
+                subscriptions: [],
+                reconnectAttempts: 0,
+                maxReconnectAttempts: 20,
+                sessionId: 'test-session-id',
+                serverUrl: 'https://artemis.test',
+                websocketUrl: 'wss://artemis.test/ws',
+            });
+
+            createService();
+            driveState('connected');
+
+            assert.ok(
+                mockStatusBarItem.tooltip instanceof vscode.MarkdownString,
+                'dev tooltip must be a MarkdownString'
+            );
+            const v = tooltipValue();
+            assert.ok(v.includes('Subscriptions (0)'), `expected "Subscriptions (0)", got: ${v}`);
+            assert.ok(v.includes('none'), `expected "none" for empty subscriptions, got: ${v}`);
         });
     });
 

--- a/extension/test/unit/services/websocketStatusBar.test.ts
+++ b/extension/test/unit/services/websocketStatusBar.test.ts
@@ -11,7 +11,7 @@ import { WebSocketStatusBarService } from '@extension/services/websocket/websock
  * Tests for WebSocketStatusBarService visibility logic.
  *
  * Uses sinon stubs to control:
- * - vscode.workspace.getConfiguration (controls showWebSocketStatusBar / developerMode)
+ * - vscode.workspace.getConfiguration (controls developerMode)
  * - vscode.window.createStatusBarItem (captures mock status bar item)
  * - vscode.commands.registerCommand (returns a no-op disposable)
  * - ArtemisWebsocketService (mock with captured onDidChangeConnectionState callback)
@@ -23,6 +23,7 @@ suite('WebSocketStatusBarService', () => {
     let sandbox: sinon.SinonSandbox;
     let mockWsService: sinon.SinonStubbedInstance<ArtemisWebsocketService> & { reconnectAttempts: number };
     let capturedCallback: (isConnected: boolean, wasEverConnected?: boolean) => void;
+    let capturedConfigCallback: (e: vscode.ConfigurationChangeEvent) => void = () => {};
     /**
      * Drive the mock through a (status, isConnected, wasEverConnected) tuple
      * and fire the captured callback so the status bar pulls the new value
@@ -45,7 +46,6 @@ suite('WebSocketStatusBarService', () => {
 
         // Default config values
         configValues = {
-            showWebSocketStatusBar: false,
             developerMode: false,
         };
 
@@ -74,8 +74,11 @@ suite('WebSocketStatusBarService', () => {
         };
         sandbox.stub(vscode.workspace, 'getConfiguration').returns(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-        // Stub onDidChangeConfiguration
-        sandbox.stub(vscode.workspace, 'onDidChangeConfiguration').returns({ dispose: () => {} } as vscode.Disposable);
+        // capture the configuration-change listener so a test can fire it
+        sandbox.stub(vscode.workspace, 'onDidChangeConfiguration').callsFake((cb) => {
+            capturedConfigCallback = cb as (e: vscode.ConfigurationChangeEvent) => void;
+            return { dispose: () => {} } as vscode.Disposable;
+        });
 
         // Stub registerCommand
         sandbox.stub(vscode.commands, 'registerCommand').callsFake(() => {
@@ -120,34 +123,27 @@ suite('WebSocketStatusBarService', () => {
     }
 
     suite('visibility', () => {
-        test('hidden when showWebSocketStatusBar=false and connected', () => {
-            configValues.showWebSocketStatusBar = false;
+        test('hidden when developerMode=false and connected', () => {
             configValues.developerMode = false;
-
             createService();
-
-            // Simulate connected
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
             driveState('connected');
-
-            // Should be hidden (setting is off, not disconnected/reconnecting)
-            assert.ok(mockStatusBarItem.hide.called, 'Status bar should be hidden when setting is off and connected');
+            assert.ok(mockStatusBarItem.hide.called, 'Hidden when developerMode off and connected');
+            assert.ok(!mockStatusBarItem.show.called, 'Not shown when developerMode off and connected');
         });
 
-        test('shown when showWebSocketStatusBar=true and connected', () => {
-            configValues.showWebSocketStatusBar = true;
-            configValues.developerMode = false;
-
+        test('shown when developerMode=true and connected', () => {
+            configValues.developerMode = true;
             createService();
-
-            // Simulate connected
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
             driveState('connected');
-
-            // Should be shown (setting is on)
-            assert.ok(mockStatusBarItem.show.called, 'Status bar should be shown when setting is on and connected');
+            assert.ok(mockStatusBarItem.show.called, 'Shown when developerMode on and connected');
+            assert.ok(!mockStatusBarItem.hide.called, 'Not hidden when developerMode on and connected');
         });
 
-        test('ALWAYS shown when disconnected (override rule ignores showWebSocketStatusBar)', () => {
-            configValues.showWebSocketStatusBar = false;
+        test('ALWAYS shown when disconnected (override rule ignores developerMode)', () => {
             configValues.developerMode = false;
 
             createService();
@@ -162,8 +158,7 @@ suite('WebSocketStatusBarService', () => {
             assert.ok(!mockStatusBarItem.hide.called, 'Status bar must NOT be hidden when disconnected');
         });
 
-        test('ALWAYS shown when reconnecting (override rule ignores showWebSocketStatusBar)', () => {
-            configValues.showWebSocketStatusBar = false;
+        test('ALWAYS shown when reconnecting (override rule ignores developerMode)', () => {
             configValues.developerMode = false;
 
             createService();
@@ -176,8 +171,7 @@ suite('WebSocketStatusBarService', () => {
             assert.ok(mockStatusBarItem.show.called, 'Status bar MUST be shown when reconnecting regardless of setting');
         });
 
-        test('ALWAYS shown when retries are exhausted (override rule ignores showWebSocketStatusBar)', () => {
-            configValues.showWebSocketStatusBar = false;
+        test('ALWAYS shown when retries are exhausted (override rule ignores developerMode)', () => {
             configValues.developerMode = false;
 
             createService();
@@ -189,11 +183,26 @@ suite('WebSocketStatusBarService', () => {
 
             assert.ok(mockStatusBarItem.show.called, 'Status bar MUST be shown when retries are exhausted');
         });
+
+        test('reacts to developerMode configuration change', () => {
+            configValues.developerMode = false;
+            createService();
+            driveState('connected');
+            mockStatusBarItem.show.resetHistory();
+            mockStatusBarItem.hide.resetHistory();
+
+            configValues.developerMode = true;
+            capturedConfigCallback({
+                affectsConfiguration: (section: string) => section === 'artemis.developerMode',
+            } as vscode.ConfigurationChangeEvent);
+
+            assert.ok(mockStatusBarItem.show.called, 'enabling developerMode shows the item while connected');
+        });
     });
 
     suite('status text', () => {
         test('connected shows "$(plug) WS Connected"', () => {
-            configValues.showWebSocketStatusBar = true;
+            configValues.developerMode = true;
 
             createService();
             driveState('connected');
@@ -209,9 +218,7 @@ suite('WebSocketStatusBarService', () => {
         });
 
         test('reconnecting shows "$(sync~spin) Reconnecting (N/20)..."', () => {
-            configValues.showWebSocketStatusBar = false;
-
-            // Set reconnect attempt count
+            configValues.developerMode = true;
             mockWsService.reconnectAttempts = 3;
 
             createService();
@@ -232,7 +239,7 @@ suite('WebSocketStatusBarService', () => {
         });
 
         test('disconnected shows "$(debug-disconnect) WS Disconnected"', () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = true;
 
             createService();
             driveState('disconnected');
@@ -270,7 +277,7 @@ suite('WebSocketStatusBarService', () => {
 
     suite('reconnect flash', () => {
         test('after reconnection with setting off, hides after 2s timeout', async () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
             const clock = sandbox.useFakeTimers();
 
             try {
@@ -296,22 +303,16 @@ suite('WebSocketStatusBarService', () => {
             }
         });
 
-        test('when setting is on, does not hide after reconnection', async () => {
-            configValues.showWebSocketStatusBar = true;
+        test('with developerMode on, does not hide after a reconnection', () => {
+            configValues.developerMode = true;
             const clock = sandbox.useFakeTimers();
-
             try {
                 createService();
+                driveState('reconnecting');
                 mockStatusBarItem.hide.resetHistory();
-
-                // Simulate successful reconnect
                 driveState('connected');
-
-                // Advance past timeout
                 clock.tick(3000);
-
-                // Should NOT be hidden since setting is on
-                assert.ok(!mockStatusBarItem.hide.called, 'Should not hide when setting is on');
+                assert.ok(!mockStatusBarItem.hide.called, 'developerMode keeps the item visible through a reconnect');
             } finally {
                 clock.restore();
             }
@@ -327,7 +328,7 @@ suite('WebSocketStatusBarService', () => {
         });
 
         test('dispose clears reconnect hide timeout', () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
             const clock = sandbox.useFakeTimers();
 
             try {
@@ -352,8 +353,8 @@ suite('WebSocketStatusBarService', () => {
     });
 
     suite('authentication gate', () => {
-        test('logged out + setting off + state disconnected → hidden', () => {
-            configValues.showWebSocketStatusBar = false;
+        test('logged out + developerMode off + state disconnected → hidden', () => {
+            configValues.developerMode = false;
 
             createService(false);
             mockStatusBarItem.show.resetHistory();
@@ -363,16 +364,16 @@ suite('WebSocketStatusBarService', () => {
 
             assert.ok(
                 mockStatusBarItem.hide.called,
-                'Status bar must be hidden when logged out and setting is off, even with disconnected state'
+                'Hidden when logged out and developerMode off'
             );
             assert.ok(
                 !mockStatusBarItem.show.called,
-                'Status bar must NOT be shown when logged out and setting is off'
+                'Not shown when logged out and developerMode off'
             );
         });
 
-        test('logged out + setting on + state disconnected → shown', () => {
-            configValues.showWebSocketStatusBar = true;
+        test('logged out + developerMode on + state disconnected → shown', () => {
+            configValues.developerMode = true;
 
             createService(false);
             mockStatusBarItem.show.resetHistory();
@@ -382,12 +383,12 @@ suite('WebSocketStatusBarService', () => {
 
             assert.ok(
                 mockStatusBarItem.show.called,
-                'Status bar must be shown when logged out but setting is explicitly on'
+                'Shown when logged out but developerMode on'
             );
         });
 
         test('logged out → logged in transition re-applies visibility (logged-in rules return)', () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
 
             const service = createService(false);
             driveState('disconnected');
@@ -397,7 +398,7 @@ suite('WebSocketStatusBarService', () => {
             // Transition: user logs in
             service.setAuthenticated(true);
 
-            // With setting off + logged in + state disconnected → needs attention → show
+            // With developerMode off + logged in + state disconnected → needs attention → show
             assert.ok(
                 mockStatusBarItem.show.called,
                 'After login, logged-in visibility rules must take over (disconnected → show)'
@@ -405,7 +406,7 @@ suite('WebSocketStatusBarService', () => {
         });
 
         test('logged in → logged out transition re-applies visibility (statusbar hides)', () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
 
             const service = createService(true);
             driveState('disconnected');
@@ -423,7 +424,7 @@ suite('WebSocketStatusBarService', () => {
         });
 
         test('setAuthenticated is idempotent (same value is a no-op)', () => {
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
 
             const service = createService(true);
             driveState('disconnected');
@@ -444,7 +445,7 @@ suite('WebSocketStatusBarService', () => {
         test('reconnectAttempts getter returns the internal counter value', () => {
             // This tests that the getter is accessible on the service
             // We test via the status bar text which reads reconnectAttempts
-            configValues.showWebSocketStatusBar = false;
+            configValues.developerMode = false;
             mockWsService.reconnectAttempts = 7;
 
             createService();


### PR DESCRIPTION
## Summary

Redesigns the WebSocket connection status bar item so it serves students by default and developers on demand. Removes the `artemis.showWebSocketStatusBar` setting and gates visibility on `artemis.developerMode` instead.

## What changed

- **Visibility gated on `developerMode`** (the `artemis.showWebSocketStatusBar` setting is gone):
  - Default (student): the item is hidden while connected and only appears when there is a problem (disconnected / reconnecting), plus a brief 2s "connected" flash after a recovery.
  - Developer mode: always visible in every state (including connected and while logged out).
- **Two-tier label:** plain language for students (`Artemis: connected` / `Artemis: offline` / `Artemis: reconnecting (n/20)`), technical for developers (`WS Connected` / `WS Disconnected` / ...).
- **Three-tier hover tooltip:** plain-language help for students (impact plus how to recover), full diagnostics for developers (connection flags, reconnect counter, subscriptions, session, server and WebSocket URLs).
- **Live re-render** of label and tooltip when `developerMode` is toggled, no reload needed.
- **Click action:** reset and reconnect (no-op while connecting / reconnecting).

## Notes

- Version bumped to `0.4.9-dev`.
- Changelog entry is under `[Unreleased]`.
- Dev tooltip: Server and WebSocket URLs now render on separate lines.

## Testing

- `npm run check-types` and `eslint`: clean.
- Unit tests: 1641 passing, 0 failures (includes the `WebSocketStatusBarService` suite: visibility rules, student/dev labels, tooltip tiers, dev-mode toggle re-render, auth gating).
- Manually verified in the Extension Development Host against `artemis.tum.de`: student vs developer label and tooltip switching, and the dev diagnostics tooltip.

Closes #320
