### PR TITLE
fix(problem-statement): tighten header spacing and add a title divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
+- **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
 
 ### Internal

--- a/extension/src/webview/views/ExerciseDetail/components/ProblemStatement.module.css
+++ b/extension/src/webview/views/ExerciseDetail/components/ProblemStatement.module.css
@@ -5,6 +5,28 @@
     max-width: 800px;
 }
 
+/* Tighten the header->body transition. The <h3> keeps its browser-default
+   top/bottom margins, which stack on top of the Container's own 12px header
+   gap and inflate the space around the title. Drop them so the Container gap
+   is the only spacing, and remove the first content block's top margin so the
+   description starts right under the heading. */
+.heading {
+    margin: 0;
+    width: 100%;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--theme-border);
+}
+
+/* Sit the first paragraph directly under the header divider. The server wraps
+   the rendered markdown in <div class="artemis-problem-statement"> (preceded by
+   two display:none <style> blocks), and that wrapper's first block carries a
+   ~13px top margin from the embedded CSS. Zero it -- the first :first-child also
+   covers a wrapper-less server. Spacing between paragraphs is untouched. */
+.problemStatement > :first-child,
+.problemStatement > :global(.artemis-problem-statement) > :first-child {
+    margin-top: 0;
+}
+
 /* Loading skeleton layout */
 .skeletonContainer {
     display: flex;

--- a/extension/src/webview/views/ExerciseDetail/components/ProblemStatement.tsx
+++ b/extension/src/webview/views/ExerciseDetail/components/ProblemStatement.tsx
@@ -109,7 +109,7 @@ export function ProblemStatement({
     };
 
     return (
-        <Container header={<h3>Exercise Description</h3>}>
+        <Container header={<h3 className={styles.heading}>Exercise Description</h3>}>
             {bodyHtml ? (
                 <div
                     ref={setContentEl}


### PR DESCRIPTION
## What

Tightens the spacing under the "Exercise Description" heading in the exercise detail view and adds a divider line beneath the title, so the rendered description starts directly under the header instead of after a large gap.

## Why

The `<h3>` heading kept its browser-default top/bottom margins, which stacked on top of the container's own header gap and the server-rendered markdown wrapper's top margin. The result was an oversized empty band between the title and the first paragraph.

## Changes

- `.heading`: zero the `<h3>` margins, add a `border-bottom` divider.
- Zero the top margin of the first content block (covers both the `.artemis-problem-statement` server wrapper and a wrapper-less server).

## Notes

Small, self-contained UI fix (2 files). Already present on `feat/struggle-v3-integration`; this cherry-picks it onto `dev` independently.