### PR TITLE
fix(intervention): open the Iris chat when Show me is clicked on the offer banner (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
+- **Proactive nudge banner:** Clicking "Show me" (or "I need more help") on the follow-up offer banner now opens the Iris chat, matching the initial hint banner.
 - **Proactive hint badge:** The "1" badge on the Iris activity-bar icon now clears when a proactive episode ends (solved, timed out, or dismissed), instead of staying visible.
 - **Fullscreen exercise view:** The exercise description now loads when an exercise is opened in the fullscreen (expanded) view, instead of showing "Failed to load the exercise description".
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -16,7 +16,7 @@ import { IrisEnabledCache } from '@extension/services/iris/irisEnabledCache';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import { VsCodeSensorHub } from '@extension/services/sensing';
 import { createProviderRegistry } from '@extension/services/ui';
-import { MOCK_NUDGE_EPISODE_ID } from '@extension/services/ui/nudgeBannerText';
+import { bannerActionOpensChat } from '@extension/services/ui/nudgeBannerText';
 import { StruggleAlertStatusBar } from '@extension/services/ui/struggleAlertStatusBar';
 import { ArtemisWebsocketService, WebSocketStatusBarService } from '@extension/services/websocket';
 import { NoAiDetectionService } from '@extension/services/workspace';
@@ -272,8 +272,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	// id) is visual only: its buttons neither record an outcome nor open the chat.
 	context.subscriptions.push(artemisWebviewProvider.onDidNudgeBannerAction((payload) => {
 		handleBannerAction?.(payload);
-		// Legacy active banner only (offer banners never carry a 'showMe' action): jump into the chat.
-		if (!('moment' in payload) && payload.action === 'showMe' && payload.episodeId !== MOCK_NUDGE_EPISODE_ID) {
+		// Any "see the hint" action opens the Iris chat: the active banner's "Show me" AND the offer
+		// banner's accept ("Show me" / "I need more help"). #344: the offer path was previously excluded.
+		if (bannerActionOpensChat(payload)) {
 			void vscode.commands.executeCommand('iris.chatView.focus');
 		}
 	}));

--- a/extension/src/extension/services/ui/nudgeBannerText.ts
+++ b/extension/src/extension/services/ui/nudgeBannerText.ts
@@ -2,8 +2,23 @@
  * Rotation text pool for the proactive nudge banner. English-only fixed pool of 4,
  * picked at random per appearance with no immediate repeat of the previous title.
  */
+import type { WebCmd } from '@shared/messageContracts';
+import { WebviewCmd } from '@shared/messageContracts';
 
 export interface NudgeText { title: string; sub: string; }
+
+type NudgeBannerActionPayload = WebCmd<typeof WebviewCmd.NudgeBannerAction>['payload'];
+
+/**
+ * A nudge-banner action that is the student's explicit request to SEE the hint, so it should
+ * open/focus the Iris chat: "Show me" on the active banner, and the offer banner's accept
+ * ("Show me" / "I need more help"). decline / dismiss / timeout do not open the chat, and the
+ * dev mock banner (sentinel id) never does (#344).
+ */
+export function bannerActionOpensChat(payload: NudgeBannerActionPayload): boolean {
+    if (payload.episodeId === MOCK_NUDGE_EPISODE_ID) { return false; }
+    return 'moment' in payload ? payload.action === 'accept' : payload.action === 'showMe';
+}
 
 /**
  * Sentinel `episodeId` for the developer-only "mock proactivity" banner. The banner's action

--- a/extension/test/logic/ui/nudgeBannerText.test.ts
+++ b/extension/test/logic/ui/nudgeBannerText.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { NUDGE_TEXTS, pickNudgeText } from '@extension/services/ui/nudgeBannerText';
+import { bannerActionOpensChat, MOCK_NUDGE_EPISODE_ID, NUDGE_TEXTS, pickNudgeText } from '@extension/services/ui/nudgeBannerText';
 
 describe('nudgeBannerText', () => {
     it('the rotation pool has exactly 4 entries', () => {
@@ -26,5 +26,28 @@ describe('nudgeBannerText', () => {
         const prevTitle = NUDGE_TEXTS[0].title;
         const filteredPool = NUDGE_TEXTS.filter(t => t.title !== prevTitle);
         expect(pickNudgeText(prevTitle, () => 0)).toEqual(filteredPool[0]);
+    });
+});
+
+describe('bannerActionOpensChat (#344)', () => {
+    it('active banner "Show me" opens the chat', () => {
+        expect(bannerActionOpensChat({ action: 'showMe', episodeId: 'ep-1' })).toBe(true);
+    });
+
+    it('offer banner accept ("Show me" / "I need more help") opens the chat, both moments', () => {
+        expect(bannerActionOpensChat({ moment: 'stuck', action: 'accept', episodeId: 'ep-1', offerId: 'o-1' })).toBe(true);
+        expect(bannerActionOpensChat({ moment: 'abandon', action: 'accept', episodeId: 'ep-1', offerId: 'o-1' })).toBe(true);
+    });
+
+    it('non-"see the hint" actions do not open the chat', () => {
+        expect(bannerActionOpensChat({ action: 'dismiss', episodeId: 'ep-1' })).toBe(false);
+        expect(bannerActionOpensChat({ action: 'timeout', episodeId: 'ep-1' })).toBe(false);
+        expect(bannerActionOpensChat({ moment: 'stuck', action: 'decline', episodeId: 'ep-1', offerId: 'o-1' })).toBe(false);
+        expect(bannerActionOpensChat({ moment: 'abandon', action: 'timeout', episodeId: 'ep-1', offerId: 'o-1' })).toBe(false);
+    });
+
+    it('the dev mock banner never opens the chat (any action)', () => {
+        expect(bannerActionOpensChat({ action: 'showMe', episodeId: MOCK_NUDGE_EPISODE_ID })).toBe(false);
+        expect(bannerActionOpensChat({ moment: 'stuck', action: 'accept', episodeId: MOCK_NUDGE_EPISODE_ID, offerId: 'o-1' })).toBe(false);
     });
 });


### PR DESCRIPTION
## What

Fixes #344 (scoped): clicking "Show me" / "I need more help" on the proactive **offer** banner (the still-stuck / abandon follow-up) now opens the Iris chat, matching the initial announcement banner.

## Scope

Agreed with the reviewer to keep this minimal. The **active-announcement** banner already opened the chat correctly (`extension.ts` invoked `iris.chatView.focus` for its `showMe` action), so that half was not a bug. The only real gap was the **offer** banner: its primary button sends `accept` (not `showMe`) and the handler excluded every payload carrying a `moment`, so the chat never opened. No new "scroll to the exact message" mechanism was added: the delivered hint lands as the newest bubble and the existing bottom-pinned auto-scroll surfaces it once the chat is focused.

## Change

- New pure predicate `bannerActionOpensChat(payload)` in `nudgeBannerText.ts`: active banner `showMe` OR offer banner `accept` (either moment) opens the chat; `decline`/`dismiss`/`timeout` and the dev mock banner never do.
- `onDidNudgeBannerAction` in `extension.ts` now focuses the chat iff that predicate is true (replacing the active-only inline condition). `handleBannerAction` still runs first, unchanged.

## Tests

- New `bannerActionOpensChat` unit tests cover all payload branches (active showMe/dismiss/timeout, offer accept/decline/timeout for both moments, and the dev mock).
- Full gate green: check-types, lint, vitest (1775), mocha (1312), both esbuild variants + clean-bundle verify. codex-reviewed.

Fixes #344.