### PR TITLE
Retire the session recorder: exclude it from the desktop build too (#336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,12 @@ jobs:
           cache: npm
           cache-dependency-path: extension/package-lock.json
       - run: npm ci
-      - run: npm run package
-      - run: npx @vscode/vsce package --no-dependencies
+      - name: Package Desktop VSIX (recorder-free) + verify
+        run: node scripts/package-desktop.js
       - name: Build Open VSX (clean) variant
         run: node esbuild.js --production --variant=openvsx
-      - name: Verify clean bundle excludes recorder/consent
-        run: node scripts/verify-clean-bundle.js
+      - name: Verify Open VSX bundle excludes recorder + struggle
+        run: node scripts/verify-clean-bundle.js --profile=openvsx
 
   viewer-lint:
     name: Viewer lint

--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -218,8 +218,6 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run package
-
       # Pin vsce explicitly (instead of npx resolving through transitive deps)
       # for bit-for-bit reproducible packaging. Same install pattern as publish
       # jobs (under RUNNER_TEMP, --ignore-scripts).
@@ -234,7 +232,7 @@ jobs:
         id: vsix
         run: |
           set -euo pipefail
-          vsce package --no-dependencies
+          node scripts/package-desktop.js
           shopt -s nullglob
           files=( *.vsix )
           if [[ ${#files[@]} -ne 1 ]]; then
@@ -252,7 +250,6 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/package-openvsx.js
-          node scripts/verify-clean-bundle.js
           name=$(ls *-openvsx.vsix)
           sha256=$(sha256sum "$name" | cut -d' ' -f1)
           echo "name=$name" >> "$GITHUB_OUTPUT"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,18 @@
         "${workspaceFolder}/extension/out/test/**/*.js"
       ],
       "preLaunchTask": "npm: pretest - extension"
+    },
+    {
+      "name": "Run Extension (Recording)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/extension"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/extension/dist/**/*.js"
+      ],
+      "preLaunchTask": "watch (recording) - extension"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,19 @@
       "label": "Build Extension (Full)",
       "group": "build",
       "problemMatcher": []
+    },
+    {
+      "label": "watch (recording) - extension",
+      "type": "shell",
+      "command": "node esbuild.js && npm run watch",
+      "options": {
+        "cwd": "${workspaceFolder}/extension",
+        "env": { "IRIS_BUILD_VARIANT": "local-recording" }
+      },
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "presentation": { "reveal": "never" }
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Changed
 
+- The session recorder and its data-collection consent are now excluded from every shipped build (Desktop/Marketplace and Open VSX). Struggle detection is unaffected on Desktop. The recorder remains available for local development via a dedicated build (`npm run package:rec` or the "Run Extension (Recording)" launch config). The `Artemis: Replay Session` and `Artemis: Open Recordings Folder` commands no longer appear in shipped builds; any existing `artemis.dataCollectionConsent` setting becomes inert (it is not removed from your settings).
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Changed
 
-- The session recorder and its data-collection consent are now excluded from every shipped build (Desktop/Marketplace and Open VSX). Struggle detection is unaffected on Desktop. The recorder remains available for local development via a dedicated build (`npm run package:rec` or the "Run Extension (Recording)" launch config). The `Artemis: Replay Session` and `Artemis: Open Recordings Folder` commands no longer appear in shipped builds; any existing `artemis.dataCollectionConsent` setting becomes inert (it is not removed from your settings).
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
 
 ### Fixed
 
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
+
+### Internal
+
+- **Session Recorder Retired From Shipped Builds**: The recorder and its consent flow are now also excluded from the Desktop/Marketplace VSIX (previously Open VSX only); they remain available through a local-only build variant that CI refuses to build.
 
 ## [0.4.8] - 2026-06-24
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -113,12 +113,13 @@ Run from `extension/`:
 
 ## Build Variants & Deployment
 
-### Two VSIX variants
+### Three build variants
 
-The release builds **two** packages from the same source:
+The release ships **two** packages from the same source, plus a third **local-only** variant for recorder development:
 
-- **Full build** (VS Marketplace) - `vsce package`, the complete feature set.
+- **Full build** (VS Marketplace) - built by `scripts/package-desktop.js` from a staging directory using `scripts/generate-clean-manifest.js`. The Desktop VSIX now also **excludes** the session recorder and the data-collection consent flow while keeping the struggle-detection engine; `scripts/verify-clean-bundle.js` fails the build if the recorder reappears in the bundle.
 - **Clean build** (Open VSX, bundled into EduIDE) - built by `scripts/package-openvsx.js` from a staging directory using `scripts/generate-clean-manifest.js`. The clean variant **excludes** the struggle-detection engine, the recording pipeline, and the data-collection consent flow; their settings (`artemis.struggleDetection.*`, `artemis.dataCollectionConsent`) and commands (`artemis.replaySession`, `artemis.openRecordingsFolder`, `artemis.showStruggleScore`) are removed from its manifest, and `scripts/verify-clean-bundle.js` fails the build if any excluded code reappears in the bundle.
+- **Local recording build** (not shipped) - keeps the session recorder and consent flow for local development, via `npm run package:rec` or the "Run Extension (Recording)" launch config. It is refused under CI (`resolveBuildVariant` fails closed when `GITHUB_ACTIONS` is set), so it never reaches a release.
 
 ### EduIDE / Theia integration
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -102,6 +102,7 @@ Run from `extension/`:
 
 - **Run Extension** (recommended) - starts watch mode and recompiles on change.
 - **Run Extension (No Watch)** - runs without auto-recompilation.
+- **Run Extension (Recording)** - starts the local-recording watch build (session recorder and consent flow present) for recorder/replay development. Not for release builds.
 - **Extension Tests** - compiles tests, then runs the suite.
 
 ### Debugging

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -119,8 +119,8 @@ Run from `extension/`:
 The release ships **two** packages from the same source, plus a third **local-only** variant for recorder development:
 
 - **Full build** (VS Marketplace) - built by `scripts/package-desktop.js` from a staging directory using `scripts/generate-clean-manifest.js`. The Desktop VSIX now also **excludes** the session recorder and the data-collection consent flow while keeping the struggle-detection engine; `scripts/verify-clean-bundle.js` fails the build if the recorder reappears in the bundle.
-- **Clean build** (Open VSX, bundled into EduIDE) - built by `scripts/package-openvsx.js` from a staging directory using `scripts/generate-clean-manifest.js`. The clean variant **excludes** the struggle-detection engine, the recording pipeline, and the data-collection consent flow; their settings (`artemis.struggleDetection.*`, `artemis.dataCollectionConsent`) and commands (`artemis.replaySession`, `artemis.openRecordingsFolder`, `artemis.showStruggleScore`) are removed from its manifest, and `scripts/verify-clean-bundle.js` fails the build if any excluded code reappears in the bundle.
-- **Local recording build** (not shipped) - keeps the session recorder and consent flow for local development, via `npm run package:rec` or the "Run Extension (Recording)" launch config. It is refused under CI (`resolveBuildVariant` fails closed when `GITHUB_ACTIONS` is set), so it never reaches a release.
+- **Clean build** (Open VSX, bundled into EduIDE) - built by `scripts/package-openvsx.js` from a staging directory using `scripts/generate-clean-manifest.js`. The clean variant **excludes** the struggle-detection engine, the recording pipeline, and the data-collection consent flow. In its manifest the `artemis.dataCollectionConsent` setting and the `artemis.replaySession` / `artemis.openRecordingsFolder` / `artemis.showStruggleScore` commands are **removed**, while the `artemis.struggleDetection.*` settings are **kept but defaulted to `false`**; `scripts/verify-clean-bundle.js --profile=openvsx` fails the build if any excluded code reappears in the bundle.
+- **Local recording build** (not shipped) - keeps the session recorder and consent flow for local development, via `npm run package:rec` or the "Run Extension (Recording)" launch config. It is refused under CI (`resolveBuildVariant` throws when `GITHUB_ACTIONS === 'true'` or `CI === 'true'`), so it never reaches a release.
 
 ### EduIDE / Theia integration
 
@@ -145,7 +145,7 @@ Releasing is driven by `.github/workflows/release-openvsx.yml` (manual `workflow
 
 ### Marketplace docs are generated
 
-The store listings show the repo-root **`README.md`** (user docs) and **`CHANGELOG.md`**. At package time these are copied into `extension/` (`scripts/sync-marketplace-docs.js` for the full build via `vscode:prepublish`; `package-openvsx.js` copies them into staging for the clean build). `extension/README.md` and `extension/CHANGELOG.md` are therefore **generated and git-ignored** - edit only the repo-root copies.
+The store listings show the repo-root **`README.md`** (user docs) and **`CHANGELOG.md`**. At package time both shipped packagers (`scripts/package-desktop.js`, `scripts/package-openvsx.js`) copy them from the repo root into their staging directory, so the listing matches the release. A plain non-staged `vsce package` (e.g. the `vscode:prepublish` hook used by the local recording build) instead runs `scripts/sync-marketplace-docs.js`, which generates `extension/README.md` and `extension/CHANGELOG.md`. Those `extension/` copies are therefore **generated and git-ignored** - edit only the repo-root copies.
 
 ## Documentation Map
 

--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -29,6 +29,11 @@ reports/**
 .github/**
 CONTRIBUTING.md
 renovate.json
+knip.json
+vitest.config.mts
+.mocharc.ui.yml
+.superpowers/**
+**/.DS_Store
 dist/meta-*.json
 .env
 .env.*

--- a/extension/esbuild.js
+++ b/extension/esbuild.js
@@ -6,15 +6,14 @@ const cssModulesPlugin = require('esbuild-css-modules-plugin');
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
 
-const variantArg = process.argv.find(a => a.startsWith('--variant='));
-const variant = variantArg ? variantArg.split('=')[1] : (process.env.IRIS_BUILD_VARIANT || 'full');
-const isOpenVsx = variant === 'openvsx';
-const recordingEnabled = isOpenVsx ? 'false' : 'true';
-const telemetryEnabled = isOpenVsx ? 'false' : 'true';
+const { resolveBuildVariant } = require('./scripts/resolveBuildVariant');
+const { variant, isOpenVsx, recording } = resolveBuildVariant({ argv: process.argv, env: process.env });
+const recordingEnabled = String(recording);
+const telemetryEnabled = String(!isOpenVsx);
 const seamAliases = {
-    '@dataCollection': path.join(__dirname, isOpenVsx
-        ? 'src/extension/dataCollection/noop.ts'
-        : 'src/extension/dataCollection/index.ts'),
+    '@dataCollection': path.join(__dirname, recording
+        ? 'src/extension/dataCollection/recording.ts'
+        : 'src/extension/dataCollection/noop.ts'),
     '@telemetry': path.join(__dirname, isOpenVsx
         ? 'src/extension/telemetry/noop.ts'
         : 'src/extension/telemetry/index.ts'),
@@ -24,7 +23,7 @@ const webviewAliases = {
         ? 'src/webview/views/StruggleDetection/stub.tsx'
         : 'src/webview/views/StruggleDetection/index.ts'),
 };
-console.log(`[build] variant: ${variant}`);
+console.log(`[build] variant: ${variant} (recording=${recording})`);
 
 const formatSize = (bytes) => {
 	const kb = bytes / 1024;

--- a/extension/knip.json
+++ b/extension/knip.json
@@ -4,6 +4,7 @@
     "src/extension.ts",
     "src/webview/index.tsx",
     "src/extension/telemetry/noop.ts",
+    "src/extension/dataCollection/recording.ts",
     "src/webview/views/StruggleDetection/stub.tsx",
     "test/**/*.{ts,tsx}",
     ".mocharc.ui.yml",

--- a/extension/package.json
+++ b/extension/package.json
@@ -122,6 +122,14 @@
         {
           "command": "artemis.showJwtToken",
           "when": "config.artemis.developerMode"
+        },
+        {
+          "command": "artemis.replaySession",
+          "when": "iris.recorder.active"
+        },
+        {
+          "command": "artemis.openRecordingsFolder",
+          "when": "iris.recorder.active"
         }
       ]
     },
@@ -205,7 +213,7 @@
         "artemis.struggleDetection.showInterventions": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Show help suggestions when struggle is detected (status bar hint and notification popups). When **disabled**, no UI prompts will appear during struggle, but data collection continues unchanged. Use this if you prefer to work without interruptions while still contributing to research data."
+          "markdownDescription": "Show help suggestions when struggle is detected (status bar hint and notification popups). When **disabled**, no UI prompts will appear during struggle. Use this if you prefer to work without interruptions."
         },
         "artemis.startPage": {
           "type": "string",
@@ -256,7 +264,9 @@
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "dev": "node esbuild.js --watch",
     "package": "npm run check-types && npm run lint:src && node esbuild.js --production",
-    "package:vsix": "npm run package && vsce package",
+    "package:vsix": "node scripts/package-desktop.js",
+    "package:openvsx": "node scripts/package-openvsx.js",
+    "package:rec": "node scripts/package-recording.js",
     "analyze": "esbuild-visualizer --metadata=dist/meta-webview.json --open",
     "analyze:text": "node -e \"const e=require('esbuild'),f=require('fs'); e.analyzeMetafile(JSON.parse(f.readFileSync('dist/meta-webview.json','utf8'))).then(console.log)\"",
     "analyze:ext": "esbuild-visualizer --metadata=dist/meta-extension.json --open",

--- a/extension/scripts/generate-clean-manifest.js
+++ b/extension/scripts/generate-clean-manifest.js
@@ -1,13 +1,13 @@
-// Produce a clean package.json (no consent setting, no recording commands, no
-// rebuild-on-package hook) and apply the cloud/Theia setting-default overrides,
-// WITHOUT mutating the source manifest. CLI writes to argv[2]. See docs/adr/002.
+// Produce a clean package.json WITHOUT mutating the source manifest. Two fail-closed
+// profiles select what is dropped:
+//   desktop  drop the recorder group only (struggle detection stays)
+//   openvsx  drop recorder + struggle groups and apply cloud/Theia setting defaults
+// CLI: generate-clean-manifest.js <out-path> --profile=desktop|openvsx. See docs/adr/002.
 const fs = require('fs');
 const path = require('path');
 
-// Cloud/Theia-tailored setting defaults (clean variant only). See ADR 002.
-// NOTE: the two struggleDetection.* entries are temporary — remove them once the
-// cloud intervention pipeline is live.
-const OPENVSX_SETTING_DEFAULTS = {
+// Cloud/Theia-tailored setting defaults (openvsx profile only). See ADR 002.
+const CLOUD_SETTING_DEFAULTS = {
     'artemis.startPage': 'workspace-exercise',
     'artemis.showStartPageSuggestion': false,
     'artemis.struggleDetection.enabled': false,
@@ -15,43 +15,97 @@ const OPENVSX_SETTING_DEFAULTS = {
     'artemis.showSetDefaultClonePathPrompt': false,
 };
 
-// Commands whose backing feature is excluded from the clean build.
-const DROPPED_COMMANDS = new Set([
-    'artemis.replaySession',
-    'artemis.openRecordingsFolder',
-    'artemis.showStruggleScore',
-]);
+const RECORDER_COMMANDS = new Set(['artemis.replaySession', 'artemis.openRecordingsFolder']);
+const STRUGGLE_COMMANDS = new Set(['artemis.showStruggleScore']);
 
-function cleanManifest(m) {
+function dropCommandsAndMenuRefs(m, commandSet) {
+    const c = m.contributes || {};
+    if (Array.isArray(c.commands)) {
+        c.commands = c.commands.filter(cmd => !commandSet.has(cmd.command));
+    }
+    const cp = c.menus && c.menus.commandPalette;
+    if (Array.isArray(cp)) {
+        c.menus.commandPalette = cp.filter(e => !commandSet.has(e.command));
+    }
+}
+
+function dropRecorderGroup(m) {
     const props = m.contributes && m.contributes.configuration && m.contributes.configuration.properties;
     if (props) { delete props['artemis.dataCollectionConsent']; }
+    dropCommandsAndMenuRefs(m, RECORDER_COMMANDS);
+}
 
-    for (const [key, value] of Object.entries(OPENVSX_SETTING_DEFAULTS)) {
+function dropStruggleGroup(m) {
+    dropCommandsAndMenuRefs(m, STRUGGLE_COMMANDS);
+}
+
+function applyCloudDefaults(m) {
+    const props = m.contributes && m.contributes.configuration && m.contributes.configuration.properties;
+    for (const [key, value] of Object.entries(CLOUD_SETTING_DEFAULTS)) {
         if (!props || !props[key]) {
             throw new Error(`generate-clean-manifest: cannot override unknown setting '${key}'`);
         }
         props[key].default = value;
     }
+}
 
-    if (Array.isArray(m.contributes && m.contributes.commands)) {
-        m.contributes.commands = m.contributes.commands.filter(c => !DROPPED_COMMANDS.has(c.command));
+// Fail-closed hardening: after dropping a command, no remaining menu/keybinding
+// contribution may still reference it. `removed` is the exact set that was dropped.
+function assertNoDanglingCommandRefs(m, removed) {
+    const c = m.contributes || {};
+    const refs = [];
+    for (const [menuKey, entries] of Object.entries(c.menus || {})) {
+        if (!Array.isArray(entries)) { continue; }
+        for (const e of entries) {
+            // A menu entry can reference a command via `command` OR `alt`.
+            if (removed.has(e.command)) { refs.push(`menus.${menuKey}: ${e.command}`); }
+            if (removed.has(e.alt)) { refs.push(`menus.${menuKey}.alt: ${e.alt}`); }
+        }
     }
+    for (const kb of c.keybindings || []) {
+        if (removed.has(kb.command)) { refs.push(`keybindings: ${kb.command}`); }
+    }
+    if (refs.length) {
+        throw new Error(`generate-clean-manifest: dangling command refs after drop: ${refs.join(', ')}`);
+    }
+}
 
+function cleanManifest(m, profile) {
+    const removed = new Set();
+    switch (profile) {
+        case 'desktop':
+            dropRecorderGroup(m);
+            RECORDER_COMMANDS.forEach(c => removed.add(c));
+            break;
+        case 'openvsx':
+            dropRecorderGroup(m);
+            dropStruggleGroup(m);
+            applyCloudDefaults(m);
+            RECORDER_COMMANDS.forEach(c => removed.add(c));
+            STRUGGLE_COMMANDS.forEach(c => removed.add(c));
+            break;
+        default:
+            throw new Error(`generate-clean-manifest: unknown profile '${profile}' (expected desktop | openvsx)`);
+    }
     if (m.scripts) { delete m.scripts['vscode:prepublish']; }
-
+    assertNoDanglingCommandRefs(m, removed);
     return m;
 }
 
 function main() {
-    const srcManifest = path.join(__dirname, '..', 'package.json');
-    const outPath = process.argv[2];
-    if (!outPath) { throw new Error('usage: generate-clean-manifest.js <out-path>'); }
+    const args = process.argv.slice(2);
+    const outPath = args.find(a => !a.startsWith('--'));
+    const profileFlag = args.find(a => a.startsWith('--profile='));
+    const profile = profileFlag ? profileFlag.slice('--profile='.length) : undefined;
+    if (!outPath) { throw new Error('usage: generate-clean-manifest.js <out-path> --profile=desktop|openvsx'); }
+    if (!profile) { throw new Error('generate-clean-manifest: --profile=desktop|openvsx is required'); }
 
-    const m = cleanManifest(JSON.parse(fs.readFileSync(srcManifest, 'utf8')));
+    const srcManifest = path.join(__dirname, '..', 'package.json');
+    const m = cleanManifest(JSON.parse(fs.readFileSync(srcManifest, 'utf8')), profile);
 
     fs.mkdirSync(path.dirname(outPath), { recursive: true });
     fs.writeFileSync(outPath, JSON.stringify(m, null, 2) + '\n');
-    console.log(`[clean-manifest] wrote ${outPath}`);
+    console.log(`[clean-manifest] wrote ${outPath} (profile=${profile})`);
 }
 
 module.exports = { cleanManifest };

--- a/extension/scripts/package-desktop.js
+++ b/extension/scripts/package-desktop.js
@@ -16,10 +16,6 @@ run('node esbuild.js --production --variant=full');
 // 1b. Fail-closed: the Desktop bundle must contain NO recorder/consent code.
 run('node scripts/verify-clean-bundle.js --profile=desktop');
 
-// 1c. Sync the single-sourced marketplace docs (normally done in vscode:prepublish,
-//     which the staged manifest drops).
-run('node scripts/sync-marketplace-docs.js');
-
 // 2. Reset the staging dir.
 fs.rmSync(staging, { recursive: true, force: true });
 fs.mkdirSync(staging, { recursive: true });

--- a/extension/scripts/package-desktop.js
+++ b/extension/scripts/package-desktop.js
@@ -1,0 +1,57 @@
+// Build the FULL (Desktop/Marketplace) variant with the recorder EXCLUDED and package
+// it from a staging dir so the source package.json is never mutated. Verifies the
+// bundle is recorder-free BEFORE any VSIX is written. Produces <name>-<ver>.vsix.
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const staging = path.join(root, 'build', 'desktop-pkg');
+const run = (cmd, opts = {}) => execSync(cmd, { stdio: 'inherit', cwd: root, ...opts });
+
+// 1. Build the full variant (recorder off; writes dist/ + non-suffixed metafiles).
+run('npm run check-types && npm run lint:src');
+run('node esbuild.js --production --variant=full');
+
+// 1b. Fail-closed: the Desktop bundle must contain NO recorder/consent code.
+run('node scripts/verify-clean-bundle.js --profile=desktop');
+
+// 1c. Sync the single-sourced marketplace docs (normally done in vscode:prepublish,
+//     which the staged manifest drops).
+run('node scripts/sync-marketplace-docs.js');
+
+// 2. Reset the staging dir.
+fs.rmSync(staging, { recursive: true, force: true });
+fs.mkdirSync(staging, { recursive: true });
+
+// 3. Copy packaged assets + the clean dist into staging.
+for (const entry of ['dist', 'media', 'LICENSE', '.vscodeignore']) {
+    const from = path.join(root, entry);
+    if (!fs.existsSync(from)) { continue; }
+    fs.cpSync(from, path.join(staging, entry), { recursive: true });
+}
+
+// 3b. README + CHANGELOG are single-sourced at the repo root; copy them so the
+//     Marketplace listing shows the same description and a Changelog tab.
+const repoRoot = path.join(root, '..');
+for (const doc of ['README.md', 'CHANGELOG.md']) {
+    const from = path.join(repoRoot, doc);
+    if (!fs.existsSync(from)) {
+        throw new Error(`[package-desktop] expected ${doc} at the repo root (${from}) but it is missing`);
+    }
+    fs.cpSync(from, path.join(staging, doc));
+}
+
+// 4. Generate the clean Desktop manifest into staging (drops recorder + consent, keeps struggle).
+run(`node scripts/generate-clean-manifest.js ${path.join(staging, 'package.json')} --profile=desktop`);
+
+// 5. Package from staging (no rebuild: staged manifest has no vscode:prepublish).
+const pkg = JSON.parse(fs.readFileSync(path.join(staging, 'package.json'), 'utf8'));
+const vsixName = `${pkg.name}-${pkg.version}.vsix`;
+const vsixOut = path.join(root, vsixName);
+const hasVsce = (() => {
+    try { execSync('vsce --version', { stdio: 'ignore' }); return true; } catch { return false; }
+})();
+const vsceCmd = hasVsce ? 'vsce' : 'npx --yes @vscode/vsce@3.9.1';
+run(`${vsceCmd} package --no-dependencies --out ${vsixOut}`, { cwd: staging });
+console.log(`[package-desktop] wrote ${vsixOut}`);

--- a/extension/scripts/package-openvsx.js
+++ b/extension/scripts/package-openvsx.js
@@ -12,6 +12,9 @@ const run = (cmd, opts = {}) => execSync(cmd, { stdio: 'inherit', cwd: root, ...
 run('npm run check-types && npm run lint:src');
 run('node esbuild.js --production --variant=openvsx');
 
+// Fail-closed: abort before staging if any recorder/struggle input leaked in.
+run('node scripts/verify-clean-bundle.js --profile=openvsx');
+
 // 2. Reset the staging dir.
 fs.rmSync(staging, { recursive: true, force: true });
 fs.mkdirSync(staging, { recursive: true });
@@ -38,7 +41,7 @@ for (const doc of ['README.md', 'CHANGELOG.md']) {
 }
 
 // 4. Generate the clean manifest into staging.
-run(`node scripts/generate-clean-manifest.js ${path.join(staging, 'package.json')}`);
+run(`node scripts/generate-clean-manifest.js ${path.join(staging, 'package.json')} --profile=openvsx`);
 
 // 5. Package from staging (no rebuild: clean manifest has no vscode:prepublish).
 const pkg = JSON.parse(fs.readFileSync(path.join(staging, 'package.json'), 'utf8'));

--- a/extension/scripts/package-recording.js
+++ b/extension/scripts/package-recording.js
@@ -1,0 +1,25 @@
+// Build a LOCAL recording-capable VSIX (recorder ON) from the SOURCE manifest. The
+// build refuses to run under CI (resolveBuildVariant guard). The variant is passed via
+// the child env so it survives vsce's vscode:prepublish rebuild and works cross-platform
+// (no `VAR=value cmd` prefix). Not for CD.
+const { execSync } = require('child_process');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const env = { ...process.env, IRIS_BUILD_VARIANT: 'local-recording' };
+const run = (cmd, opts = {}) => execSync(cmd, { stdio: 'inherit', cwd: root, env, ...opts });
+
+// check-types + lint:src + esbuild --production, variant from env.
+run('npm run package');
+
+const hasVsce = (() => {
+    try { execSync('vsce --version', { stdio: 'ignore', env }); return true; } catch { return false; }
+})();
+const vsceCmd = hasVsce ? 'vsce' : 'npx --yes @vscode/vsce@3.9.1';
+// Distinct `-recording` output name so a local recording VSIX is never confused with (or
+// overwrites) the shippable Desktop VSIX. vsce triggers vscode:prepublish -> npm run
+// package, which inherits `env` and stays local-recording.
+const pkg = JSON.parse(require('fs').readFileSync(path.join(root, 'package.json'), 'utf8'));
+const vsixOut = path.join(root, `${pkg.name}-${pkg.version}-recording.vsix`);
+run(`${vsceCmd} package --no-dependencies --out ${vsixOut}`);
+console.log(`[package-recording] wrote ${vsixOut}`);

--- a/extension/scripts/resolveBuildVariant.js
+++ b/extension/scripts/resolveBuildVariant.js
@@ -1,0 +1,25 @@
+// Pure, testable resolver for the esbuild build variant + derived flags. Three
+// mutually-exclusive variants:
+//   full             shipped Desktop/Marketplace: struggle on, recorder off
+//   openvsx          shipped Open VSX / EduIDE clean: struggle off, recorder off
+//   local-recording  local dev only: recorder on; REFUSED under CI (fail-safe)
+const VARIANTS = ['full', 'openvsx', 'local-recording'];
+
+function resolveBuildVariant({ argv = [], env = {} } = {}) {
+    const flag = argv.find(a => a.startsWith('--variant='));
+    const variant = flag ? flag.slice('--variant='.length) : (env.IRIS_BUILD_VARIANT || 'full');
+    if (!VARIANTS.includes(variant)) {
+        throw new Error(`resolveBuildVariant: unknown variant '${variant}' (expected ${VARIANTS.join(' | ')})`);
+    }
+    const isCI = env.GITHUB_ACTIONS === 'true' || env.CI === 'true';
+    if (variant === 'local-recording' && isCI) {
+        throw new Error('resolveBuildVariant: local-recording is a local-only variant and is refused under CI');
+    }
+    return {
+        variant,
+        isOpenVsx: variant === 'openvsx',
+        recording: variant === 'local-recording',
+    };
+}
+
+module.exports = { resolveBuildVariant, VARIANTS };

--- a/extension/scripts/verify-clean-bundle.js
+++ b/extension/scripts/verify-clean-bundle.js
@@ -1,57 +1,92 @@
-// Fail-closed proof that the Open VSX bundle excludes recorder/consent/replay/struggle-engine.
+// Fail-closed proof that a shipped bundle excludes forbidden inputs. Two profiles:
+//   desktop  forbids the recorder feature only (struggle detection is ALLOWED)
+//   openvsx  forbids the recorder feature AND the struggle engine + struggle view
 // Reads the variant metafiles and asserts no forbidden input path is present.
+// CLI: verify-clean-bundle.js --profile=desktop|openvsx.
 const fs = require('fs');
 const path = require('path');
 
-// The whole telemetry-engine subtree (struggle detection, metrics, intervention,
-// session recorder, replay, URI filtering) is excluded from the clean Open VSX
-// build via the @telemetry seam. Deny the entire subtree by DEFAULT (fail-closed):
-// any file under it is forbidden unless explicitly allowlisted. This replaces an
-// earlier hand-picked denylist that silently let unlisted files (e.g. uriFilter.ts)
-// through if they were ever pulled into the clean bundle.
-const TELEMETRY_SUBTREE = 'src/extension/services/telemetry/';
-const TELEMETRY_ALLOWED = [
-    // Shared type + config declarations only (no engine/recorder/consent logic).
-    'src/extension/services/telemetry/types.ts',
-];
-
-// Excluded code that lives OUTSIDE the telemetry subtree.
-const FORBIDDEN = [
+// Recorder feature entry points. Both recorder layouts are listed so the set stays
+// correct after the struggle-v3 rebase (dev nests it under services/telemetry/; the
+// struggle branch splits it into services/recording/). NOTE: services/sensing/ is the
+// SHARED SensorHub used by the Desktop struggle engine and is deliberately NOT here.
+const RECORDER_FORBIDDEN = [
+    'src/extension/services/telemetry/recording/',
+    'src/extension/services/telemetry/replay/',
+    'src/extension/services/recording/',
     'src/extension/services/auth/consentService.ts',
     'src/extension/activation/sessionRecorderWiring.ts',
-    // Struggle-detection webview view, excluded via the @struggleView alias.
-    // stub.tsx, types.ts, and index.ts are NOT forbidden (stub is the alias target).
-    'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
-    'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
+    'src/extension/dataCollection/index.ts',
+    'src/extension/dataCollection/recording.ts',
 ];
 
-function isForbiddenInput(input) {
-    const p = input.replace(/\\/g, '/');
-    if (p.includes(TELEMETRY_SUBTREE)) {
-        return !TELEMETRY_ALLOWED.some(allowed => p.includes(allowed));
-    }
-    return FORBIDDEN.some(f => p.includes(f));
+// Struggle engine (Open VSX only). On dev the engine is the whole services/telemetry/
+// subtree (deny by default, allow types.ts); the struggle branch splits it out.
+const TELEMETRY_SUBTREE = 'src/extension/services/telemetry/';
+const TELEMETRY_ALLOWED = ['src/extension/services/telemetry/types.ts'];
+const STRUGGLE_SUBTREES = [
+    'src/extension/services/struggle/',
+    'src/extension/services/intervention/',
+    'src/extension/services/struggleIntervention/',
+];
+// The struggle-detection webview lives under this prefix. Only the alias stub and the
+// type/re-export files are allowed in the clean bundle; every OTHER file (view, hook,
+// nested module) is forbidden. Prefix+allowlist (not an explicit file list) so new view
+// files added on the struggle branch are still caught after the rebase.
+const STRUGGLE_VIEW_PREFIX = 'src/webview/views/StruggleDetection/';
+const STRUGGLE_VIEW_ALLOWED = ['stub.tsx', 'types.ts', 'index.ts'];
+const STRUGGLE_MODULES = ['node_modules/recharts'];
+
+function isRecorderForbidden(p) {
+    return RECORDER_FORBIDDEN.some(f => p.includes(f));
 }
 
-function forbiddenInputs(metafilePath) {
+function isStruggleForbidden(p) {
+    if (p.includes(TELEMETRY_SUBTREE)) {
+        // ...recorder sub-paths under here are already covered by RECORDER_FORBIDDEN.
+        return !TELEMETRY_ALLOWED.some(a => p.endsWith(a));
+    }
+    const viewIdx = p.indexOf(STRUGGLE_VIEW_PREFIX);
+    if (viewIdx !== -1) {
+        const rest = p.slice(viewIdx + STRUGGLE_VIEW_PREFIX.length);
+        return !STRUGGLE_VIEW_ALLOWED.includes(rest); // any nested/other view file is forbidden
+    }
+    return STRUGGLE_SUBTREES.some(s => p.includes(s))
+        || STRUGGLE_MODULES.some(m => p.includes(m));
+}
+
+function forbiddenInputs(metafilePath, profile) {
+    let check;
+    switch (profile) {
+        case 'desktop': check = isRecorderForbidden; break;
+        case 'openvsx': check = p => isRecorderForbidden(p) || isStruggleForbidden(p); break;
+        default: throw new Error(`verify-clean-bundle: unknown profile '${profile}' (expected desktop | openvsx)`);
+    }
     const meta = JSON.parse(fs.readFileSync(metafilePath, 'utf8'));
-    return Object.keys(meta.inputs || {}).filter(isForbiddenInput);
+    return Object.keys(meta.inputs || {}).filter(input => check(input.replace(/\\/g, '/')));
 }
 
 function main() {
+    const profileFlag = process.argv.slice(2).find(a => a.startsWith('--profile='));
+    const profile = profileFlag ? profileFlag.slice('--profile='.length) : undefined;
+    if (profile !== 'desktop' && profile !== 'openvsx') {
+        throw new Error(`verify-clean-bundle: --profile=desktop|openvsx is required (got '${profile}')`);
+    }
+
+    const suffix = profile === 'openvsx' ? '-openvsx' : '';
     const root = path.join(__dirname, '..');
-    const metas = ['dist/meta-extension-openvsx.json', 'dist/meta-webview-openvsx.json']
+    const metas = [`dist/meta-extension${suffix}.json`, `dist/meta-webview${suffix}.json`]
         .map(p => path.join(root, p));
     const hits = metas.flatMap(m => {
-        if (!fs.existsSync(m)) { throw new Error(`missing metafile: ${m} (build openvsx variant first)`); }
-        return forbiddenInputs(m).map(i => `${path.basename(m)}: ${i}`);
+        if (!fs.existsSync(m)) { throw new Error(`missing metafile: ${m} (build the ${profile} bundle first)`); }
+        return forbiddenInputs(m, profile).map(i => `${path.basename(m)}: ${i}`);
     });
     if (hits.length > 0) {
-        console.error('FAIL: forbidden inputs in clean bundle:\n' + hits.join('\n'));
+        console.error(`FAIL (${profile}): forbidden inputs in bundle:\n` + hits.join('\n'));
         process.exit(1);
     }
-    console.log('OK: clean bundle contains no recorder/consent/replay, struggle-engine, or struggle-view inputs');
+    console.log(`OK (${profile}): bundle contains no forbidden inputs`);
 }
 
-module.exports = { forbiddenInputs, FORBIDDEN };
+module.exports = { forbiddenInputs, RECORDER_FORBIDDEN };
 if (require.main === module) { main(); }

--- a/extension/scripts/verify-clean-bundle.js
+++ b/extension/scripts/verify-clean-bundle.js
@@ -63,7 +63,14 @@ function forbiddenInputs(metafilePath, profile) {
         default: throw new Error(`verify-clean-bundle: unknown profile '${profile}' (expected desktop | openvsx)`);
     }
     const meta = JSON.parse(fs.readFileSync(metafilePath, 'utf8'));
-    return Object.keys(meta.inputs || {}).filter(input => check(input.replace(/\\/g, '/')));
+    const inputs = meta && meta.inputs;
+    // Fail-closed: a real esbuild metafile always has a populated `inputs` object. An
+    // empty/missing/array `inputs` means the file is malformed or not a metafile at all
+    // (e.g. a plain package.json), so refuse it rather than pass vacuously.
+    if (typeof inputs !== 'object' || inputs === null || Array.isArray(inputs) || Object.keys(inputs).length === 0) {
+        throw new Error(`verify-clean-bundle: '${metafilePath}' has no usable 'inputs' (malformed or not an esbuild metafile)`);
+    }
+    return Object.keys(inputs).filter(input => check(input.replace(/\\/g, '/')));
 }
 
 function main() {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -219,8 +219,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		websocketStatusBarService.setAuthenticated(false);
 	}
 
-	// Data collection (consent + recorder + recording commands). Excluded from the
-	// Open VSX build via the @dataCollection alias swap.
+	// Data collection (consent + recorder + recording commands). Noop for both shipped
+	// variants (Desktop full + Open VSX) via the @dataCollection alias swap; real only
+	// for the local-recording build.
 	activeDataCollection = wireDataCollection({
 		context,
 		artemisWebsocketService,

--- a/extension/src/extension/dataCollection/index.ts
+++ b/extension/src/extension/dataCollection/index.ts
@@ -9,7 +9,7 @@ import { executeReplayCommand } from '@extension/services/telemetry/replay';
 
 import type { DataCollectionDeps, DataCollectionHandle } from './types';
 
-/** Webview command handlers for opening/replaying recordings (full build only). */
+/** Webview command handlers for opening/replaying recordings (recording build only). */
 export function createRecordingWebviewHandlers(globalStorageUri: vscode.Uri): CommandMap {
     return {
         openRecordingsFolder: async () => {
@@ -22,7 +22,7 @@ export function createRecordingWebviewHandlers(globalStorageUri: vscode.Uri): Co
     };
 }
 
-/** Wire consent + recorder + recording palette commands. Full build only. */
+/** Wire consent + recorder + recording palette commands. Recording build only. */
 export function wireDataCollection(deps: DataCollectionDeps): DataCollectionHandle {
     const { context } = deps;
     const consentService = new ConsentService();

--- a/extension/src/extension/dataCollection/noop.ts
+++ b/extension/src/extension/dataCollection/noop.ts
@@ -1,20 +1,26 @@
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 
 import type { CommandMap } from '@extension/controller/commands/types';
 
 import type { DataCollectionDeps, DataCollectionHandle } from './types';
 
+const RECORDER_ACTIVE_KEY = 'iris.recorder.active';
+
 /**
- * No-op data-collection seam for the Open VSX (clean) variant. Imports nothing
- * from consent/recording/replay, so esbuild keeps that subtree out of the bundle.
+ * No-op data-collection seam for the shipped builds (Desktop `full` + Open VSX).
+ * Imports nothing from consent/recording, so esbuild keeps that subtree out of the
+ * bundle, and explicitly marks the recorder inactive so recorder commands stay hidden.
  */
 export function wireDataCollection(_deps: DataCollectionDeps): DataCollectionHandle {
+    void vscode.commands.executeCommand('setContext', RECORDER_ACTIVE_KEY, false);
     return {
-        async dispose(): Promise<void> { /* nothing to tear down */ },
+        async dispose(): Promise<void> {
+            void vscode.commands.executeCommand('setContext', RECORDER_ACTIVE_KEY, false);
+        },
     };
 }
 
-/** No recording webview handlers in the clean build. */
+/** No recording webview handlers in the shipped builds. */
 export function createRecordingWebviewHandlers(_globalStorageUri: vscode.Uri): CommandMap {
     return {};
 }

--- a/extension/src/extension/dataCollection/recording.ts
+++ b/extension/src/extension/dataCollection/recording.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+import type { CommandMap } from '@extension/controller/commands/types';
+
+import { createRecordingWebviewHandlers as createRealHandlers, wireDataCollection as wireReal } from './index';
+import type { DataCollectionDeps, DataCollectionHandle } from './types';
+
+const RECORDER_ACTIVE_KEY = 'iris.recorder.active';
+
+/**
+ * Real data-collection seam for the local-recording build variant. Wraps the
+ * untouched index.ts wiring and publishes the `iris.recorder.active` context key so
+ * the manifest shows recorder commands only when the recorder is actually present.
+ */
+export function wireDataCollection(deps: DataCollectionDeps): DataCollectionHandle {
+    const handle = wireReal(deps);
+    void vscode.commands.executeCommand('setContext', RECORDER_ACTIVE_KEY, true);
+    let disposed = false;
+    return {
+        async dispose(): Promise<void> {
+            if (disposed) { return; }
+            disposed = true;
+            try {
+                await handle.dispose();
+            } finally {
+                void vscode.commands.executeCommand('setContext', RECORDER_ACTIVE_KEY, false);
+            }
+        },
+    };
+}
+
+export const createRecordingWebviewHandlers: (globalStorageUri: vscode.Uri) => CommandMap = createRealHandlers;

--- a/extension/test/logic/dataCollection/noopSeam.test.ts
+++ b/extension/test/logic/dataCollection/noopSeam.test.ts
@@ -1,14 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import * as vscode from 'vscode';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRecordingWebviewHandlers, wireDataCollection } from '@extension/dataCollection/noop';
 
 describe('no-op data-collection seam', () => {
+    afterEach(() => vi.restoreAllMocks());
+
     it('returns an empty webview handler map', () => {
         expect(createRecordingWebviewHandlers({} as never)).toEqual({});
     });
 
-    it('returns a handle whose dispose resolves without side effects', async () => {
+    it('marks the recorder inactive on wiring and on disposal', async () => {
+        const setContext = vi.spyOn(vscode.commands, 'executeCommand');
         const handle = wireDataCollection({} as never);
+        expect(setContext).toHaveBeenCalledWith('setContext', 'iris.recorder.active', false);
+        setContext.mockClear();
         await expect(handle.dispose()).resolves.toBeUndefined();
+        expect(setContext).toHaveBeenCalledWith('setContext', 'iris.recorder.active', false);
     });
 });

--- a/extension/test/logic/scripts/generateCleanManifest.test.ts
+++ b/extension/test/logic/scripts/generateCleanManifest.test.ts
@@ -1,22 +1,20 @@
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-// Resolve the plain-JS generator (in scripts/, no path alias). join(__dirname, ...)
-// keeps the require argument computed (lint rule) and avoids import.meta (CJS target).
 type ConfigProp = { type?: string; default?: unknown };
 type Manifest = {
     contributes: {
         configuration: { properties: Record<string, ConfigProp> };
         commands: { command: string }[];
+        menus?: { commandPalette?: { command: string; when?: string }[] };
     };
     scripts: Record<string, string>;
 };
 
 const { cleanManifest } = require(
     join(__dirname, '../../../scripts/generate-clean-manifest.js')
-) as {
-    cleanManifest: (m: Manifest) => Manifest;
-};
+) as { cleanManifest: (m: Manifest, profile: string) => Manifest };
 
 function baseManifest(): Manifest {
     return {
@@ -38,39 +36,104 @@ function baseManifest(): Manifest {
                 { command: 'artemis.openRecordingsFolder' },
                 { command: 'artemis.showStruggleScore' },
             ],
+            menus: {
+                commandPalette: [
+                    { command: 'artemis.replaySession', when: 'iris.recorder.active' },
+                    { command: 'artemis.openRecordingsFolder', when: 'iris.recorder.active' },
+                    { command: 'artemis.login' },
+                ],
+            },
         },
         scripts: { 'vscode:prepublish': 'npm run package', package: 'noop' },
     };
 }
 
 describe('generate-clean-manifest: cleanManifest', () => {
-    it('applies the cloud setting-default overrides', () => {
-        const props = cleanManifest(baseManifest()).contributes.configuration.properties;
-        expect(props['artemis.startPage'].default).toBe('workspace-exercise');
-        expect(props['artemis.showStartPageSuggestion'].default).toBe(false);
-        expect(props['artemis.struggleDetection.enabled'].default).toBe(false);
-        expect(props['artemis.struggleDetection.showInterventions'].default).toBe(false);
-        expect(props['artemis.showSetDefaultClonePathPrompt'].default).toBe(false);
+    it('throws on an unknown profile', () => {
+        expect(() => cleanManifest(baseManifest(), 'bogus')).toThrow(/unknown profile 'bogus'/);
     });
 
-    it('leaves non-overridden settings untouched', () => {
-        const props = cleanManifest(baseManifest()).contributes.configuration.properties;
-        expect(props['artemis.serverUrl'].default).toBe('https://artemis.tum.de');
+    it('throws when the profile is missing (fail-closed, never defaults)', () => {
+        expect(() => (cleanManifest as (m: Manifest) => Manifest)(baseManifest()))
+            .toThrow(/unknown profile 'undefined'/);
     });
 
-    it('removes the consent setting and dropped commands (recording + struggle score)', () => {
-        const m = cleanManifest(baseManifest());
-        expect(m.contributes.configuration.properties['artemis.dataCollectionConsent']).toBeUndefined();
-        expect(m.contributes.commands.map(c => c.command)).toEqual(['artemis.login']);
+    describe('desktop profile', () => {
+        it('drops the recorder group but keeps struggle', () => {
+            const m = cleanManifest(baseManifest(), 'desktop');
+            expect(m.contributes.configuration.properties['artemis.dataCollectionConsent']).toBeUndefined();
+            expect(m.contributes.commands.map(c => c.command)).toEqual([
+                'artemis.login', 'artemis.showStruggleScore',
+            ]);
+            // struggle settings keep their real defaults on Desktop
+            expect(m.contributes.configuration.properties['artemis.struggleDetection.enabled'].default).toBe(true);
+        });
+        it('drops the recorder commandPalette entries (no dangling ref)', () => {
+            const cp = cleanManifest(baseManifest(), 'desktop').contributes.menus!.commandPalette!;
+            expect(cp.map(e => e.command)).toEqual(['artemis.login']);
+        });
     });
 
-    it('drops the prepublish hook', () => {
-        expect(cleanManifest(baseManifest()).scripts['vscode:prepublish']).toBeUndefined();
+    describe('openvsx profile', () => {
+        it('applies the cloud setting-default overrides', () => {
+            const props = cleanManifest(baseManifest(), 'openvsx').contributes.configuration.properties;
+            expect(props['artemis.startPage'].default).toBe('workspace-exercise');
+            expect(props['artemis.struggleDetection.enabled'].default).toBe(false);
+            expect(props['artemis.struggleDetection.showInterventions'].default).toBe(false);
+        });
+        it('removes consent + recording + struggle-score commands', () => {
+            const m = cleanManifest(baseManifest(), 'openvsx');
+            expect(m.contributes.configuration.properties['artemis.dataCollectionConsent']).toBeUndefined();
+            expect(m.contributes.commands.map(c => c.command)).toEqual(['artemis.login']);
+        });
+        it('throws if an override key is missing (renamed/removed setting)', () => {
+            const m = baseManifest();
+            delete m.contributes.configuration.properties['artemis.startPage'];
+            expect(() => cleanManifest(m, 'openvsx')).toThrow(/cannot override unknown setting 'artemis\.startPage'/);
+        });
     });
 
-    it('throws if an override key is missing (renamed/removed setting)', () => {
+    it('drops the prepublish hook for both profiles', () => {
+        expect(cleanManifest(baseManifest(), 'desktop').scripts['vscode:prepublish']).toBeUndefined();
+        expect(cleanManifest(baseManifest(), 'openvsx').scripts['vscode:prepublish']).toBeUndefined();
+    });
+
+    it('throws on a dangling command reference left after a drop', () => {
         const m = baseManifest();
-        delete m.contributes.configuration.properties['artemis.startPage'];
-        expect(() => cleanManifest(m)).toThrow(/cannot override unknown setting 'artemis\.startPage'/);
+        m.contributes.menus!.commandPalette!.push({ command: 'artemis.replaySession', when: 'editorFocus' });
+        // Force a menu that references a dropped command but is NOT a commandPalette entry
+        (m.contributes.menus as Record<string, unknown>)['editor/context'] = [{ command: 'artemis.replaySession' }];
+        expect(() => cleanManifest(m, 'desktop')).toThrow(/dangling command refs/);
+    });
+
+    it('throws on a dangling reference via a menu `alt` after a drop', () => {
+        const m = baseManifest();
+        (m.contributes.menus as Record<string, unknown>)['editor/context'] = [
+            { command: 'artemis.login', alt: 'artemis.replaySession' },
+        ];
+        expect(() => cleanManifest(m, 'desktop')).toThrow(/dangling command refs/);
+    });
+});
+
+describe('generate-clean-manifest against the real package.json', () => {
+    const realManifest = (): Manifest => JSON.parse(readFileSync(join(__dirname, '../../../package.json'), 'utf8'));
+
+    it('desktop: drops recorder + consent, keeps struggle', () => {
+        const m = cleanManifest(realManifest(), 'desktop');
+        const cmds = m.contributes.commands.map(c => c.command);
+        const cp = (m.contributes.menus?.commandPalette ?? []).map(e => e.command);
+        expect(cmds).not.toContain('artemis.replaySession');
+        expect(cmds).not.toContain('artemis.openRecordingsFolder');
+        expect(cp).not.toContain('artemis.replaySession');
+        expect(m.contributes.configuration.properties['artemis.dataCollectionConsent']).toBeUndefined();
+        expect(cmds).toContain('artemis.showStruggleScore'); // struggle kept on Desktop
+    });
+
+    it('openvsx: drops recorder + struggle groups and applies cloud defaults', () => {
+        const m = cleanManifest(realManifest(), 'openvsx');
+        const cmds = m.contributes.commands.map(c => c.command);
+        expect(cmds).not.toContain('artemis.replaySession');
+        expect(cmds).not.toContain('artemis.showStruggleScore');
+        expect(m.contributes.configuration.properties['artemis.struggleDetection.enabled'].default).toBe(false);
     });
 });

--- a/extension/test/logic/scripts/resolveBuildVariant.test.ts
+++ b/extension/test/logic/scripts/resolveBuildVariant.test.ts
@@ -1,0 +1,43 @@
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const { resolveBuildVariant } = require(
+    join(__dirname, '../../../scripts/resolveBuildVariant.js')
+) as {
+    resolveBuildVariant: (o: { argv?: string[]; env?: Record<string, string> }) => {
+        variant: string; isOpenVsx: boolean; recording: boolean;
+    };
+};
+
+describe('resolveBuildVariant', () => {
+    it('defaults to full (recorder off) with no flag or env', () => {
+        expect(resolveBuildVariant({ argv: [], env: {} })).toEqual({
+            variant: 'full', isOpenVsx: false, recording: false,
+        });
+    });
+    it('reads --variant= from argv', () => {
+        expect(resolveBuildVariant({ argv: ['node', 'esbuild.js', '--variant=openvsx'], env: {} }))
+            .toEqual({ variant: 'openvsx', isOpenVsx: true, recording: false });
+    });
+    it('reads IRIS_BUILD_VARIANT from env', () => {
+        expect(resolveBuildVariant({ argv: [], env: { IRIS_BUILD_VARIANT: 'local-recording' } }).recording).toBe(true);
+    });
+    it('argv flag wins over env', () => {
+        expect(resolveBuildVariant({ argv: ['--variant=full'], env: { IRIS_BUILD_VARIANT: 'local-recording' } }).recording)
+            .toBe(false);
+    });
+    it('throws on an unknown variant', () => {
+        expect(() => resolveBuildVariant({ argv: ['--variant=bogus'], env: {} })).toThrow(/unknown variant 'bogus'/);
+    });
+    it('refuses local-recording under GITHUB_ACTIONS', () => {
+        expect(() => resolveBuildVariant({ argv: ['--variant=local-recording'], env: { GITHUB_ACTIONS: 'true' } }))
+            .toThrow(/refused under CI/);
+    });
+    it('refuses local-recording under CI=true', () => {
+        expect(() => resolveBuildVariant({ argv: [], env: { IRIS_BUILD_VARIANT: 'local-recording', CI: 'true' } }))
+            .toThrow(/refused under CI/);
+    });
+    it('does NOT treat CI=false as CI', () => {
+        expect(resolveBuildVariant({ argv: ['--variant=local-recording'], env: { CI: 'false' } }).recording).toBe(true);
+    });
+});

--- a/extension/test/logic/scripts/verifyCleanBundle.test.ts
+++ b/extension/test/logic/scripts/verifyCleanBundle.test.ts
@@ -3,11 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-// Resolve the plain-JS verifier (in scripts/, no path alias). join(__dirname, ...)
-// keeps the require argument computed (not an upward-relative literal, per lint rule)
-// and avoids import.meta (disallowed under the CommonJS type-check target).
 const { forbiddenInputs } = require(join(__dirname, '../../../scripts/verify-clean-bundle.js')) as {
-    forbiddenInputs: (metafilePath: string) => string[];
+    forbiddenInputs: (metafilePath: string, profile: string) => string[];
 };
 
 function metaWith(inputs: string[]): string {
@@ -18,52 +15,70 @@ function metaWith(inputs: string[]): string {
 }
 
 describe('verify-clean-bundle', () => {
-    it('flags recorder/consent inputs', () => {
-        const f = metaWith([
-            'src/extension/services/telemetry/recording/sessionRecorder.ts',
-            'src/extension/services/auth/consentService.ts',
-            'src/extension/services/telemetry/metrics/errorQuotientEngine.ts',
-        ]);
-        expect(forbiddenInputs(f)).toHaveLength(3);
+    it('throws on an unknown profile', () => {
+        expect(() => forbiddenInputs(metaWith([]), 'bogus')).toThrow(/unknown profile 'bogus'/);
     });
 
-    it('passes a clean input set', () => {
-        const f = metaWith([
-            'src/extension/services/telemetry/types.ts',
-            'src/extension/dataCollection/noop.ts',
-        ]);
-        expect(forbiddenInputs(f)).toEqual([]);
+    describe('desktop profile (recorder forbidden, struggle allowed)', () => {
+        it('forbids recorder/consent/replay/seam inputs (both layouts)', () => {
+            const f = metaWith([
+                'src/extension/services/telemetry/recording/sessionRecorder.ts', // dev layout
+                'src/extension/services/telemetry/replay/replayEngine.ts',        // dev layout
+                'src/extension/services/recording/sessionRecorder.ts',            // struggle layout
+                'src/extension/services/auth/consentService.ts',
+                'src/extension/activation/sessionRecorderWiring.ts',
+                'src/extension/dataCollection/index.ts',
+                'src/extension/dataCollection/recording.ts',
+            ]);
+            expect(forbiddenInputs(f, 'desktop')).toHaveLength(7);
+        });
+        it('ALLOWS the shared SensorHub and the struggle engine', () => {
+            const f = metaWith([
+                'src/extension/services/sensing/sensorHub.ts',
+                'src/extension/services/telemetry/telemetryManager.ts',
+                'src/extension/services/struggle/struggleEngine.ts',
+                'src/extension/dataCollection/noop.ts',
+            ]);
+            expect(forbiddenInputs(f, 'desktop')).toEqual([]);
+        });
     });
 
-    it('flags the struggle engine entry points', () => {
-        const f = metaWith([
-            'src/extension/services/telemetry/telemetryManager.ts',
-            'src/extension/services/telemetry/decision/interventionDecisionEngine.ts',
-            'src/extension/services/telemetry/eventPipeline/boundaryTriggerEmitter.ts',
-            'src/extension/services/telemetry/types.ts', // allowed
-        ]);
-        expect(forbiddenInputs(f)).toHaveLength(3);
-    });
-
-    it('flags the struggle-detection webview view files', () => {
-        const f = metaWith([
-            'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
-            'src/webview/views/StruggleDetection/StruggleDetectionView.module.css',
-            'src/webview/views/StruggleDetection/stub.tsx', // allowed
-            'src/webview/views/StruggleDetection/types.ts', // allowed
-        ]);
-        expect(forbiddenInputs(f)).toHaveLength(2);
-    });
-
-    it('is fail-closed: flags unlisted telemetry-subtree files, allows only types.ts', () => {
-        const f = metaWith([
-            'src/extension/services/telemetry/uriFilter.ts', // recorder util, never explicitly listed
-            'src/extension/services/telemetry/someNewFile.ts', // any future addition
-            'src/extension/services/telemetry/types.ts', // allowlisted exception
-        ]);
-        expect(forbiddenInputs(f)).toEqual([
-            'src/extension/services/telemetry/uriFilter.ts',
-            'src/extension/services/telemetry/someNewFile.ts',
-        ]);
+    describe('openvsx profile (recorder + struggle forbidden)', () => {
+        it('forbids the struggle engine (dev telemetry subtree) but allows types.ts', () => {
+            const f = metaWith([
+                'src/extension/services/telemetry/telemetryManager.ts',
+                'src/extension/services/telemetry/uriFilter.ts',
+                'src/extension/services/telemetry/types.ts', // allowed
+            ]);
+            expect(forbiddenInputs(f, 'openvsx')).toEqual([
+                'src/extension/services/telemetry/telemetryManager.ts',
+                'src/extension/services/telemetry/uriFilter.ts',
+            ]);
+        });
+        it('forbids the struggle split layout', () => {
+            const f = metaWith([
+                'src/extension/services/struggle/struggleEngine.ts',
+                'src/extension/services/intervention/interventionService.ts',
+                'src/extension/services/struggleIntervention/struggleInterventionService.ts',
+            ]);
+            expect(forbiddenInputs(f, 'openvsx')).toHaveLength(3);
+        });
+        it('forbids every StruggleDetection view/hook file except stub/types/index', () => {
+            const f = metaWith([
+                'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
+                'src/webview/views/StruggleDetection/components/EpisodeHistoryPanel.tsx',
+                'src/webview/views/StruggleDetection/hooks/useSlotCountdowns.ts',
+                'src/webview/views/StruggleDetection/glossary.ts',
+                'src/webview/views/StruggleDetection/stub.tsx', // allowed (alias target)
+                'src/webview/views/StruggleDetection/types.ts', // allowed
+                'src/webview/views/StruggleDetection/index.ts', // allowed
+            ]);
+            expect(forbiddenInputs(f, 'openvsx')).toEqual([
+                'src/webview/views/StruggleDetection/StruggleDetectionView.tsx',
+                'src/webview/views/StruggleDetection/components/EpisodeHistoryPanel.tsx',
+                'src/webview/views/StruggleDetection/hooks/useSlotCountdowns.ts',
+                'src/webview/views/StruggleDetection/glossary.ts',
+            ]);
+        });
     });
 });

--- a/extension/test/logic/scripts/verifyCleanBundle.test.ts
+++ b/extension/test/logic/scripts/verifyCleanBundle.test.ts
@@ -14,6 +14,13 @@ function metaWith(inputs: string[]): string {
     return file;
 }
 
+function writeRawMeta(content: unknown): string {
+    const dir = mkdtempSync(join(tmpdir(), 'meta-'));
+    const file = join(dir, 'meta.json');
+    writeFileSync(file, JSON.stringify(content));
+    return file;
+}
+
 describe('verify-clean-bundle', () => {
     it('throws on an unknown profile', () => {
         expect(() => forbiddenInputs(metaWith([]), 'bogus')).toThrow(/unknown profile 'bogus'/);
@@ -79,6 +86,21 @@ describe('verify-clean-bundle', () => {
                 'src/webview/views/StruggleDetection/hooks/useSlotCountdowns.ts',
                 'src/webview/views/StruggleDetection/glossary.ts',
             ]);
+        });
+    });
+
+    describe('fail-closed on a malformed metafile', () => {
+        it('throws on empty inputs', () => {
+            expect(() => forbiddenInputs(writeRawMeta({ inputs: {} }), 'desktop')).toThrow(/no usable 'inputs'/);
+        });
+        it('throws on missing inputs', () => {
+            expect(() => forbiddenInputs(writeRawMeta({}), 'desktop')).toThrow(/no usable 'inputs'/);
+        });
+        it('throws on null inputs', () => {
+            expect(() => forbiddenInputs(writeRawMeta({ inputs: null }), 'desktop')).toThrow(/no usable 'inputs'/);
+        });
+        it('throws on array inputs', () => {
+            expect(() => forbiddenInputs(writeRawMeta({ inputs: [] }), 'openvsx')).toThrow(/no usable 'inputs'/);
         });
     });
 });

--- a/extension/test/react/__helpers__/vscode.stub.ts
+++ b/extension/test/react/__helpers__/vscode.stub.ts
@@ -21,3 +21,7 @@ export const Uri = {
         return { scheme: url.protocol.replace(':', ''), authority: url.host, path, fsPath: path, toString: () => value };
     },
 };
+
+export const commands = {
+    executeCommand: async (..._args: unknown[]): Promise<undefined> => undefined,
+};


### PR DESCRIPTION
Closes #336.

## What

Retires the session recorder from **every shipped build**. The recorder and the data-collection consent flow are now excluded from the Desktop (`full`, VS Marketplace) VSIX as well as the Open VSX one, while **struggle detection stays in Desktop**. The recorder survives only as a **local-only `local-recording` build** that CI can never produce.

## Three build variants

Resolved centrally by `scripts/resolveBuildVariant.js` from `IRIS_BUILD_VARIANT` (+ argv), fail-closed:

| Variant | Recorder | Struggle | Built by |
|---|---|---|---|
| `full` (VS Marketplace) | ❌ excluded | ✅ kept | `npm run package:vsix` |
| `openvsx` (Open VSX / EduIDE) | ❌ excluded | ❌ excluded (settings kept, defaulted `false`) | `npm run package:openvsx` |
| `local-recording` (never shipped) | ✅ present | ✅ present | `npm run package:rec` / "Run Extension (Recording)" |

## How it works

- **esbuild seam** — the `@dataCollection` alias resolves to a real wrapper (`recording.ts`) only when `recording` is true, otherwise to `noop.ts`. `@telemetry` / `@struggleView` stay keyed on `isOpenVsx`, so Desktop keeps struggle.
- **Fail-safe** — `resolveBuildVariant` throws when `local-recording` is requested under CI (`GITHUB_ACTIONS === 'true'` or `CI === 'true'`). Both shipped packagers hard-code their own variant; neither workflow ever passes `local-recording`.
- **Fail-closed manifest + bundle checks** — `generate-clean-manifest.js` (required `desktop`/`openvsx` profile, `default: throw`) drops the recorder contributions from the shipped manifests; `verify-clean-bundle.js` fails the build if any forbidden input reappears in the bundle. The verifier accepts both the `dev` and the struggle-branch recorder layouts so it stays correct after the struggle-v3 rebase, and deliberately does **not** forbid the shared `services/sensing/` SensorHub.
- **Runtime context key** — `iris.recorder.active` gates the recorder command-palette entries; the shipped manifests also drop those commands (belt-and-suspenders).
- Desktop/Open VSX package from a **staging dir** so the source `package.json` is never mutated.

## Verification (all three built locally)

- `check-types` clean · 61/61 logic tests · `knip` clean
- `full`: `OK (desktop): bundle contains no forbidden inputs`; manifest has **no** recorder commands, **keeps** `showStruggleScore` + `struggleDetection.*` (default `true`)
- `openvsx`: `OK (openvsx): bundle contains no forbidden inputs`; struggle excluded, settings defaulted `false`
- `local-recording`: recorder present (`extension.js` 406 KB vs 340 KB Desktop)
- Fail-safe: `CI=true` / `GITHUB_ACTIONS=true` + `local-recording` → build/packager exit 1; unknown variant → throws
- All three VSIXs package to the same clean 98-file set

## Notes

- The recorder **source stays in the repo** — only the build output changes.
- Dropped Desktop commands (`artemis.replaySession`, `artemis.openRecordingsFolder`) and the inert `artemis.dataCollectionConsent` setting are the only user-facing changes; struggle detection is untouched.
- `.github/` workflow changes are exercised for the first time by this PR's CI run.
