### PR TITLE
refactor(webview): unify sidebar/fullscreen init + push plumbing (fixes fullscreen description, #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
+- **Fullscreen exercise view:** The exercise description now loads when an exercise is opened in the fullscreen (expanded) view, instead of showing "Failed to load the exercise description".
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
 

--- a/extension/src/extension/provider/artemisWebviewProvider.ts
+++ b/extension/src/extension/provider/artemisWebviewProvider.ts
@@ -33,6 +33,7 @@ import {
     StartPageResolver,
     SubmissionWebSocketHandler,
     ViewInitDataService,
+    WebviewBroadcaster,
 } from '@extension/services/ui';
 import type { NudgeText } from '@extension/services/ui/nudgeBannerText';
 import { OFFER_TEXTS } from '@extension/services/ui/nudgeBannerText';
@@ -108,6 +109,14 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
      */
     private readonly _sidebarSender: (m: ExtensionToWebviewMessage) => void;
 
+    /**
+     * Fans global push signals (proactive-consent, .noai, server-rendered
+     * problem statement) out to every live webview: the sidebar plus each open
+     * fullscreen panel. Producers broadcast once instead of targeting the
+     * sidebar only and letting each panel re-subscribe on its own.
+     */
+    private readonly _broadcaster = new WebviewBroadcaster();
+
     private readonly _onDidChangeViewNavigation = new vscode.EventEmitter<{ from: string; to: string }>();
     public readonly onDidChangeViewNavigation = this._onDidChangeViewNavigation.event;
 
@@ -139,6 +148,9 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         // One stable closure created immediately so the feed's Map<Sink,refcount>
         // always sees the same key for this sidebar host across re-resolves.
         this._sidebarSender = (m) => this._postMessageSafe(m);
+        // The sidebar is a permanent broadcast target (its sender is a safe no-op
+        // when no view is resolved). Panels register/unregister themselves.
+        this._disposables.push(this._broadcaster, this._broadcaster.addSink(this._sidebarSender));
         this._extensionUri = deps.extensionUri;
         this._extensionContext = deps.extensionContext;
         this._authManager = deps.authManager;
@@ -188,24 +200,44 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         // 6. Start page resolver.
         this._startPageResolver = new StartPageResolver(this._artemisApi, this._courseDataCache);
 
-        // 7. Fullscreen panel manager — only stores the getter, safe before _messageHandler exists.
+        // 7. Fullscreen panel manager — lazy getters, safe before _messageHandler / _viewInitDataService exist.
         this._fullscreenPanelManager = new FullscreenPanelManager(
             this._extensionUri,
             this._extensionContext,
             () => this._messageHandler,
-            this._noAiDetectionService,
+            () => this._viewInitDataService,
+            this._broadcaster,
         );
 
         // 7b. SSR coordinator — owns the theme listener and background SSR.
         //     Must be built BEFORE the navigation facade because the facade's
         //     backgroundRenderProblemStatement callback routes through it.
+        //     Broadcasts the rendered PS (tagged with exerciseId) to every open
+        //     webview; each exercise view applies only its own exercise's render.
         this._ssrCoordinator = new WebviewSSRCoordinator({
             appStateManager: this._appStateManager,
             renderService: this._renderService,
-            postMessage: (msg) => this._postMessageSafe(msg),
+            postMessage: (msg) => this._broadcaster.broadcast(msg),
             fetchExerciseDetails: (exerciseId) => fetchAndEnrichExerciseDetails(this._artemisApi, exerciseId),
         });
         this._disposables.push(this._ssrCoordinator);
+
+        // 7c. Global push producers → broadcast to every open webview. Registered at
+        //     provider lifetime (NOT per sidebar resolve) because they now also feed
+        //     persistent fullscreen panels; the sidebar sender is a no-op with no view.
+        this._disposables.push(
+            // #342: a proactive-help consent flip repaints the AskIris card (grant restores the
+            // remembered level, revoke parks it at Off); the view re-requests its control state.
+            vscode.workspace.onDidChangeConfiguration(event => {
+                if (event.affectsConfiguration(`${VSCODE_CONFIG.IRIS.SECTION}.${VSCODE_CONFIG.IRIS.PROACTIVE_EGRESS_KEY}`)) {
+                    this._broadcaster.broadcast({ type: ExtensionMsg.UpdateProactiveConsent });
+                }
+            }),
+            // #334: a .noai create/delete live-refreshes the exercise card (the view re-requests on this).
+            this._noAiDetectionService.onNoAiStatusChanged(isNoAiDetected => {
+                this._broadcaster.broadcast({ type: ExtensionMsg.UpdateNoAiStatus, isNoAiDetected });
+            }),
+        );
 
         // 8. Navigation facade — constructed BEFORE the message handler because
         //    the message handler receives the facade as its actionHandler.
@@ -439,25 +471,16 @@ export class ArtemisWebviewProvider extends BaseWebviewProvider implements vscod
         });
         this._viewDisposables.push(visibilityListener);
 
-        // Listen for configuration changes to re-render when settings change
+        // Re-render the sidebar HTML when developerMode changes (sidebar-only concern).
+        // The proactive-consent and .noai push signals are handled once at provider
+        // lifetime and broadcast to every webview (see step 7c), so they are no longer
+        // wired per sidebar resolve.
         const configListener = vscode.workspace.onDidChangeConfiguration(event => {
             if (event.affectsConfiguration('artemis.developerMode')) {
                 this.refreshTheme();
             }
-            // #342: a consent flip must repaint the AskIris proactive card live (grant restores the remembered
-            // level, revoke parks it at Off). The clean build no longer early-returns here: the webview's
-            // re-request now yields a card there too (no proactive capability just changes its content).
-            if (event.affectsConfiguration(`${VSCODE_CONFIG.IRIS.SECTION}.${VSCODE_CONFIG.IRIS.PROACTIVE_EGRESS_KEY}`)) {
-                this._postMessageSafe({ type: ExtensionMsg.UpdateProactiveConsent });
-            }
         });
         this._viewDisposables.push(configListener);
-
-        // #334: a .noai create/delete must live-refresh the exercise card (the view re-requests on this message).
-        const noAiListener = this._noAiDetectionService.onNoAiStatusChanged(isNoAiDetected => {
-            this._postMessageSafe({ type: ExtensionMsg.UpdateNoAiStatus, isNoAiDetected });
-        });
-        this._viewDisposables.push(noAiListener);
     }
 
     // ── Rendering ──────────────────────────────────────────────────────

--- a/extension/src/extension/provider/webviewSSRCoordinator.ts
+++ b/extension/src/extension/provider/webviewSSRCoordinator.ts
@@ -58,6 +58,12 @@ export class WebviewSSRCoordinator implements vscode.Disposable {
 
         const exercise = exerciseData.exercise;
         const exerciseId = exercise.id;
+        // The rendered message is broadcast and filtered by exerciseId downstream,
+        // so an id is required. Without one we cannot target the result — skip.
+        if (exerciseId === undefined) {
+            logger.info('[SSR] Skipping render: current exercise has no id', LogCategory.GENERAL);
+            return;
+        }
         const participation = exercise.studentParticipations?.[0];
 
         logger.info(`[SSR] Starting background render for exercise ${exerciseId}`, LogCategory.GENERAL);
@@ -80,6 +86,7 @@ export class WebviewSSRCoordinator implements vscode.Disposable {
                 this.deps.postMessage({
                     type: ExtensionMsg.ProblemStatementRendered,
                     html: rendered.html,
+                    exerciseId,
                 });
                 logger.info(`[SSR] Server render cached + sent (hash: ${rendered.contentHash.slice(0, 8)})`, LogCategory.GENERAL);
             }

--- a/extension/src/extension/services/ui/fullscreenPanelManager.ts
+++ b/extension/src/extension/services/ui/fullscreenPanelManager.ts
@@ -7,12 +7,10 @@ import { isWebviewMessage } from '@shared/messageContracts/typeGuards';
 
 import type { WebViewMessageHandler } from '@extension/controller/webViewMessageHandler';
 import { LogCategory, logger } from '@extension/services/loggingService';
-import type { NoAiDetectionService } from '@extension/services/workspace';
-import { collectExerciseSources, detectWorkspaceExercise, detectWorkspaceForRepoUris } from '@extension/services/workspace/workspaceDetectionService';
-import { getTheiaEnvironment } from '@extension/theia/theiaEnvironment';
 import type { ExerciseDetailsResponse } from '@extension/types';
-import { VSCODE_CONFIG } from '@extension/utils';
 
+import type { ViewInitDataService } from './viewInitDataService';
+import type { WebviewBroadcaster } from './webviewBroadcaster';
 import { getReactWebviewHtml } from './webviewHtml';
 
 export class FullscreenPanelManager {
@@ -20,68 +18,27 @@ export class FullscreenPanelManager {
         private readonly _extensionUri: vscode.Uri,
         private readonly _extensionContext: vscode.ExtensionContext,
         private readonly _getMessageHandler: () => WebViewMessageHandler,
-        private readonly _noAiDetectionService: NoAiDetectionService,
+        // Lazy: the init service is constructed after this manager. Shared with the
+        // sidebar so both transports build identical exercise/course init payloads.
+        private readonly _getViewInitData: () => ViewInitDataService,
+        // Every panel registers its transport here so global pushes (consent,
+        // .noai, SSR) reach it without the panel re-subscribing on its own.
+        private readonly _broadcaster: WebviewBroadcaster,
     ) {}
 
     public openExerciseFullscreen(exerciseData: ExerciseDetailsResponse): void {
         const exerciseTitle = exerciseData?.exercise?.title || 'Exercise';
-        // #342: the sidebar provider's own config listener re-pushes the proactive-help card on a
-        // consent flip, but it posts through the sidebar's own transport and can never reach this
-        // panel's independent webview - so this panel needs its own listener to stay in sync.
-        let consentSub: vscode.Disposable | undefined;
-        let noAiSub: vscode.Disposable | undefined;
         this._openFullscreenPanel({
             viewType: 'artemis.exerciseFullscreen',
             title: `Exercise: ${exerciseTitle}`,
             viewName: 'exerciseDetail',
+            // Same shared builder the sidebar uses (repoStatus, dev-tools gating, and the
+            // cached SSR). onReady also fires on RequestInit; rebuilding each time is fine.
+            // Consent/.noai/SSR live updates arrive via the broadcaster (registered in
+            // _openFullscreenPanel), so this panel no longer needs its own listeners.
             onReady: (postSafe) => {
-                const isManagedEnvironment = getTheiaEnvironment().isManagedEnvironment;
-                const repoUris = (exerciseData.exercise?.studentParticipations ?? [])
-                    .map(p => p.repositoryUri)
-                    .filter((uri): uri is string => !!uri);
-
-                if (repoUris.length > 0) {
-                    detectWorkspaceForRepoUris(repoUris).then((repoStatus) => {
-                        postSafe({
-                            type: ExtensionMsg.ExerciseDetailInit,
-                            exerciseData,
-                            hideDeveloperTools: false,
-                            isManagedEnvironment,
-                            repoStatus,
-                        });
-                    }).catch(() => {
-                        postSafe({
-                            type: ExtensionMsg.ExerciseDetailInit,
-                            exerciseData,
-                            hideDeveloperTools: false,
-                            isManagedEnvironment,
-                        });
-                    });
-                } else {
-                    postSafe({
-                        type: ExtensionMsg.ExerciseDetailInit,
-                        exerciseData,
-                        hideDeveloperTools: false,
-                        isManagedEnvironment,
-                    });
-                }
-
-                // onReady can fire again on a RequestInit; only wire the subscription once.
-                if (!consentSub) {
-                    consentSub = vscode.workspace.onDidChangeConfiguration((event) => {
-                        if (event.affectsConfiguration(`${VSCODE_CONFIG.IRIS.SECTION}.${VSCODE_CONFIG.IRIS.PROACTIVE_EGRESS_KEY}`)) {
-                            postSafe({ type: ExtensionMsg.UpdateProactiveConsent });
-                        }
-                    });
-                }
-                // #334: mirrors the sidebar's own .noai live-refresh (this panel has its own webview).
-                if (!noAiSub) {
-                    noAiSub = this._noAiDetectionService.onNoAiStatusChanged(isNoAiDetected => {
-                        postSafe({ type: ExtensionMsg.UpdateNoAiStatus, isNoAiDetected });
-                    });
-                }
+                void this._getViewInitData().buildExerciseDetailInit(exerciseData).then(({ msg }) => postSafe(msg));
             },
-            onDispose: () => { consentSub?.dispose(); consentSub = undefined; noAiSub?.dispose(); noAiSub = undefined; },
         });
     }
 
@@ -107,28 +64,7 @@ export class FullscreenPanelManager {
             title: `Course: ${courseTitle}`,
             viewName: 'courseDetail',
             onReady: (postSafe) => {
-                const config = vscode.workspace.getConfiguration('artemis');
-                const developerMode = config.get<boolean>('developerMode', false);
-                const sources = collectExerciseSources([{
-                    course: courseData.course,
-                    exercises: courseData.course.exercises,
-                }]);
-
-                detectWorkspaceExercise(sources).then((detectedExercise) => {
-                    postSafe({
-                        type: ExtensionMsg.CourseDetailInit,
-                        courseData: courseData,
-                        workspaceExerciseId: detectedExercise?.id ?? null,
-                        hideDeveloperTools: !developerMode,
-                    });
-                }).catch(() => {
-                    postSafe({
-                        type: ExtensionMsg.CourseDetailInit,
-                        courseData: courseData,
-                        workspaceExerciseId: null,
-                        hideDeveloperTools: !developerMode,
-                    });
-                });
+                void this._getViewInitData().buildCourseDetailInit(courseData).then(postSafe);
             },
         });
     }
@@ -195,6 +131,11 @@ export class FullscreenPanelManager {
             }
         };
 
+        // Register this panel's transport once (at creation, NOT in onReady which
+        // re-fires on RequestInit) so global pushes reach it; postSafe buffers
+        // anything that arrives before the webview signals Ready.
+        const sinkRegistration = this._broadcaster.addSink(postSafe);
+
         const messageListener = panel.webview.onDidReceiveMessage(async (message: unknown) => {
             if (disposed) { return; }
             if (!isWebviewMessage(message)) { return; }
@@ -233,6 +174,7 @@ export class FullscreenPanelManager {
         panel.onDidDispose(() => {
             disposed = true;
             pendingMessages = [];
+            sinkRegistration.dispose();
             messageListener.dispose();
             options.onDispose?.(postSafe);
         });

--- a/extension/src/extension/services/ui/index.ts
+++ b/extension/src/extension/services/ui/index.ts
@@ -5,4 +5,5 @@ export { createProviderRegistry, type IProviderRegistry } from './providerRegist
 export { StartPageResolver } from './startPageResolver';
 export { SubmissionWebSocketHandler } from './submissionWebSocketHandler';
 export { ViewInitDataService } from './viewInitDataService';
+export { WebviewBroadcaster, type WebviewSink } from './webviewBroadcaster';
 export { getReactWebviewHtml } from './webviewHtml';

--- a/extension/src/extension/services/ui/viewInitDataService.ts
+++ b/extension/src/extension/services/ui/viewInitDataService.ts
@@ -15,10 +15,13 @@ import {
 } from '@extension/services/workspace/workspaceDetectionService';
 import type { IStruggleCoordinator } from '@extension/telemetry/contract';
 import { getTheiaEnvironment } from '@extension/theia/theiaEnvironment';
-import type { CourseDashboardEntry, ExerciseDetail } from '@extension/types';
+import type { CourseDashboardEntry, ExerciseDetail, ExerciseDetailsResponse } from '@extension/types';
 import { resolveServerUrl } from '@extension/utils';
 
 import { selectRecentCourses } from './recentCourseSelector';
+
+/** Resolved workspace status for an exercise's repos, incl. the matched workspace URI (if any). */
+type ExerciseRepoStatus = Awaited<ReturnType<typeof detectWorkspaceForRepoUris>>;
 
 export class ViewInitDataService {
     private _initGeneration = 0;
@@ -145,6 +148,32 @@ export class ViewInitDataService {
         });
     }
 
+    /**
+     * Build the course-detail init payload used by BOTH the sidebar and the
+     * fullscreen panel. Pure and total (never rejects): a workspace-detection
+     * failure resolves to `workspaceExerciseId: null`.
+     */
+    public async buildCourseDetailInit(courseData: CourseDetailData): Promise<ExtensionToWebviewMessage> {
+        const sources = collectExerciseSources([{
+            course: courseData.course,
+            exercises: courseData.course.exercises,
+        }]);
+        let workspaceExerciseId: number | null = null;
+        try {
+            const detectedExercise = await detectWorkspaceExercise(sources);
+            workspaceExerciseId = detectedExercise?.id ?? null;
+        } catch (error) {
+            logger.error('Failed to detect workspace exercise for course detail', LogCategory.VIEW, error);
+            workspaceExerciseId = null;
+        }
+        return {
+            type: ExtensionMsg.CourseDetailInit,
+            courseData,
+            workspaceExerciseId,
+            hideDeveloperTools: !this._isDeveloperMode(),
+        };
+    }
+
     public sendCourseDetailInit(): void {
         const courseData = this._appStateManager.currentCourseData;
         if (!courseData) {
@@ -152,31 +181,66 @@ export class ViewInitDataService {
             this._postMessage({ type: ExtensionMsg.ViewInitError, error: 'Course data is not available. Please go back and try again.' });
             return;
         }
-
-        const sources = collectExerciseSources([{
-            course: courseData.course,
-            exercises: courseData.course.exercises,
-        }]);
-
         const gen = this._initGeneration;
-        detectWorkspaceExercise(sources).then((detectedExercise) => {
+        void this.buildCourseDetailInit(courseData).then((msg) => {
             if (gen !== this._initGeneration) { return; }
-            this._postMessage({
-                type: ExtensionMsg.CourseDetailInit,
-                courseData,
-                workspaceExerciseId: detectedExercise?.id ?? null,
-                hideDeveloperTools: !this._isDeveloperMode(),
-            });
-        }).catch((error) => {
-            if (gen !== this._initGeneration) { return; }
-            logger.error('Failed to detect workspace exercise for course detail', LogCategory.VIEW, error);
-            this._postMessage({
-                type: ExtensionMsg.CourseDetailInit,
-                courseData,
-                workspaceExerciseId: null,
-                hideDeveloperTools: !this._isDeveloperMode(),
-            });
+            this._postMessage(msg);
         });
+    }
+
+    /**
+     * Build the exercise-detail init payload used by BOTH the sidebar and the
+     * fullscreen panel. Pure and total: it never rejects (a workspace-detection
+     * failure resolves to `repoStatus: undefined`) and has no side effects, so
+     * the caller owns posting and any repo-context wiring. `exerciseData` is
+     * passed explicitly — the sidebar hands its app-state exercise, a panel
+     * hands its own immutable snapshot.
+     *
+     * The cached server-rendered problem statement lives in global app state, so
+     * it is included ONLY when that cache belongs to THIS exercise; otherwise it
+     * is omitted and the live `problemStatementRendered` broadcast fills it in.
+     */
+    public async buildExerciseDetailInit(
+        exerciseData: ExerciseDetailsResponse,
+    ): Promise<{ msg: ExtensionToWebviewMessage; repoStatus?: ExerciseRepoStatus }> {
+        const isManagedEnvironment = getTheiaEnvironment().isManagedEnvironment;
+        const hideDeveloperTools = !this._isDeveloperMode();
+
+        const repoUris = (exerciseData.exercise?.studentParticipations ?? [])
+            .map(p => p.repositoryUri)
+            .filter((uri): uri is string => !!uri);
+
+        let repoStatus: ExerciseRepoStatus | undefined;
+        if (repoUris.length > 0) {
+            try {
+                repoStatus = await detectWorkspaceForRepoUris(repoUris);
+            } catch (error) {
+                logger.error('Failed to detect workspace status for exercise detail', LogCategory.VIEW, error);
+                repoStatus = undefined;
+            }
+        }
+
+        // Read the SSR cache as LATE as possible (after the detection await), so a render that
+        // completes while we await does not lose its broadcast to a stale init: an init posted
+        // with an older `undefined` snapshot would otherwise clear the just-applied problem
+        // statement. Still guarded to THIS exercise via a coherent post-await id snapshot.
+        const currentId = this._appStateManager.currentExerciseData?.exercise?.id;
+        const serverRenderedProblemStatement =
+            currentId !== undefined && currentId === exerciseData.exercise?.id
+                ? (this._appStateManager.serverRenderedProblemStatement ?? undefined)
+                : undefined;
+
+        return {
+            msg: {
+                type: ExtensionMsg.ExerciseDetailInit,
+                exerciseData,
+                hideDeveloperTools,
+                isManagedEnvironment,
+                repoStatus,
+                serverRenderedProblemStatement,
+            },
+            repoStatus,
+        };
     }
 
     public sendExerciseDetailInit(): void {
@@ -187,53 +251,21 @@ export class ViewInitDataService {
             return;
         }
 
-        const isManagedEnvironment = getTheiaEnvironment().isManagedEnvironment;
-
-        const participations = exerciseData.exercise?.studentParticipations ?? [];
-        const repoUris = participations
-            .map(p => p.repositoryUri)
-            .filter((uri): uri is string => !!uri);
-
-        if (repoUris.length > 0) {
-            const exerciseId = exerciseData.exercise?.id;
-            const gen = this._initGeneration;
-            detectWorkspaceForRepoUris(repoUris).then((repoStatus) => {
-                if (gen !== this._initGeneration) { return; }
-                // Set repo context so workspace listeners can auto-detect changes on file save
-                if (repoStatus.matchedUri && exerciseId !== undefined) {
-                    const handler = this._messageHandler;
-                    handler.setRepositoryContext(repoStatus.matchedUri, exerciseId);
-                }
-                this._postMessage({
-                    type: ExtensionMsg.ExerciseDetailInit,
-                    exerciseData,
-                    hideDeveloperTools: !this._isDeveloperMode(),
-                    isManagedEnvironment,
-                    repoStatus,
-                    serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
-                });
-            }).catch((error) => {
-                if (gen !== this._initGeneration) { return; }
-                logger.error('Failed to detect workspace status for exercise detail', LogCategory.VIEW, error);
+        const gen = this._initGeneration;
+        const exerciseId = exerciseData.exercise?.id;
+        void this.buildExerciseDetailInit(exerciseData).then(({ msg, repoStatus }) => {
+            // Drop a stale build: the active view moved on while detection was in flight.
+            if (gen !== this._initGeneration) { return; }
+            // Repo context lets workspace listeners auto-detect changes on file save. A matched
+            // repo sets it; a missing repoStatus (no repos, or detection failed) clears it; a
+            // detected-but-unmatched repo leaves it untouched (preserves prior behavior).
+            if (repoStatus?.matchedUri && exerciseId !== undefined) {
+                this._messageHandler.setRepositoryContext(repoStatus.matchedUri, exerciseId);
+            } else if (!repoStatus) {
                 this._messageHandler.clearRepositoryContext();
-                this._postMessage({
-                    type: ExtensionMsg.ExerciseDetailInit,
-                    exerciseData,
-                    hideDeveloperTools: !this._isDeveloperMode(),
-                    isManagedEnvironment,
-                    serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
-                });
-            });
-        } else {
-            this._messageHandler.clearRepositoryContext();
-            this._postMessage({
-                type: ExtensionMsg.ExerciseDetailInit,
-                exerciseData,
-                hideDeveloperTools: !this._isDeveloperMode(),
-                isManagedEnvironment,
-                serverRenderedProblemStatement: this._appStateManager.serverRenderedProblemStatement ?? undefined,
-            });
-        }
+            }
+            this._postMessage(msg);
+        });
     }
 
     public sendAiConfigInit(): void {

--- a/extension/src/extension/services/ui/webviewBroadcaster.ts
+++ b/extension/src/extension/services/ui/webviewBroadcaster.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+
+import type { ExtensionToWebviewMessage } from '@shared/messageContracts';
+
+import { LogCategory, logger } from '@extension/services/loggingService';
+
+export type WebviewSink = (msg: ExtensionToWebviewMessage) => void;
+
+/**
+ * Fans a single extension->webview message out to every live transport: the
+ * sidebar sender plus each open fullscreen panel. This is what keeps the two
+ * (independent) webviews in sync for global push signals (proactive-consent,
+ * .noai, the server-rendered problem statement) instead of each producer
+ * hand-wiring the sidebar only and every panel re-subscribing on its own.
+ *
+ * Kept intentionally minimal: a plain `Set<Sink>` with per-sink exception
+ * isolation. No dev-mode gating, buffering, backfill, or refcounts — those are
+ * feature concerns that belong to `LiveEngineFeed`, not the generic push path.
+ * Registration is idempotent (Set) and each `addSink` hands back a `Disposable`
+ * so callers remove exactly what they added on webview/panel disposal.
+ */
+export class WebviewBroadcaster implements vscode.Disposable {
+    private readonly _sinks = new Set<WebviewSink>();
+
+    /** Register a transport. Returns a disposable that unregisters it. */
+    addSink(sink: WebviewSink): vscode.Disposable {
+        this._sinks.add(sink);
+        return new vscode.Disposable(() => { this._sinks.delete(sink); });
+    }
+
+    /** Deliver `msg` to every registered transport; one failing sink never blocks the rest. */
+    broadcast(msg: ExtensionToWebviewMessage): void {
+        for (const sink of this._sinks) {
+            try {
+                sink(msg);
+            } catch (err) {
+                logger.warn(`Webview broadcast to a sink failed: ${err}`, LogCategory.VIEW);
+            }
+        }
+    }
+
+    dispose(): void {
+        this._sinks.clear();
+    }
+}

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -583,8 +583,10 @@ interface ExtensionMsgPayloads {
         }>;
     };
 
-    // Server-side problem statement rendering
-    problemStatementRendered: RenderedProblemStatementPayload;
+    // Server-side problem statement rendering. Broadcast to every open webview,
+    // so it carries the exerciseId it belongs to; each exercise-detail view
+    // applies it only when the id matches the exercise it is currently showing.
+    problemStatementRendered: RenderedProblemStatementPayload & { exerciseId: number };
 
     /**
      * Emitted by the extension host on every DELIVERED terminal (dismiss / progress-close /

--- a/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
+++ b/extension/src/webview/views/ExerciseDetail/ExerciseDetailView.tsx
@@ -127,9 +127,15 @@ export function ExerciseDetailView({ vscodeApi }: ExerciseDetailViewProps) {
         if (msg.type === ExtensionMsg.ViewInitError) {
             setError(msg.error);
         }
-        // Progressive upgrade: server-rendered problem statement arrived
+        // Progressive upgrade: server-rendered problem statement arrived. This is broadcast to every
+        // open webview, so apply it only when it belongs to the exercise THIS view is showing. Read
+        // the live id from the store at message time (not the closed-over exerciseData) to avoid the
+        // useExtensionMessage stale-closure hazard, matching the noAi/consent handlers below.
         if (msg.type === ExtensionMsg.ProblemStatementRendered) {
-            setServerRenderedPS({ html: msg.html });
+            const currentId = useExerciseDetailStore.getState().exerciseData?.exercise?.id;
+            if (currentId !== undefined && msg.exerciseId === currentId) {
+                setServerRenderedPS({ html: msg.html });
+            }
         }
         // Proactive control state (spec §12.2). Stored UNCONDITIONALLY here, tagged with its exerciseId; the render
         // below only paints it when the tag matches the live exercise, so a late update for a previous exercise can

--- a/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
+++ b/extension/test/react/views/ExerciseDetail/ExerciseDetailView.test.tsx
@@ -210,11 +210,28 @@ describe('ExerciseDetailView', () => {
 		dispatchExtensionMessage({
 			type: ExtensionMsg.ProblemStatementRendered,
 			html: '<html><body><p>Solve the problem.</p></body></html>',
+			exerciseId: 42,
 		});
 
 		await waitFor(() => {
 			expect(screen.getByText('Solve the problem.')).toBeInTheDocument();
 		});
+	});
+
+	it('ignores a server-rendered problem statement broadcast for a different exercise', async () => {
+		useExerciseDetailStore.setState({ exerciseData: makeExerciseData(), isLoading: false });
+		const mockApi = createMockVsCodeApi();
+		render(<ExerciseDetailView vscodeApi={mockApi} />);
+
+		// The current exercise is 42; a broadcast tagged for another exercise must not paint here.
+		dispatchExtensionMessage({
+			type: ExtensionMsg.ProblemStatementRendered,
+			html: '<html><body><p>Other exercise content.</p></body></html>',
+			exerciseId: 999,
+		});
+
+		await new Promise(r => setTimeout(r, 50));
+		expect(screen.queryByText('Other exercise content.')).not.toBeInTheDocument();
 	});
 
 	it('shows "Ask Iris" section', () => {
@@ -560,6 +577,7 @@ describe('ExerciseDetailView', () => {
 		dispatchExtensionMessage({
 			type: ExtensionMsg.ProblemStatementRendered,
 			html: '<html><body><span class="artemis-task" data-task-name="taskA" data-test-ids="1,2">taskA</span></body></html>',
+			exerciseId: 42,
 		});
 
 		await waitFor(() => {
@@ -632,7 +650,7 @@ describe('ExerciseDetailView', () => {
 	async function clickTaskAndOpenOverlay(html: string) {
 		const mockApi = createMockVsCodeApi();
 		const { container } = render(<ExerciseDetailView vscodeApi={mockApi} />);
-		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html });
+		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html, exerciseId: 42 });
 		await waitFor(() => {
 			expect(container.querySelector('.artemis-task[data-test-ids]')).not.toBeNull();
 		});
@@ -797,7 +815,7 @@ describe('ExerciseDetailView', () => {
 		const mockApi = createMockVsCodeApi();
 		const postMessageMock = vi.mocked(mockApi.postMessage);
 		const { container } = render(<ExerciseDetailView vscodeApi={mockApi} />);
-		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html: taskHtml('1,2') });
+		dispatchExtensionMessage({ type: ExtensionMsg.ProblemStatementRendered, html: taskHtml('1,2'), exerciseId: 42 });
 		await waitFor(() => expect(container.querySelector('.artemis-task[data-test-ids]')).not.toBeNull());
 		await userEvent.click(container.querySelector('.artemis-task[data-test-ids]')!);
 

--- a/extension/test/unit/provider/webviewSSRCoordinator.test.ts
+++ b/extension/test/unit/provider/webviewSSRCoordinator.test.ts
@@ -194,7 +194,28 @@ suite('WebviewSSRCoordinator', () => {
         sinon.assert.calledWith(stubs.postMessage, sinon.match({
             type: ExtensionMsg.ProblemStatementRendered,
             html: '<p>Hello</p>',
+            exerciseId: 42,
         }));
+    });
+
+    test('scheduleRender skips when the current exercise has no id (cannot target the broadcast)', async () => {
+        const exercise = { problemStatement: '# Hello', studentParticipations: [{ id: 7 }] };
+        const exerciseData = { exercise } as unknown as ExerciseDetailsResponse;
+        const renderStub = sandbox.stub().resolves({ html: '<p>Hello</p>', contentHash: 'abcdef1234567890' });
+        const { deps, stubs } = buildDeps({
+            appStateManager: {
+                currentState: 'exercise-detail',
+                currentExerciseData: exerciseData,
+                serverRenderedProblemStatement: null as { html: string } | null,
+                showExerciseDetail: sandbox.stub(),
+            },
+            renderService: { render: renderStub, invalidateAll: sandbox.stub() },
+        });
+
+        await new WebviewSSRCoordinator(deps).scheduleRender();
+
+        sinon.assert.notCalled(renderStub);
+        sinon.assert.notCalled(stubs.postMessage);
     });
 
     test('dispose disposes the theme listener', () => {

--- a/extension/test/unit/services/ui/fullscreenPanelManager.test.ts
+++ b/extension/test/unit/services/ui/fullscreenPanelManager.test.ts
@@ -5,6 +5,7 @@ import * as sinon from 'sinon';
 import { WebviewMsgType } from '@shared/messageContracts';
 
 import { FullscreenPanelManager } from '@extension/services/ui/fullscreenPanelManager';
+import { WebviewBroadcaster } from '@extension/services/ui/webviewBroadcaster';
 
 suite('FullscreenPanelManager.openStruggleFullscreen', () => {
     let sandbox: sinon.SinonSandbox;
@@ -32,8 +33,13 @@ suite('FullscreenPanelManager.openStruggleFullscreen', () => {
 
     function makeManager(): FullscreenPanelManager {
         const ctx = { subscriptions: [] } as unknown as vscode.ExtensionContext;
-        const fakeNoAi = { onNoAiStatusChanged: () => ({ dispose() {} }), dispose() {} } as any;
-        return new FullscreenPanelManager(vscode.Uri.parse('file:///ext'), ctx, () => ({} as never), fakeNoAi);
+        return new FullscreenPanelManager(
+            vscode.Uri.parse('file:///ext'),
+            ctx,
+            () => ({} as never),
+            () => ({} as never),
+            new WebviewBroadcaster(),
+        );
     }
 
     test('Ready posts the init and subscribes once; RequestInit re-sends WITHOUT re-subscribing; dispose tears down', () => {
@@ -81,11 +87,15 @@ suite('FullscreenPanelManager.openStruggleFullscreen', () => {
     });
 });
 
-suite('FullscreenPanelManager.openExerciseFullscreen - #342 consent flip', () => {
+suite('FullscreenPanelManager.openExerciseFullscreen - shared builder + broadcast sink', () => {
     let sandbox: sinon.SinonSandbox;
     let postMessage: sinon.SinonStub;
     let messageHandler: (m: unknown) => void;
     let disposeHandler: () => void;
+    let broadcaster: WebviewBroadcaster;
+    let buildExerciseDetailInit: sinon.SinonStub;
+
+    const flush = () => new Promise(r => setTimeout(r, 0));
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -102,111 +112,59 @@ suite('FullscreenPanelManager.openExerciseFullscreen - #342 consent flip', () =>
             dispose() { /* noop */ },
         };
         sandbox.stub(vscode.window, 'createWebviewPanel').returns(panel as unknown as vscode.WebviewPanel);
+        broadcaster = new WebviewBroadcaster();
+        buildExerciseDetailInit = sandbox.stub().resolves({ msg: { type: 'exerciseDetailInit' }, repoStatus: undefined });
     });
     teardown(() => sandbox.restore());
 
     function makeManager(): FullscreenPanelManager {
         const ctx = { subscriptions: [] } as unknown as vscode.ExtensionContext;
-        const fakeNoAi = { onNoAiStatusChanged: () => ({ dispose() {} }), dispose() {} } as any;
-        return new FullscreenPanelManager(vscode.Uri.parse('file:///ext'), ctx, () => ({} as never), fakeNoAi);
+        return new FullscreenPanelManager(
+            vscode.Uri.parse('file:///ext'),
+            ctx,
+            () => ({} as never),
+            () => ({ buildExerciseDetailInit } as never),
+            broadcaster,
+        );
     }
 
-    test('a real config flip repaints an open fullscreen exercise panel, and the listener is disposed on close', async () => {
-        const cfg = () => vscode.workspace.getConfiguration('artemis.iris');
-        const prev = cfg().get('proactiveCodeEgress');
-
-        const awaitConsentMsg = async (deadlineMs: number): Promise<boolean> => {
-            const deadline = Date.now() + deadlineMs;
-            while (Date.now() < deadline) {
-                if (postMessage.getCalls().some(c => (c.args[0] as { type?: string })?.type === 'updateProactiveConsent')) {
-                    return true;
-                }
-                await new Promise(r => setTimeout(r, 50));
-            }
-            return false;
-        };
-
-        try {
-            // Normalize first (no assertion): a leaked value from another test would make the
-            // flip below a config no-op that fires no event.
-            await cfg().update('proactiveCodeEgress', 'ask', vscode.ConfigurationTarget.Global);
-
-            const exerciseData = { exercise: { title: 'Test Exercise', studentParticipations: [] } };
-            makeManager().openExerciseFullscreen(exerciseData as never);
-            messageHandler({ type: WebviewMsgType.Ready });
-
-            postMessage.resetHistory();
-            await cfg().update('proactiveCodeEgress', 'enabled', vscode.ConfigurationTarget.Global);
-            assert.ok(await awaitConsentMsg(2000), 'expected updateProactiveConsent to be posted to the fullscreen panel after a consent flip');
-
-            // Panel close disposes the config subscription: a further flip must not post again.
-            disposeHandler();
-            postMessage.resetHistory();
-            await cfg().update('proactiveCodeEgress', 'disabled', vscode.ConfigurationTarget.Global);
-            assert.ok(!(await awaitConsentMsg(300)), 'the disposed panel must not receive further consent updates');
-        } finally {
-            await cfg().update('proactiveCodeEgress', prev, vscode.ConfigurationTarget.Global);
-        }
-    });
-});
-
-suite('FullscreenPanelManager.openExerciseFullscreen - #334 .noai flip', () => {
-    let sandbox: sinon.SinonSandbox;
-    let postMessage: sinon.SinonStub;
-    let messageHandler: (m: unknown) => void;
-    let disposeHandler: () => void;
-
-    setup(() => {
-        sandbox = sinon.createSandbox();
-        postMessage = sandbox.stub();
-        const panel = {
-            webview: {
-                html: '',
-                cspSource: 'vscode-resource:',
-                asWebviewUri: (u: vscode.Uri) => u,
-                postMessage,
-                onDidReceiveMessage: (cb: (m: unknown) => void) => { messageHandler = cb; return { dispose() { /* noop */ } }; },
-            },
-            onDidDispose: (cb: () => void) => { disposeHandler = cb; return { dispose() { /* noop */ } }; },
-            dispose() { /* noop */ },
-        };
-        sandbox.stub(vscode.window, 'createWebviewPanel').returns(panel as unknown as vscode.WebviewPanel);
-    });
-    teardown(() => sandbox.restore());
-
-    const exerciseData = { exercise: { id: 1, title: 'X', studentParticipations: [] } };
-    let noAiCb: (v: boolean) => void = () => {};
-    const disposeSpy = sinon.spy();
-
-    function makeManager(): FullscreenPanelManager {
-        const ctx = { subscriptions: [] } as unknown as vscode.ExtensionContext;
-        const fakeNoAi = {
-            onNoAiStatusChanged: (cb: (value: boolean) => void) => { noAiCb = cb; return { dispose: disposeSpy }; },
-        } as any;
-        return new FullscreenPanelManager(vscode.Uri.parse('file:///ext'), ctx, () => ({} as never), fakeNoAi);
-    }
-
-    const awaitNoAiMsg = async (deadlineMs: number): Promise<boolean> => {
-        const start = Date.now();
-        while (Date.now() - start < deadlineMs) {
-            if (postMessage.getCalls().some(c => (c.args[0] as { type?: string })?.type === 'updateNoAiStatus')) { return true; }
-            await new Promise(r => setTimeout(r, 20));
-        }
-        return false;
-    };
-
-    test('a .noai flip posts updateNoAiStatus (both directions), and the subscription is disposed once with the panel', async () => {
+    test('Ready builds the init via the shared builder and posts it', async () => {
+        const exerciseData = { exercise: { id: 1, title: 'X', studentParticipations: [] } };
         makeManager().openExerciseFullscreen(exerciseData as never);
         messageHandler({ type: WebviewMsgType.Ready });
+        await flush();
 
-        postMessage.resetHistory();
-        noAiCb(true);
-        assert.ok(await awaitNoAiMsg(2000), 'expected updateNoAiStatus after .noai appears');
-        postMessage.resetHistory();
-        noAiCb(false);
-        assert.ok(await awaitNoAiMsg(2000), 'expected updateNoAiStatus after .noai disappears');
+        sinon.assert.calledOnce(buildExerciseDetailInit);
+        sinon.assert.calledWith(buildExerciseDetailInit, exerciseData);
+        assert.ok(postMessage.getCalls().some(c => (c.args[0] as { type?: string })?.type === 'exerciseDetailInit'));
+    });
 
+    test('a broadcast reaches the open panel and stops after the panel is disposed', () => {
+        const exerciseData = { exercise: { id: 1, title: 'X', studentParticipations: [] } };
+        makeManager().openExerciseFullscreen(exerciseData as never);
+        messageHandler({ type: WebviewMsgType.Ready });
+        postMessage.resetHistory();
+
+        // A global push (e.g. consent) fans out through the broadcaster to this panel.
+        broadcaster.broadcast({ type: 'updateProactiveConsent' } as never);
+        assert.ok(postMessage.getCalls().some(c => (c.args[0] as { type?: string })?.type === 'updateProactiveConsent'));
+
+        // After the panel closes its sink is removed: a further broadcast must not reach it.
         disposeHandler();
-        assert.ok(disposeSpy.calledOnce, 'the .noai subscription must be disposed exactly once with the panel');
+        postMessage.resetHistory();
+        broadcaster.broadcast({ type: 'updateNoAiStatus', isNoAiDetected: true } as never);
+        sinon.assert.notCalled(postMessage);
+    });
+
+    test('a broadcast before Ready is buffered and delivered once the panel signals Ready', () => {
+        const exerciseData = { exercise: { id: 1, title: 'X', studentParticipations: [] } };
+        makeManager().openExerciseFullscreen(exerciseData as never);
+
+        // Registered at creation → a push before Ready is buffered by postSafe, not dropped.
+        broadcaster.broadcast({ type: 'updateProactiveConsent' } as never);
+        sinon.assert.notCalled(postMessage);
+
+        messageHandler({ type: WebviewMsgType.Ready });
+        assert.ok(postMessage.getCalls().some(c => (c.args[0] as { type?: string })?.type === 'updateProactiveConsent'));
     });
 });

--- a/extension/test/unit/services/ui/webviewBroadcaster.test.ts
+++ b/extension/test/unit/services/ui/webviewBroadcaster.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { WebviewBroadcaster } from '@extension/services/ui/webviewBroadcaster';
+
+suite('WebviewBroadcaster', () => {
+    test('fans a message out to every registered sink', () => {
+        const b = new WebviewBroadcaster();
+        const a = sinon.stub();
+        const c = sinon.stub();
+        b.addSink(a);
+        b.addSink(c);
+
+        const msg = { type: 'updateProactiveConsent' } as never;
+        b.broadcast(msg);
+
+        sinon.assert.calledOnceWithExactly(a, msg);
+        sinon.assert.calledOnceWithExactly(c, msg);
+    });
+
+    test('addSink returns a disposable that unregisters exactly that sink', () => {
+        const b = new WebviewBroadcaster();
+        const a = sinon.stub();
+        const c = sinon.stub();
+        const regA = b.addSink(a);
+        b.addSink(c);
+
+        regA.dispose();
+        b.broadcast({ type: 'updateProactiveConsent' } as never);
+
+        sinon.assert.notCalled(a);
+        sinon.assert.calledOnce(c);
+    });
+
+    test('a throwing sink does not block the others (per-sink isolation)', () => {
+        const b = new WebviewBroadcaster();
+        const bad = sinon.stub().throws(new Error('sink blew up'));
+        const good = sinon.stub();
+        b.addSink(bad);
+        b.addSink(good);
+
+        assert.doesNotThrow(() => b.broadcast({ type: 'updateNoAiStatus', isNoAiDetected: true } as never));
+        sinon.assert.calledOnce(good);
+    });
+
+    test('dispose clears all sinks', () => {
+        const b = new WebviewBroadcaster();
+        const a = sinon.stub();
+        b.addSink(a);
+
+        b.dispose();
+        b.broadcast({ type: 'updateProactiveConsent' } as never);
+
+        sinon.assert.notCalled(a);
+    });
+
+    test('registering the same sink twice is idempotent (Set semantics)', () => {
+        const b = new WebviewBroadcaster();
+        const a = sinon.stub();
+        b.addSink(a);
+        b.addSink(a);
+
+        b.broadcast({ type: 'updateProactiveConsent' } as never);
+
+        sinon.assert.calledOnce(a);
+    });
+});


### PR DESCRIPTION
## What

The exercise/course detail pages run as two independent webviews: the sidebar `WebviewView` and the fullscreen `WebviewPanel`. Each built its own init payload and wired its own push listeners, so they had drifted apart. This unifies both paths and fixes #358 (the exercise description never loaded in the fullscreen view) as a direct consequence.

## Changes

**Shared init builders (Axis 1)**
- New `buildExerciseDetailInit` / `buildCourseDetailInit` on `ViewInitDataService`, used by BOTH the sidebar and the fullscreen panel (mirrors the existing `buildStruggleDetectionInit`). Builders are pure and total (never reject; a workspace-detection failure resolves to no repo status).
- The fullscreen panel no longer rebuilds init inline, so it now receives the cached server-rendered problem statement (this is the #358 fix) and the same developer-tools gating as the sidebar.
- The sidebar sender keeps its `setRepositoryContext`/`clearRepositoryContext` side effect and the `_initGeneration` staleness guard (captured before the await, re-checked before both the context mutation and the post).

**Broadcast layer (Axis 2)**
- New small `WebviewBroadcaster` (`Set<Sink>`, `addSink(): Disposable`, per-sink exception isolation) fans global push signals (proactive consent, `.noai`, the rendered problem statement) out to every open webview.
- The panel's duplicate consent/`.noai` listeners are removed; the producers move to provider lifetime and broadcast once. The per-resolve `developerMode -> refreshTheme` stays sidebar-only.
- Each panel registers its transport once at creation and unregisters on dispose.

**SSR targeting**
- `problemStatementRendered` is tagged with its `exerciseId` and filtered per view (the view reads its live exercise id at message time), so a broadcast only paints the exercise that view is showing. The cached SSR is read as late as possible (after workspace detection) and only when it belongs to the shown exercise, avoiding a stale init clearing a just-applied render.

## Behavior note

Fullscreen exercise/course views now hide Developer Tools unless `artemis.developerMode` is on, matching the sidebar (previously the fullscreen exercise view always showed them). This was a deliberate decision to remove the drift.

Known limitation (unchanged scope): a fullscreen panel left open for one exercise while the sidebar navigates to another does not get live problem-statement refreshes, because the render coordinator only renders the current exercise. The description still loads correctly on open.

## Testing

- `check-types`, `lint`, `vitest` (ExerciseDetail suite incl. a new mismatched-exerciseId-ignored test), `mocha` (1312 tests, 0 failures; new `WebviewBroadcaster` + shared-builder/broadcast-sink suites, plus a missing-id SSR guard test), and both esbuild variants (full + openvsx clean) with the clean-bundle verifier.

Fixes #358.