### PR TITLE
fix(auth): auto-logout on server URL change, remove redundant Clear Credentials prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 ### Changed
 
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
+- **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
 
 ## [0.4.8] - 2026-06-24
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -22,7 +22,7 @@ import {
     detectPlatformCapabilities,
     initializeTheiaContext,
 } from '@extension/theia';
-import { VSCODE_CONFIG } from '@extension/utils';
+import { resolveServerUrl, VSCODE_CONFIG } from '@extension/utils';
 import { wireDataCollection } from '@dataCollection';
 import { createTelemetryManager } from '@telemetry';
 
@@ -232,9 +232,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		contextStore,
 	});
 
-	// Configuration listener
+	// Configuration listener for the Artemis server URL.
 	if (theiaEnv.isManagedEnvironment) {
-		// In managed Theia environments, revert unauthorized changes to locked settings
+		// In managed Theia environments, revert unauthorized changes to the locked setting.
 		context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
 			if (event.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.SERVER_URL_KEY}`) && theiaEnv.artemisUrl) {
 				const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
@@ -243,26 +243,31 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 		}));
 	} else {
-		// In VS Code: prompt user to clear credentials when server URL changes
-		context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.SERVER_URL_KEY}`)) {
-				logger.info('Artemis server URL configuration changed', LogCategory.CONFIG);
-				const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-				const newServerUrl = config.get<string>(VSCODE_CONFIG.SERVER_URL_KEY);
-				if (newServerUrl) {
-					vscode.window.showInformationMessage(
-						`Artemis server URL updated to: ${newServerUrl}. You may need to log in again if you were authenticated to a different server.`,
-						'Clear Credentials'
-					).then(selection => {
-						if (selection === 'Clear Credentials') {
-							authManager.clear().then(async () => {
-								await updateAuthContext(false);
-								vscode.window.showInformationMessage('Stored credentials cleared. Please log in again.');
-								artemisWebviewProvider.showLogin();
-							});
-						}
-					});
+		// On Desktop the server URL is freely configurable. When it actually changes
+		// while the user is logged in, clear the stored credentials and return to the
+		// login view: a token issued by the previous server is not valid on a different
+		// one. The last URL is tracked so a no-op settings save does not log the user out.
+		let lastServerUrl = resolveServerUrl();
+		context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async event => {
+			if (!event.affectsConfiguration(`${VSCODE_CONFIG.ARTEMIS_SECTION}.${VSCODE_CONFIG.SERVER_URL_KEY}`)) {
+				return;
+			}
+			const newServerUrl = resolveServerUrl();
+			if (newServerUrl === lastServerUrl) {
+				return;
+			}
+			lastServerUrl = newServerUrl;
+			try {
+				if (!(await authManager.hasAuthToken())) {
+					return;
 				}
+				logger.info('Artemis server URL changed; clearing credentials stored for the previous server', LogCategory.CONFIG);
+				await authManager.clear();
+				await updateAuthContext(false);
+				artemisWebviewProvider.showLogin();
+				vscode.window.showInformationMessage('Artemis server changed. Please log in again.');
+			} catch (error) {
+				logger.error('Failed to clear credentials after server URL change', LogCategory.AUTH, error);
 			}
 		}));
 	}

--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -380,7 +380,7 @@ export class ArtemisApiService {
         }
 
         // Store as cookie string — Desktop auth sends Cookie header, not Bearer
-        await this.authManager.storeArtemisCredentials(jwtCookie, this.getServerUrl(), rememberMe);
+        await this.authManager.storeArtemisCredentials(jwtCookie, rememberMe);
 
         return { success: true };
     }

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -235,7 +235,6 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
             {
                 onAuthenticated: (userInfo) => this._navigationFacade.navigateToStartPage(userInfo),
                 hideLoadingAndSendServerUrl: () => this._navigationFacade.hideLoadingAndSendServerUrl(),
-                showLogin: () => this._navigationFacade.showLogin(),
             },
         );
 
@@ -297,9 +296,6 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         this._messageHandler.setMessageSender((message: ExtensionToWebviewMessage) => {
             this._postMessageSafe(message);
         });
-
-        // Check if server URL has changed and clear credentials if needed
-        this._authFlowHandler.checkServerUrlChange();
 
         // Check for existing authentication and auto-login if valid
         this._authFlowHandler.checkExistingAuthentication();

--- a/extension/src/extension/services/auth/authFlowHandler.ts
+++ b/extension/src/extension/services/auth/authFlowHandler.ts
@@ -1,14 +1,11 @@
-import * as vscode from 'vscode';
-
 import type { ExtensionToWebviewMessage } from '@shared/messageContracts';
 import { ExtensionMsg } from '@shared/messageContracts';
 
 import { ArtemisApiService } from '@extension/api';
 import type { UserInfo } from '@extension/controller/appStateManager';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import { getTheiaEnvironment } from '@extension/theia';
 import { ApiError } from '@extension/types';
-import { CONFIG, resolveServerUrl, VSCODE_CONFIG } from '@extension/utils';
+import { resolveServerUrl } from '@extension/utils';
 
 import { AuthManager } from './authManager';
 
@@ -21,37 +18,8 @@ export class AuthFlowHandler {
         private readonly _callbacks: {
             onAuthenticated: (userInfo: UserInfo) => Promise<void>;
             hideLoadingAndSendServerUrl: () => void;
-            showLogin: () => void;
         },
     ) {}
-
-    public async checkServerUrlChange(): Promise<void> {
-        // In Theia, the server URL is environment-managed — skip change detection
-        if (getTheiaEnvironment().isTheia) { return; }
-
-        try {
-            const hasAuth = await this._authManager.hasAuthToken();
-            if (hasAuth) {
-                const isServerUrlChanged = await this._authManager.isServerUrlChanged(resolveServerUrl());
-                if (isServerUrlChanged) {
-                    const config = vscode.workspace.getConfiguration(VSCODE_CONFIG.ARTEMIS_SECTION);
-                    const currentServerUrl = config.get<string>(VSCODE_CONFIG.SERVER_URL_KEY, CONFIG.ARTEMIS_SERVER_URL_DEFAULT);
-
-                    vscode.window.showWarningMessage(
-                        `The Artemis server URL has changed to ${currentServerUrl}. Your stored credentials may no longer be valid.`,
-                        'Clear Credentials',
-                        'Keep Credentials'
-                    ).then(selection => {
-                        if (selection === 'Clear Credentials') {
-                            this._callbacks.showLogin();
-                        }
-                    });
-                }
-            }
-        } catch (error) {
-            logger.error('Error checking server URL change', LogCategory.AUTH, error);
-        }
-    }
 
     public async checkExistingAuthentication(): Promise<void> {
         try {

--- a/extension/src/extension/services/auth/authManager.ts
+++ b/extension/src/extension/services/auth/authManager.ts
@@ -32,26 +32,6 @@ export class AuthManager {
     }
 
     /**
-     * Returns the server URL that was active at the time of last successful login.
-     * Used exclusively for URL-change detection: if the user changes their
-     * `artemis.serverUrl` setting after login, stored credentials may be stale.
-     * The live server URL is always resolved via `resolveServerUrl()`.
-     */
-    public async getStoredLoginServerUrl(): Promise<string | undefined> {
-        return await this.context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_SERVER_URL);
-    }
-
-    /**
-     * Checks whether the user changed the server URL since their last login.
-     * @param currentUrl The currently resolved server URL from settings/env.
-     */
-    public async isServerUrlChanged(currentUrl: string): Promise<boolean> {
-        const storedUrl = await this.getStoredLoginServerUrl();
-        if (!storedUrl) { return false; }
-        return storedUrl !== currentUrl;
-    }
-
-    /**
      * Returns the raw JWT string (without any "jwt=" cookie prefix), suitable
      * for use in a `Cookie: jwt=<value>` or `Authorization: Bearer <value>` header.
      *
@@ -98,11 +78,10 @@ export class AuthManager {
         return { 'Cookie': token };
     }
 
-    public async storeArtemisCredentials(token: string, serverUrl: string, persist: boolean): Promise<void> {
+    public async storeArtemisCredentials(token: string, persist: boolean): Promise<void> {
         this.memoryToken = token;
         if (persist) {
             await this.context.secrets.store(CONFIG.SECRET_KEYS.ARTEMIS_TOKEN, token);
-            await this.context.secrets.store(CONFIG.SECRET_KEYS.ARTEMIS_SERVER_URL, serverUrl);
         }
     }
 
@@ -110,7 +89,6 @@ export class AuthManager {
         this.memoryToken = undefined;
         try {
             await this.context.secrets.delete(CONFIG.SECRET_KEYS.ARTEMIS_TOKEN);
-            await this.context.secrets.delete(CONFIG.SECRET_KEYS.ARTEMIS_SERVER_URL);
         } catch (err) {
             logger.error('Failed to clear auth credentials from secrets:', LogCategory.AUTH, err);
         }

--- a/extension/src/extension/theia/theiaAuthProvider.ts
+++ b/extension/src/extension/theia/theiaAuthProvider.ts
@@ -31,7 +31,6 @@ export async function authenticateFromEnvironment(
     // Store raw JWT in memory only — never persist ENV tokens to SecretStorage
     await authManager.storeArtemisCredentials(
         theiaEnv.artemisToken,
-        theiaEnv.artemisUrl,
         false,
     );
 

--- a/extension/src/extension/utils/constants.ts
+++ b/extension/src/extension/utils/constants.ts
@@ -4,7 +4,6 @@ export const CONFIG = {
     AUTH_COOKIE_NAME: 'jwt',
     SECRET_KEYS: {
         ARTEMIS_TOKEN: 'artemis-auth-token',
-        ARTEMIS_SERVER_URL: 'artemis-server-url',
     },
     WEBVIEW: {
         VIEW_TYPE: 'artemis.loginView',

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -611,8 +611,6 @@ suite('Artemis API Service Test Suite', () => {
         await apiService.markMessageHelpful(sessionId, messageId, true);
     });
 
-    // isServerUrlChanged moved to AuthManager — tested in authManager.test.ts
-
     test('should fallback to creating VCS token when none exists', async () => {
         const participationId = 9;
         let attempt = 0;

--- a/extension/test/unit/services/artemisWebsocketService.test.ts
+++ b/extension/test/unit/services/artemisWebsocketService.test.ts
@@ -147,7 +147,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
         wsService = new TestableArtemisWebsocketService(authManager);
 
         // Mock auth
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
 
         // Track state changes via EventEmitter (no immediate replay on subscribe)
         const states: boolean[] = [];
@@ -176,7 +176,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('should subscribe to topics and receive messages', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         const p = wsService.connect();
         await flushMicrotasks();
         wsService.mockClient!.simulateConnect();
@@ -218,7 +218,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('should handle disconnection', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         const p = wsService.connect();
         await flushMicrotasks();
         wsService.mockClient!.simulateConnect();
@@ -234,7 +234,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('should handle STOMP errors', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         const p = wsService.connect();
         await flushMicrotasks();
         wsService.mockClient!.simulateConnect();
@@ -263,7 +263,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('should connect when disconnected', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
 
         // Not connected yet
         assert.strictEqual(wsService.isConnected(), false);
@@ -285,7 +285,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('should subscribe to Iris session and receive messages', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         const p = wsService.connect();
         await flushMicrotasks();
         wsService.mockClient!.simulateConnect();
@@ -332,7 +332,7 @@ suite('Artemis WebSocket Service Test Suite', () => {
 
     test('stale unsubscribe should not remove active subscription', async () => {
         wsService = new TestableArtemisWebsocketService(authManager);
-        await authManager.storeArtemisCredentials('jwt=token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         const p = wsService.connect();
         await flushMicrotasks();
         wsService.mockClient!.simulateConnect();

--- a/extension/test/unit/services/auth/authFlowHandler.test.ts
+++ b/extension/test/unit/services/auth/authFlowHandler.test.ts
@@ -34,7 +34,6 @@ suite('AuthFlowHandler.checkExistingAuthentication', () => {
             {
                 onAuthenticated: opts.onAuthenticated ?? (async (info) => { state.authenticatedWith = info; }),
                 hideLoadingAndSendServerUrl: () => { state.hideCalled = true; },
-                showLogin: () => { /* noop */ },
             },
         );
         return { handler, state };

--- a/extension/test/unit/services/auth/authManager.test.ts
+++ b/extension/test/unit/services/auth/authManager.test.ts
@@ -16,15 +16,12 @@ suite('AuthManager Test Suite', () => {
 
     test('should store and retrieve credentials', async () => {
         const jwt = 'jwt=12345';
-        const url = 'https://artemis.example.com';
 
-        await authManager.storeArtemisCredentials(jwt, url, true);
+        await authManager.storeArtemisCredentials(jwt, true);
 
         const storedJwt = await context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_TOKEN);
-        const storedUrl = await context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_SERVER_URL);
 
         assert.strictEqual(storedJwt, jwt);
-        assert.strictEqual(storedUrl, url);
 
         const headers = await authManager.getAuthHeaders();
         assert.deepStrictEqual(headers, { 'Cookie': jwt });
@@ -32,23 +29,19 @@ suite('AuthManager Test Suite', () => {
 
     test('should clear credentials', async () => {
         const jwt = 'jwt=12345';
-        const url = 'https://artemis.example.com';
 
-        await authManager.storeArtemisCredentials(jwt, url, true);
+        await authManager.storeArtemisCredentials(jwt, true);
         await authManager.clear();
 
         const storedJwt = await context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_TOKEN);
-        const storedUrl = await context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_SERVER_URL);
 
         assert.strictEqual(storedJwt, undefined);
-        assert.strictEqual(storedUrl, undefined);
     });
 
     test('should use memory token if not persisted', async () => {
         const jwt = 'jwt=memory';
-        const url = 'https://artemis.example.com';
 
-        await authManager.storeArtemisCredentials(jwt, url, false);
+        await authManager.storeArtemisCredentials(jwt, false);
 
         const storedJwt = await context.secrets.get(CONFIG.SECRET_KEYS.ARTEMIS_TOKEN);
         assert.strictEqual(storedJwt, undefined); // Should not be in secrets
@@ -59,7 +52,7 @@ suite('AuthManager Test Suite', () => {
 
     test('should return correct auth headers', async () => {
         const jwt = 'jwt=token';
-        await authManager.storeArtemisCredentials(jwt, 'url', false);
+        await authManager.storeArtemisCredentials(jwt, false);
 
         const headers = await authManager.getAuthHeaders();
         assert.deepStrictEqual(headers, { 'Cookie': jwt });
@@ -68,7 +61,7 @@ suite('AuthManager Test Suite', () => {
     test('should return Bearer headers when enableBearerAuth is called', async () => {
         const jwt = 'eyJhbGciOiJIUzI1NiJ9.raw-token';
         authManager.enableBearerAuth();
-        await authManager.storeArtemisCredentials(jwt, 'url', false);
+        await authManager.storeArtemisCredentials(jwt, false);
 
         const headers = await authManager.getAuthHeaders();
         assert.deepStrictEqual(headers, { 'Authorization': `Bearer ${jwt}` });
@@ -94,59 +87,15 @@ suite('AuthManager Test Suite', () => {
     });
 
     test('hasAuthToken returns true when only in-memory token is set', async () => {
-        await authManager.storeArtemisCredentials('jwt=memory', 'https://example.com', false);
+        await authManager.storeArtemisCredentials('jwt=memory', false);
         const result = await authManager.hasAuthToken();
         assert.strictEqual(result, true);
     });
 
     test('hasAuthToken returns false after clear', async () => {
-        await authManager.storeArtemisCredentials('jwt=token', 'https://example.com', true);
+        await authManager.storeArtemisCredentials('jwt=token', true);
         await authManager.clear();
         const result = await authManager.hasAuthToken();
-        assert.strictEqual(result, false);
-    });
-
-    // --- getStoredLoginServerUrl / isServerUrlChanged ---
-
-    test('getStoredLoginServerUrl returns undefined when not stored', async () => {
-        const result = await authManager.getStoredLoginServerUrl();
-        assert.strictEqual(result, undefined);
-    });
-
-    test('getStoredLoginServerUrl returns stored URL after persist', async () => {
-        const url = 'https://artemis.example.com';
-        await authManager.storeArtemisCredentials('jwt=token', url, true);
-        const result = await authManager.getStoredLoginServerUrl();
-        assert.strictEqual(result, url);
-    });
-
-    test('getStoredLoginServerUrl returns undefined when not persisted', async () => {
-        await authManager.storeArtemisCredentials('jwt=memory', 'https://example.com', false);
-        const result = await authManager.getStoredLoginServerUrl();
-        assert.strictEqual(result, undefined);
-    });
-
-    test('getStoredLoginServerUrl returns undefined after clear', async () => {
-        await authManager.storeArtemisCredentials('jwt=token', 'https://example.com', true);
-        await authManager.clear();
-        const result = await authManager.getStoredLoginServerUrl();
-        assert.strictEqual(result, undefined);
-    });
-
-    test('isServerUrlChanged returns false when no stored URL', async () => {
-        const result = await authManager.isServerUrlChanged('https://new.example.com');
-        assert.strictEqual(result, false);
-    });
-
-    test('isServerUrlChanged returns true when URL differs', async () => {
-        await authManager.storeArtemisCredentials('jwt=token', 'https://old.example.com', true);
-        const result = await authManager.isServerUrlChanged('https://new.example.com');
-        assert.strictEqual(result, true);
-    });
-
-    test('isServerUrlChanged returns false when URL matches', async () => {
-        await authManager.storeArtemisCredentials('jwt=token', 'https://same.example.com', true);
-        const result = await authManager.isServerUrlChanged('https://same.example.com');
         assert.strictEqual(result, false);
     });
 

--- a/extension/test/unit/services/websocket.test.ts
+++ b/extension/test/unit/services/websocket.test.ts
@@ -197,7 +197,7 @@ suite('ArtemisWebsocketService Safety Features', () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
         // Pre-authenticate to avoid auth errors
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
         wsService = new TestableArtemisWebsocketService(authManager);
     });
 
@@ -319,7 +319,7 @@ suite('ArtemisWebsocketService Connection State Management', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
         wsService = new TestableArtemisWebsocketService(authManager);
     });
 
@@ -417,7 +417,7 @@ suite('ArtemisWebsocketService Reconnection Logic', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
         wsService = new TestableArtemisWebsocketService(authManager);
     });
 
@@ -520,7 +520,7 @@ suite('IrisWebSocketSessionClient Safety Features', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
 
         wsService = new TestableArtemisWebsocketService(authManager);
 
@@ -647,7 +647,7 @@ suite('IrisWebSocketSessionClient Subscription Management', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
 
         wsService = new TestableArtemisWebsocketService(authManager);
 
@@ -821,7 +821,7 @@ suite('WebSocket Integration Tests', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
 
         wsService = new TestableArtemisWebsocketService(authManager);
 
@@ -951,7 +951,7 @@ suite('WebSocket Race Condition Fixes', () => {
     setup(async () => {
         context = new MockExtensionContext();
         authManager = new AuthManager(context);
-        await authManager.storeArtemisCredentials('jwt=test-token', 'https://artemis.example.com', true);
+        await authManager.storeArtemisCredentials('jwt=test-token', true);
         wsService = new TestableArtemisWebsocketService(authManager);
     });
 


### PR DESCRIPTION
## Summary

Investigates and resolves #327: the "Clear Credentials" notifications shown when the Artemis server URL changes.

There were two overlapping manual prompts on a server-URL change, both redundant and one broken:

- **extension.ts** (Desktop config listener): an info message with a "Clear Credentials" button that actually cleared.
- **AuthFlowHandler.checkServerUrlChange** (from the webview provider): a warning with "Clear Credentials"/"Keep Credentials" whose "Clear Credentials" button only opened the login view and **never cleared anything**.

## What changed

- **Removed both prompts.** Changing the server URL while logged in now **logs you out automatically**: it clears the stored credentials, disconnects the WebSocket, returns to the login view, and shows "Artemis server changed. Please log in again." A token issued by the previous server is not valid on a different one, so the session is dropped. A no-op settings save (same URL value) does not log you out.
- As a backstop, any request that still hits a `401` is auto-cleared centrally (`ArtemisApiService.request` + `onAuthExpired`), unchanged.
- The explicit `artemis.logout` command remains for clearing credentials on demand.

### Dead-code cleanup (consequences of the removal)

- Removed `AuthManager.isServerUrlChanged()` and `getStoredLoginServerUrl()` (no callers after the prompt removal).
- Dropped the `serverUrl` parameter from `AuthManager.storeArtemisCredentials()` and stopped persisting the `ARTEMIS_SERVER_URL` secret; removed the `SECRET_KEYS.ARTEMIS_SERVER_URL` constant. The secret was only ever read for URL-change detection.
- Removed the now-unused `showLogin` callback from `AuthFlowHandler` (only the removed `checkServerUrlChange` used it).
- Updated callers (`artemisApi.ts`, `theiaAuthProvider.ts`) and tests for the new `storeArtemisCredentials` signature.

## Not affected (verified)

Theia/EduIDE detection (`getTheiaEnvironment` / data-bridge), the active server URL (`resolveServerUrl` from the setting/env), the clone vs. "Open in Artemis" button (`isManagedEnvironment`), and "Open in browser" (`resolveServerUrl`) do not depend on the removed secret. Cookie (Desktop) / Bearer (Theia) auth split is unchanged. The auto-logout listener runs on Desktop only (managed Theia keeps its locked-setting revert).

Note: existing installs may retain an orphaned `artemis-server-url` secret. It is never read after this change and is harmless; no migration code is added.

## Testing

- `npm run check-types` and `eslint`: clean.
- Unit tests: 1641 passing, 0 failures, 3 skipped.
- Manually verified in the Extension Development Host: switching the server URL while logged in immediately clears credentials, disconnects the WebSocket, and shows the login view; logging into the new server then works.

Closes #327
