### PR TITLE
fix(auth): detect stale credentials at startup via empty /account response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
 
+### Fixed
+
+- **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
+
 ## [0.4.8] - 2026-06-24
 
 ### Changed

--- a/extension/src/extension/api/artemisApi.ts
+++ b/extension/src/extension/api/artemisApi.ts
@@ -155,7 +155,15 @@ export class ArtemisApiService {
     // Get current user information
     async getCurrentUser(): Promise<ArtemisUser> {
         const response = await this.makeRequest('/api/core/public/account');
-        return parseArtemisUser(await response.json());
+        const body = (await response.text()).trim();
+        if (!body) {
+            // /api/core/public/account is public: an unauthenticated request gets a
+            // 200 with an empty body rather than a 401. Surface it as a 401 so callers
+            // (notably startup credential validation) clear the stale token instead of
+            // treating the empty response as a transient failure and keeping it.
+            throw new ApiError('Not authenticated', 401);
+        }
+        return parseArtemisUser(JSON.parse(body));
     }
 
     // Get archived courses (inactive courses from previous semesters)

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -55,7 +55,7 @@ suite('Artemis API Service Test Suite', () => {
             return {
                 ok: true,
                 status: 200,
-                json: async () => mockUser,
+                text: async () => JSON.stringify(mockUser),
             } as any;
         };
 
@@ -63,6 +63,25 @@ suite('Artemis API Service Test Suite', () => {
         assert.ok(user);
         assert.strictEqual(user.id, 1);
         assert.strictEqual(user.login, 'test');
+    });
+
+    test('treats a 200 account response with an empty body as unauthenticated (401)', async () => {
+        // /api/core/public/account is public: an unauthenticated request gets a 200
+        // with an empty body rather than a 401. getCurrentUser must surface this as a
+        // 401 so startup credential validation clears the stale token.
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            text: async () => '',
+        } as any);
+
+        try {
+            await apiService.getCurrentUser();
+            assert.fail('Should have thrown error');
+        } catch (error: unknown) {
+            assert.ok(error instanceof ApiError);
+            assert.strictEqual((error as ApiError).status, 401);
+        }
     });
 
     test('should handle 401 error', async () => {

--- a/extension/test/unit/api/artemisApi.test.ts
+++ b/extension/test/unit/api/artemisApi.test.ts
@@ -84,6 +84,22 @@ suite('Artemis API Service Test Suite', () => {
         }
     });
 
+    test('treats a 200 account response with a whitespace-only body as unauthenticated (401)', async () => {
+        global.fetch = async () => ({
+            ok: true,
+            status: 200,
+            text: async () => '   \n',
+        } as any);
+
+        try {
+            await apiService.getCurrentUser();
+            assert.fail('Should have thrown error');
+        } catch (error: unknown) {
+            assert.ok(error instanceof ApiError);
+            assert.strictEqual((error as ApiError).status, 401);
+        }
+    });
+
     test('should handle 401 error', async () => {
         global.fetch = async () => ({
             ok: false,


### PR DESCRIPTION
## Summary

Fixes #330: stored credentials that are no longer valid on the configured Artemis server were not reliably detected at startup, so an invalid token lingered until a later request happened to fail.

## Root cause

`ArtemisApiService.getCurrentUser()` validates against `GET /api/core/public/account`. That endpoint is **public**: for an unauthenticated / foreign cookie it returns **HTTP 200 with an empty body**, not a `401`. `response.json()` then threw a `SyntaxError`, which the startup validation path (`AuthFlowHandler.checkExistingAuthentication`) treated as a transient failure and therefore **kept** the invalid token.

## Fix

`getCurrentUser()` now reads the body as text and surfaces an empty `200` as `ApiError('Not authenticated', 401)`:

```ts
const response = await this.makeRequest('/api/core/public/account');
const body = (await response.text()).trim();
if (!body) {
    throw new ApiError('Not authenticated', 401);
}
return parseArtemisUser(JSON.parse(body));
```

`checkExistingAuthentication` needs no change: its existing `if (ApiError && status === 401)` branch now clears the stale credentials and updates the auth context (which also disconnects the WebSocket and updates the status bar).

The `401` is only raised **after** a successful HTTP response (`response.ok`). Genuine transient/network/5xx errors still throw earlier in `makeRequest`, so credentials are correctly kept in those cases. A non-empty but malformed body still throws (transient, kept) exactly as before.

## Scope

- Only `getCurrentUser` changes. The other callers are unaffected: the login flow calls it right after a successful `authenticate()` (a user is always returned), and the clone flow already catches any error and defaults the username.
- The optimistic startup bootstrap (connect WebSocket / mark authenticated on token presence, then tear down on a failed validation) is intentionally left as-is, so a brief "appears authenticated" window can still occur for a stale token before validation completes. Eliminating that would require gating startup on a validation round-trip; it was deliberately kept out of scope.

## Testing

- `npm run check-types` and `eslint`: clean.
- Unit tests: 1635 passing, 0 failures, 3 skipped. Added a test that `getCurrentUser` raises `ApiError(401)` for a `200` with an empty body, and updated the success-path test to drive the text-based parsing.

Closes #330
