### PR TITLE
Stream Iris answers and migrate from stages to activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Changed
 
+- **Iris streaming:** Iris answers now stream into the chat as they are generated instead of appearing all at once, and the chat shows which tools Iris used during a run (with that trail kept on the finished answer). This replaces the progress display that stopped working with Artemis 9.6.
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
 

--- a/extension/src/extension/provider/baseWebviewProvider.ts
+++ b/extension/src/extension/provider/baseWebviewProvider.ts
@@ -135,8 +135,10 @@ export abstract class BaseWebviewProvider {
 
     /**
      * Safely post a message to the webview, queuing it if not ready yet.
-     * Deduplicates by message type (keeps latest) and enforces a hard cap.
-     * Event-type messages are always appended without deduplication.
+     * Coalesces same-type messages (keeps latest), but only within the
+     * segment of the queue after the most recent event-type message — see
+     * `coalescePending`. Event-type messages are always appended without
+     * deduplication. Enforces a hard cap on the queue length.
      */
     protected _postMessageSafe(message: ExtensionToWebviewMessage): void {
         if (this._webviewReady && this._view) {

--- a/extension/src/extension/provider/baseWebviewProvider.ts
+++ b/extension/src/extension/provider/baseWebviewProvider.ts
@@ -7,6 +7,44 @@ import { isWebviewMessage } from '@shared/messageContracts/typeGuards';
 import { LogCategory, logger } from '@extension/services/loggingService';
 
 /**
+ * Queue a message, coalescing repeat snapshots without letting one cross an
+ * event boundary.
+ *
+ * Deduplication gives "latest wins" within a streaming segment, which is what
+ * run-UI snapshots want. But replacing at the ORIGINAL index would move a later
+ * snapshot in front of an event message queued between them, inverting the
+ * commit ordering the Iris chat depends on. So we only coalesce against the
+ * segment following the most recent event message.
+ *
+ * Exported for testing.
+ */
+export function coalescePending(
+    queue: ExtensionToWebviewMessage[],
+    message: ExtensionToWebviewMessage,
+    eventTypes: ReadonlySet<string>,
+): void {
+    if (eventTypes.has(message.type)) {
+        queue.push(message);
+        return;
+    }
+
+    let segmentStart = 0;
+    for (let i = queue.length - 1; i >= 0; i--) {
+        if (eventTypes.has(queue[i].type)) {
+            segmentStart = i + 1;
+            break;
+        }
+    }
+    for (let i = segmentStart; i < queue.length; i++) {
+        if (queue[i].type === message.type) {
+            queue[i] = message;
+            return;
+        }
+    }
+    queue.push(message);
+}
+
+/**
  * Shared base class for webview providers.
  * Encapsulates the ready-signal handshake (queuing messages until the
  * webview's React shell has signalled readiness) and common message
@@ -104,18 +142,7 @@ export abstract class BaseWebviewProvider {
         if (this._webviewReady && this._view) {
             this._view.webview.postMessage(message);
         } else {
-            if (BaseWebviewProvider.EVENT_TYPES.has(message.type)) {
-                // Event messages carry unique data — never deduplicate
-                this._pendingMessages.push(message);
-            } else {
-                // Deduplicate: replace existing message with same type
-                const idx = this._pendingMessages.findIndex(m => m.type === message.type);
-                if (idx !== -1) {
-                    this._pendingMessages[idx] = message;
-                } else {
-                    this._pendingMessages.push(message);
-                }
-            }
+            coalescePending(this._pendingMessages, message, BaseWebviewProvider.EVENT_TYPES);
 
             // Safety net: drop oldest if over hard cap
             while (this._pendingMessages.length > BaseWebviewProvider.MAX_PENDING) {

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -18,6 +18,7 @@ import {
     IrisChatSessionService,
     IrisWebSocketSessionClient,
 } from '@extension/services/iris';
+import { createRunLifecycle, IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { ITelemetryManager, StruggleContext } from '@extension/services/telemetry';
 import { getReactWebviewHtml } from '@extension/services/ui';
@@ -56,6 +57,13 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     private _chatContextManager: ChatContextManager;
     private _websocketMessageHandler: IrisWebSocketMessageHandler;
     private _noAiDetectionService: NoAiDetectionService;
+
+    /**
+     * Single owner of the Iris run state machine. Injected into the WS handler
+     * (which drives it from inbound frames) and, via narrow callbacks, into the
+     * message + session services (which drive the send lifecycle and resets).
+     */
+    private readonly _runs = new IrisRunStateMachine();
 
     /**
      * Context-keyed single-flight guard for chat-session reloads. Auto-retry
@@ -167,12 +175,18 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         this._chatSessionService = new IrisChatSessionService(
             deps,
             () => this._irisSessionManager,
+            { resetRuns: () => this._websocketMessageHandler.resetRuns() },
         );
         this._chatMessageService = new ChatMessageService(
             deps,
             this._websocketService,
             () => this._irisSessionManager,
             this._chatSessionService,
+            createRunLifecycle(
+                this._runs,
+                () => this._websocketMessageHandler.resetRunUiAndPublish(),
+                () => this._websocketMessageHandler.publishCurrentRunUi(),
+            ),
         );
         this._chatContextManager = new ChatContextManager(
             deps,
@@ -183,6 +197,8 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             this._websocketService,
             () => this._irisSessionManager,
             (message) => this._postMessageSafe(message),
+            this._runs,
+            () => this._contextStore.snapshot().activeSession?.id,
             (artemisSessionId, title) => {
                 if (this._contextStore.updateSessionTitle(artemisSessionId, title)) {
                     this._viewStatePresenter.postSnapshot();
@@ -692,18 +708,16 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             return;
         }
 
-        // Fallback for builds that don't carry the new correlation IDs.
-        // Posting an assistant AddMessage causes the existing webview
-        // handler to call resetTransientChatUi, which clears the stuck
-        // indicator at the cost of a slightly noisier UX.
-        this._postMessageSafe({
-            type: ExtensionMsg.AddMessage,
-            message: {
-                role: 'assistant',
-                content: errorMessage,
-                timestamp: Date.now(),
-            }
-        });
+        // Fallback for builds that don't carry the new correlation IDs (so
+        // there is no optimistic message to mark failed). The old fallback
+        // posted an assistant AddMessage purely to trigger the webview's
+        // resetTransientChatUi — but Task 9 removes exactly that reset, so a
+        // bubble here would no longer unstick anything. Instead surface the
+        // reason as a notification and release the composer via the run-UI
+        // projection, which now owns clearing the indicator. Deliberately no
+        // AddMessage: that is what makes localSessionId genuinely required.
+        vscode.window.showWarningMessage(errorMessage);
+        this._websocketMessageHandler.publishCurrentRunUi();
     }
 
     private _friendlyRejectionMessage(result: { reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable'; contextLabel?: string }): string {
@@ -857,14 +871,24 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             const errorMessage = error instanceof Error ? error.message : String(error);
             this._onDidAttemptIrisChatSend.fire({ content, status: 'failed', errorMessage });
             vscode.window.showErrorMessage(`Failed to send message: ${errorMessage}`);
-            this._postMessageSafe({
-                type: ExtensionMsg.AddMessage,
-                message: {
-                    role: 'assistant',
-                    content: `Error: ${errorMessage}`,
-                    timestamp: Date.now()
-                }
-            });
+            // Belt and braces: release the composer even if the throw left no
+            // open generation to abort. The bubble carries no runUi, so on its
+            // own it would leave run state (and the indicator) untouched.
+            this._websocketMessageHandler.publishCurrentRunUi();
+            // Use the captured send-time localSessionId, never the live
+            // snapshot: after a mid-flight session switch the live snapshot
+            // would file this send's error under the new session.
+            if (localSessionId) {
+                this._postMessageSafe({
+                    type: ExtensionMsg.AddMessage,
+                    localSessionId,
+                    message: {
+                        role: 'assistant',
+                        content: `Error: ${errorMessage}`,
+                        timestamp: Date.now(),
+                    },
+                });
+            }
         }
     }
 

--- a/extension/src/extension/services/iris/chat/chatMessageService.ts
+++ b/extension/src/extension/services/iris/chat/chatMessageService.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { ExtensionMsg } from '@shared/messageContracts';
 
 import type { IrisServiceDeps } from '@extension/services/iris/context/sessionSyncUtils';
+import type { RunLifecycle } from '@extension/services/iris/irisRunStateMachine';
 import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { StruggleContext } from '@extension/services/telemetry';
@@ -41,6 +42,7 @@ export class ChatMessageService {
         private readonly _websocketService: ArtemisWebsocketService | undefined,
         private readonly _getIrisWebSocketSessionClient: () => IrisWebSocketSessionClient | undefined,
         private readonly _chatSessionService: IrisChatSessionService,
+        private readonly _runLifecycle: RunLifecycle,
     ) { }
 
     public async sendMessage(input: SendMessageInput): Promise<SendMessageResult> {
@@ -95,11 +97,18 @@ export class ChatMessageService {
             })}`);
         }
 
-        if (!this.deps.artemisApiService) {
-            throw new Error('Artemis API service not available');
-        }
-
+        // Open the generation BEFORE the missing-API guard and all the
+        // preparation steps, every one of which can throw (guard,
+        // _ensureWebSocketConnection, _ensureIrisSession, session guard,
+        // _collectUncommittedFiles) — not just the POST. The webview has
+        // already set streaming=true by now, so a throw with no open
+        // generation would leave nothing to abort and the composer would hang.
+        const generation = this._runLifecycle.beginGeneration();
         try {
+            if (!this.deps.artemisApiService) {
+                throw new Error('Artemis API service not available');
+            }
+
             // Check WebSocket connection before sending
             await this._ensureWebSocketConnection();
 
@@ -134,6 +143,9 @@ export class ChatMessageService {
 
         } catch (error: unknown) {
             logger.error('Error sending chat message', LogCategory.IRIS_CHAT, error);
+            // Abort only THIS send's generation so a concurrent/newer send is
+            // untouched, then rethrow for the provider's error handling.
+            this._runLifecycle.abortGeneration(generation);
             throw error;
         }
     }

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -4,6 +4,7 @@ import { MalformedResponseError } from '@extension/domain/errors';
 import { resolveCourseIdFromContext } from '@extension/services/iris/context/courseIdResolver';
 import type { IrisServiceDeps } from '@extension/services/iris/context/sessionSyncUtils';
 import { fetchSessionsWithMessages, importSessionsToStore } from '@extension/services/iris/context/sessionSyncUtils';
+import { isIrisActivity } from '@extension/services/iris/parseIrisWs';
 import type { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ActiveContext, ApiError, type IrisChatMessage, type IrisSettingsResponse } from '@extension/types';
@@ -411,7 +412,9 @@ export class IrisChatSessionService {
                     role: (msg.sender === 'USER' ? 'user' : 'assistant') as 'user' | 'assistant',
                     content: content,
                     timestamp: msg.sentAt ? new Date(msg.sentAt).getTime() : Date.now(),
-                    helpful: (msg as { helpful?: boolean | null }).helpful
+                    helpful: (msg as { helpful?: boolean | null }).helpful,
+                    activities: Array.isArray(msg.activities) ? msg.activities.filter(isIrisActivity) : undefined,
+                    final: typeof msg.final === 'boolean' ? msg.final : undefined
                 };
             });
 

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -61,6 +61,7 @@ export class IrisChatSessionService {
     constructor(
         private readonly deps: IrisServiceDeps,
         private readonly _getIrisWebSocketSessionClient: () => IrisWebSocketSessionClient | undefined,
+        private readonly _runReset: { resetRuns: () => void },
     ) { }
 
     public get contextLoadToken(): number {
@@ -446,6 +447,10 @@ export class IrisChatSessionService {
     public createNewSession(): void {
         logger.info('Creating new session', LogCategory.IRIS_CHAT);
 
+        // Drop host run state before the Iris session is reset, or the old
+        // run's projection survives into the new conversation.
+        this._runReset.resetRuns();
+
         const irisSessionManager = this._getIrisWebSocketSessionClient();
         if (irisSessionManager) {
             irisSessionManager.resetSession();
@@ -518,6 +523,10 @@ export class IrisChatSessionService {
 
     public switchToSession(sessionId: string): void {
         logger.info('Switching to session:', LogCategory.IRIS_CHAT, sessionId);
+
+        // Drop host run state before the Iris session is reset, or the old
+        // run's projection survives into the switched-to conversation.
+        this._runReset.resetRuns();
 
         const irisSessionManager = this._getIrisWebSocketSessionClient();
         if (irisSessionManager) {
@@ -649,6 +658,10 @@ export class IrisChatSessionService {
 
     private _clearAllSessions(): void {
         logger.info('Clearing all local sessions', LogCategory.IRIS_CHAT);
+
+        // Drop host run state before the Iris session is reset, or the old
+        // run's projection survives the Reset & Sync.
+        this._runReset.resetRuns();
 
         const irisSessionManager = this._getIrisWebSocketSessionClient();
         if (irisSessionManager) {

--- a/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
+++ b/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
@@ -1,13 +1,15 @@
 import * as vscode from 'vscode';
 
-import type { ExtensionToWebviewMessage, WebSocketDisplayStatus } from '@shared/messageContracts';
+import type { ExtensionToWebviewMessage, IrisRunUiProjection, WebSocketDisplayStatus } from '@shared/messageContracts';
 import { ExtensionMsg } from '@shared/messageContracts';
 
-import { isVisibleIrisStage } from '@extension/services/iris/parseIrisWs';
+import { IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+import type { IrisWebSocketMessage } from '@extension/services/iris/parseIrisWs';
+import { isIrisActivity, isIrisWebSocketMessage } from '@extension/services/iris/parseIrisWs';
 import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
-import type { IrisChatMessage } from '@extension/types';
+import type { IrisActivityDTO, IrisRunState } from '@extension/types';
 
 import { extractIrisMessageContent } from './messageUtils';
 
@@ -31,77 +33,193 @@ export class IrisWebSocketMessageHandler {
     private readonly _onDidReceiveIrisChatMessage = new vscode.EventEmitter<ReceivedIrisChatMessage>();
     public readonly onDidReceiveIrisChatMessage = this._onDidReceiveIrisChatMessage.event;
 
+    // Run-scoped UI projection. Held here (not just the draft) so a later
+    // PARTIAL cannot erase a known runState/error and so a disconnect reset
+    // can republish a clean projection without inventing a frame.
+    private _draft: { runId: string; text: string } | null = null;
+    private _activities: IrisActivityDTO[] = [];
+    private _runState: IrisRunState | null = null;
+    private _error: { message?: string } | null = null;
+    private _revision = 0;
+
     constructor(
         private readonly _websocketService: ArtemisWebsocketService | undefined,
         private readonly _getIrisWebSocketSessionClient: () => IrisWebSocketSessionClient | undefined,
         private readonly _postMessage: (message: ExtensionToWebviewMessage) => void,
+        private readonly _runs: IrisRunStateMachine,
+        private readonly _getLocalSessionId: () => string | undefined,
         private readonly _onSessionTitleUpdate?: (artemisSessionId: number, title: string) => void,
     ) { }
 
     public handleIrisWebSocketMessage(data: unknown): void {
-        logger.info(`Received Iris WebSocket message: ${JSON.stringify(data, null, 2)}`, LogCategory.WEBSOCKET);
-
-        // Runtime type guard for the incoming WebSocket payload
-        if (!this._isIrisWebSocketPayload(data)) {
-            logger.info(`Unknown message type or format: ${JSON.stringify(data)}`, LogCategory.WEBSOCKET);
+        if (!isIrisWebSocketMessage(data) || typeof data.type !== 'string') {
+            logger.info(`Unknown message format: ${JSON.stringify(data)}`, LogCategory.WEBSOCKET);
             return;
         }
 
-        // Extract sessionTitle if present (sent with both MESSAGE and STATUS payloads)
+        // Admission MUST come first: a stale run must not be able to rename the
+        // live session via sessionTitle.
+        if (!this._runs.admit(data)) {
+            logger.info(`Discarded frame from non-current run ${String(data.runId)}`, LogCategory.WEBSOCKET);
+            return;
+        }
+
         this._handleSessionTitle(data);
 
-        // Handle different message types
-        if (data.type === 'MESSAGE' && data.message) {
-            logger.info('Processing MESSAGE type', LogCategory.WEBSOCKET);
-            // Extract content from the message
-            const msg = data.message;
-            const content = extractIrisMessageContent(msg.content);
-
-            logger.info(`📝 Extracted content length: ${content.length} chars`, LogCategory.WEBSOCKET);
-            logger.info(`👤 Message sender: ${msg.sender}`, LogCategory.WEBSOCKET);
-
-            // Only show assistant messages (user messages were already shown)
-            if (msg.sender !== 'USER' && content) {
-                logger.info('🤖 Sending assistant message to webview (this should hide thinking indicator)', LogCategory.WEBSOCKET);
-                const sentAtMs = msg.sentAt ? new Date(msg.sentAt).getTime() : undefined;
-                this._postMessage({
-                    type: ExtensionMsg.AddMessage,
-                    message: {
-                        id: msg.id,
-                        role: 'assistant',
-                        content: content,
-                        timestamp: sentAtMs ?? Date.now(),
-                        helpful: typeof msg['helpful'] === 'boolean' ? msg['helpful'] : null
-                    }
-                });
-
-                // Build the enriched received-message payload for recording.
-                // sessionId is not available in the per-message payload; it is
-                // stored at the subscription level. We omit it here and rely on
-                // the recorder consumer to enrich it if needed in the future.
-                const receivedMsg: ReceivedIrisChatMessage = {
-                    content,
-                    messageId: msg.id !== undefined ? String(msg.id) : undefined,
-                    sentAt: sentAtMs,
-                };
-                this._onDidReceiveIrisChatMessage.fire(receivedMsg);
-                logger.info('Assistant message sent to webview', LogCategory.WEBSOCKET);
-            } else {
-                logger.info('Skipping message (either USER message or no content)', LogCategory.WEBSOCKET);
-            }
-        } else if (data.type === 'STATUS') {
-            const rawStages = data['stages'];
-            if (Array.isArray(rawStages)) {
-                const visibleStages = (rawStages as unknown[]).filter(isVisibleIrisStage);
-                logger.info(`Iris status update: ${visibleStages.length} visible stage(s)`, LogCategory.WEBSOCKET);
-                this._postMessage({
-                    type: ExtensionMsg.UpdateIrisStages,
-                    stages: visibleStages,
-                });
-            } else {
-                logger.info(`Iris STATUS message without stages array: ${JSON.stringify(data)}`, LogCategory.WEBSOCKET);
+        // Mirror run state into the projection ONLY when the machine accepted
+        // the transition. A stale unscoped FINISHED would otherwise produce
+        // waiting:true together with runState:'FINISHED' and wipe the visuals
+        // of the run that is actually still going.
+        if (data.runState && this._runs.applyRunState(data.runId, data.runState)) {
+            this._runState = data.runState;
+            this._error = data.error ?? null;
+            if (data.runState !== 'RUNNING') {
+                this._draft = null;
+                this._activities = [];
             }
         }
+
+        switch (data.type) {
+            case 'PARTIAL': this._handlePartial(data); break;
+            case 'STATUS': this._handleStatus(data); break;
+            case 'MESSAGE': this._handleMessage(data); break;
+            default:
+                logger.info(`Unhandled Iris frame type: ${data.type}`, LogCategory.WEBSOCKET);
+                this.publishCurrentRunUi();
+        }
+    }
+
+    private _handlePartial(frame: IrisWebSocketMessage): void {
+        const { runId, partialResult, partialSeq } = frame;
+        if (!runId || typeof partialResult !== 'string' || typeof partialSeq !== 'number') { return; }
+        if (!this._runs.acceptPartial(runId, partialSeq)) { return; }
+        this._draft = { runId, text: partialResult };
+        this.publishCurrentRunUi();
+    }
+
+    private _handleStatus(frame: IrisWebSocketMessage): void {
+        const { runId, activitySeq } = frame;
+        if (runId && typeof activitySeq === 'number' && Array.isArray(frame.activities)) {
+            if (!this._runs.acceptActivities(runId, activitySeq)) { return; }
+            this._activities = frame.activities.filter(isIrisActivity);
+        }
+        this.publishCurrentRunUi();
+    }
+
+    private _handleMessage(frame: IrisWebSocketMessage): void {
+        const msg = frame.message;
+        if (!msg) {
+            // A terminal MESSAGE frame can arrive with no message body. It has
+            // already changed waiting state above, so it must still publish.
+            this.publishCurrentRunUi();
+            return;
+        }
+
+        const intermediate = frame.final === false || msg.final === false;
+        this._runs.finalizeRun(frame.runId, intermediate);
+
+        const content = extractIrisMessageContent(msg.content);
+        if (msg.sender === 'USER' || !content) {
+            // Still publish: a terminal frame with no renderable content must not
+            // leave the webview showing a stale waiting state.
+            this.publishCurrentRunUi();
+            return;
+        }
+
+        // A run-ID-less MESSAGE is a resend that attaches memories or activities
+        // to an already-persisted message. It must upsert WITHOUT touching the
+        // current run's draft or feed, which may belong to a different run.
+        const isRunScoped = frame.runId !== undefined;
+        if (isRunScoped) {
+            this._draft = null;
+            if (!intermediate) { this._activities = []; }
+        }
+
+        const localSessionId = this._getLocalSessionId();
+        if (!localSessionId) {
+            // No active session to attribute this message to. Dropping is
+            // correct: rendering it would attach it to whatever session the
+            // user opens next.
+            logger.info('Dropping Iris message: no active local session', LogCategory.WEBSOCKET);
+            return;
+        }
+
+        const sentAtMs = msg.sentAt ? new Date(msg.sentAt).getTime() : undefined;
+        this._postMessage({
+            type: ExtensionMsg.AddMessage,
+            localSessionId,
+            message: {
+                id: msg.id,
+                role: 'assistant',
+                content,
+                timestamp: sentAtMs ?? Date.now(),
+                helpful: typeof msg['helpful'] === 'boolean' ? msg['helpful'] : null,
+                activities: Array.isArray(msg.activities) ? msg.activities.filter(isIrisActivity) : undefined,
+                final: intermediate ? false : undefined,
+            },
+            runUi: isRunScoped ? this._buildProjection() : undefined,
+        });
+
+        // Only a run-scoped final answer feeds the recorder path. A run-ID-less
+        // resend is a memory/activity attachment on a message already recorded,
+        // so firing here would double-count it.
+        if (isRunScoped && !intermediate) {
+            this._onDidReceiveIrisChatMessage.fire({
+                content,
+                messageId: msg.id !== undefined ? String(msg.id) : undefined,
+                sentAt: sentAtMs,
+            });
+        }
+    }
+
+    /**
+     * `undefined` when there is no active local session. `localSessionId` on the
+     * projection is a required `string`, and the accessor is
+     * `snapshot().activeSession?.id`, so the narrowing has to happen HERE.
+     * "The webview will reject it" is not reachable: tsc rejects it first.
+     */
+    private _buildProjection(): IrisRunUiProjection | undefined {
+        const localSessionId = this._getLocalSessionId();
+        if (!localSessionId) { return undefined; }
+        return {
+            localSessionId,
+            revision: ++this._revision,
+            draft: this._draft,
+            activities: this._activities,
+            waiting: this._runs.waiting,
+            runState: this._runState,
+            error: this._error,
+        };
+    }
+
+    /** Publishes the current projection. */
+    public publishCurrentRunUi(): void {
+        const projection = this._buildProjection();
+        if (!projection) { return; }
+        this._postMessage({ type: ExtensionMsg.UpdateIrisRunUi, projection });
+    }
+
+    /**
+     * Clears the projection (draft/activities/runState/error) but NOT the
+     * machine or the revision, then publishes. Called on beginGeneration so a
+     * new send does not republish the previous run's FAILED/error.
+     */
+    public resetRunUiAndPublish(): void {
+        this._draft = null;
+        this._activities = [];
+        this._runState = null;
+        this._error = null;
+        this.publishCurrentRunUi();
+    }
+
+    /** Clears run state (including the machine) and publishes the empty projection. */
+    public resetRuns(): void {
+        this._runs.reset();
+        this._draft = null;
+        this._activities = [];
+        this._runState = null;
+        this._error = null;
+        this.publishCurrentRunUi();
     }
 
     private _handleSessionTitle(data: Record<string, unknown>): void {
@@ -118,10 +236,6 @@ export class IrisWebSocketMessageHandler {
 
         logger.info(`Session title received: "${sessionTitle}" for session ${artemisSessionId}`, LogCategory.WEBSOCKET);
         this._onSessionTitleUpdate?.(artemisSessionId, sessionTitle);
-    }
-
-    private _isIrisWebSocketPayload(data: unknown): data is Record<string, unknown> & { type: string; message?: IrisChatMessage } {
-        return typeof data === 'object' && data !== null && 'type' in data && typeof (data as { type: unknown }).type === 'string';
     }
 
     public async handleReconnectWebSocket(): Promise<ReconnectResult> {

--- a/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
+++ b/extension/src/extension/services/iris/chat/irisWebSocketMessageHandler.ts
@@ -36,6 +36,12 @@ export class IrisWebSocketMessageHandler {
     // Run-scoped UI projection. Held here (not just the draft) so a later
     // PARTIAL cannot erase a known runState/error and so a disconnect reset
     // can republish a clean projection without inventing a frame.
+    //
+    // NOTE: on disconnect, only the webview store is reset (via
+    // UpdateWebSocketStatus -> resetTransientChatUi in the webview). This
+    // handler-side projection is intentionally left untouched here; clearing
+    // it on reconnect is owned by the deferred reconnect-reconciliation work,
+    // not an oversight of this handler.
     private _draft: { runId: string; text: string } | null = null;
     private _activities: IrisActivityDTO[] = [];
     private _runState: IrisRunState | null = null;
@@ -115,13 +121,21 @@ export class IrisWebSocketMessageHandler {
             return;
         }
 
+        const content = extractIrisMessageContent(msg.content);
+        if (msg.sender === 'USER') {
+            // A USER frame is the echoed prompt, never a run terminator; it must
+            // not finalize the current run even if the server ever scopes it to
+            // a runId.
+            this.publishCurrentRunUi();
+            return;
+        }
+
         const intermediate = frame.final === false || msg.final === false;
         this._runs.finalizeRun(frame.runId, intermediate);
 
-        const content = extractIrisMessageContent(msg.content);
-        if (msg.sender === 'USER' || !content) {
-            // Still publish: a terminal frame with no renderable content must not
-            // leave the webview showing a stale waiting state.
+        if (!content) {
+            // Bodiless assistant final answer: finalized above (waiting
+            // cleared), but nothing to render.
             this.publishCurrentRunUi();
             return;
         }

--- a/extension/src/extension/services/iris/irisRunStateMachine.ts
+++ b/extension/src/extension/services/iris/irisRunStateMachine.ts
@@ -1,0 +1,133 @@
+import type { IrisRunState } from '@shared/types/apiResponses';
+
+import type { IrisWebSocketMessage } from './parseIrisWs';
+
+/**
+ * Owns "which Iris run is current, and are we waiting for an answer".
+ *
+ * Pure logic, no `vscode` import, so it is unit-testable under vitest. The
+ * guard set mirrors the Artemis web client's chat service, which needs the same
+ * protections against out-of-order, superseded and late frames.
+ */
+export class IrisRunStateMachine {
+    private _currentRunId: string | undefined;
+    private _generation = 0;
+    private _pendingGeneration = false;
+    private _waiting = false;
+    private readonly _knownRunIds = new Set<string>();
+    private readonly _terminalStateByRunId = new Map<string, IrisRunState>();
+    private readonly _finalizedRunIds = new Set<string>();
+    private readonly _lastPartialSeqByRunId = new Map<string, number>();
+    private readonly _lastActivitySeqByRunId = new Map<string, number>();
+
+    public get waiting(): boolean { return this._waiting; }
+    public get currentRunId(): string | undefined { return this._currentRunId; }
+    public get generation(): number { return this._generation; }
+    public get pendingGeneration(): boolean { return this._pendingGeneration; }
+
+    /**
+     * Frame-level admission. MUST run before any per-field handling, including
+     * `sessionTitle`: otherwise a stale run can still rename the live session.
+     */
+    public admit(frame: IrisWebSocketMessage): boolean {
+        const runId = frame.runId;
+        if (!runId) {
+            // Short server overloads omit runId. Admitted, but callers must not
+            // let such a frame bind or finalize a run.
+            return true;
+        }
+
+        const isKnown = this._knownRunIds.has(runId);
+        if (this._pendingGeneration && isKnown) { return false; }
+
+        if (!isKnown) {
+            this._knownRunIds.add(runId);
+            this._currentRunId = runId;
+            this._pendingGeneration = false;
+        }
+        if (this._currentRunId && runId !== this._currentRunId) { return false; }
+
+        const terminal = this._terminalStateByRunId.get(runId);
+        if (terminal && frame.runState && frame.runState !== terminal) {
+            // Terminal state is monotonic: a late RUNNING must not resurrect it.
+            return false;
+        }
+        return true;
+    }
+
+    public acceptPartial(runId: string, seq: number): boolean {
+        if (this._finalizedRunIds.has(runId)) { return false; }
+        const last = this._lastPartialSeqByRunId.get(runId);
+        if (last !== undefined && seq <= last) { return false; }
+        this._lastPartialSeqByRunId.set(runId, seq);
+        return true;
+    }
+
+    public acceptActivities(runId: string, seq: number): boolean {
+        if (this._finalizedRunIds.has(runId)) { return false; }
+        const last = this._lastActivitySeqByRunId.get(runId);
+        if (last !== undefined && seq <= last) { return false; }
+        this._lastActivitySeqByRunId.set(runId, seq);
+        return true;
+    }
+
+    /** @returns the generation id, so the caller can abort exactly its own send. */
+    public beginGeneration(): number {
+        this._generation += 1;
+        this._pendingGeneration = true;
+        this._waiting = true;
+        return this._generation;
+    }
+
+    public abortGeneration(generation: number): void {
+        if (generation !== this._generation) { return; }
+        this._pendingGeneration = false;
+        this._waiting = false;
+    }
+
+    public finalizeRun(runId: string | undefined, intermediate: boolean): void {
+        // A run-ID-less MESSAGE (e.g. a memory attach on an already-persisted
+        // message) must never end the current run.
+        if (!runId || intermediate) { return; }
+        this._finalizedRunIds.add(runId);
+        this._lastPartialSeqByRunId.delete(runId);
+        if (runId === this._currentRunId) { this._waiting = false; }
+    }
+
+    /**
+     * @returns whether the transition was ACCEPTED. The caller must not mirror
+     *   `runState`/`error` into its projection when this returns false, or the
+     *   guard would protect only half the state: the machine would still be
+     *   waiting while the projection claimed FINISHED.
+     */
+    public applyRunState(runId: string | undefined, state: IrisRunState): boolean {
+        if (state === 'RUNNING') { return true; }
+
+        if (runId) {
+            if (runId !== this._currentRunId) { return false; }
+            this._terminalStateByRunId.set(runId, state);
+            if (!this._pendingGeneration) { this._waiting = false; }
+            return true;
+        }
+
+        // Unscoped terminal: it can only belong to the run already bound. While
+        // a NEW generation is pending it must not clear waiting, or a late
+        // FINISHED from the previous run unblocks the new one.
+        if (this._pendingGeneration || !this._currentRunId) { return false; }
+        this._terminalStateByRunId.set(this._currentRunId, state);
+        this._waiting = false;
+        return true;
+    }
+
+
+    public reset(): void {
+        this._currentRunId = undefined;
+        this._pendingGeneration = false;
+        this._waiting = false;
+        this._knownRunIds.clear();
+        this._terminalStateByRunId.clear();
+        this._finalizedRunIds.clear();
+        this._lastPartialSeqByRunId.clear();
+        this._lastActivitySeqByRunId.clear();
+    }
+}

--- a/extension/src/extension/services/iris/irisRunStateMachine.ts
+++ b/extension/src/extension/services/iris/irisRunStateMachine.ts
@@ -131,3 +131,37 @@ export class IrisRunStateMachine {
         this._lastActivitySeqByRunId.clear();
     }
 }
+
+/** The send-path's view of the machine: open a generation, or abort it. */
+export interface RunLifecycle {
+    beginGeneration(): number;
+    abortGeneration(generation: number): void;
+}
+
+/**
+ * Wraps {@link IrisRunStateMachine} so opening/aborting a generation also
+ * PUBLISHES the resulting projection. Extracted so the publish-on-transition
+ * behaviour is testable without a provider.
+ *
+ * `onBegin` must clear the handler projection first (then publish), or a new
+ * send republishes the previous run's FAILED/error together with
+ * `waiting: true` and the old alert flashes back until the first frame of the
+ * new run. `onAbort` just publishes the now `waiting: false` projection.
+ */
+export function createRunLifecycle(
+    runs: IrisRunStateMachine,
+    onBegin: () => void,
+    onAbort: () => void,
+): RunLifecycle {
+    return {
+        beginGeneration: () => {
+            const generation = runs.beginGeneration();
+            onBegin();
+            return generation;
+        },
+        abortGeneration: (generation: number) => {
+            runs.abortGeneration(generation);
+            onAbort();
+        },
+    };
+}

--- a/extension/src/extension/services/iris/parseIrisWs.ts
+++ b/extension/src/extension/services/iris/parseIrisWs.ts
@@ -15,7 +15,7 @@
  * at the call site — matching how live WS data is consumed elsewhere.
  */
 
-import type { IrisChatMessage, IrisStageDTO } from '@extension/types';
+import type { IrisActivityDTO, IrisChatMessage, IrisRunState, IrisStageDTO } from '@extension/types';
 
 /**
  * Minimal structural shape of an incoming Iris WebSocket frame. Exported
@@ -24,6 +24,14 @@ import type { IrisChatMessage, IrisStageDTO } from '@extension/types';
 export type IrisWebSocketMessage = Record<string, unknown> & {
     type?: string;
     message?: IrisChatMessage;
+    runId?: string;
+    runState?: IrisRunState;
+    partialResult?: string;
+    partialSeq?: number;
+    activities?: unknown;
+    activitySeq?: number;
+    final?: boolean;
+    error?: { message?: string } | null;
 };
 
 /**
@@ -47,4 +55,22 @@ export function isVisibleIrisStage(stage: unknown): stage is IrisStageDTO {
         return false;
     }
     return (stage as { internal?: unknown }).internal !== true;
+}
+
+const ACTIVITY_STATES = new Set(['RUNNING', 'FINISHED', 'FAILED']);
+const ACTIVITY_KINDS = new Set(['TOOL', 'COMMAND']);
+
+/**
+ * True if `value` is a usable activity entry. Unlike stages there is no
+ * `internal` flag to filter on: the server already curates activities.
+ */
+export function isIrisActivity(value: unknown): value is IrisActivityDTO {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    const a = value as Record<string, unknown>;
+    return typeof a['id'] === 'string'
+        && typeof a['name'] === 'string'
+        && typeof a['kind'] === 'string' && ACTIVITY_KINDS.has(a['kind'])
+        && typeof a['state'] === 'string' && ACTIVITY_STATES.has(a['state']);
 }

--- a/extension/src/extension/services/iris/parseIrisWs.ts
+++ b/extension/src/extension/services/iris/parseIrisWs.ts
@@ -6,16 +6,14 @@
  * UI (chat panel, status indicator), so a wrong-shaped frame just causes
  * a missing render — there's no downstream replay aggregation to corrupt.
  * The guards therefore check the minimum needed to safely call the
- * payload an `IrisWebSocketMessage` / `IrisStageDTO`:
+ * payload an `IrisWebSocketMessage`:
  *   - object shape (not null, not array, not primitive)
- *   - the one field the consumer actually reads to gate behaviour
- *     (`internal` for stages)
  *
  * Everything else stays as a permissive `[key: string]: unknown` lookup
  * at the call site — matching how live WS data is consumed elsewhere.
  */
 
-import type { IrisActivityDTO, IrisChatMessage, IrisRunState, IrisStageDTO } from '@extension/types';
+import type { IrisActivityDTO, IrisChatMessage, IrisRunState } from '@extension/types';
 
 /**
  * Minimal structural shape of an incoming Iris WebSocket frame. Exported
@@ -41,20 +39,6 @@ export type IrisWebSocketMessage = Record<string, unknown> & {
  */
 export function isIrisWebSocketMessage(data: unknown): data is IrisWebSocketMessage {
     return data !== null && typeof data === 'object' && !Array.isArray(data);
-}
-
-/**
- * True if `stage` is a plain object whose `internal` flag is not `true`.
- * This is exactly the predicate the STATUS handler uses to decide whether
- * to surface a stage in the UI — extracting it removes the inline `as
- * IrisStageDTO` cast from `irisWebSocketMessageHandler.ts` while keeping
- * the gating semantics identical.
- */
-export function isVisibleIrisStage(stage: unknown): stage is IrisStageDTO {
-    if (stage === null || typeof stage !== 'object' || Array.isArray(stage)) {
-        return false;
-    }
-    return (stage as { internal?: unknown }).internal !== true;
 }
 
 const ACTIVITY_STATES = new Set(['RUNNING', 'FINISHED', 'FAILED']);

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -6,7 +6,6 @@ import type {
     ExerciseDetailsResponse,
     IrisActivityDTO,
     IrisRunState,
-    IrisStageDTO,
     ResultSummary,
     SubmissionSummary,
 } from '@shared/types/apiResponses';
@@ -68,7 +67,6 @@ export const ExtensionMsg = {
     ShowUnavailableState: 'showUnavailableState',
     HideUnavailableState: 'hideUnavailableState',
     UpdateNoAiStatus: 'updateNoAiStatus',
-    UpdateIrisStages: 'updateIrisStages',
     UpdateIrisRunUi: 'updateIrisRunUi',
     SendRejected: 'sendRejected',
 
@@ -217,11 +215,10 @@ interface ExtensionMsgPayloads {
     addMessage: {
         /**
          * Session this bubble belongs to; the webview drops stale sessions.
-         * OPTIONAL in Phase A so the three existing producers and the typed
-         * React fixtures keep compiling. Task 10 (Phase C) tightens it to
-         * required once every producer sets it.
+         * Both producers (the WS handler and the provider's catch path) only
+         * ever emit when they have a session id to attribute the bubble to.
          */
-        localSessionId?: string;
+        localSessionId: string;
         message: {
             id?: number;
             role: 'user' | 'assistant';
@@ -268,9 +265,6 @@ interface ExtensionMsgPayloads {
     updateNoAiStatus: {
         isNoAiDetected: boolean;
         noAiFilePath?: string;
-    };
-    updateIrisStages: {
-        stages: IrisStageDTO[];
     };
     updateIrisRunUi: {
         projection: IrisRunUiProjection;

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -4,6 +4,8 @@
 
 import type {
     ExerciseDetailsResponse,
+    IrisActivityDTO,
+    IrisRunState,
     IrisStageDTO,
     ResultSummary,
     SubmissionSummary,
@@ -67,6 +69,7 @@ export const ExtensionMsg = {
     HideUnavailableState: 'hideUnavailableState',
     UpdateNoAiStatus: 'updateNoAiStatus',
     UpdateIrisStages: 'updateIrisStages',
+    UpdateIrisRunUi: 'updateIrisRunUi',
     SendRejected: 'sendRejected',
 
     // Exercise/Repo responses
@@ -88,6 +91,25 @@ export type ExtensionMsg = (typeof ExtensionMsg)[keyof typeof ExtensionMsg];
 /** Server-rendered problem statement fragment (body HTML returned by Artemis SSR endpoint). */
 interface RenderedProblemStatementPayload {
     html: string;
+}
+
+/**
+ * The host's view of run-scoped chat UI. Sent as a standalone snapshot
+ * (`updateIrisRunUi`) while streaming, and embedded in `addMessage` so a commit
+ * and its resulting UI state are applied atomically. The webview must never be
+ * able to observe the draft cleared before the committed message landed.
+ */
+export interface IrisRunUiProjection {
+    /** Rejects a projection belonging to a session we already left. */
+    localSessionId: string;
+    /** Monotonic; the webview drops anything not strictly newer. */
+    revision: number;
+    /** `null` clears the draft. Always `null` on a commit. */
+    draft: { runId: string; text: string } | null;
+    activities: IrisActivityDTO[];
+    waiting: boolean;
+    runState: IrisRunState | null;
+    error?: { message?: string } | null;
 }
 
 /** Payload definitions for each Extension->Webview message */
@@ -193,13 +215,27 @@ interface ExtensionMsgPayloads {
         showDiagnostics?: boolean;
     };
     addMessage: {
+        /**
+         * Session this bubble belongs to; the webview drops stale sessions.
+         * OPTIONAL in Phase A so the three existing producers and the typed
+         * React fixtures keep compiling. Task 10 (Phase C) tightens it to
+         * required once every producer sets it.
+         */
+        localSessionId?: string;
         message: {
             id?: number;
             role: 'user' | 'assistant';
             content: string;
             timestamp: number;
             helpful?: boolean | null;
+            activities?: IrisActivityDTO[];
+            final?: boolean;
         };
+        /**
+         * Omitted for non-run bubbles (the provider's error messages), which
+         * must leave run state untouched.
+         */
+        runUi?: IrisRunUiProjection;
     };
     loadMessages: {
         /** Local session UUID this load belongs to. The webview ignores
@@ -213,6 +249,8 @@ interface ExtensionMsgPayloads {
             content: string;
             timestamp: number;
             helpful?: boolean | null;
+            activities?: IrisActivityDTO[];
+            final?: boolean;
         }>;
     };
     loadMessagesError: { localSessionId: string };
@@ -233,6 +271,9 @@ interface ExtensionMsgPayloads {
     };
     updateIrisStages: {
         stages: IrisStageDTO[];
+    };
+    updateIrisRunUi: {
+        projection: IrisRunUiProjection;
     };
     /**
      * Posted by the extension host when a user-initiated `sendMessage`

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -179,6 +179,10 @@ export interface IrisChatMessage {
     sender?: string;
     sentAt?: string;
     content?: IrisChatMessageContent[];
+    /** Tool activity persisted with this message; rendered as the trail. */
+    activities?: IrisActivityDTO[];
+    /** `false` marks an intermediate message. Absent or `true` means final. */
+    final?: boolean;
     [key: string]: unknown;
 }
 
@@ -195,6 +199,21 @@ export interface IrisStageDTO {
     message?: string;
     internal?: boolean;
     [key: string]: unknown;
+}
+
+export type IrisRunState = 'RUNNING' | 'FINISHED' | 'FAILED';
+export type IrisActivityState = 'RUNNING' | 'FINISHED' | 'FAILED';
+export type IrisActivityKind = 'TOOL' | 'COMMAND';
+
+/** One tool or command invocation reported by a Pyris run. */
+export interface IrisActivityDTO {
+    id: string;
+    kind: IrisActivityKind;
+    name: string;
+    state: IrisActivityState;
+    detail?: string;
+    result?: string;
+    durationMillis?: number;
 }
 
 export interface IrisSettingsResponse {

--- a/extension/src/shared/types/apiResponses.ts
+++ b/extension/src/shared/types/apiResponses.ts
@@ -192,15 +192,6 @@ export interface IrisChatMessageContent {
     [key: string]: unknown;
 }
 
-export interface IrisStageDTO {
-    name?: string;
-    weight?: number;
-    state?: 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE' | 'SKIPPED' | 'ERROR';
-    message?: string;
-    internal?: boolean;
-    [key: string]: unknown;
-}
-
 export type IrisRunState = 'RUNNING' | 'FINISHED' | 'FAILED';
 export type IrisActivityState = 'RUNNING' | 'FINISHED' | 'FAILED';
 export type IrisActivityKind = 'TOOL' | 'COMMAND';

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-import type { ExtMsg, WebSocketDisplayStatus } from '@shared/messageContracts';
+import type { ExtMsg, IrisRunUiProjection, WebSocketDisplayStatus } from '@shared/messageContracts';
+import type { IrisActivityDTO, IrisRunState } from '@shared/types/apiResponses';
 
 import type {
     ChatContext,
@@ -56,6 +57,15 @@ interface ChatState {
     // Iris processing stages
     irisStages: IrisStageDTO[];
 
+    // Run UI (streaming draft, activities, run state) — projected atomically
+    // with the webview's active session/revision via applyRunUi/applyCommit.
+    liveDraft: { runId: string; text: string } | null;
+    activities: IrisActivityDTO[];
+    runState: IrisRunState | null;
+    runError: { message?: string } | null;
+    /** Monotonic guard against out-of-order/stale run UI projections. */
+    lastRunUiRevision: number;
+
     // UI state
     isLoading: boolean;
     webSocketStatus: ChatWebSocketStatus;
@@ -77,7 +87,28 @@ interface ChatState {
     applyLoadedMessages: (localSessionId: string, messages: ChatMessage[]) => void;
     /** Record that hydration failed for the given session. */
     setMessageLoadError: (localSessionId: string) => void;
+    /** Upserts by server `id`; messages without one always append (see `upsertMessage`). */
     addMessage: (message: ChatMessage) => void;
+    /**
+     * Apply a standalone run-UI snapshot (streaming draft/activities/run
+     * state). Rejects a projection for a session we already left, or one
+     * that is not strictly newer than the last applied revision.
+     */
+    applyRunUi: (projection: IrisRunUiProjection, activeLocalSessionId: string) => void;
+    /**
+     * Commit a message and (optionally) its run-UI projection in one atomic
+     * update, so the webview can never observe the draft cleared before the
+     * committed message lands. The message's session is checked
+     * independently of the projection's, since a projection-less commit
+     * (e.g. an error bubble) still must not land in a session we already
+     * left.
+     */
+    applyCommit: (
+        message: ChatMessage,
+        projection: IrisRunUiProjection | undefined,
+        messageLocalSessionId: string,
+        activeLocalSessionId: string,
+    ) => void;
     /**
      * Mark a still-pending user message as failed. Returns `true` only if
      * a matching message was found AND it was a pending user send
@@ -114,6 +145,20 @@ const IDLE_STREAMING: StreamingState = {
     isStreaming: false,
 };
 
+/**
+ * Artemis resends a persisted message to attach memories or activities, so a
+ * message with a known server id replaces its bubble instead of duplicating it.
+ * Messages with no server id (optimistic and error bubbles) always append.
+ */
+function upsertMessage(messages: ChatMessage[], message: ChatMessage): ChatMessage[] {
+    if (message.id === undefined) { return [...messages, message]; }
+    const idx = messages.findIndex((m) => m.id === message.id);
+    if (idx === -1) { return [...messages, message]; }
+    const next = [...messages];
+    next[idx] = { ...next[idx], ...message, localId: next[idx].localId };
+    return next;
+}
+
 export const useChatStore = create<ChatState>()(
     devtools(
         (set) => ({
@@ -128,6 +173,11 @@ export const useChatStore = create<ChatState>()(
             messageLoad: null,
             streaming: IDLE_STREAMING,
             irisStages: [],
+            liveDraft: null,
+            activities: [],
+            runState: null,
+            runError: null,
+            lastRunUiRevision: 0,
             isLoading: false,
             webSocketStatus: 'unknown',
             disabledMessage: null,
@@ -178,9 +228,45 @@ export const useChatStore = create<ChatState>()(
             },
 
             addMessage: (message) => {
-                set((state) => ({
-                    messages: [...state.messages, message],
-                }), false, 'addMessage');
+                set((state) => ({ messages: upsertMessage(state.messages, message) }), false, 'addMessage');
+            },
+
+            applyRunUi: (projection, activeLocalSessionId) => {
+                if (projection.localSessionId !== activeLocalSessionId) { return; }
+                if (projection.revision <= useChatStore.getState().lastRunUiRevision) { return; }
+                set({
+                    liveDraft: projection.draft,
+                    activities: projection.activities,
+                    runState: projection.runState,
+                    runError: projection.error ?? null,
+                    streaming: { isStreaming: projection.waiting },
+                    lastRunUiRevision: projection.revision,
+                }, false, 'applyRunUi');
+            },
+
+            applyCommit: (message, projection, messageLocalSessionId, activeLocalSessionId) => {
+                // Session-check the MESSAGE independently: a projection-less
+                // error bubble still must not land in a session we already left.
+                if (messageLocalSessionId !== activeLocalSessionId) { return; }
+
+                // One set() so the message and its run state can never be
+                // observed apart, and the draft is never cleared first.
+                set((s) => {
+                    const messages = upsertMessage(s.messages, message);
+                    const accepts = projection !== undefined
+                        && projection.localSessionId === activeLocalSessionId
+                        && projection.revision > s.lastRunUiRevision;
+                    if (!accepts) { return { messages }; }
+                    return {
+                        messages,
+                        liveDraft: projection.draft,
+                        activities: projection.activities,
+                        runState: projection.runState,
+                        runError: projection.error ?? null,
+                        streaming: { isStreaming: projection.waiting },
+                        lastRunUiRevision: projection.revision,
+                    };
+                }, false, 'applyCommit');
             },
 
             markMessageFailed: (localId, errorMessage, errorReason) => {
@@ -211,6 +297,11 @@ export const useChatStore = create<ChatState>()(
                     messageLoad: null,
                     irisStages: [],
                     streaming: IDLE_STREAMING,
+                    liveDraft: null,
+                    activities: [],
+                    runState: null,
+                    runError: null,
+                    lastRunUiRevision: 0,
                 }, false, 'clearMessages');
             },
 
@@ -229,6 +320,11 @@ export const useChatStore = create<ChatState>()(
                 set({
                     irisStages: [],
                     streaming: IDLE_STREAMING,
+                    liveDraft: null,
+                    activities: [],
+                    runState: null,
+                    runError: null,
+                    lastRunUiRevision: 0,
                 }, false, 'resetTransientChatUi');
             },
 

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -9,7 +9,6 @@ import type {
     ChatMessage,
     ChatSession,
     ContextItem,
-    IrisStageDTO,
     ReferencedFilesData,
     StreamingState,
 } from '@webview/views/IrisChat/types';
@@ -53,9 +52,6 @@ interface ChatState {
 
     // Streaming
     streaming: StreamingState;
-
-    // Iris processing stages
-    irisStages: IrisStageDTO[];
 
     // Run UI (streaming draft, activities, run state) — projected atomically
     // with the webview's active session/revision via applyRunUi/applyCommit.
@@ -127,8 +123,6 @@ interface ChatState {
     // Streaming actions
     startStreaming: () => void;
 
-    // Iris stage actions
-    setIrisStages: (stages: IrisStageDTO[]) => void;
     resetTransientChatUi: () => void;
 
     // UI actions
@@ -172,7 +166,6 @@ export const useChatStore = create<ChatState>()(
             messages: [],
             messageLoad: null,
             streaming: IDLE_STREAMING,
-            irisStages: [],
             liveDraft: null,
             activities: [],
             runState: null,
@@ -295,7 +288,6 @@ export const useChatStore = create<ChatState>()(
                 set({
                     messages: [],
                     messageLoad: null,
-                    irisStages: [],
                     streaming: IDLE_STREAMING,
                     liveDraft: null,
                     activities: [],
@@ -312,13 +304,8 @@ export const useChatStore = create<ChatState>()(
                 }, false, 'startStreaming');
             },
 
-            setIrisStages: (stages) => {
-                set({ irisStages: stages }, false, 'setIrisStages');
-            },
-
             resetTransientChatUi: () => {
                 set({
-                    irisStages: [],
                     streaming: IDLE_STREAMING,
                     liveDraft: null,
                     activities: [],

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -130,6 +130,8 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                         content: m.content,
                         timestamp: m.timestamp,
                         helpful: m.helpful ?? null,
+                        activities: m.activities,
+                        final: m.final,
                         status: 'sent' as const,
                     })),
                 );

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -244,7 +244,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             return;
         }
 
-        // Clear any stale stages/streaming from previous request
+        // Clear any stale streaming state from the previous request
         resetTransientChatUi();
 
         // Add optimistic message

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -109,15 +109,14 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 // clears the draft/waiting atomically with the committed
                 // message when a runUi is attached, and leaves them untouched
                 // for an intermediate (final:false) message so the waiting flag
-                // survives until the run truly ends. Both real producers always
-                // set localSessionId (and drop the message when they have no
-                // active session), so the empty-string fallback is only a type
-                // guard for the still-optional Phase-A contract.
+                // survives until the run truly ends. Both producers always set
+                // localSessionId (and drop the message when they have no
+                // active session), so it is required on the wire contract.
                 const activeLocalSessionId = useChatStore.getState().activeSessionId ?? '';
                 applyCommit(
                     mapped,
                     msg.runUi,
-                    msg.localSessionId ?? '',
+                    msg.localSessionId,
                     activeLocalSessionId,
                 );
                 break;

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Info from 'lucide-react/dist/esm/icons/info';
 import Menu from 'lucide-react/dist/esm/icons/menu';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { VsCodeApi } from '@shared/messageContracts';
 import { ExtensionMsg, postCommand } from '@shared/messageContracts';
@@ -15,7 +15,7 @@ import { ChatMessageList } from './components/ChatMessageList';
 import { ContextSelector } from './components/ContextSelector';
 import { ReferencedFiles } from './components/ReferencedFiles';
 import styles from './IrisChatView.module.css';
-import type { IrisStageDTO } from './types';
+import type { ChatMessage } from './types';
 
 interface IrisChatViewProps {
     vscodeApi: VsCodeApi;
@@ -28,7 +28,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         applyLoadedMessages, setMessageLoadError,
         clearMessages, setReferencedFiles, setWebSocketStatus,
         setDisabledMessage, setUnavailableMessage, setNoAiDetected,
-        setIrisStages, resetTransientChatUi,
+        resetTransientChatUi, applyRunUi, applyCommit,
         markMessageFailed,
     } = store;
     const [sideMenuOpen, setSideMenuOpen] = useState(false);
@@ -94,18 +94,38 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
             case ExtensionMsg.AddMessage: {
                 const m = msg.message;
-                addMessage({
+                const mapped: ChatMessage = {
                     id: m.id,
                     localId: crypto.randomUUID(),
                     role: m.role,
                     content: m.content,
                     timestamp: m.timestamp,
                     helpful: m.helpful ?? null,
+                    activities: m.activities,
+                    final: m.final,
                     status: 'sent',
-                });
-                if (m.role === 'assistant') {
-                    resetTransientChatUi();
-                }
+                };
+                // The projection now owns the transient run UI: applyCommit
+                // clears the draft/waiting atomically with the committed
+                // message when a runUi is attached, and leaves them untouched
+                // for an intermediate (final:false) message so the waiting flag
+                // survives until the run truly ends. Both real producers always
+                // set localSessionId (and drop the message when they have no
+                // active session), so the empty-string fallback is only a type
+                // guard for the still-optional Phase-A contract.
+                const activeLocalSessionId = useChatStore.getState().activeSessionId ?? '';
+                applyCommit(
+                    mapped,
+                    msg.runUi,
+                    msg.localSessionId ?? '',
+                    activeLocalSessionId,
+                );
+                break;
+            }
+
+            case ExtensionMsg.UpdateIrisRunUi: {
+                const activeLocalSessionId = useChatStore.getState().activeSessionId ?? '';
+                applyRunUi(msg.projection, activeLocalSessionId);
                 break;
             }
 
@@ -191,11 +211,6 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 break;
             }
 
-            case ExtensionMsg.UpdateIrisStages: {
-                setIrisStages(msg.stages);
-                break;
-            }
-
             case ExtensionMsg.SendRejected: {
                 // Ignore stale rejections that arrive after the user already
                 // switched session — the corresponding optimistic message
@@ -217,7 +232,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 break;
             }
         }
-    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, setIrisStages, resetTransientChatUi, markMessageFailed]);
+    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, resetTransientChatUi, applyRunUi, applyCommit, markMessageFailed]);
 
     const handleSendMessage = (text: string) => {
         const localId = crypto.randomUUID();
@@ -372,14 +387,6 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     } else if (showUnavailableBanner) {
         disabledPlaceholder = 'Iris is temporarily unavailable. Retry to reload.';
     }
-
-    // Derive active stage: first stage that is not DONE or SKIPPED.
-    // NOT_STARTED is intentionally included: it shows dots immediately while
-    // Artemis transitions the stage to IN_PROGRESS (provides instant feedback).
-    const activeStage = useMemo<IrisStageDTO | null>(
-        () => store.irisStages.find(s => s.state !== 'DONE' && s.state !== 'SKIPPED') ?? null,
-        [store.irisStages],
-    );
 
     // Hydrated when either no context is selected (legit "Select a course"
     // steady state) or when the active session has a successful load. The
@@ -589,7 +596,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     <ChatMessageList
                         messages={store.messages}
                         streaming={store.streaming}
-                        activeStage={activeStage}
+                        activities={store.activities}
+                        liveDraft={store.liveDraft}
+                        runState={store.runState}
+                        runError={store.runError}
                         onFeedback={handleFeedback}
                         onSendPrompt={handleSendMessage}
                         hasContext={store.context !== null}

--- a/extension/src/webview/views/IrisChat/activityLabels.ts
+++ b/extension/src/webview/views/IrisChat/activityLabels.ts
@@ -1,0 +1,47 @@
+import type { IrisActivityDTO } from '@shared/types/apiResponses';
+
+/**
+ * Ported from the Artemis web client's `iris.json` activity keys (16 entries).
+ * The extension has no i18n framework, so this is a plain constant. Pyris can
+ * add tools without an Artemis release, hence the prettify fallback.
+ */
+const ACTIVITY_LABELS: Readonly<Record<string, string>> = {
+    lecture_content_retrieval: 'Reading lecture',
+    faq_content_retrieval: 'Reading FAQs',
+    get_course_details: 'Looking up course info',
+    get_exercise_list: 'Looking up exercises',
+    get_exercise_problem_statement: 'Reading problem statement',
+    get_student_exercise_metrics: 'Checking your progress',
+    get_competency_list: 'Looking up competencies',
+    get_submission_details: 'Reading your submission',
+    get_additional_exercise_details: 'Looking up exercise info',
+    get_build_logs_analysis_tool: 'Checking build logs',
+    get_feedbacks: 'Reading feedback',
+    repository_files: 'Browsing your code',
+    file_lookup: 'Reading a file',
+    memiris_search_for_memories: 'Recalling memories',
+    memiris_find_similar_memories: 'Finding related memories',
+    generate_mcq_questions: 'Creating quiz questions',
+};
+
+export function prettifyActivityName(name: string): string {
+    const label = name.replace(/_/g, ' ').trim();
+    if (!label) { return ''; }
+    return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+}
+
+export function activityLabel(name: string): string {
+    return ACTIVITY_LABELS[name] ?? prettifyActivityName(name);
+}
+
+/** Sub-100ms durations render as a meaningless "0.0s", so they are dropped. */
+export function formatActivityDuration(activity: IrisActivityDTO): string | undefined {
+    if (activity.state !== 'FINISHED' || activity.durationMillis === undefined) { return undefined; }
+    if (activity.durationMillis < 100) { return undefined; }
+    return `${(activity.durationMillis / 1000).toFixed(1)}s`;
+}
+
+export function activityTrailSummary(activities: IrisActivityDTO[]): string {
+    const total = activities.reduce((sum, a) => sum + (a.durationMillis ?? 0), 0);
+    return `Tools used: ${activities.length} · ${(total / 1000).toFixed(1)}s`;
+}

--- a/extension/src/webview/views/IrisChat/components/ActivityFeed.module.css
+++ b/extension/src/webview/views/IrisChat/components/ActivityFeed.module.css
@@ -1,0 +1,78 @@
+.feedLive {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 4px 16px;
+}
+
+.feedTrail {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 4px 16px 8px 16px;
+    opacity: 0.85;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    padding: 3px 8px;
+    border-radius: 10px;
+    background: var(--vscode-editor-background);
+    border: 1px solid var(--vscode-panel-border);
+    font-family: var(--vscode-editor-font-family);
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--vscode-descriptionForeground);
+}
+
+.icon {
+    flex-shrink: 0;
+    display: inline-block;
+}
+
+.stateRunning .icon {
+    animation: spin 1s linear infinite;
+}
+
+.stateFinished .icon {
+    color: var(--vscode-charts-green);
+}
+
+.stateFailed .icon {
+    color: var(--vscode-errorForeground);
+}
+
+.label {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.detail {
+    min-width: 0;
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--vscode-foreground);
+    opacity: 0.75;
+}
+
+.duration {
+    flex-shrink: 0;
+    color: var(--vscode-descriptionForeground);
+    opacity: 0.7;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .stateRunning .icon {
+        animation: none;
+    }
+}

--- a/extension/src/webview/views/IrisChat/components/ActivityFeed.tsx
+++ b/extension/src/webview/views/IrisChat/components/ActivityFeed.tsx
@@ -1,0 +1,60 @@
+import type { IrisActivityDTO, IrisActivityState } from '@shared/types/apiResponses';
+
+import { activityLabel, formatActivityDuration } from '@webview/views/IrisChat/activityLabels';
+
+import styles from './ActivityFeed.module.css';
+
+interface ActivityFeedProps {
+    activities: IrisActivityDTO[];
+    mode: 'live' | 'trail';
+}
+
+const STATE_ICON: Readonly<Record<IrisActivityState, string>> = {
+    RUNNING: '◌',
+    FINISHED: '✓',
+    FAILED: '✕',
+};
+
+function stateClass(state: IrisActivityState): string {
+    switch (state) {
+        case 'RUNNING':
+            return styles.stateRunning;
+        case 'FINISHED':
+            return styles.stateFinished;
+        case 'FAILED':
+            return styles.stateFailed;
+    }
+}
+
+export function ActivityFeed({ activities, mode }: ActivityFeedProps) {
+    if (activities.length === 0) {
+        return null;
+    }
+
+    const isLive = mode === 'live';
+
+    return (
+        <div
+            className={isLive ? styles.feedLive : styles.feedTrail}
+            data-testid={`activity-feed-${mode}`}
+            aria-live={isLive ? 'polite' : undefined}
+            aria-label={isLive ? 'Iris activity' : 'Iris tool activity trail'}
+        >
+            {activities.map((activity) => {
+                const duration = formatActivityDuration(activity);
+                return (
+                    <span key={activity.id} className={`${styles.chip} ${stateClass(activity.state)}`}>
+                        <span className={styles.icon} aria-hidden="true">{STATE_ICON[activity.state]}</span>
+                        <span className={styles.label}>{activityLabel(activity.name)}</span>
+                        {activity.detail && (
+                            <span className={styles.detail} title={activity.detail}>{activity.detail}</span>
+                        )}
+                        {duration && (
+                            <span className={styles.duration}>{duration}</span>
+                        )}
+                    </span>
+                );
+            })}
+        </div>
+    );
+}

--- a/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react';
 
-import { useAutoScroll } from '@webview/hooks/useAutoScroll';
-import type { ChatMessage, IrisStageDTO, StreamingState } from '@webview/views/IrisChat/types';
+import type { IrisActivityDTO, IrisRunState } from '@shared/types/apiResponses';
 
+import { useAutoScroll } from '@webview/hooks/useAutoScroll';
+import type { ChatMessage, StreamingState } from '@webview/views/IrisChat/types';
+
+import { ActivityFeed } from './ActivityFeed';
 import styles from './ChatMessageList.module.css';
 import { MessageBubble } from './MessageBubble';
 import { ThinkingIndicator } from './ThinkingIndicator';
@@ -11,7 +14,14 @@ import { WelcomeState } from './WelcomeState';
 interface ChatMessageListProps {
     messages: ChatMessage[];
     streaming: StreamingState;
-    activeStage: IrisStageDTO | null;
+    /** Live tool/command activity for the in-flight run. */
+    activities: IrisActivityDTO[];
+    /** The streaming answer draft, or null when none is in flight. */
+    liveDraft: { runId: string; text: string } | null;
+    /** Current run lifecycle state (drives the FAILED error branch). */
+    runState: IrisRunState | null;
+    /** Error payload for a FAILED run. */
+    runError: { message?: string } | null;
     onFeedback: (messageId: number, feedback: 'positive' | 'negative') => void;
     onSendPrompt: (text: string) => void;
     hasContext: boolean;
@@ -30,7 +40,10 @@ interface ChatMessageListProps {
 export function ChatMessageList({
     messages,
     streaming,
-    activeStage,
+    activities,
+    liveDraft,
+    runState,
+    runError,
     onFeedback,
     onSendPrompt,
     hasContext,
@@ -45,15 +58,15 @@ export function ChatMessageList({
         scrollOnSend();
     }, [messages.length, scrollOnSend]);
 
-    // Show welcome state when no messages
-    const showWelcome = messages.length === 0;
+    // An in-flight (or just-failed) run has its own surfaces to show even
+    // before the first message lands, so it suppresses the welcome state.
+    const hasRunSurface =
+        streaming.isStreaming || activities.length > 0 || !!liveDraft || runState === 'FAILED';
+    const showWelcome = messages.length === 0 && !hasRunSurface;
 
-    // Stage indicator (real Iris pipeline stages) takes priority; the
-    // legacy thinking-dots fall back when streaming flag is set but no
-    // stages have been published yet.
-    const showStageIndicator = activeStage !== null;
-    const showLegacyThinking = !showStageIndicator && streaming.isStreaming;
-    const showThinking = showStageIndicator || showLegacyThinking;
+    // The thinking indicator is the "nothing to show yet" placeholder: once the
+    // run has produced activities or a draft, those richer surfaces replace it.
+    const showThinking = streaming.isStreaming && activities.length === 0 && !liveDraft;
 
     return (
         <div ref={scrollRef} className={styles.scrollContainer}>
@@ -74,15 +87,29 @@ export function ChatMessageList({
                             />
                         ))}
 
-                        {/* Show thinking indicator while waiting for the assistant
-                            response (cleared by resetTransientChatUi once
-                            AddMessage arrives). */}
-                        {showThinking && (
-                            <ThinkingIndicator
-                                isVisible={true}
-                                activeStage={showStageIndicator ? activeStage : null}
+                        {/* Live run surfaces, in order: activity feed, the
+                            streaming answer draft, then the thinking placeholder
+                            (only while nothing richer exists yet). */}
+                        <ActivityFeed activities={activities} mode="live" />
+
+                        {liveDraft && (
+                            <MessageBubble
+                                isDraft
+                                message={{
+                                    localId: `draft-${liveDraft.runId}`,
+                                    role: 'assistant',
+                                    content: liveDraft.text,
+                                    timestamp: Date.now(),
+                                    status: 'sending',
+                                }}
                             />
                         )}
+
+                        <ThinkingIndicator
+                            isVisible={showThinking}
+                            runState={runState}
+                            error={runError}
+                        />
                     </>
                 )}
             </div>

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
@@ -47,6 +47,19 @@
     composes: richContent from '../../../styles/richContent.module.css';
 }
 
+/* Tool-activity trail shown above a finished assistant answer. */
+.trail {
+    margin-bottom: 8px;
+}
+
+.trailSummary {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 0;
+}
+
 /* Wrapper so the error footer can sit directly under the bubble while
    still respecting the message wrapper's row-reverse for user messages. */
 .bubbleColumn {

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
@@ -8,13 +8,19 @@ import { Streamdown } from 'streamdown';
 
 import { useStreamdownConfig } from '@webview/hooks/useStreamdownConfig';
 import { formatRelativeTime } from '@webview/utils/formatRelativeTime';
+import { activityTrailSummary } from '@webview/views/IrisChat/activityLabels';
 import type { ChatMessage } from '@webview/views/IrisChat/types';
 
+import { ActivityFeed } from './ActivityFeed';
 import styles from './MessageBubble.module.css';
 
 interface MessageBubbleProps {
     message: ChatMessage;
-    onFeedback: (messageId: number, feedback: 'positive' | 'negative') => void;
+    /**
+     * Optional: a draft (streaming) bubble has nothing to rate, so it renders
+     * without feedback controls and needs no handler.
+     */
+    onFeedback?: (messageId: number, feedback: 'positive' | 'negative') => void;
     /** Invoked when the Retry button on a failed user message is clicked. */
     onRetry?: (localId: string) => void;
     /**
@@ -23,6 +29,11 @@ interface MessageBubbleProps {
      * Iris still disabled for the exercise).
      */
     retryDisabled?: boolean;
+    /**
+     * Marks the live streaming draft. Streamdown renders in streaming mode
+     * (incomplete-markdown tolerant) and feedback controls are suppressed.
+     */
+    isDraft?: boolean;
 }
 
 function MessageBubbleComponent({
@@ -30,6 +41,7 @@ function MessageBubbleComponent({
     onFeedback,
     onRetry,
     retryDisabled,
+    isDraft,
 }: MessageBubbleProps) {
     const [hovering, setHovering] = useState(false);
     const isAssistant = message.role === 'assistant';
@@ -41,12 +53,16 @@ function MessageBubbleComponent({
 
     const handleFeedback = (feedback: 'positive' | 'negative') => {
         if (message.id !== undefined) {
-            onFeedback(message.id, feedback);
+            onFeedback?.(message.id, feedback);
         }
     };
 
     const hasFeedback = message.helpful !== undefined && message.helpful !== null;
     const isFailed = message.status === 'error';
+    const hasTrail = isAssistant && !!message.activities && message.activities.length > 0;
+    // A draft, and any intermediate (`final === false`) message, cannot be
+    // rated: the run is still in flight so there is nothing final to judge.
+    const showFeedback = isAssistant && !isFailed && !isDraft && message.final !== false;
 
     return (
         <div
@@ -65,19 +81,31 @@ function MessageBubbleComponent({
                         [styles.error]: isFailed,
                     })}
                 >
+                    {/* Tool-activity trail, rendered above the answer for
+                        finished assistant messages that carried activities. */}
+                    {hasTrail && (
+                        <details className={styles.trail} open>
+                            <summary className={styles.trailSummary}>
+                                {activityTrailSummary(message.activities!)}
+                            </summary>
+                            <ActivityFeed activities={message.activities!} mode="trail" />
+                        </details>
+                    )}
+
                     {/* Always render the original message content. The error
                         footer below augments it instead of replacing it, so the
                         user can see what they tried to send. */}
                     <div className={styles.content}>
                         <Streamdown
-                            mode="static"
+                            mode={isDraft ? 'streaming' : 'static'}
+                            parseIncompleteMarkdown={isDraft}
                             components={streamdownComponents}
                         >
                             {message.content}
                         </Streamdown>
                     </div>
 
-                    {isAssistant && !isFailed && (
+                    {showFeedback && (
                         <div
                             className={clsx(styles.feedbackContainer, {
                                 [styles.visible]: hovering || hasFeedback,
@@ -155,6 +183,9 @@ const areEqual = (prev: MessageBubbleProps, next: MessageBubbleProps) => {
         prev.message.status === next.message.status &&
         prev.message.errorMessage === next.message.errorMessage &&
         prev.message.errorReason === next.message.errorReason &&
+        prev.message.final === next.message.final &&
+        prev.message.activities === next.message.activities &&
+        prev.isDraft === next.isDraft &&
         prev.retryDisabled === next.retryDisabled &&
         prev.onRetry === next.onRetry &&
         prev.onFeedback === next.onFeedback

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import type { IrisStageDTO } from '@webview/views/IrisChat/types';
+import type { IrisRunState } from '@shared/types/apiResponses';
 
 import styles from './ThinkingIndicator.module.css';
 
@@ -14,25 +14,29 @@ const ROTATION_INTERVAL_MS = 2600;
 
 interface ThinkingIndicatorProps {
     isVisible?: boolean;
-    activeStage?: IrisStageDTO | null;
+    runState?: IrisRunState | null;
+    error?: { message?: string } | null;
 }
 
 export function ThinkingIndicator({
     isVisible = true,
-    activeStage = null,
+    runState = null,
+    error = null,
 }: ThinkingIndicatorProps) {
-    if (!isVisible) { return null; }
-
-    if (activeStage?.state === 'ERROR') {
+    // A failed run surfaces its error regardless of the waiting flag: the run
+    // is over, so `isVisible` (the "still waiting" gate) no longer applies.
+    if (runState === 'FAILED') {
         return (
             <div className={styles.container}>
                 <div className={styles.errorContainer} role="alert">
                     <span className={styles.errorIcon} aria-hidden="true">&#9888;</span>
-                    <span className={styles.errorText}>{activeStage.message || 'An error occurred'}</span>
+                    <span className={styles.errorText}>{error?.message || 'An error occurred'}</span>
                 </div>
             </div>
         );
     }
+
+    if (!isVisible) { return null; }
 
     const irisLogoUri = document.getElementById('root')?.dataset.irisLogoUri;
 
@@ -41,51 +45,27 @@ export function ThinkingIndicator({
             {irisLogoUri && (
                 <img src={irisLogoUri} alt="" className={styles.logo} />
             )}
-            {activeStage?.state === 'IN_PROGRESS' ? (
-                <StageLabel activeStage={activeStage} />
-            ) : null}
+            <RotatingLabel />
         </div>
     );
 }
 
-/** Internal component managing label rotation, keyed on stageKey for stable identity */
-function StageLabel({ activeStage }: { activeStage: IrisStageDTO }) {
-    const stageKey = `${activeStage.name}:${activeStage.state}`;
-    const initialLabel = (activeStage.message && activeStage.message.length > 0)
-        ? activeStage.message
-        : ROTATION_LABELS[0];
-
-    const [displayLabel, setDisplayLabel] = useState(initialLabel);
+/** Cycles through the reassurance labels while a response is pending. */
+function RotatingLabel() {
+    const [displayLabel, setDisplayLabel] = useState(ROTATION_LABELS[0]);
     const [animKey, setAnimKey] = useState(0);
     const rotationIndex = useRef(0);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
-    // Effect 1: Reset rotation when stage identity changes
     useEffect(() => {
-        const startLabel = (activeStage.message && activeStage.message.length > 0)
-            ? activeStage.message
-            : ROTATION_LABELS[0];
-        rotationIndex.current = 0;
-        setDisplayLabel(startLabel);
-        setAnimKey((k) => k + 1);
-
-        const interval = setInterval(() => {
+        intervalRef.current = setInterval(() => {
             rotationIndex.current = (rotationIndex.current + 1) % ROTATION_LABELS.length;
             setDisplayLabel(ROTATION_LABELS[rotationIndex.current]);
             setAnimKey((k) => k + 1);
         }, ROTATION_INTERVAL_MS);
 
-        return () => clearInterval(interval);
-        // Intentionally keyed on stageKey only — restarts rotation when stage identity changes
-    }, [stageKey]);
-
-    // Effect 2: Update label when server message changes without restarting timer
-    useEffect(() => {
-        if (activeStage.message && activeStage.message.length > 0) {
-            setDisplayLabel(activeStage.message);
-            setAnimKey((k) => k + 1);
-        }
-        // Intentionally only reacts to message text changes, not full stageKey re-keying
-    }, [activeStage.message]);
+        return () => clearInterval(intervalRef.current);
+    }, []);
 
     return (
         <span className={styles.statusText} aria-live="polite">

--- a/extension/src/webview/views/IrisChat/types.ts
+++ b/extension/src/webview/views/IrisChat/types.ts
@@ -1,6 +1,5 @@
 import type { ExerciseRef } from '@shared/types';
 import type { IrisActivityDTO } from '@shared/types/apiResponses';
-export type { IrisStageDTO } from '@shared/types/apiResponses';
 
 // Chat message as rendered in the UI
 export interface ChatMessage {

--- a/extension/src/webview/views/IrisChat/types.ts
+++ b/extension/src/webview/views/IrisChat/types.ts
@@ -1,4 +1,5 @@
 import type { ExerciseRef } from '@shared/types';
+import type { IrisActivityDTO } from '@shared/types/apiResponses';
 export type { IrisStageDTO } from '@shared/types/apiResponses';
 
 // Chat message as rendered in the UI
@@ -18,6 +19,10 @@ export interface ChatMessage {
      * stays non-retryable as long as `.noai` is still detected).
      */
     errorReason?: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable';
+    /** Tool activity persisted with the message; renders as the trail. */
+    activities?: IrisActivityDTO[];
+    /** `false` marks an intermediate message: no feedback controls, run continues. */
+    final?: boolean;
 }
 
 // Chat session summary (from extension)

--- a/extension/test/logic/iris/irisRunStateMachine.test.ts
+++ b/extension/test/logic/iris/irisRunStateMachine.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+
+describe('IrisRunStateMachine', () => {
+    let m: IrisRunStateMachine;
+    beforeEach(() => { m = new IrisRunStateMachine(); });
+
+    describe('admission', () => {
+        it('admits frames without a runId', () => {
+            expect(m.admit({ type: 'STATUS' })).toBe(true);
+        });
+        it('binds the first run it sees', () => {
+            expect(m.admit({ type: 'STATUS', runId: 'A' })).toBe(true);
+            expect(m.currentRunId).toBe('A');
+        });
+        it('rejects a superseded run', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.admit({ type: 'STATUS', runId: 'B' });
+            expect(m.admit({ type: 'STATUS', runId: 'A' })).toBe(false);
+        });
+        it('rejects the previous run while a new generation is pending', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.beginGeneration();
+            expect(m.admit({ type: 'STATUS', runId: 'A' })).toBe(false);
+        });
+        it('binds a genuinely new run during a pending generation', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.beginGeneration();
+            expect(m.admit({ type: 'STATUS', runId: 'B' })).toBe(true);
+            expect(m.currentRunId).toBe('B');
+            expect(m.pendingGeneration).toBe(false);
+        });
+        it('rejects a late RUNNING after the run went terminal', () => {
+            m.admit({ type: 'STATUS', runId: 'A', runState: 'RUNNING' });
+            m.applyRunState('A', 'FAILED');
+            expect(m.admit({ type: 'STATUS', runId: 'A', runState: 'RUNNING' })).toBe(false);
+        });
+    });
+
+    describe('sequence guards', () => {
+        it('accepts strictly increasing partial sequences', () => {
+            expect(m.acceptPartial('A', 1)).toBe(true);
+            expect(m.acceptPartial('A', 2)).toBe(true);
+        });
+        it('rejects repeated and out-of-order partials', () => {
+            m.acceptPartial('A', 2);
+            expect(m.acceptPartial('A', 2)).toBe(false);
+            expect(m.acceptPartial('A', 1)).toBe(false);
+        });
+        it('rejects a partial after the run was finalized', () => {
+            m.acceptPartial('A', 1);
+            m.finalizeRun('A', false);
+            expect(m.acceptPartial('A', 2)).toBe(false);
+        });
+        it('guards activities independently of partials', () => {
+            expect(m.acceptActivities('A', 5)).toBe(true);
+            expect(m.acceptActivities('A', 5)).toBe(false);
+            expect(m.acceptPartial('A', 1)).toBe(true);
+        });
+    });
+
+    describe('waiting lifecycle', () => {
+        it('is false initially', () => expect(m.waiting).toBe(false));
+        it('becomes true on beginGeneration', () => {
+            m.beginGeneration();
+            expect(m.waiting).toBe(true);
+        });
+        it('abortGeneration only aborts its own generation', () => {
+            const g1 = m.beginGeneration();
+            const g2 = m.beginGeneration();
+            m.abortGeneration(g1);
+            expect(m.waiting).toBe(true);   // g1 is stale, must not clear g2
+            m.abortGeneration(g2);
+            expect(m.waiting).toBe(false);
+        });
+        it('stays true after an intermediate message', () => {
+            m.beginGeneration();
+            m.admit({ type: 'MESSAGE', runId: 'A' });
+            m.finalizeRun('A', true);
+            expect(m.waiting).toBe(true);
+        });
+        it('clears on a final message', () => {
+            m.beginGeneration();
+            m.admit({ type: 'MESSAGE', runId: 'A' });
+            m.finalizeRun('A', false);
+            expect(m.waiting).toBe(false);
+        });
+        it('clears on FINISHED alone, with no message', () => {
+            m.beginGeneration();
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.applyRunState('A', 'FINISHED');
+            expect(m.waiting).toBe(false);
+        });
+        it('clears on FAILED', () => {
+            m.beginGeneration();
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.applyRunState('A', 'FAILED');
+            expect(m.waiting).toBe(false);
+        });
+        it('a scoped late terminal from run A does not clear waiting for run B', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.beginGeneration();
+            m.admit({ type: 'STATUS', runId: 'B' });
+            m.applyRunState('A', 'FINISHED');
+            expect(m.waiting).toBe(true);
+        });
+        // THE load-bearing case: unscoped terminal while the next generation is pending.
+        it('an UNSCOPED late terminal does not clear waiting for a pending generation', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.beginGeneration();               // pending, no run bound yet
+            expect(m.applyRunState(undefined, 'FINISHED')).toBe(false);
+            expect(m.waiting).toBe(true);
+        });
+        it('reports acceptance so the caller can gate its projection', () => {
+            m.admit({ type: 'STATUS', runId: 'A' });
+            expect(m.applyRunState('A', 'FINISHED')).toBe(true);
+            expect(m.applyRunState('B', 'FAILED')).toBe(false);   // not the current run
+        });
+        it('a run-ID-less MESSAGE never finalizes the current run', () => {
+            m.beginGeneration();
+            m.admit({ type: 'MESSAGE', runId: 'A' });
+            m.finalizeRun(undefined, false);
+            expect(m.waiting).toBe(true);
+        });
+        it('reset clears everything', () => {
+            m.beginGeneration();
+            m.admit({ type: 'STATUS', runId: 'A' });
+            m.reset();
+            expect(m.waiting).toBe(false);
+            expect(m.currentRunId).toBeUndefined();
+            expect(m.acceptPartial('A', 1)).toBe(true);
+        });
+    });
+});

--- a/extension/test/logic/iris/irisRunStateMachine.test.ts
+++ b/extension/test/logic/iris/irisRunStateMachine.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+import { createRunLifecycle, IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
 
 describe('IrisRunStateMachine', () => {
     let m: IrisRunStateMachine;
@@ -130,6 +130,53 @@ describe('IrisRunStateMachine', () => {
             expect(m.waiting).toBe(false);
             expect(m.currentRunId).toBeUndefined();
             expect(m.acceptPartial('A', 1)).toBe(true);
+        });
+    });
+
+    describe('createRunLifecycle', () => {
+        it('publishes on begin and on abort', () => {
+            const onBegin = vi.fn();
+            const onAbort = vi.fn();
+            const lifecycle = createRunLifecycle(m, onBegin, onAbort);
+
+            const g = lifecycle.beginGeneration();
+            expect(onBegin).toHaveBeenCalledTimes(1);
+            expect(onAbort).not.toHaveBeenCalled();
+            expect(m.waiting).toBe(true);
+
+            lifecycle.abortGeneration(g);
+            expect(onAbort).toHaveBeenCalledTimes(1);
+            expect(m.waiting).toBe(false);
+        });
+
+        it('a begin from a FAILED projection yields waiting:true with runState/error/draft/activities cleared', () => {
+            // Model the handler projection the lifecycle's onBegin clears. onBegin
+            // runs AFTER beginGeneration, so machine.waiting is already true when
+            // the (mirrored) resetRunUiAndPublish builds its snapshot.
+            let projection = {
+                draft: { runId: 'A', text: 'partial' } as { runId: string; text: string } | null,
+                activities: ['stale-activity'] as unknown[],
+                runState: 'FAILED' as string | null,
+                error: { message: 'boom' } as { message?: string } | null,
+                waiting: false,
+            };
+            let snapshot: typeof projection | undefined;
+            const onBegin = (): void => {
+                // Mirrors handler.resetRunUiAndPublish: clear the projection
+                // fields (NOT the machine), then publish off machine.waiting.
+                projection = { draft: null, activities: [], runState: null, error: null, waiting: m.waiting };
+                snapshot = projection;
+            };
+
+            const lifecycle = createRunLifecycle(m, onBegin, () => { /* no-op */ });
+            lifecycle.beginGeneration();
+
+            expect(snapshot).toBeDefined();
+            expect(snapshot!.waiting).toBe(true);
+            expect(snapshot!.runState).toBeNull();
+            expect(snapshot!.error).toBeNull();
+            expect(snapshot!.draft).toBeNull();
+            expect(snapshot!.activities).toEqual([]);
         });
     });
 });

--- a/extension/test/logic/iris/irisWebSocketMessageHandler.test.ts
+++ b/extension/test/logic/iris/irisWebSocketMessageHandler.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// IrisWebSocketMessageHandler allocates a `new vscode.EventEmitter()` field
+// (_onDidReceiveIrisChatMessage), so constructing the REAL handler needs that
+// symbol. Mirror the shared vitest vscode stub (which has no EventEmitter)
+// with a minimal one; nothing else here touches vscode at runtime.
+vi.mock('vscode', () => {
+    class EventEmitter<T> {
+        event = (): { dispose(): void } => ({ dispose: () => { /* no-op */ } });
+        fire(_value?: T): void { /* no-op */ }
+        dispose(): void { /* no-op */ }
+    }
+    return { EventEmitter };
+});
+
+import type { ExtensionToWebviewMessage } from '@shared/messageContracts';
+
+import { IrisWebSocketMessageHandler } from '@extension/services/iris/chat/irisWebSocketMessageHandler';
+import { IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+
+/**
+ * Regression coverage for the FIX described in the whole-branch review: a
+ * USER-sender MESSAGE frame must never finalize the current run, even if it
+ * arrives scoped to the current run's runId (today the server always sends
+ * USER frames with runId/runState null, but the handler must not depend on
+ * that contract — see the comment on `_handleMessage`).
+ */
+describe('IrisWebSocketMessageHandler: USER frames never finalize a run', () => {
+    it('a USER MESSAGE scoped to the current run leaves it waiting and still accepting PARTIALs', () => {
+        const runs = new IrisRunStateMachine();
+        const posted: ExtensionToWebviewMessage[] = [];
+
+        const handler = new IrisWebSocketMessageHandler(
+            undefined,
+            () => undefined,
+            (message) => posted.push(message),
+            runs,
+            () => 's1',
+        );
+
+        // Start a generation and bind run 'A' as current, mirroring a real send.
+        runs.beginGeneration();
+        handler.handleIrisWebSocketMessage({ type: 'PARTIAL', runId: 'A', partialResult: 'first draft', partialSeq: 1 });
+        expect(runs.currentRunId).toBe('A');
+        expect(runs.waiting).toBe(true);
+
+        // A USER frame scoped to the current run (the hypothetical dangerous
+        // case the FIX guards against, not today's actual server behaviour).
+        handler.handleIrisWebSocketMessage({
+            type: 'MESSAGE',
+            runId: 'A',
+            message: { sender: 'USER', content: 'the user prompt, echoed back' },
+        });
+
+        // The run must still be waiting: the USER frame must not have reached
+        // finalizeRun.
+        expect(runs.waiting).toBe(true);
+
+        // A subsequent assistant PARTIAL for the same run must still be
+        // accepted. If the USER frame had wrongly finalized run 'A', it would
+        // be in `_finalizedRunIds` and this PARTIAL would be silently dropped.
+        posted.length = 0;
+        handler.handleIrisWebSocketMessage({ type: 'PARTIAL', runId: 'A', partialResult: 'second draft', partialSeq: 2 });
+
+        const runUiUpdates = posted.filter((m) => m.type === 'updateIrisRunUi');
+        expect(runUiUpdates).toHaveLength(1);
+        const projection = runUiUpdates[0] as Extract<ExtensionToWebviewMessage, { type: 'updateIrisRunUi' }>;
+        expect(projection.projection.draft).toEqual({ runId: 'A', text: 'second draft' });
+    });
+});

--- a/extension/test/logic/iris/webviewQueueOrdering.test.ts
+++ b/extension/test/logic/iris/webviewQueueOrdering.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { coalescePending } from '@extension/provider/baseWebviewProvider';
+
+const EVENTS = new Set(['websocketUpdate', 'addMessage']);
+const snap = (revision: number) => ({ type: 'updateIrisRunUi', revision } as never);
+const commit = (id: number) => ({ type: 'addMessage', id } as never);
+
+describe('coalescePending', () => {
+    it('coalesces two snapshots when no event separates them', () => {
+        const q = [snap(1)];
+        coalescePending(q, snap(2), EVENTS);
+        expect(q).toEqual([snap(2)]);
+    });
+
+    it('appends a snapshot that follows an event instead of replacing in place', () => {
+        const q = [snap(1), commit(10)];
+        coalescePending(q, snap(2), EVENTS);
+        expect(q).toEqual([snap(1), commit(10), snap(2)]);
+    });
+
+    it('coalesces only within the segment after the last event', () => {
+        const q = [snap(1), commit(10), snap(2)];
+        coalescePending(q, snap(3), EVENTS);
+        expect(q).toEqual([snap(1), commit(10), snap(3)]);
+    });
+
+    it('always appends event messages', () => {
+        const q = [snap(1)];
+        coalescePending(q, commit(10), EVENTS);
+        expect(q).toEqual([snap(1), commit(10)]);
+    });
+
+    it('still coalesces unrelated non-event types independently', () => {
+        const q = [{ type: 'updateNoAiStatus' } as never, snap(1)];
+        coalescePending(q, { type: 'updateNoAiStatus', v: 2 } as never, EVENTS);
+        expect(q).toEqual([{ type: 'updateNoAiStatus', v: 2 }, snap(1)]);
+    });
+});

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -81,6 +81,11 @@ describe('Iris Chat Flow', () => {
 			messages: [],
 			messageLoad: null,
 			streaming: { isStreaming: false },
+			liveDraft: null,
+			activities: [],
+			runState: null,
+			runError: null,
+			lastRunUiRevision: 0,
 			isLoading: false,
 			webSocketStatus: 'connected',
 			disabledMessage: null,
@@ -270,13 +275,13 @@ describe('Iris Chat Flow', () => {
 			expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
 		});
 
-		it('assistant addMessage clears the transient thinking + stages UI', async () => {
+		it('assistant addMessage with a runUi clears the transient draft + waiting UI', async () => {
 			useChatStore.setState({ context: exerciseContext, ...HYDRATED });
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
-			// Pre-state: thinking indicator on, stages populated (as if STATUS
-			// frame had pushed pipeline stages).
+			// Pre-state: thinking indicator on, a partial draft in flight (as if
+			// UpdateIrisRunUi frames had streamed a growing answer).
 			act(() => {
 				useChatStore.getState().addMessage({
 					localId: 'user-msg-1',
@@ -285,20 +290,26 @@ describe('Iris Chat Flow', () => {
 					timestamp: Date.now(),
 					status: 'sending',
 				});
-				useChatStore.getState().startStreaming();
-				useChatStore.getState().setIrisStages([
-					{ name: 'thinking', weight: 10, state: 'IN_PROGRESS', message: 'Thinking', internal: false },
-				]);
+				useChatStore.getState().applyRunUi({
+					localSessionId: 'local-test', revision: 1,
+					draft: { runId: 'A', text: 'partial' },
+					activities: [], waiting: true, runState: 'RUNNING',
+				}, 'local-test');
 			});
 
 			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
-			expect(useChatStore.getState().irisStages).toHaveLength(1);
+			expect(useChatStore.getState().liveDraft?.text).toBe('partial');
 
-			// The Artemis MESSAGE frame arrives — extension forwards it as
-			// AddMessage. IrisChatView's handler calls resetTransientChatUi
-			// for assistant messages.
+			// The Artemis MESSAGE frame arrives — extension forwards it as an
+			// AddMessage carrying the commit projection, which clears the draft
+			// and waiting flag atomically with the committed message.
 			dispatchExtensionMessage({
 				type: 'addMessage',
+				localSessionId: 'local-test',
+				runUi: {
+					localSessionId: 'local-test', revision: 2, draft: null,
+					activities: [], waiting: false, runState: 'FINISHED',
+				},
 				message: {
 					id: 99,
 					role: 'assistant',
@@ -311,7 +322,7 @@ describe('Iris Chat Flow', () => {
 				expect(screen.getByText('Final answer.')).toBeInTheDocument();
 			});
 			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
-			expect(useChatStore.getState().irisStages).toEqual([]);
+			expect(useChatStore.getState().liveDraft).toBeNull();
 		});
 	});
 
@@ -362,9 +373,11 @@ describe('Iris Chat Flow', () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
-			// Extension pushes a new message
+			// Extension pushes a new message. localSessionId must match the
+			// active session or applyCommit drops it.
 			dispatchExtensionMessage({
 				type: 'addMessage',
+				localSessionId: 'local-test',
 				message: {
 					id: 10,
 					role: 'assistant',

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -128,6 +128,7 @@ describe('Message contracts: ExtensionToWebviewMessage types', () => {
     it('IrisChatAddMessage has correct message shape', () => {
         const msg = {
             type: 'addMessage' as const,
+            localSessionId: 'session-local-1',
             message: {
                 id: 1,
                 role: 'assistant' as const,
@@ -153,20 +154,6 @@ describe('Message contracts: ExtensionToWebviewMessage types', () => {
         } satisfies ExtMsg<'websocketUpdate'>;
 
         expect(msg.updateType).toBe('newResult');
-    });
-
-    it('UpdateIrisStagesMessage has required stages array', () => {
-        const msg = {
-            type: 'updateIrisStages' as const,
-            stages: [
-                { name: 'thinking', weight: 10, state: 'IN_PROGRESS' as const, message: 'Thinking hard', internal: false },
-            ],
-        } satisfies ExtMsg<'updateIrisStages'>;
-
-        expect(msg.type).toBe('updateIrisStages');
-        expect(Array.isArray(msg.stages)).toBe(true);
-        expect(msg.stages[0].name).toBe('thinking');
-        expect(msg.stages[0].state).toBe('IN_PROGRESS');
     });
 
     it('UpdateIrisRunUiMessage has a well-formed run-UI projection', () => {

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -168,6 +168,40 @@ describe('Message contracts: ExtensionToWebviewMessage types', () => {
         expect(msg.stages[0].name).toBe('thinking');
         expect(msg.stages[0].state).toBe('IN_PROGRESS');
     });
+
+    it('UpdateIrisRunUiMessage has a well-formed run-UI projection', () => {
+        const msg = {
+            type: 'updateIrisRunUi' as const,
+            projection: {
+                localSessionId: 'session-local-1',
+                revision: 3,
+                draft: { runId: 'run-1', text: 'partial answer...' },
+                activities: [],
+                waiting: true,
+                runState: 'RUNNING' as const,
+            },
+        } satisfies ExtMsg<'updateIrisRunUi'>;
+
+        expect(msg.type).toBe('updateIrisRunUi');
+        expect(msg.projection.localSessionId).toBe('session-local-1');
+        expect(msg.projection.draft?.runId).toBe('run-1');
+        expect(msg.projection.runState).toBe('RUNNING');
+    });
+
+    it('IrisChatAddMessage is valid without runUi (non-run bubble, e.g. provider error)', () => {
+        const msg = {
+            type: 'addMessage' as const,
+            localSessionId: 'session-local-1',
+            message: {
+                role: 'assistant' as const,
+                content: 'Error: something went wrong',
+                timestamp: 1_700_000_000_000,
+            },
+        } satisfies ExtMsg<'addMessage'>;
+
+        expect(msg.type).toBe('addMessage');
+        expect('runUi' in msg).toBe(false);
+    });
 });
 
 // ============================================================================

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -5,7 +5,7 @@ import type { ExtMsg, IrisRunUiProjection } from '@shared/messageContracts';
 import type { IrisActivityDTO } from '@shared/types/apiResponses';
 
 import { useChatStore } from '@webview/stores/useChatStore';
-import type { ChatMessage, IrisStageDTO, ReferencedFilesData } from '@webview/views/IrisChat/types';
+import type { ChatMessage, ReferencedFilesData } from '@webview/views/IrisChat/types';
 
 const makeMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
 	localId: 'local-1',
@@ -24,12 +24,11 @@ const makeIrisState = (overrides: Partial<ExtMsg<'updateIrisState'>['state']> = 
 	...overrides,
 });
 
-const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
-	name: 'thinking',
-	weight: 10,
-	state: 'IN_PROGRESS',
-	message: 'Thinking hard',
-	internal: false,
+const makeActivity = (overrides: Partial<IrisActivityDTO> = {}): IrisActivityDTO => ({
+	id: 'a1',
+	kind: 'TOOL',
+	name: 'file_lookup',
+	state: 'RUNNING',
 	...overrides,
 });
 
@@ -431,53 +430,26 @@ describe('useChatStore', () => {
 		expect(result.current.context).toBeNull();
 	});
 
-	it('initializes with empty irisStages', () => {
-		const { result } = renderHook(() => useChatStore());
-		expect(result.current.irisStages).toEqual([]);
-	});
-
-	it('setIrisStages replaces the stages array', () => {
-		const { result } = renderHook(() => useChatStore());
-		const stages = [makeStage({ name: 'thinking' }), makeStage({ name: 'analyzing', state: 'NOT_STARTED' })];
-
-		act(() => {
-			result.current.setIrisStages(stages);
-		});
-
-		expect(result.current.irisStages).toHaveLength(2);
-		expect(result.current.irisStages[0].name).toBe('thinking');
-		expect(result.current.irisStages[1].state).toBe('NOT_STARTED');
-	});
-
-	it('setIrisStages replaces previous stages', () => {
+	it('resetTransientChatUi clears the run UI and streaming state', () => {
 		const { result } = renderHook(() => useChatStore());
 
 		act(() => {
-			result.current.setIrisStages([makeStage({ name: 'old' })]);
-		});
-
-		act(() => {
-			result.current.setIrisStages([makeStage({ name: 'new' })]);
-		});
-
-		expect(result.current.irisStages).toHaveLength(1);
-		expect(result.current.irisStages[0].name).toBe('new');
-	});
-
-	it('resetTransientChatUi clears irisStages and streaming state', () => {
-		const { result } = renderHook(() => useChatStore());
-
-		act(() => {
-			result.current.setIrisStages([makeStage()]);
-			result.current.startStreaming();
+			result.current.applyRunUi({
+				localSessionId: 's1', revision: 1, draft: { runId: 'A', text: 'partial' },
+				activities: [makeActivity()], waiting: true, runState: 'RUNNING',
+			}, 's1');
 		});
 
 		act(() => {
 			result.current.resetTransientChatUi();
 		});
 
-		expect(result.current.irisStages).toEqual([]);
 		expect(result.current.streaming.isStreaming).toBe(false);
+		expect(result.current.liveDraft).toBeNull();
+		expect(result.current.activities).toEqual([]);
+		expect(result.current.runState).toBeNull();
+		expect(result.current.runError).toBeNull();
+		expect(result.current.lastRunUiRevision).toBe(0);
 	});
 
 	it('resetTransientChatUi does not clear messages', () => {
@@ -485,7 +457,10 @@ describe('useChatStore', () => {
 
 		act(() => {
 			result.current.addMessage(makeMessage({ localId: 'msg-1' }));
-			result.current.setIrisStages([makeStage()]);
+			result.current.applyRunUi({
+				localSessionId: 's1', revision: 1, draft: { runId: 'A', text: 'partial' },
+				activities: [makeActivity()], waiting: true, runState: 'RUNNING',
+			}, 's1');
 		});
 
 		act(() => {
@@ -493,7 +468,8 @@ describe('useChatStore', () => {
 		});
 
 		expect(result.current.messages).toHaveLength(1);
-		expect(result.current.irisStages).toEqual([]);
+		expect(result.current.liveDraft).toBeNull();
+		expect(result.current.activities).toEqual([]);
 	});
 
 	describe('markMessageFailed', () => {
@@ -611,22 +587,6 @@ describe('useChatStore', () => {
 
 			expect(result.current.messages).toHaveLength(1);
 		});
-	});
-
-	it('clearMessages also clears irisStages', () => {
-		const { result } = renderHook(() => useChatStore());
-
-		act(() => {
-			result.current.addMessage(makeMessage({ localId: 'msg-1' }));
-			result.current.setIrisStages([makeStage()]);
-		});
-
-		act(() => {
-			result.current.clearMessages();
-		});
-
-		expect(result.current.messages).toEqual([]);
-		expect(result.current.irisStages).toEqual([]);
 	});
 
 	it('clearMessages also clears the run UI (draft, activities, run state, revision)', () => {

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -664,5 +664,26 @@ describe('useChatStore', () => {
 			useChatStore.getState().applyCommit(msg(5, 'stale'), undefined, 's-old', 's1');
 			expect(useChatStore.getState().messages).toHaveLength(0);
 		});
+
+		it('applies the message but rejects a stale-revision projection, leaving run-UI fields untouched', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 5, draft: { runId: 'A', text: 'live' }, waiting: true }), 's1');
+			useChatStore.getState().applyCommit(msg(6, 'final'), projection({ revision: 5 }), 's1', 's1');
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 6 && m.content === 'final')).toBe(true);
+			expect(useChatStore.getState().liveDraft).toEqual({ runId: 'A', text: 'live' });
+			expect(useChatStore.getState().runState).toBeNull();
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			expect(useChatStore.getState().lastRunUiRevision).toBe(5);
+		});
+
+		it('applies the message but rejects a projection scoped to another session, leaving run-UI fields untouched', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 1, draft: { runId: 'A', text: 'live' }, waiting: true }), 's1');
+			useChatStore.getState().applyCommit(msg(7, 'final'), projection({ revision: 2, localSessionId: 's2' }), 's1', 's1');
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 7 && m.content === 'final')).toBe(true);
+			expect(useChatStore.getState().liveDraft).toEqual({ runId: 'A', text: 'live' });
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			expect(useChatStore.getState().lastRunUiRevision).toBe(1);
+		});
 	});
 });

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -1,7 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import type { ExtMsg } from '@shared/messageContracts';
+import type { ExtMsg, IrisRunUiProjection } from '@shared/messageContracts';
+import type { IrisActivityDTO } from '@shared/types/apiResponses';
 
 import { useChatStore } from '@webview/stores/useChatStore';
 import type { ChatMessage, IrisStageDTO, ReferencedFilesData } from '@webview/views/IrisChat/types';
@@ -626,5 +627,82 @@ describe('useChatStore', () => {
 
 		expect(result.current.messages).toEqual([]);
 		expect(result.current.irisStages).toEqual([]);
+	});
+
+	it('clearMessages also clears the run UI (draft, activities, run state, revision)', () => {
+		const { result } = renderHook(() => useChatStore());
+
+		act(() => {
+			const activity: IrisActivityDTO = { id: 'a1', kind: 'TOOL', name: 'search', state: 'RUNNING' };
+			result.current.applyRunUi({
+				localSessionId: 's1', revision: 3, draft: { runId: 'A', text: 'partial' },
+				activities: [activity],
+				waiting: true, runState: 'RUNNING',
+			}, 's1');
+		});
+
+		act(() => {
+			result.current.clearMessages();
+		});
+
+		expect(result.current.liveDraft).toBeNull();
+		expect(result.current.activities).toEqual([]);
+		expect(result.current.runState).toBeNull();
+		expect(result.current.runError).toBeNull();
+		expect(result.current.lastRunUiRevision).toBe(0);
+	});
+
+	describe('streaming and commits', () => {
+		const projection = (over: Partial<IrisRunUiProjection> = {}): IrisRunUiProjection => ({
+			localSessionId: 's1', revision: 1, draft: null, activities: [],
+			waiting: false, runState: null, ...over,
+		});
+		const msg = (id: number | undefined, content: string): ChatMessage => ({
+			id, localId: `l${id ?? 'x'}`, role: 'assistant', content, timestamp: 0, status: 'sent',
+		});
+
+		it('upserts by server id instead of duplicating', () => {
+			useChatStore.getState().addMessage(msg(7, 'first'));
+			useChatStore.getState().addMessage(msg(7, 'first with memories'));
+			expect(useChatStore.getState().messages).toHaveLength(1);
+			expect(useChatStore.getState().messages[0].content).toBe('first with memories');
+		});
+
+		it('appends messages without a server id', () => {
+			useChatStore.getState().addMessage({ ...msg(undefined, 'a'), localId: 'l1' });
+			useChatStore.getState().addMessage({ ...msg(undefined, 'b'), localId: 'l2' });
+			expect(useChatStore.getState().messages).toHaveLength(2);
+		});
+
+		it('applies a newer projection and rejects an older revision', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 5, draft: { runId: 'A', text: 'hi' } }), 's1');
+			expect(useChatStore.getState().liveDraft?.text).toBe('hi');
+			useChatStore.getState().applyRunUi(projection({ revision: 4, draft: { runId: 'A', text: 'stale' } }), 's1');
+			expect(useChatStore.getState().liveDraft?.text).toBe('hi');
+		});
+
+		it('rejects a projection for another session', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 9, draft: { runId: 'A', text: 'x' } }), 's2');
+			expect(useChatStore.getState().liveDraft).toBeNull();
+		});
+
+		it('applies a commit atomically: message present, draft cleared, one update', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 1, draft: { runId: 'A', text: 'partial' } }), 's1');
+			useChatStore.getState().applyCommit(msg(3, 'final'), projection({ revision: 2 }), 's1', 's1');
+			expect(useChatStore.getState().messages).toHaveLength(1);
+			expect(useChatStore.getState().liveDraft).toBeNull();
+		});
+
+		it('inserts a projection-less bubble without touching run state', () => {
+			useChatStore.getState().applyRunUi(projection({ revision: 1, waiting: true }), 's1');
+			useChatStore.getState().applyCommit(msg(4, 'error'), undefined, 's1', 's1');
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			expect(useChatStore.getState().messages).toHaveLength(1);
+		});
+
+		it('drops a projection-less bubble from a stale session', () => {
+			useChatStore.getState().applyCommit(msg(5, 'stale'), undefined, 's-old', 's1');
+			expect(useChatStore.getState().messages).toHaveLength(0);
+		});
 	});
 });

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -58,7 +58,11 @@ describe('IrisChatView', () => {
 			messages: [],
 			messageLoad: null,
 			streaming: { isStreaming: false },
-			irisStages: [],
+			liveDraft: null,
+			activities: [],
+			runState: null,
+			runError: null,
+			lastRunUiRevision: 0,
 			isLoading: false,
 			webSocketStatus: 'connected',
 			disabledMessage: null,
@@ -195,11 +199,15 @@ describe('IrisChatView', () => {
 	});
 
 	it('adds a single message from addMessage extension event', async () => {
+		// applyCommit drops a message whose localSessionId does not match the
+		// active session, so both must line up for the commit to land.
+		useChatStore.setState({ activeSessionId: 'local-test' });
 		const mockApi = createMockVsCodeApi();
 		render(<IrisChatView vscodeApi={mockApi} />);
 
 		dispatchExtensionMessage({
 			type: 'addMessage',
+			localSessionId: 'local-test',
 			message: { id: 5, role: 'assistant', content: 'New reply', timestamp: Date.now() },
 		});
 
@@ -730,10 +738,16 @@ describe('IrisChatView', () => {
 		});
 	});
 
-	describe('irisStages reset paths', () => {
+	describe('run UI projection and reset paths', () => {
 		beforeEach(() => {
+			// Seed an in-flight run: waiting flag on, a partial draft and a
+			// running activity, so each path can assert whether it is cleared.
 			useChatStore.setState({
-				irisStages: [{ name: 'thinking', state: 'IN_PROGRESS', message: 'Thinking', weight: 10 }],
+				streaming: { isStreaming: true },
+				liveDraft: { runId: 'A', text: 'partial' },
+				activities: [{ id: 'a1', kind: 'TOOL', name: 'file_lookup', state: 'RUNNING' }],
+				runState: 'RUNNING',
+				lastRunUiRevision: 0,
 				context: {
 					type: 'exercise',
 					id: 1,
@@ -745,36 +759,66 @@ describe('IrisChatView', () => {
 			});
 		});
 
-		it('clears irisStages when assistant AddMessage arrives', async () => {
+		it('commits an assistant message with a runUi and clears the run UI atomically', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			dispatchExtensionMessage({
 				type: 'addMessage',
+				localSessionId: 'local-test',
+				runUi: {
+					localSessionId: 'local-test', revision: 5, draft: null,
+					activities: [], waiting: false, runState: 'FINISHED',
+				},
 				message: { id: 1, role: 'assistant', content: 'Response', timestamp: Date.now() },
 			});
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toEqual([]);
+				expect(screen.getByText('Response')).toBeInTheDocument();
 			});
+			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+			expect(useChatStore.getState().liveDraft).toBeNull();
+			expect(useChatStore.getState().activities).toEqual([]);
 		});
 
-		it('does not clear irisStages when user AddMessage arrives', async () => {
+		it('does not clear the waiting flag when an intermediate (final:false) message arrives', async () => {
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// An intermediate message carries no runUi: the run continues, so
+			// the waiting flag (and the rest of the run UI) must survive.
+			dispatchExtensionMessage({
+				type: 'addMessage',
+				localSessionId: 'local-test',
+				message: { id: 2, role: 'assistant', content: 'Intermediate', timestamp: Date.now(), final: false },
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText('Intermediate')).toBeInTheDocument();
+			});
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			expect(useChatStore.getState().liveDraft?.text).toBe('partial');
+		});
+
+		it('applies a standalone UpdateIrisRunUi projection', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			dispatchExtensionMessage({
-				type: 'addMessage',
-				message: { id: 1, role: 'user', content: 'Question', timestamp: Date.now() },
+				type: 'updateIrisRunUi',
+				projection: {
+					localSessionId: 'local-test', revision: 2,
+					draft: { runId: 'B', text: 'new draft' },
+					activities: [], waiting: true, runState: 'RUNNING',
+				},
 			});
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toHaveLength(1);
+				expect(useChatStore.getState().liveDraft?.text).toBe('new draft');
 			});
 		});
 
-		it('clears irisStages when LoadMessages arrives', async () => {
-			useChatStore.setState({ activeSessionId: 'local-test' });
+		it('clears the run UI when LoadMessages arrives', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
@@ -786,44 +830,53 @@ describe('IrisChatView', () => {
 			});
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toEqual([]);
+				expect(useChatStore.getState().streaming.isStreaming).toBe(false);
 			});
+			expect(useChatStore.getState().liveDraft).toBeNull();
 		});
 
-		it('clears irisStages when ClearChatMessages arrives', async () => {
+		it('clears the run UI when ClearChatMessages arrives', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			dispatchExtensionMessage({ type: 'clearChatMessages' });
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toEqual([]);
+				expect(useChatStore.getState().liveDraft).toBeNull();
 			});
+			expect(useChatStore.getState().activities).toEqual([]);
 		});
 
-		it('clears irisStages when UpdateWebSocketStatus reports a non-connected state', async () => {
+		it('clears the run UI when UpdateWebSocketStatus reports a non-connected state', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			dispatchExtensionMessage({ type: 'updateWebSocketStatus', status: 'disconnected' });
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toEqual([]);
+				expect(useChatStore.getState().streaming.isStreaming).toBe(false);
 			});
+			expect(useChatStore.getState().liveDraft).toBeNull();
+			expect(useChatStore.getState().activities).toEqual([]);
 		});
 
-		it('does not clear irisStages when UpdateWebSocketStatus reports connected', async () => {
+		it('does not clear the run UI when UpdateWebSocketStatus reports connected', async () => {
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			dispatchExtensionMessage({ type: 'updateWebSocketStatus', status: 'connected' });
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toHaveLength(1);
+				expect(useChatStore.getState().webSocketStatus).toBe('connected');
 			});
+			expect(useChatStore.getState().liveDraft?.text).toBe('partial');
+			expect(useChatStore.getState().streaming.isStreaming).toBe(true);
 		});
 
-		it('clears irisStages when user sends a message', async () => {
+		it('clears the run draft when the user sends a message', async () => {
+			// Streaming must be off for the input to be enabled; the stale
+			// draft/activities from a previous run should be cleared on send.
+			useChatStore.setState({ streaming: { isStreaming: false } });
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
@@ -831,24 +884,9 @@ describe('IrisChatView', () => {
 			await userEvent.type(textarea, 'Hello{Enter}');
 
 			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toEqual([]);
+				expect(useChatStore.getState().liveDraft).toBeNull();
 			});
-		});
-
-		it('sets irisStages when UpdateIrisStages arrives', async () => {
-			useChatStore.setState({ irisStages: [] });
-			const mockApi = createMockVsCodeApi();
-			render(<IrisChatView vscodeApi={mockApi} />);
-
-			dispatchExtensionMessage({
-				type: 'updateIrisStages',
-				stages: [{ name: 'analyzing', state: 'IN_PROGRESS', message: 'Analyzing', weight: 20 }],
-			});
-
-			await waitFor(() => {
-				expect(useChatStore.getState().irisStages).toHaveLength(1);
-				expect(useChatStore.getState().irisStages[0].name).toBe('analyzing');
-			});
+			expect(useChatStore.getState().activities).toEqual([]);
 		});
 	});
 });

--- a/extension/test/react/views/IrisChat/components/ActivityFeed.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ActivityFeed.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { activityLabel, prettifyActivityName } from '@webview/views/IrisChat/activityLabels';
+import { ActivityFeed } from '@webview/views/IrisChat/components/ActivityFeed';
+
+const act = (over = {}) => ({ id: 'a1', kind: 'TOOL' as const, name: 'file_lookup', state: 'RUNNING' as const, ...over });
+
+describe('activityLabel', () => {
+    it('translates a known slug', () => {
+        expect(activityLabel('get_build_logs_analysis_tool')).toBe('Checking build logs');
+    });
+    it('prettifies an unknown slug', () => {
+        expect(activityLabel('some_new_pyris_tool')).toBe('Some new pyris tool');
+    });
+    it('handles an empty name', () => {
+        expect(prettifyActivityName('')).toBe('');
+    });
+});
+
+describe('ActivityFeed', () => {
+    it('renders a label per activity', () => {
+        render(<ActivityFeed activities={[act(), act({ id: 'a2', name: 'repository_files' })]} mode="live" />);
+        expect(screen.getByText('Reading a file')).toBeTruthy();
+        expect(screen.getByText('Browsing your code')).toBeTruthy();
+    });
+    it('renders detail when present', () => {
+        render(<ActivityFeed activities={[act({ detail: 'Submission.java' })]} mode="live" />);
+        expect(screen.getByText('Submission.java')).toBeTruthy();
+    });
+    it('shows durations but suppresses sub-100ms', () => {
+        render(<ActivityFeed mode="trail" activities={[
+            act({ id: 'a1', state: 'FINISHED', durationMillis: 1200 }),
+            act({ id: 'a2', state: 'FINISHED', durationMillis: 40 }),
+        ]} />);
+        expect(screen.getByText('1.2s')).toBeTruthy();
+        expect(screen.queryByText('0.0s')).toBeNull();
+    });
+    it('renders nothing when empty', () => {
+        const { container } = render(<ActivityFeed activities={[]} mode="live" />);
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatMessageList.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ChatMessage, IrisStageDTO, StreamingState } from '@webview/views/IrisChat/types';
+import type { IrisActivityDTO, IrisRunState } from '@shared/types/apiResponses';
+
+import type { ChatMessage, StreamingState } from '@webview/views/IrisChat/types';
 
 // Mock use-stick-to-bottom (ESM package used via useAutoScroll)
 vi.mock('use-stick-to-bottom', () => ({
@@ -36,14 +38,6 @@ const defaultStreaming: StreamingState = {
 	isStreaming: false,
 };
 
-const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
-    name: 'thinking',
-    weight: 10,
-    state: 'IN_PROGRESS',
-    message: 'Thinking hard',
-    ...overrides,
-});
-
 function makeMessage(overrides: Partial<ChatMessage> = {}, index = 0): ChatMessage {
 	return {
 		localId: `msg-${index}`,
@@ -54,88 +48,76 @@ function makeMessage(overrides: Partial<ChatMessage> = {}, index = 0): ChatMessa
 	};
 }
 
+interface RenderListOverrides {
+	messages?: ChatMessage[];
+	streaming?: StreamingState;
+	activities?: IrisActivityDTO[];
+	liveDraft?: { runId: string; text: string } | null;
+	runState?: IrisRunState | null;
+	runError?: { message?: string } | null;
+	hasContext?: boolean;
+}
+
+/**
+ * Renders ChatMessageList with sensible defaults for every required prop so
+ * new cases can override only what they exercise and can never silently omit
+ * a required prop (which would otherwise make the component crash or render
+ * an unrelated branch).
+ */
+function renderList(overrides: RenderListOverrides = {}) {
+	return render(
+		<ChatMessageList
+			messages={overrides.messages ?? []}
+			streaming={overrides.streaming ?? defaultStreaming}
+			activities={overrides.activities ?? []}
+			liveDraft={overrides.liveDraft ?? null}
+			runState={overrides.runState ?? null}
+			runError={overrides.runError ?? null}
+			onFeedback={vi.fn()}
+			onSendPrompt={vi.fn()}
+			hasContext={overrides.hasContext ?? true}
+		/>
+	);
+}
+
 describe('ChatMessageList', () => {
 	it('renders welcome state when no messages', () => {
-		render(
-			<ChatMessageList
-				messages={[]}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({ hasContext: true });
 		// WelcomeState renders with Iris greeting when hasContext is true
 		expect(screen.getByText("Hi! I'm Iris, your AI tutor.")).toBeInTheDocument();
 	});
 
 	it('renders no-context welcome state when hasContext is false', () => {
-		render(
-			<ChatMessageList
-				messages={[]}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={false}
-			/>
-		);
+		renderList({ hasContext: false });
 		expect(
 			screen.getByText('Select a course or exercise to start chatting with Iris.')
 		).toBeInTheDocument();
 	});
 
 	it('renders messages when messages array is non-empty', () => {
-		const messages = [
-			makeMessage({ role: 'user', content: 'Hello Iris' }, 0),
-			makeMessage({ role: 'assistant', content: 'Hi there!' }, 1),
-		];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({
+			messages: [
+				makeMessage({ role: 'user', content: 'Hello Iris' }, 0),
+				makeMessage({ role: 'assistant', content: 'Hi there!' }, 1),
+			],
+		});
 		expect(screen.getByText('Hello Iris')).toBeInTheDocument();
 		expect(screen.getByText('Hi there!')).toBeInTheDocument();
 	});
 
 	it('does not render welcome state when messages exist', () => {
-		const messages = [makeMessage({ content: 'Hello' }, 0)];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({ messages: [makeMessage({ content: 'Hello' }, 0)] });
 		expect(screen.queryByText("Hi! I'm Iris, your AI tutor.")).not.toBeInTheDocument();
 	});
 
 	it('renders messages in order (user then assistant)', () => {
-		const messages = [
-			makeMessage({ role: 'user', content: 'Question 1' }, 0),
-			makeMessage({ role: 'assistant', content: 'Answer 1' }, 1),
-			makeMessage({ role: 'user', content: 'Question 2' }, 2),
-		];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({
+			messages: [
+				makeMessage({ role: 'user', content: 'Question 1' }, 0),
+				makeMessage({ role: 'assistant', content: 'Answer 1' }, 1),
+				makeMessage({ role: 'user', content: 'Question 2' }, 2),
+			],
+		});
 
 		const allText = screen.getAllByTestId('streamdown').map(el => el.textContent);
 		// Streamdown renders content in DOM order
@@ -144,66 +126,18 @@ describe('ChatMessageList', () => {
 		expect(allText[2]).toBe('Question 2');
 	});
 
-	it('shows thinking indicator when streaming is active', () => {
-		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
-		const streamingState: StreamingState = { isStreaming: true };
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={streamingState}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
-		expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
-	});
-
-	it('does not show thinking indicator when not streaming', () => {
-		const messages = [makeMessage({ content: 'Done' }, 0)];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
-		expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument();
-	});
-
 	it('renders scroll container div', () => {
-		const { container } = render(
-			<ChatMessageList
-				messages={[]}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		const { container } = renderList();
 		// The scroll container is the outermost div
 		expect(container.firstChild).toBeInTheDocument();
 	});
 
 	it('renders multiple messages as separate MessageBubble elements', () => {
-		const messages = Array.from({ length: 5 }, (_, i) =>
-			makeMessage({ role: i % 2 === 0 ? 'user' : 'assistant', content: `Msg ${i}` }, i)
-		);
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({
+			messages: Array.from({ length: 5 }, (_, i) =>
+				makeMessage({ role: i % 2 === 0 ? 'user' : 'assistant', content: `Msg ${i}` }, i)
+			),
+		});
 		// All 5 messages should be rendered
 		for (let i = 0; i < 5; i++) {
 			expect(screen.getByText(`Msg ${i}`)).toBeInTheDocument();
@@ -211,67 +145,45 @@ describe('ChatMessageList', () => {
 	});
 
 	it('passes onFeedback to message bubbles (feedback buttons visible on hover)', () => {
-		const onFeedback = vi.fn();
-		const messages = [makeMessage({ role: 'assistant', content: 'Answer' }, 0)];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={null}
-				onFeedback={onFeedback}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
+		renderList({ messages: [makeMessage({ role: 'assistant', content: 'Answer' }, 0)] });
 		// onFeedback is passed through — verify message renders
 		expect(screen.getByText('Answer')).toBeInTheDocument();
 	});
 
-	it('shows stage indicator when activeStage is present', () => {
-		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={defaultStreaming}
-				activeStage={makeStage()}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
-		expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+	it('renders the draft bubble from liveDraft', () => {
+		renderList({ liveDraft: { runId: 'A', text: 'partial answer' } });
+		expect(screen.getByText('partial answer')).toBeTruthy();
 	});
 
-	it('stage indicator takes priority over legacy thinking dots when both could apply', () => {
-		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
-		const streamingState: StreamingState = { isStreaming: true };
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={streamingState}
-				activeStage={makeStage()}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
-		// Stage indicator wins — its message is rendered.
-		expect(screen.getByText('Thinking hard')).toBeInTheDocument();
+	it('hides the thinking indicator once a draft exists', () => {
+		renderList({ streaming: { isStreaming: true }, liveDraft: { runId: 'A', text: 'x' } });
+		expect(screen.queryByTestId('thinking-indicator')).toBeNull();
 	});
 
-	it('shows legacy thinking dots when streaming but no activeStage', () => {
-		const messages = [makeMessage({ role: 'user', content: 'Question' }, 0)];
-		const streamingState: StreamingState = { isStreaming: true };
-		render(
-			<ChatMessageList
-				messages={messages}
-				streaming={streamingState}
-				activeStage={null}
-				onFeedback={vi.fn()}
-				onSendPrompt={vi.fn()}
-				hasContext={true}
-			/>
-		);
-		expect(screen.getByTestId('thinking-indicator')).toBeInTheDocument();
+	it('hides the thinking indicator once activities exist', () => {
+		renderList({ streaming: { isStreaming: true }, activities: [
+			{ id: 'a1', kind: 'TOOL', name: 'file_lookup', state: 'RUNNING' },
+		] });
+		expect(screen.queryByTestId('thinking-indicator')).toBeNull();
+		expect(screen.getByTestId('activity-feed-live')).toBeTruthy();
+	});
+
+	it('shows the thinking indicator while waiting with neither', () => {
+		renderList({ streaming: { isStreaming: true } });
+		expect(screen.getByTestId('thinking-indicator')).toBeTruthy();
+	});
+
+	it('does not show thinking indicator when not streaming', () => {
+		renderList({ messages: [makeMessage({ content: 'Done' }, 0)] });
+		expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument();
+	});
+
+	it('renders the trail on a finished assistant message', () => {
+		renderList({ messages: [{
+			id: 1, localId: 'l1', role: 'assistant', content: 'done', timestamp: 0, status: 'sent',
+			activities: [{ id: 'a1', kind: 'TOOL', name: 'file_lookup', state: 'FINISHED', durationMillis: 300 }],
+		}] });
+		expect(screen.getByTestId('activity-feed-trail')).toBeTruthy();
+		expect(screen.getByText(/Tools used: 1/)).toBeTruthy();
 	});
 });

--- a/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ThinkingIndicator.test.tsx
@@ -2,15 +2,6 @@ import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThinkingIndicator } from '@webview/views/IrisChat/components/ThinkingIndicator';
-import type { IrisStageDTO } from '@webview/views/IrisChat/types';
-
-const makeStage = (overrides: Partial<IrisStageDTO> = {}): IrisStageDTO => ({
-    name: 'thinking',
-    weight: 10,
-    state: 'IN_PROGRESS',
-    message: 'Thinking hard',
-    ...overrides,
-});
 
 describe('ThinkingIndicator', () => {
     beforeEach(() => {
@@ -22,46 +13,23 @@ describe('ThinkingIndicator', () => {
     });
 
     it('renders when isVisible is true (default)', () => {
-        const { container } = render(<ThinkingIndicator isVisible={true} />);
+        const { container } = render(<ThinkingIndicator isVisible runState={null} error={null} />);
         expect(container.firstChild).toBeInTheDocument();
     });
 
-    it('returns null when isVisible is false', () => {
-        const { container } = render(<ThinkingIndicator isVisible={false} />);
+    it('renders nothing when hidden and not failed', () => {
+        const { container } = render(<ThinkingIndicator isVisible={false} runState={null} error={null} />);
         expect(container.firstChild).toBeNull();
     });
 
-    it('renders container with no label when no activeStage (fallback)', () => {
-        const { container } = render(<ThinkingIndicator />);
-        expect(container.firstChild).toBeInTheDocument();
-        expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
+    it('renders a rotating label while thinking', () => {
+        render(<ThinkingIndicator isVisible runState={null} error={null} />);
+        expect(screen.getByTestId('thinking-indicator')).toBeTruthy();
+        expect(screen.getByText('Thinking hard')).toBeTruthy();
     });
 
-    it('shows stage label when activeStage is IN_PROGRESS', () => {
-        render(<ThinkingIndicator activeStage={makeStage({ message: 'Thinking hard' })} />);
-        expect(screen.getByText('Thinking hard')).toBeInTheDocument();
-    });
-
-    it('shows no label when activeStage is NOT_STARTED', () => {
-        render(
-            <ThinkingIndicator activeStage={makeStage({ state: 'NOT_STARTED' })} />
-        );
-        expect(screen.queryByText('Thinking hard')).not.toBeInTheDocument();
-    });
-
-    it('shows error state when activeStage is ERROR', () => {
-        render(<ThinkingIndicator activeStage={makeStage({ state: 'ERROR', message: 'Something failed' })} />);
-        expect(screen.getByRole('alert')).toBeInTheDocument();
-        expect(screen.getByText('Something failed')).toBeInTheDocument();
-    });
-
-    it('shows default error message when ERROR stage has no message', () => {
-        render(<ThinkingIndicator activeStage={makeStage({ state: 'ERROR', message: undefined })} />);
-        expect(screen.getByText('An error occurred')).toBeInTheDocument();
-    });
-
-    it('rotates labels every 2600ms when IN_PROGRESS', () => {
-        render(<ThinkingIndicator activeStage={makeStage()} />);
+    it('rotates labels every 2600ms while visible', () => {
+        render(<ThinkingIndicator isVisible runState="RUNNING" error={null} />);
         expect(screen.getByText('Thinking hard')).toBeInTheDocument();
 
         act(() => { vi.advanceTimersByTime(2600); });
@@ -77,8 +45,23 @@ describe('ThinkingIndicator', () => {
         expect(screen.getByText('Thinking hard')).toBeInTheDocument();
     });
 
-    it('has aria-live polite on status text', () => {
-        const { container } = render(<ThinkingIndicator activeStage={makeStage()} />);
+    it('renders the error branch on FAILED', () => {
+        render(<ThinkingIndicator isVisible runState="FAILED" error={{ message: 'Pyris exploded' }} />);
+        expect(screen.getByRole('alert').textContent).toContain('Pyris exploded');
+    });
+
+    it('falls back to generic copy when the server sends no message', () => {
+        render(<ThinkingIndicator isVisible runState="FAILED" error={null} />);
+        expect(screen.getByRole('alert').textContent).toContain('An error occurred');
+    });
+
+    it('renders the error branch on FAILED even when not visible (run is over)', () => {
+        render(<ThinkingIndicator isVisible={false} runState="FAILED" error={{ message: 'boom' }} />);
+        expect(screen.getByRole('alert').textContent).toContain('boom');
+    });
+
+    it('has aria-live polite on the status text', () => {
+        const { container } = render(<ThinkingIndicator isVisible runState="RUNNING" error={null} />);
         const ariaLive = container.querySelector('[aria-live="polite"]');
         expect(ariaLive).toBeInTheDocument();
     });

--- a/extension/test/unit/services/chatMessageService.test.ts
+++ b/extension/test/unit/services/chatMessageService.test.ts
@@ -6,6 +6,7 @@ import { ArtemisApiService } from '@extension/api';
 import { ChatMessageService } from '@extension/services/iris/chat/chatMessageService';
 import { IrisChatSessionService } from '@extension/services/iris/chat/chatSessionService';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
+import type { RunLifecycle } from '@extension/services/iris/irisRunStateMachine';
 import * as workspaceFileChecker from '@extension/services/workspace/workspaceFileChecker';
 import type { ActiveContext } from '@extension/types';
 import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
@@ -20,6 +21,7 @@ suite('ChatMessageService', () => {
     let checkWorkspaceFilesStub: sinon.SinonStub;
     let configGetStub: sinon.SinonStub;
     let mockSessionManager: { currentSessionId: number | undefined };
+    let mockLifecycle: { beginGeneration: sinon.SinonStub; abortGeneration: sinon.SinonStub };
     let service: ChatMessageService;
 
     const activeContext: ActiveContext = {
@@ -44,7 +46,10 @@ suite('ChatMessageService', () => {
         excludedCount: 1,
     };
 
-    function createService(apiService?: ArtemisApiService | undefined): ChatMessageService {
+    function createService(
+        apiService?: ArtemisApiService | undefined,
+        overrides?: { websocketService?: unknown; lifecycle?: RunLifecycle },
+    ): ChatMessageService {
         service = new ChatMessageService(
             {
                 contextStore,
@@ -52,9 +57,10 @@ suite('ChatMessageService', () => {
                 postMessage: postMessageSpy,
                 postSnapshot: postSnapshotSpy,
             },
-            { isConnected: () => true, connect: sandbox.stub().resolves() } as any,
+            (overrides?.websocketService ?? { isConnected: () => true, connect: sandbox.stub().resolves() }) as any,
             () => mockSessionManager as any,
             mockChatSessionService as any,
+            (overrides?.lifecycle ?? mockLifecycle) as unknown as RunLifecycle,
         );
         return service;
     }
@@ -85,6 +91,8 @@ suite('ChatMessageService', () => {
         postSnapshotSpy = sinon.spy();
 
         mockSessionManager = { currentSessionId: 42 };
+
+        mockLifecycle = { beginGeneration: sandbox.stub().returns(1), abortGeneration: sandbox.stub() };
 
         checkWorkspaceFilesStub = sandbox.stub(workspaceFileChecker, 'checkWorkspaceFiles').resolves(defaultFileResult);
 
@@ -325,6 +333,50 @@ suite('ChatMessageService', () => {
 
             assert.ok(mockApiService.sendChatMessage.calledOnce);
             assert.strictEqual(mockApiService.sendChatMessage.firstCall.args[2], undefined);
+        });
+    });
+
+    suite('Run-generation lifecycle', () => {
+        test('aborts this send\'s generation when the POST throws', async () => {
+            // The generation is opened before the send; a failing POST must
+            // abort exactly it so the composer is released.
+            const lifecycle = { beginGeneration: sandbox.stub().returns(7), abortGeneration: sandbox.stub() };
+            createService(mockApiService as unknown as ArtemisApiService, { lifecycle });
+            mockApiService.sendChatMessage.rejects(new Error('POST failed'));
+
+            await assert.rejects(
+                () => service.sendMessage({ text: 'Hello', isNoAiEnabled: false }),
+                /POST failed/,
+            );
+
+            assert.ok(lifecycle.beginGeneration.calledOnce, 'generation must be opened');
+            assert.ok(
+                lifecycle.abortGeneration.calledOnceWithExactly(7),
+                'abortGeneration must be called with this send\'s generation',
+            );
+        });
+
+        test('aborts the generation when a pre-POST step throws (before the POST)', async () => {
+            // The old plan missed this case: the generation is opened above the
+            // preparation steps, so a throw in _ensureWebSocketConnection (here,
+            // isConnected throwing) must still abort — the POST is never reached.
+            const lifecycle = { beginGeneration: sandbox.stub().returns(7), abortGeneration: sandbox.stub() };
+            const throwingWs = {
+                isConnected: () => { throw new Error('ws down'); },
+                connect: sandbox.stub().resolves(),
+            };
+            createService(mockApiService as unknown as ArtemisApiService, { websocketService: throwingWs, lifecycle });
+
+            await assert.rejects(
+                () => service.sendMessage({ text: 'Hello', isNoAiEnabled: false }),
+                /ws down/,
+            );
+
+            assert.ok(
+                lifecycle.abortGeneration.calledOnceWithExactly(7),
+                'abortGeneration must fire even when the failure precedes the POST',
+            );
+            assert.ok(mockApiService.sendChatMessage.notCalled, 'the POST must never be reached');
         });
     });
 });

--- a/extension/test/unit/services/chatSessionService.test.ts
+++ b/extension/test/unit/services/chatSessionService.test.ts
@@ -1095,6 +1095,61 @@ suite('IrisChatSessionService Test Suite', () => {
                 'LoadMessagesError must carry the local session id that ended up active after import',
             );
         });
+
+        test('LoadMessages carries activities (filtered) and final through the history path', async () => {
+            // Persisted Iris messages carry a tool `activities` trail and a
+            // `final` flag. The mapping in chatSessionService must forward
+            // both instead of silently discarding them on reload, and it
+            // must drop malformed activity entries rather than forward them
+            // as-is (isIrisActivity is the shared runtime guard).
+            const context: ActiveContext = {
+                type: 'course',
+                id: 101,
+                title: 'Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now()
+            };
+            contextStore.setActiveContext(context);
+
+            mockApiService.getIrisCourseChatSettings.resolves({ settings: { enabled: true } });
+
+            const validActivity = { id: 'a1', kind: 'TOOL', name: 'search', state: 'RUNNING' };
+            const malformedActivity = { id: 'a2', name: 'bad-activity', state: 'RUNNING' }; // missing `kind` — must be filtered out
+
+            mockApiService.listChatSessionsForCourse.resolves([
+                { id: 1, entityId: 101, mode: 'COURSE_CHAT', creationDate: '2024-01-01T10:00:00Z' },
+            ]);
+            mockApiService.getChatMessages.withArgs(1).resolves([
+                {
+                    id: 100,
+                    sender: 'LLM',
+                    content: [{ textContent: 'Working on it' }],
+                    activities: [validActivity, malformedActivity],
+                    final: false,
+                } as never,
+            ]);
+
+            mockIrisWebSocketSessionClient.initializeSession.resolves(1);
+
+            await chatSessionService.loadAllSessionsForContext();
+
+            const loadMessagesCall = postMessageSpy.getCalls().find(
+                c => c.args[0]?.type === 'loadMessages'
+            );
+            assert.ok(loadMessagesCall, 'Should emit loadMessages');
+
+            const messages = (loadMessagesCall!.args[0] as {
+                messages: Array<{ activities?: unknown[]; final?: boolean }>;
+            }).messages;
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].final, false, 'final:false must survive the mapping');
+            assert.deepStrictEqual(
+                messages[0].activities,
+                [validActivity],
+                'the malformed activity entry must be filtered out; the valid one must survive',
+            );
+        });
     });
 
     suite('createNewSession', () => {

--- a/extension/test/unit/services/chatSessionService.test.ts
+++ b/extension/test/unit/services/chatSessionService.test.ts
@@ -16,6 +16,7 @@ suite('IrisChatSessionService Test Suite', () => {
     let mockIrisWebSocketSessionClient: sinon.SinonStubbedInstance<IrisWebSocketSessionClient>;
     let postMessageSpy: sinon.SinonSpy;
     let onPostSnapshotSpy: sinon.SinonSpy;
+    let resetRunsSpy: sinon.SinonSpy;
     // resetToWorkspaceSpy removed — workspace redirect moved to provider
     let mockContext: MockExtensionContext;
 
@@ -36,6 +37,7 @@ suite('IrisChatSessionService Test Suite', () => {
         // Create spies for callbacks
         postMessageSpy = sinon.spy();
         onPostSnapshotSpy = sinon.spy();
+        resetRunsSpy = sinon.spy();
         chatSessionService = new IrisChatSessionService(
             {
                 contextStore,
@@ -44,6 +46,7 @@ suite('IrisChatSessionService Test Suite', () => {
                 postSnapshot: onPostSnapshotSpy,
             },
             () => mockIrisWebSocketSessionClient as any,
+            { resetRuns: resetRunsSpy },
         );
     });
 
@@ -159,6 +162,7 @@ suite('IrisChatSessionService Test Suite', () => {
                     postSnapshot: onPostSnapshotSpy,
                 },
                 () => mockIrisWebSocketSessionClient as any,
+                { resetRuns: resetRunsSpy },
             );
 
             const result = await serviceWithoutApi.checkAndLoadIrisSettings(courseContext);
@@ -466,6 +470,7 @@ suite('IrisChatSessionService Test Suite', () => {
                     postSnapshot: onPostSnapshotSpy,
                 },
                 () => mockIrisWebSocketSessionClient as any,
+                { resetRuns: resetRunsSpy },
             );
 
             const context: ActiveContext = {
@@ -1359,6 +1364,66 @@ suite('IrisChatSessionService Test Suite', () => {
             await assert.rejects(
                 () => chatSessionService.resetAndReloadSessions(),
                 /Server down/
+            );
+        });
+    });
+
+    suite('resetRuns on conversation-reset paths', () => {
+        // Each reset path clears the WS session and messages, so each must also
+        // drop host run state or the old run's projection survives into the new
+        // conversation. resetRuns must fire BEFORE the Iris session reset.
+        const context: ActiveContext = {
+            type: 'course',
+            id: 101,
+            title: 'Test Course',
+            source: 'user-selected',
+            locked: false,
+            selectedAt: Date.now()
+        };
+
+        test('switchToSession resets runs before resetting the Iris session', () => {
+            contextStore.setActiveContext(context);
+            contextStore.createSession();
+            const sessionId = contextStore.snapshot().sessions[0].id;
+            mockIrisWebSocketSessionClient.initializeSession.resolves(1);
+            mockApiService.getChatMessages.resolves([]);
+
+            chatSessionService.switchToSession(sessionId);
+
+            assert.ok(resetRunsSpy.calledOnce, 'resetRuns must fire on switchToSession');
+            assert.ok(
+                resetRunsSpy.calledBefore(mockIrisWebSocketSessionClient.resetSession),
+                'resetRuns must fire before the Iris session reset',
+            );
+        });
+
+        test('createNewSession resets runs before resetting the Iris session', () => {
+            contextStore.setActiveContext(context);
+            mockIrisWebSocketSessionClient.createNewSession.resolves(42);
+
+            chatSessionService.createNewSession();
+
+            assert.ok(resetRunsSpy.calledOnce, 'resetRuns must fire on createNewSession');
+            assert.ok(
+                resetRunsSpy.calledBefore(mockIrisWebSocketSessionClient.resetSession),
+                'resetRuns must fire before the Iris session reset',
+            );
+        });
+
+        test('resetAndReloadSessions (_clearAllSessions) resets runs', async () => {
+            contextStore.setActiveContext(context);
+            mockApiService.listChatSessionsForCourse.resolves([]);
+            mockIrisWebSocketSessionClient.createNewSession.resolves(99);
+
+            await chatSessionService.resetAndReloadSessions();
+
+            // _clearAllSessions runs first and resets runs before its
+            // resetSession; the no-server-sessions fallback (createNewSession)
+            // resets again, so the spy fires at least once.
+            assert.ok(resetRunsSpy.called, 'resetRuns must fire on Reset & Sync');
+            assert.ok(
+                resetRunsSpy.calledBefore(mockIrisWebSocketSessionClient.resetSession),
+                'the first resetRuns must fire before the first Iris session reset',
             );
         });
     });

--- a/extension/test/unit/services/iris/parseIrisWs.test.ts
+++ b/extension/test/unit/services/iris/parseIrisWs.test.ts
@@ -9,7 +9,7 @@
 
 import * as assert from 'assert';
 
-import { isIrisActivity, isIrisWebSocketMessage, isVisibleIrisStage } from '@extension/services/iris/parseIrisWs';
+import { isIrisActivity, isIrisWebSocketMessage } from '@extension/services/iris/parseIrisWs';
 
 suite('isIrisWebSocketMessage', () => {
     test('accepts a plain object', () => {
@@ -36,41 +36,6 @@ suite('isIrisWebSocketMessage', () => {
         assert.strictEqual(isIrisWebSocketMessage('STATUS'), false);
         assert.strictEqual(isIrisWebSocketMessage(42), false);
         assert.strictEqual(isIrisWebSocketMessage(true), false);
-    });
-});
-
-suite('isVisibleIrisStage', () => {
-    test('accepts an object without an internal flag (default-visible)', () => {
-        assert.strictEqual(isVisibleIrisStage({ name: 'Compile', state: 'DONE' }), true);
-    });
-
-    test('accepts an object with internal: false', () => {
-        assert.strictEqual(isVisibleIrisStage({ name: 'Compile', internal: false }), true);
-    });
-
-    test('rejects an object with internal: true', () => {
-        assert.strictEqual(isVisibleIrisStage({ name: 'Bookkeeping', internal: true }), false);
-    });
-
-    test('accepts an object with truthy-but-not-true internal value', () => {
-        // Production code checks `internal !== true`. Anything other than
-        // literal `true` (including 1, 'yes', objects) means "visible".
-        // Documenting this here so the guard's lenient semantic is intentional.
-        assert.strictEqual(isVisibleIrisStage({ internal: 1 }), true);
-        assert.strictEqual(isVisibleIrisStage({ internal: 'yes' }), true);
-    });
-
-    test('rejects null', () => {
-        assert.strictEqual(isVisibleIrisStage(null), false);
-    });
-
-    test('rejects arrays', () => {
-        assert.strictEqual(isVisibleIrisStage([]), false);
-    });
-
-    test('rejects primitives', () => {
-        assert.strictEqual(isVisibleIrisStage('Compile'), false);
-        assert.strictEqual(isVisibleIrisStage(0), false);
     });
 });
 

--- a/extension/test/unit/services/iris/parseIrisWs.test.ts
+++ b/extension/test/unit/services/iris/parseIrisWs.test.ts
@@ -9,7 +9,7 @@
 
 import * as assert from 'assert';
 
-import { isIrisWebSocketMessage, isVisibleIrisStage } from '@extension/services/iris/parseIrisWs';
+import { isIrisActivity, isIrisWebSocketMessage, isVisibleIrisStage } from '@extension/services/iris/parseIrisWs';
 
 suite('isIrisWebSocketMessage', () => {
     test('accepts a plain object', () => {
@@ -71,5 +71,31 @@ suite('isVisibleIrisStage', () => {
     test('rejects primitives', () => {
         assert.strictEqual(isVisibleIrisStage('Compile'), false);
         assert.strictEqual(isVisibleIrisStage(0), false);
+    });
+});
+
+suite('isIrisActivity', () => {
+    const valid = { id: 'a1', kind: 'TOOL', name: 'file_lookup', state: 'RUNNING' };
+
+    test('accepts a well-formed activity', () => {
+        assert.strictEqual(isIrisActivity(valid), true);
+    });
+
+    test('rejects an unknown state', () => {
+        assert.strictEqual(isIrisActivity({ ...valid, state: 'DONE' }), false);
+    });
+
+    test('rejects an unknown kind', () => {
+        assert.strictEqual(isIrisActivity({ ...valid, kind: 'MAGIC' }), false);
+    });
+
+    test('rejects missing or wrongly typed id and name', () => {
+        assert.strictEqual(isIrisActivity({ ...valid, id: undefined }), false);
+        assert.strictEqual(isIrisActivity({ ...valid, name: 42 }), false);
+    });
+
+    test('rejects non-objects', () => {
+        assert.strictEqual(isIrisActivity(null), false);
+        assert.strictEqual(isIrisActivity([valid]), false);
     });
 });


### PR DESCRIPTION
Closes #353

> **Draft:** the full automated suite passes, but streaming has not yet been verified against a live Artemis 9.7.x instance. Undraft only after that manual check.

Artemis 9.6 both streams Iris answers as `PARTIAL` frames and replaced the stage status system with run state plus activities. The extension did neither, so answers appeared only when complete and the progress indicator has been dead against production since 9.6. This branch consumes both.

## What changed

- The host owns run state in a pure state machine with frame-level admission, sequence guards and terminal monotonicity.
- Answers render incrementally into a draft bubble; the persisted message replaces it atomically.
- Tool activity renders as a live feed during the run and as a trail on the finished message, including after a session reload.
- The webview message queue no longer lets a queued snapshot overtake a committed message.
- Messages upsert by server id, so an Artemis memory-attach resend no longer duplicates a bubble.
- The old `stages` progress system is removed end to end.

## Compatibility

Targets Artemis 9.6+. The stage path is removed rather than kept as a fallback; against an older server the chat still works (the final message is unchanged), only the progress indicator degrades.

## Deliberately out of scope

Reconnect reconciliation (recovering a run whose final frame was missed during a disconnect) is deferred to a separate issue. On disconnect the extension keeps its existing behaviour of resetting the transient chat UI, so this branch is not a regression there.

## Testing

`npm run test:all` (unit 1348, react 963), `npm run check-types`, `npm run lint`, and `npm run package` all green. Manual verification against a local Artemis 9.7.x is still pending (see the draft note above).
