### PR TITLE
fix(intervention): clear the proactive badge when an episode ends (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
+- **Proactive hint badge:** The "1" badge on the Iris activity-bar icon now clears when a proactive episode ends (solved, timed out, or dismissed), instead of staying visible.
 - **Fullscreen exercise view:** The exercise description now loads when an exercise is opened in the fullscreen (expanded) view, instead of showing "Failed to load the exercise description".
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.

--- a/extension/src/extension/services/struggleIntervention/struggleInterventionService.ts
+++ b/extension/src/extension/services/struggleIntervention/struggleInterventionService.ts
@@ -1578,6 +1578,11 @@ export class StruggleInterventionService implements AlertSink {
         this._deps.clearInline();
         this._deps.clearEpisodeLamp();
         this._deps.hideActiveBanner();
+        // The activity-bar badge marks an OUTSTANDING proactive hint, so it belongs to the live
+        // episode: clear it on every terminal exit (RECOVERED close, watchdog/ABANDON force-free,
+        // dismiss, new-exercise), the same one-place teardown as the other episode surfaces above.
+        // Without this it strands at "1" after a solved/timed-out close (#343).
+        this._deps.setBadge(false);
         this._latch.reset();
         this._watchdog?.disarm();
         this._watchdog = undefined;

--- a/extension/test/logic/struggleIntervention/resolveEpisode.test.ts
+++ b/extension/test/logic/struggleIntervention/resolveEpisode.test.ts
@@ -21,6 +21,8 @@ describe('resolveEpisode (manual "Solved it" → RECOVERED)', () => {
         await Promise.resolve();
         expect(deps.setEpisodeOutcome).toHaveBeenCalledWith(42, 'ep-solved', 'RECOVERED');
         expect(deps.foldEpisode).toHaveBeenCalledWith('ep-solved', 'RECOVERED');
+        // #343: the activity-bar badge must clear when the episode closes (no stranded "1").
+        expect(deps.setBadge).toHaveBeenCalledWith(false);
         // No praise: manual "Solved it" carries no LLM praise message (third fold arg absent).
         const foldCall = (deps.foldEpisode as ReturnType<typeof vi.fn>).mock.calls[0];
         expect(foldCall[2]).toBeUndefined();

--- a/extension/test/logic/struggleIntervention/struggleInterventionService.test.ts
+++ b/extension/test/logic/struggleIntervention/struggleInterventionService.test.ts
@@ -682,6 +682,21 @@ describe('StruggleInterventionService', () => {
         // Teardown uses ONLY the mode-guarded clear (parked/jump), not the unconditional clearLamp.
         expect(deps.clearLamp).not.toHaveBeenCalled();
     });
+
+    // #343: the activity-bar badge marks an outstanding proactive hint and is episode-scoped, so the
+    // shared terminal seam must clear it too (previously it stranded at "1" after a solved/timed-out close).
+    it('a terminal episode exit clears the activity-bar badge', () => {
+        const deps = fakeDeps();
+        const svc = new StruggleInterventionService(deps);
+        simulateDecidePending(svc, 'ep-1', false);
+        svc.onServerActive('ep-1', 8, 'src/B.java', 84, 'check punctuation', 0.9);
+        vi.mocked(deps.setBadge).mockClear();           // ignore the delivery-time badge set
+
+        svc.dismissEpisode();                           // terminal exit -> _clearEpisodeRuntime()
+
+        expect(deps.setBadge).toHaveBeenCalledWith(false);
+        expect(svc._slot.isFree()).toBe(true);
+    });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes #343: the "1" badge on the Iris activity-bar icon stayed visible after a proactive episode closed (reproduced for both a solved/RECOVERED close and a timed-out/ABANDONED close).

## Root cause

The badge marks an outstanding proactive hint, so it is episode-scoped like the inline cue, the episode lamp, the active banner, and any pending offer. Those are all retired in `_clearEpisodeRuntime()` (the single terminal chokepoint hit by every terminal transition), but the badge clear was missing there. It was only cleared on the level-Off path and the consent/session `reset()` path, so ordinary episode ends left it stranded at "1".

## Fix

Add `setBadge(false)` to `_clearEpisodeRuntime()`, alongside the other surface clears. This covers every terminal outcome (RECOVERED, ABANDONED/timeout, DISMISSED, parked discard, force-free, new-exercise) in one place. Non-terminal transitions (replace-delivered, reveal) deliberately do not call this chokepoint, so a superseding hint keeps the badge.

## Tests

- `resolveEpisode` ("Solved it" -> RECOVERED) now asserts the badge clears.
- A new terminal-cleanup test asserts a terminal exit clears the badge (mirrors the existing inline-cue and lamp cleanup tests on the shared seam).
- Full gate green: check-types, lint, vitest (1771), mocha (1312). codex-reviewed.