### PR TITLE
feat(iris): reconnect reconciliation for Iris streaming (#355)

### DIFF
--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -18,6 +18,7 @@ import {
     IrisChatSessionService,
     IrisWebSocketSessionClient,
 } from '@extension/services/iris';
+import { historyResolvesRun } from '@extension/services/iris/chat/historyResolution';
 import type { CourseHistoryEntry } from '@extension/services/iris/context/courseHistory';
 import { buildCourseHistory } from '@extension/services/iris/context/courseHistory';
 import { createRunLifecycle, IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
@@ -44,6 +45,18 @@ interface ExerciseContextChangeEvent {
     exerciseRoot?: vscode.Uri;
 }
 
+/**
+ * Generation-scoped baseline for reconnect reconciliation. A bare id is not
+ * enough: `generation` is the anti-stale key that lets a POST for an older
+ * send be told apart from the still-current one (codex round 1, findings 1-4).
+ */
+interface ReconcileMarker {
+    generation: number;       // _runs.generation at dispatch; the anti-stale key
+    localSessionId: string;
+    artemisSessionId: number; // the id onDidResubscribe fires
+    baselineMessageId: number;
+}
+
 export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.WebviewViewProvider, vscode.Disposable, IChatWebviewProvider {
     // ── Static properties ──────────────────────────────────────────────
     public static readonly viewType = 'iris.chatView';
@@ -66,6 +79,16 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
      * message + session services (which drive the send lifecycle and resets).
      */
     private readonly _runs = new IrisRunStateMachine();
+
+    /** Generation-scoped baseline for reconnect reconciliation. `undefined`
+     *  when no send is outstanding. Overwritten on each successful POST, cleared
+     *  by _resetRunsAndMarker on session/context navigation. */
+    private _reconcileMarker: ReconcileMarker | undefined;
+    /** Single-flight for the reconcile fetch. `_reconcilePendingAgain` coalesces
+     *  a resubscribe that arrives while a fetch is in flight, so the run is
+     *  re-checked once after it settles instead of being dropped. */
+    private _reconcileInFlight = false;
+    private _reconcilePendingAgain = false;
 
     /**
      * Context-keyed single-flight guard for chat-session reloads. Auto-retry
@@ -168,6 +191,11 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                 this._chatSessionService.resetAvailability();
                 this._postMessageSafe({ type: ExtensionMsg.HideDisabledState });
                 this._postMessageSafe({ type: ExtensionMsg.HideUnavailableState });
+                // A real context change must also drop run state + the reconcile
+                // marker: the outgoing context's in-flight run has nothing to do
+                // with the now-active context, and a stale marker could otherwise
+                // reconcile against the wrong session.
+                this._resetRunsAndMarker();
             })
         );
         this._disposables.push(
@@ -202,7 +230,7 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         this._chatSessionService = new IrisChatSessionService(
             deps,
             () => this._irisSessionManager,
-            { resetRuns: () => this._websocketMessageHandler.resetRuns() },
+            { resetRuns: () => this._resetRunsAndMarker() },
         );
         this._chatMessageService = new ChatMessageService(
             deps,
@@ -242,6 +270,11 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             );
             this._disposables.push(
                 this._irisSessionManager.onDidConnectionStateChange(() => this._websocketMessageHandler.publishCurrentStatus())
+            );
+            this._disposables.push(
+                this._irisSessionManager.onDidResubscribe((sessionId) => {
+                    void this._reconcileOnResubscribe(sessionId);
+                }),
             );
 
             // Auto-retry chat reload on websocket reconnect when the chat is
@@ -349,6 +382,98 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         };
         this._reloadInFlight = entry;
         return entry.promise;
+    }
+
+    // ── Reconnect reconciliation ───────────────────────────────────────
+
+    /**
+     * Reset the run machine AND the reconcile marker together so they can never
+     * drift. Used on every real context change and by every session-navigation
+     * resetRuns path.
+     */
+    private _resetRunsAndMarker(): void {
+        this._reconcileMarker = undefined;
+        this._reconcilePendingAgain = false;
+        this._websocketMessageHandler.resetRuns();
+    }
+
+    /**
+     * After a genuine resubscribe (not the premature connection event), recover a
+     * run whose terminal frame was missed during the disconnect. Gated so an idle,
+     * pre-dispatch, or never-bound run opens nothing, and so a stale fetch can
+     * neither resolve nor mutate the wrong run/session. Resolves only on
+     * conclusive proof (a persisted assistant message past the baseline), never on
+     * mere fetch success.
+     */
+    private async _reconcileOnResubscribe(resubscribedSessionId: number): Promise<void> {
+        const marker = this._reconcileMarker;
+        // Gate: a send is outstanding for the CURRENT generation, we are still
+        // waiting, and the current generation has bound its run (so resolveCurrentRun
+        // is safe, see Task 2). pendingGeneration true => first frame never arrived
+        // => fall back to manual reload, do not resolve out-of-band.
+        if (!marker
+            || !this._runs.waiting
+            || this._runs.pendingGeneration
+            || marker.generation !== this._runs.generation
+            || marker.artemisSessionId !== resubscribedSessionId) {
+            return;
+        }
+        if (this._reconcileInFlight) { this._reconcilePendingAgain = true; return; }
+
+        // Confirm the marker still matches the live session before fetching.
+        const snapshot = this._contextStore.snapshot();
+        if (snapshot.activeSession?.id !== marker.localSessionId
+            || snapshot.activeSession?.artemisSessionId !== marker.artemisSessionId) {
+            return;
+        }
+        // Pin the bound run: within ONE generation, admit() can rebind
+        // _currentRunId to a later unknown run (A -> C) without bumping generation.
+        // History proving A finished must not then finalize C.
+        const boundRunId = this._runs.currentRunId;
+        if (!boundRunId) { return; }
+
+        this._reconcileInFlight = true;
+        try {
+            const messages = await this._chatSessionService.fetchActiveSessionHistory(marker.artemisSessionId);
+            // Re-validate EVERYTHING after the await: a newer send (generation++),
+            // a same-generation run rebind (currentRunId changed), a terminal frame
+            // (waiting=false), or a session/context switch during the fetch must all
+            // abort both the merge and the resolve.
+            if (this._reconcileMarker !== marker
+                || this._runs.generation !== marker.generation
+                || this._runs.currentRunId !== boundRunId
+                || !this._runs.waiting
+                || this._runs.pendingGeneration) {
+                return;
+            }
+            const live = this._contextStore.snapshot();
+            if (live.activeSession?.id !== marker.localSessionId
+                || live.activeSession?.artemisSessionId !== marker.artemisSessionId) {
+                return;
+            }
+            // Only now is it safe to mutate the webview and resolve.
+            this._postMessageSafe({
+                type: ExtensionMsg.MergeSessionMessages,
+                localSessionId: marker.localSessionId,
+                artemisSessionId: marker.artemisSessionId,
+                messages,
+            });
+            if (historyResolvesRun(messages, marker.baselineMessageId)) {
+                this._runs.resolveCurrentRun();
+                this._websocketMessageHandler.publishCurrentRunUi();
+                this._reconcileMarker = undefined;
+            }
+        } catch (err: unknown) {
+            logger.error('Reconnect reconciliation failed', LogCategory.IRIS_CHAT, err);
+        } finally {
+            this._reconcileInFlight = false;
+            if (this._reconcilePendingAgain) {
+                this._reconcilePendingAgain = false;
+                // Re-run once for the coalesced trigger, using the current session.
+                const again = this._contextStore.snapshot().activeSession?.artemisSessionId;
+                if (again !== undefined) { void this._reconcileOnResubscribe(again); }
+            }
+        }
     }
 
     public resolveWebviewView(
@@ -1069,6 +1194,34 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             });
 
             if (result.sent) {
+                // Confirm the optimistic bubble INDEPENDENTLY of the marker: an older
+                // out-of-order send still needs its bubble stamped, and this must never
+                // touch a newer marker.
+                if (result.sentMessageId !== undefined && localId && localSessionId) {
+                    this._postMessageSafe({
+                        type: ExtensionMsg.ConfirmSentMessage,
+                        localSessionId,
+                        localId,
+                        id: result.sentMessageId,
+                    });
+                }
+                // Open the marker ONLY for the still-current, still-waiting generation.
+                // The state machine supports overlapping generations, so a POST for an
+                // older generation can return after a newer send started; it must not
+                // replace or clear the newer generation's marker.
+                const artemisSessionId = this._irisSessionManager?.currentSessionId;
+                if (result.sentMessageId !== undefined
+                    && localSessionId
+                    && artemisSessionId !== undefined
+                    && result.generation === this._runs.generation
+                    && this._runs.waiting) {
+                    this._reconcileMarker = {
+                        generation: result.generation,
+                        localSessionId,
+                        artemisSessionId,
+                        baselineMessageId: result.sentMessageId,
+                    };
+                }
                 this._onDidAttemptIrisChatSend.fire({ content, status: 'sent' });
                 this._onDidSendIrisChatMessage.fire(content);
             } else {

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -460,7 +460,11 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             });
             if (historyResolvesRun(messages, marker.baselineMessageId)) {
                 this._runs.resolveCurrentRun();
-                this._websocketMessageHandler.publishCurrentRunUi();
+                // A pure WS drop mid-answer never clears the handler's own
+                // draft/activities/error (only the webview store is reset on
+                // disconnect), so a plain republish would resurrect the stale
+                // partial as a phantom duplicate bubble. Clear it here.
+                this._websocketMessageHandler.resetRunUiAndPublish();
                 this._reconcileMarker = undefined;
             }
         } catch (err: unknown) {

--- a/extension/src/extension/services/iris/chat/chatMessageService.ts
+++ b/extension/src/extension/services/iris/chat/chatMessageService.ts
@@ -20,7 +20,7 @@ interface SendMessageInput {
 }
 
 type SendMessageResult =
-    | { sent: true }
+    | { sent: true; sentMessageId?: number; generation: number }
     | {
         sent: false;
         reason: 'no-ai' | 'no-context' | 'iris-disabled' | 'iris-unavailable';
@@ -74,16 +74,26 @@ export class ChatMessageService {
             return { sent: false, reason, contextLabel, capturedContext: activeContext };
         }
 
-        await this._sendToIris(input.text, activeContext, input.struggleContext);
-        return { sent: true };
+        const { messageId, generation } = await this._sendToIris(input.text, activeContext, input.struggleContext);
+        return { sent: true, sentMessageId: messageId, generation };
     }
 
-    private async _sendToIris(messageText: string, activeContext: ActiveContext, struggleContext?: StruggleContext): Promise<void> {
+    private async _sendToIris(
+        messageText: string,
+        activeContext: ActiveContext,
+        struggleContext?: StruggleContext,
+    ): Promise<{ messageId: number | undefined; generation: number }> {
         logger.websocket(`📤 handleChatMessage called with: ${JSON.stringify({ text: messageText?.substring(0, 50) })}`);
 
         if (!messageText) {
             logger.websocket('⚠️ No text in message, returning');
-            return;
+            // No send happens on this path, so open and immediately abort the
+            // generation rather than leaving it open forever (nothing will
+            // ever complete it) or skipping it (the composer would hang, per
+            // the comment below on the same invariant for the prep steps).
+            const skippedGeneration = this._runLifecycle.beginGeneration();
+            this._runLifecycle.abortGeneration(skippedGeneration);
+            return { messageId: undefined, generation: skippedGeneration };
         }
 
         logger.websocket(`✅ Active context: ${JSON.stringify({ type: activeContext.type, id: activeContext.id, title: activeContext.title })}`);
@@ -129,7 +139,7 @@ export class ChatMessageService {
                 messageLength: messageText.length,
                 hasUncommittedFiles: uncommittedFiles ? uncommittedFiles.size : 0
             })}`);
-            await this.deps.artemisApiService.sendChatMessage(
+            const persisted = await this.deps.artemisApiService.sendChatMessage(
                 irisSessionManager.currentSessionId,
                 messageText,
                 uncommittedFiles
@@ -140,6 +150,16 @@ export class ChatMessageService {
             // Note: The assistant's response will arrive via WebSocket
             this.deps.contextStore.incrementActiveSessionMessageCount();
             this.deps.postSnapshot();
+
+            // The API parser only validates object-shape, so a null or
+            // stringified id is possible at runtime; a missing id is a
+            // degraded (not ordinary-success) path, since it leaves reconnect
+            // reconciliation with no marker to open.
+            const messageId = typeof persisted?.id === 'number' ? persisted.id : undefined;
+            if (messageId === undefined) {
+                logger.warn('Send persisted without a numeric id; reconnect reconciliation unavailable for this send', LogCategory.IRIS_CHAT);
+            }
+            return { messageId, generation };
 
         } catch (error: unknown) {
             logger.error('Error sending chat message', LogCategory.IRIS_CHAT, error);

--- a/extension/src/extension/services/iris/chat/chatSessionService.ts
+++ b/extension/src/extension/services/iris/chat/chatSessionService.ts
@@ -48,6 +48,28 @@ function describeError(error: unknown): string {
 }
 
 /**
+ * Maps persisted Iris messages to the webview's message shape. Shared by
+ * `initializeIrisSessionAndLoadMessages` (the live load path) and
+ * `fetchActiveSessionHistory` (the reconnect-reconciliation fetch), so both
+ * paths format history identically.
+ */
+function formatIrisMessages(messages: IrisChatMessage[] | undefined) {
+    return (messages ?? []).map((msg: IrisChatMessage) => {
+        const content = extractIrisMessageContent(msg.content);
+
+        return {
+            id: msg.id,
+            role: (msg.sender === 'USER' ? 'user' : 'assistant') as 'user' | 'assistant',
+            content: content,
+            timestamp: msg.sentAt ? new Date(msg.sentAt).getTime() : Date.now(),
+            helpful: (msg as { helpful?: boolean | null }).helpful,
+            activities: Array.isArray(msg.activities) ? msg.activities.filter(isIrisActivity) : undefined,
+            final: typeof msg.final === 'boolean' ? msg.final : undefined
+        };
+    });
+}
+
+/**
  * Orchestrates Iris chat session lifecycle (create, load, switch).
  *
  * Session ID ownership model:
@@ -417,19 +439,7 @@ export class IrisChatSessionService {
                 this.deps.postSnapshot();
             }
 
-            const formattedMessages = (messages ?? []).map((msg: IrisChatMessage) => {
-                const content = extractIrisMessageContent(msg.content);
-
-                return {
-                    id: msg.id,
-                    role: (msg.sender === 'USER' ? 'user' : 'assistant') as 'user' | 'assistant',
-                    content: content,
-                    timestamp: msg.sentAt ? new Date(msg.sentAt).getTime() : Date.now(),
-                    helpful: (msg as { helpful?: boolean | null }).helpful,
-                    activities: Array.isArray(msg.activities) ? msg.activities.filter(isIrisActivity) : undefined,
-                    final: typeof msg.final === 'boolean' ? msg.final : undefined
-                };
-            });
+            const formattedMessages = formatIrisMessages(messages);
 
             // Correct the active session's messageCount to the number of
             // messages actually loaded. This matters for sessions created via
@@ -471,6 +481,21 @@ export class IrisChatSessionService {
             const errorMessage = error instanceof Error ? error.message : String(error);
             throw new Error(`Failed to connect to Iris: ${errorMessage}`);
         }
+    }
+
+    /**
+     * Fetch + format the active session's persisted history for reconnect
+     * reconciliation. Returns the messages; posts nothing. The provider posts
+     * the MergeSessionMessages after its generation/session validation, so a
+     * stale fetch cannot mutate the webview. Non-destructive: no
+     * clear/import/switch, no messageCount rewrite.
+     */
+    public async fetchActiveSessionHistory(
+        artemisSessionId: number,
+    ): Promise<ReturnType<typeof formatIrisMessages>> {
+        if (!this.deps.artemisApiService) { return []; }
+        const messages = await this.deps.artemisApiService.getChatMessages(artemisSessionId);
+        return formatIrisMessages(messages);
     }
 
     // ── User-driven: create / switch / reset ──────────────────────────

--- a/extension/src/extension/services/iris/chat/historyResolution.ts
+++ b/extension/src/extension/services/iris/chat/historyResolution.ts
@@ -1,0 +1,15 @@
+/**
+ * Conclusive proof that an in-flight Iris answer completed while we were
+ * disconnected: the fetched session history contains a non-intermediate
+ * assistant message newer than the send baseline. Persisted history alone
+ * cannot prove a run ended (a missed FAILED frame produces no message), so the
+ * caller must only treat this `true` as resolution, never fetch-success.
+ */
+export function historyResolvesRun(
+    messages: ReadonlyArray<{ id?: number; role: 'user' | 'assistant'; final?: boolean }>,
+    baselineId: number,
+): boolean {
+    return messages.some(
+        (m) => m.role === 'assistant' && m.final !== false && m.id !== undefined && m.id > baselineId,
+    );
+}

--- a/extension/src/extension/services/iris/irisRunStateMachine.ts
+++ b/extension/src/extension/services/iris/irisRunStateMachine.ts
@@ -95,6 +95,30 @@ export class IrisRunStateMachine {
     }
 
     /**
+     * Resolve the in-flight answer out of band: a persisted assistant message
+     * past the send baseline was found after a reconnect (see
+     * {@link historyResolvesRun}). Finalizes the bound run so a late frame cannot
+     * resurrect it and clears `_waiting`, without discarding the known-run guards
+     * (unlike {@link reset}).
+     *
+     * No-op while `_pendingGeneration` is true: the current generation has not
+     * bound its run yet, so `_currentRunId` still belongs to a PREVIOUS generation
+     * (beginGeneration does not clear it). Resolving then would finalize the wrong
+     * run and clear a pending flag a later generation relies on. The never-bound
+     * case therefore falls back to the manual reload rather than resolving here;
+     * this makes the Core boundary an invariant of the machine, not just a
+     * provider convention.
+     */
+    public resolveCurrentRun(): void {
+        if (this._pendingGeneration) { return; }
+        if (this._currentRunId) {
+            this._finalizedRunIds.add(this._currentRunId);
+            this._lastPartialSeqByRunId.delete(this._currentRunId);
+        }
+        this._waiting = false;
+    }
+
+    /**
      * @returns whether the transition was ACCEPTED. The caller must not mirror
      *   `runState`/`error` into its projection when this returns false, or the
      *   guard would protect only half the state: the machine would still be

--- a/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
+++ b/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
@@ -121,13 +121,13 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
      * 
      * SAFETY: This method never calls connect() on the WebSocket service.
      */
-    private async _subscribeIfConnected(sessionId: number): Promise<void> {
+    private async _subscribeIfConnected(sessionId: number, force = false): Promise<void> {
         // Check rate limiting BEFORE tearing down the existing subscription.
         // Previous code unsubscribed first, then returned on rate-limit,
         // leaving zero active subscriptions.
         const now = Date.now();
         const timeSinceLastAttempt = now - this._lastResubscribeAttempt;
-        if (timeSinceLastAttempt < MIN_RESUBSCRIBE_INTERVAL_MS) {
+        if (!force && timeSinceLastAttempt < MIN_RESUBSCRIBE_INTERVAL_MS) {
             logger.session(`Rate limited: ${MIN_RESUBSCRIBE_INTERVAL_MS - timeSinceLastAttempt}ms until next subscribe`);
             return;
         }
@@ -196,7 +196,7 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
                 // subscriptions are gone at the protocol level regardless of whether
                 // we received a disconnect notification (which is debounced by 5 s).
                 logger.session(`(Re)connected, resubscribing to session: ${this._currentArtemisSessionId}`);
-                void this._subscribeIfConnected(this._currentArtemisSessionId);
+                void this._subscribeIfConnected(this._currentArtemisSessionId, true);
             }
         });
     }

--- a/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
+++ b/extension/src/extension/services/iris/transport/irisWebSocketSessionClient.ts
@@ -37,6 +37,8 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
     public readonly onDidReceiveMessage = this._onDidReceiveMessage.event;
     private readonly _onDidConnectionStateChange = new vscode.EventEmitter<boolean>();
     public readonly onDidConnectionStateChange = this._onDidConnectionStateChange.event;
+    private readonly _onDidResubscribe = new vscode.EventEmitter<number>();
+    public readonly onDidResubscribe = this._onDidResubscribe.event;
 
     constructor(
         private readonly _artemisApiService: ArtemisApiService,
@@ -57,6 +59,7 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
         this.unsubscribe();
         this._onDidReceiveMessage.dispose();
         this._onDidConnectionStateChange.dispose();
+        this._onDidResubscribe.dispose();
     }
 
     public get currentSessionId(): number | undefined {
@@ -148,6 +151,7 @@ export class IrisWebSocketSessionClient implements vscode.Disposable {
                 (data: unknown) => this._handleWebSocketMessage(data)
             );
             logger.session(`Successfully subscribed to session: ${sessionId}`);
+            this._onDidResubscribe.fire(sessionId);
         } catch (error) {
             logger.sessionError('Failed to subscribe:', error);
         }

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -73,6 +73,8 @@ export const ExtensionMsg = {
     UpdateNoAiStatus: 'updateNoAiStatus',
     UpdateIrisRunUi: 'updateIrisRunUi',
     SendRejected: 'sendRejected',
+    MergeSessionMessages: 'mergeSessionMessages',
+    ConfirmSentMessage: 'confirmSentMessage',
 
     // Exercise/Repo responses
     UpdateRepoStatus: 'updateRepoStatus',
@@ -254,6 +256,31 @@ interface ExtensionMsgPayloads {
             final?: boolean;
         }>;
     };
+    /**
+     * Non-destructive reconnect reconciliation: same shape as `loadMessages`
+     * but merged by id into the live list instead of replacing it, so a
+     * mid-answer disconnect that missed the terminal frame recovers the
+     * persisted answer without wiping optimistic/error bubbles.
+     */
+    mergeSessionMessages: {
+        localSessionId: string;
+        artemisSessionId: number;
+        messages: Array<{
+            id?: number;
+            role: 'user' | 'assistant';
+            content: string;
+            timestamp: number;
+            helpful?: boolean | null;
+            activities?: IrisActivityDTO[];
+            final?: boolean;
+        }>;
+    };
+    /**
+     * Reconciles the optimistic user bubble with its persisted server id from
+     * the send POST response, so a later history merge matches it by id (no
+     * duplicate) and the bubble leaves its `sending` state.
+     */
+    confirmSentMessage: { localSessionId: string; localId: string; id: number };
     loadMessagesError: { localSessionId: string };
     /**
      * A pre-switch open failure: the course overview fetch failed, or the

--- a/extension/src/webview/stores/mergeHistory.ts
+++ b/extension/src/webview/stores/mergeHistory.ts
@@ -1,0 +1,29 @@
+import type { ChatMessage } from '@webview/views/IrisChat/types';
+
+/**
+ * Non-destructive merge of a persisted history snapshot into the live message
+ * list, used by the reconnect reconciliation path. Unlike the destructive
+ * `applyLoadedMessages` replace, this preserves the optimistic/error bubbles
+ * that carry no server id and keeps each surviving bubble's `localId` (React
+ * identity) and `status`. Incoming history is authoritative for persisted
+ * fields and defines the order; unmatched live bubbles follow, in order.
+ */
+export function mergeHistory(existing: ChatMessage[], incoming: ChatMessage[]): ChatMessage[] {
+    const existingById = new Map<number, ChatMessage>();
+    for (const m of existing) {
+        if (m.id !== undefined) { existingById.set(m.id, m); }
+    }
+    const incomingIds = new Set<number>();
+    const merged = incoming.map((inc) => {
+        if (inc.id !== undefined) { incomingIds.add(inc.id); }
+        const prev = inc.id !== undefined ? existingById.get(inc.id) : undefined;
+        // `...inc` wins for persisted fields; explicitly keep the live bubble's
+        // identity (`localId`) and `status` so a matched, already-confirmed
+        // user bubble is not silently re-stamped by the view mapping's
+        // `status: 'sent'`. New inserts (no `prev`) take whatever the caller
+        // provided (the view maps them as `sent`).
+        return prev ? { ...prev, ...inc, localId: prev.localId, status: prev.status } : inc;
+    });
+    const leftover = existing.filter((m) => m.id === undefined || !incomingIds.has(m.id));
+    return [...merged, ...leftover];
+}

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -4,6 +4,7 @@ import { devtools } from 'zustand/middleware';
 import type { ExtMsg, IrisRunUiProjection, WebSocketDisplayStatus } from '@shared/messageContracts';
 import type { IrisActivityDTO, IrisRunState } from '@shared/types/apiResponses';
 
+import { mergeHistory } from '@webview/stores/mergeHistory';
 import type { CourseHistoryEntryVM } from '@webview/views/IrisChat/historyBuckets';
 import type {
     ChatContext,
@@ -106,6 +107,14 @@ interface ChatState {
     setIrisState: (state: ExtMsg<'updateIrisState'>['state']) => void;
     /** Apply messages and record a successful hydration for the given session. */
     applyLoadedMessages: (localSessionId: string, messages: ChatMessage[]) => void;
+    /**
+     * Non-destructive counterpart to `applyLoadedMessages`, used by the
+     * reconnect reconciliation path: merges a persisted history snapshot
+     * into the live list instead of replacing it, so an in-flight optimistic
+     * bubble survives. Ignored if `localSessionId` no longer matches the
+     * active session (the reconcile landed after a session switch).
+     */
+    mergeLoadedMessages: (localSessionId: string, messages: ChatMessage[]) => void;
     /** Record that hydration failed for the given session. */
     setMessageLoadError: (localSessionId: string) => void;
     /** Upserts by server `id`; messages without one always append (see `upsertMessage`). */
@@ -143,6 +152,8 @@ interface ChatState {
         errorReason: NonNullable<ChatMessage['errorReason']>,
     ) => boolean;
     removeMessage: (localId: string) => void;
+    /** Stamps a still-pending optimistic user bubble with its server id and `status: 'sent'`. No-op if no such bubble exists. */
+    confirmSentMessage: (localId: string, id: number) => void;
     clearMessages: () => void;
 
     // Course history actions
@@ -250,6 +261,11 @@ export const useChatStore = create<ChatState>()(
                 }, false, 'applyLoadedMessages');
             },
 
+            mergeLoadedMessages: (localSessionId, messages) => {
+                if (localSessionId !== useChatStore.getState().activeSessionId) { return; }
+                set((s) => ({ messages: mergeHistory(s.messages, messages) }), false, 'mergeLoadedMessages');
+            },
+
             setMessageLoadError: (localSessionId) => {
                 set({
                     messageLoad: { localSessionId, status: 'error' },
@@ -318,6 +334,16 @@ export const useChatStore = create<ChatState>()(
                 set((state) => ({
                     messages: state.messages.filter((m) => m.localId !== localId),
                 }), false, 'removeMessage');
+            },
+
+            confirmSentMessage: (localId, id) => {
+                set((s) => ({
+                    messages: s.messages.map((m) =>
+                        m.localId === localId && m.role === 'user'
+                            ? { ...m, id, status: 'sent' as const }
+                            : m,
+                    ),
+                }), false, 'confirmSentMessage');
             },
 
             clearMessages: () => {

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -32,7 +32,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         setDisabledMessage, setUnavailableMessage, setNoAiDetected,
         resetTransientChatUi, applyRunUi, applyCommit,
         markMessageFailed, applyCourseHistory, setCourseHistoryError,
-        setOpenSessionError,
+        setOpenSessionError, mergeLoadedMessages, confirmSentMessage,
     } = store;
     const [sideMenuOpen, setSideMenuOpen] = useState(false);
     const [contextSwitching, setContextSwitching] = useState(false);
@@ -274,8 +274,35 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 }
                 break;
             }
+
+            case ExtensionMsg.MergeSessionMessages: {
+                if (msg.localSessionId !== useChatStore.getState().activeSessionId) { break; }
+                // Deliberately NO resetTransientChatUi(): a merge must not wipe a live draft.
+                // It only folds the persisted history into the list by id.
+                mergeLoadedMessages(
+                    msg.localSessionId,
+                    msg.messages.map((m) => ({
+                        id: m.id,
+                        localId: crypto.randomUUID(),
+                        role: m.role,
+                        content: m.content,
+                        timestamp: m.timestamp,
+                        helpful: m.helpful ?? null,
+                        activities: m.activities,
+                        final: m.final,
+                        status: 'sent' as const,
+                    })),
+                );
+                break;
+            }
+
+            case ExtensionMsg.ConfirmSentMessage: {
+                if (msg.localSessionId !== useChatStore.getState().activeSessionId) { break; }
+                confirmSentMessage(msg.localId, msg.id);
+                break;
+            }
         }
-    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, resetTransientChatUi, applyRunUi, applyCommit, markMessageFailed, applyCourseHistory, setCourseHistoryError, setOpenSessionError]);
+    }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setMessageLoadError, clearMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, resetTransientChatUi, applyRunUi, applyCommit, markMessageFailed, applyCourseHistory, setCourseHistoryError, setOpenSessionError, mergeLoadedMessages, confirmSentMessage]);
 
     const handleSendMessage = (text: string) => {
         const localId = crypto.randomUUID();

--- a/extension/test/logic/iris/historyResolution.test.ts
+++ b/extension/test/logic/iris/historyResolution.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { historyResolvesRun } from '@extension/services/iris/chat/historyResolution';
+
+describe('historyResolvesRun', () => {
+    it('true when a final assistant message is newer than the baseline', () => {
+        expect(historyResolvesRun([{ id: 12, role: 'assistant' }], 11)).toBe(true);
+    });
+    it('false when the only newer assistant message is intermediate (final:false)', () => {
+        expect(historyResolvesRun([{ id: 12, role: 'assistant', final: false }], 11)).toBe(false);
+    });
+    it('false when the newest assistant message is not past the baseline', () => {
+        expect(historyResolvesRun([{ id: 11, role: 'assistant' }], 11)).toBe(false);
+    });
+    it('false when the newer message is a user message', () => {
+        expect(historyResolvesRun([{ id: 12, role: 'user' }], 11)).toBe(false);
+    });
+    it('treats final:true and final:undefined as terminal', () => {
+        expect(historyResolvesRun([{ id: 12, role: 'assistant', final: true }], 11)).toBe(true);
+        expect(historyResolvesRun([{ id: 12, role: 'assistant', final: undefined }], 11)).toBe(true);
+    });
+});

--- a/extension/test/logic/iris/historyResolution.test.ts
+++ b/extension/test/logic/iris/historyResolution.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+
 import { historyResolvesRun } from '@extension/services/iris/chat/historyResolution';
 
 describe('historyResolvesRun', () => {

--- a/extension/test/logic/iris/irisRunStateMachine.test.ts
+++ b/extension/test/logic/iris/irisRunStateMachine.test.ts
@@ -179,4 +179,31 @@ describe('IrisRunStateMachine', () => {
             expect(snapshot!.activities).toEqual([]);
         });
     });
+
+    describe('resolveCurrentRun', () => {
+        it('clears waiting and finalizes the bound run so late frames are rejected', () => {
+            const m = new IrisRunStateMachine();
+            m.beginGeneration();
+            m.admit({ type: 'PARTIAL', runId: 'r1', partialSeq: 0 } as any);
+            expect(m.pendingGeneration).toBe(false);
+            expect(m.waiting).toBe(true);
+            m.resolveCurrentRun();
+            expect(m.waiting).toBe(false);
+            expect(m.acceptPartial('r1', 5)).toBe(false);
+        });
+
+        it('is a no-op while the current generation is still pending (never-bound run)', () => {
+            const m = new IrisRunStateMachine();
+            m.beginGeneration();
+            m.admit({ type: 'PARTIAL', runId: 'A', partialSeq: 0 } as any);
+            m.finalizeRun('A', false);
+            m.beginGeneration();
+            expect(m.pendingGeneration).toBe(true);
+            m.resolveCurrentRun();
+            expect(m.pendingGeneration).toBe(true);
+            expect(m.waiting).toBe(true);
+            expect(m.admit({ type: 'PARTIAL', runId: 'B', partialSeq: 0 } as any)).toBe(true);
+            expect(m.currentRunId).toBe('B');
+        });
+    });
 });

--- a/extension/test/logic/iris/irisWebSocketSessionClient.resubscribe.test.ts
+++ b/extension/test/logic/iris/irisWebSocketSessionClient.resubscribe.test.ts
@@ -33,6 +33,7 @@ vi.mock('vscode', () => {
 import type { ArtemisApiService } from '@extension/api';
 import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
 import type { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
+import type { ActiveContext } from '@extension/types';
 
 /** Minimum interval between resubscription attempts, mirrored from the client. */
 const MIN_RESUBSCRIBE_INTERVAL_MS = 3000;
@@ -42,12 +43,26 @@ const noopApiService = {} as unknown as ArtemisApiService;
 function createWebsocketServiceStub(options: {
     isConnected?: () => boolean;
     subscribeToIrisSession?: (id: number, onMessage: (m: unknown) => void) => () => void;
-}): ArtemisWebsocketService {
-    return {
+}): { service: ArtemisWebsocketService; fireConnectionState: (connected: boolean) => void } {
+    const connectionStateListeners: Array<(e: { connected: boolean }) => void> = [];
+
+    const service = {
         isConnected: options.isConnected ?? (() => true),
         subscribeToIrisSession: options.subscribeToIrisSession ?? (() => () => { /* unsubscribe no-op */ }),
-        onDidChangeConnectionState: () => ({ dispose: () => { /* no-op */ } }),
+        onDidChangeConnectionState: (listener: (e: { connected: boolean }) => void) => {
+            connectionStateListeners.push(listener);
+            return { dispose: () => { /* no-op */ } };
+        },
     } as unknown as ArtemisWebsocketService;
+
+    return {
+        service,
+        fireConnectionState: (connected: boolean) => {
+            for (const listener of [...connectionStateListeners]) {
+                listener({ connected });
+            }
+        },
+    };
 }
 
 describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
@@ -56,7 +71,7 @@ describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
     });
 
     it('fires the sessionId exactly once after a real successful subscribe', async () => {
-        const websocketService = createWebsocketServiceStub({ isConnected: () => true });
+        const { service: websocketService } = createWebsocketServiceStub({ isConnected: () => true });
         const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
 
         const fired: number[] = [];
@@ -68,7 +83,7 @@ describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
     });
 
     it('does not fire when the WebSocket is not connected', async () => {
-        const websocketService = createWebsocketServiceStub({ isConnected: () => false });
+        const { service: websocketService } = createWebsocketServiceStub({ isConnected: () => false });
         const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
 
         const fired: number[] = [];
@@ -80,7 +95,7 @@ describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
     });
 
     it('does not fire on a rate-limited second call within MIN_RESUBSCRIBE_INTERVAL_MS', async () => {
-        const websocketService = createWebsocketServiceStub({ isConnected: () => true });
+        const { service: websocketService } = createWebsocketServiceStub({ isConnected: () => true });
         const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
 
         const fired: number[] = [];
@@ -100,7 +115,7 @@ describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
     });
 
     it('does not fire when subscribeToIrisSession throws', async () => {
-        const websocketService = createWebsocketServiceStub({
+        const { service: websocketService } = createWebsocketServiceStub({
             isConnected: () => true,
             subscribeToIrisSession: () => {
                 throw new Error('subscribe failed');
@@ -113,5 +128,40 @@ describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
 
         await expect(client.subscribeToSession(42)).resolves.toBeUndefined();
         expect(fired).toEqual([]);
+    });
+
+    it('forces a resubscribe via the connection-state monitor even within MIN_RESUBSCRIBE_INTERVAL_MS', async () => {
+        const { service: websocketService, fireConnectionState } = createWebsocketServiceStub({ isConnected: () => true });
+        const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
+
+        const fired: number[] = [];
+        client.onDidResubscribe((sessionId) => fired.push(sessionId));
+
+        const activeContext: ActiveContext = {
+            type: 'exercise',
+            id: 1,
+            title: 'test exercise',
+            source: 'system-default',
+            locked: false,
+            selectedAt: 0,
+        };
+
+        const nowSpy = vi.spyOn(Date, 'now');
+
+        nowSpy.mockReturnValue(1_000_000);
+        await client.initializeSession(activeContext, 42);
+
+        // Simulate a rapid reconnect flap well within the rate-limit window
+        // (STOMP's own reconnectDelay is 500ms, so this is the common case).
+        // Every reconnect is a fresh STOMP session, so the connection-state
+        // monitor must force the resubscribe through the throttle instead of
+        // silently dropping it.
+        nowSpy.mockReturnValue(1_000_000 + MIN_RESUBSCRIBE_INTERVAL_MS - 1);
+        fireConnectionState(true);
+        // Let the void-returning async call inside the monitor callback settle.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(fired).toEqual([42, 42]);
     });
 });

--- a/extension/test/logic/iris/irisWebSocketSessionClient.resubscribe.test.ts
+++ b/extension/test/logic/iris/irisWebSocketSessionClient.resubscribe.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// IrisWebSocketSessionClient allocates two `new vscode.EventEmitter()` fields
+// in the constructor path (_onDidReceiveMessage, _onDidConnectionStateChange,
+// and the one under test, _onDidResubscribe). The shared vitest vscode stub
+// has no EventEmitter, so mirror it here with a REAL emitter (stores and
+// invokes listeners) rather than the no-op emitter used by handler-only
+// tests, because these assertions depend on whether a fire actually reaches
+// a subscribed listener.
+vi.mock('vscode', () => {
+    class EventEmitter<T> {
+        private _listeners: Array<(e: T) => void> = [];
+        event = (listener: (e: T) => void): { dispose(): void } => {
+            this._listeners.push(listener);
+            return {
+                dispose: () => {
+                    this._listeners = this._listeners.filter((l) => l !== listener);
+                },
+            };
+        };
+        fire(value: T): void {
+            for (const listener of [...this._listeners]) {
+                listener(value);
+            }
+        }
+        dispose(): void {
+            this._listeners = [];
+        }
+    }
+    return { EventEmitter };
+});
+
+import type { ArtemisApiService } from '@extension/api';
+import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
+import type { ArtemisWebsocketService } from '@extension/services/websocket/artemisWebsocketService';
+
+/** Minimum interval between resubscription attempts, mirrored from the client. */
+const MIN_RESUBSCRIBE_INTERVAL_MS = 3000;
+
+const noopApiService = {} as unknown as ArtemisApiService;
+
+function createWebsocketServiceStub(options: {
+    isConnected?: () => boolean;
+    subscribeToIrisSession?: (id: number, onMessage: (m: unknown) => void) => () => void;
+}): ArtemisWebsocketService {
+    return {
+        isConnected: options.isConnected ?? (() => true),
+        subscribeToIrisSession: options.subscribeToIrisSession ?? (() => () => { /* unsubscribe no-op */ }),
+        onDidChangeConnectionState: () => ({ dispose: () => { /* no-op */ } }),
+    } as unknown as ArtemisWebsocketService;
+}
+
+describe('IrisWebSocketSessionClient: onDidResubscribe', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('fires the sessionId exactly once after a real successful subscribe', async () => {
+        const websocketService = createWebsocketServiceStub({ isConnected: () => true });
+        const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
+
+        const fired: number[] = [];
+        client.onDidResubscribe((sessionId) => fired.push(sessionId));
+
+        await client.subscribeToSession(42);
+
+        expect(fired).toEqual([42]);
+    });
+
+    it('does not fire when the WebSocket is not connected', async () => {
+        const websocketService = createWebsocketServiceStub({ isConnected: () => false });
+        const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
+
+        const fired: number[] = [];
+        client.onDidResubscribe((sessionId) => fired.push(sessionId));
+
+        await client.subscribeToSession(42);
+
+        expect(fired).toEqual([]);
+    });
+
+    it('does not fire on a rate-limited second call within MIN_RESUBSCRIBE_INTERVAL_MS', async () => {
+        const websocketService = createWebsocketServiceStub({ isConnected: () => true });
+        const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
+
+        const fired: number[] = [];
+        client.onDidResubscribe((sessionId) => fired.push(sessionId));
+
+        const nowSpy = vi.spyOn(Date, 'now');
+
+        nowSpy.mockReturnValue(1_000_000);
+        await client.subscribeToSession(42);
+
+        // Well within the rate-limit window: the second attempt must be
+        // suppressed entirely, so no second fire should reach the listener.
+        nowSpy.mockReturnValue(1_000_000 + MIN_RESUBSCRIBE_INTERVAL_MS - 1);
+        await client.subscribeToSession(43);
+
+        expect(fired).toEqual([42]);
+    });
+
+    it('does not fire when subscribeToIrisSession throws', async () => {
+        const websocketService = createWebsocketServiceStub({
+            isConnected: () => true,
+            subscribeToIrisSession: () => {
+                throw new Error('subscribe failed');
+            },
+        });
+        const client = new IrisWebSocketSessionClient(noopApiService, websocketService);
+
+        const fired: number[] = [];
+        client.onDidResubscribe((sessionId) => fired.push(sessionId));
+
+        await expect(client.subscribeToSession(42)).resolves.toBeUndefined();
+        expect(fired).toEqual([]);
+    });
+});

--- a/extension/test/logic/webview/mergeHistory.test.ts
+++ b/extension/test/logic/webview/mergeHistory.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeHistory } from '@webview/stores/mergeHistory';
+import type { ChatMessage } from '@webview/views/IrisChat/types';
+
+function msg(over: Partial<ChatMessage> & { localId: string }): ChatMessage {
+    return {
+        role: 'assistant',
+        content: 'x',
+        timestamp: 0,
+        ...over,
+    };
+}
+
+describe('mergeHistory', () => {
+    it('merges a persisted history snapshot into the live list without duplicating or reordering', () => {
+        const existing: ChatMessage[] = [
+            msg({ id: 1, role: 'assistant', content: 'old answer', localId: 'a' }),
+            msg({ id: 2, role: 'user', content: 'my question', localId: 'b', status: 'sent' }),
+            msg({ role: 'assistant', content: 'Error: x', localId: 'e' }),
+        ];
+        const incoming: ChatMessage[] = [
+            msg({ id: 1, role: 'assistant', content: 'old answer', localId: 'x' }),
+            msg({ id: 2, role: 'user', content: 'my question', localId: 'y' }),
+            msg({ id: 3, role: 'assistant', content: 'the recovered answer', localId: 'z' }),
+        ];
+
+        const result = mergeHistory(existing, incoming);
+
+        expect(result.map((m) => m.id)).toEqual([1, 2, 3, undefined]);
+
+        // Matched bubbles keep their live localId and status.
+        expect(result[0].localId).toBe('a');
+        expect(result[1].localId).toBe('b');
+        expect(result[1].status).toBe('sent');
+
+        // The newly-recovered bubble is present with its incoming content.
+        expect(result[2].id).toBe(3);
+        expect(result[2].content).toBe('the recovered answer');
+        expect(result[2].localId).toBe('z');
+
+        // The error bubble (no id) is kept, appended after the canonical history.
+        expect(result[3].localId).toBe('e');
+
+        // No duplicate of the user bubble.
+        expect(result.filter((m) => m.id === 2)).toHaveLength(1);
+    });
+
+    it('keeps an existing bubble whose id is absent from the incoming history, in its original order', () => {
+        const existing: ChatMessage[] = [
+            msg({ id: 1, role: 'assistant', content: 'a1', localId: 'a' }),
+            msg({ id: 99, role: 'assistant', content: 'orphaned', localId: 'orphan' }),
+        ];
+        const incoming: ChatMessage[] = [
+            msg({ id: 1, role: 'assistant', content: 'a1', localId: 'x' }),
+        ];
+
+        const result = mergeHistory(existing, incoming);
+
+        expect(result.map((m) => m.localId)).toEqual(['a', 'orphan']);
+    });
+
+    it('returns the incoming history unchanged when there is no existing state', () => {
+        const incoming: ChatMessage[] = [
+            msg({ id: 1, role: 'assistant', content: 'a1', localId: 'x' }),
+        ];
+
+        const result = mergeHistory([], incoming);
+
+        expect(result).toEqual(incoming);
+    });
+});

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -686,4 +686,70 @@ describe('useChatStore', () => {
 			expect(useChatStore.getState().lastRunUiRevision).toBe(1);
 		});
 	});
+
+	describe('mergeLoadedMessages', () => {
+		it('merges history into the live list, preserving an optimistic user bubble already stamped with an id', () => {
+			useChatStore.getState().setIrisState(makeIrisState({ activeSessionId: 's1' }));
+			useChatStore.getState().addMessage({
+				id: 2, localId: 'optimistic-b', role: 'user', content: 'my question', timestamp: 1, status: 'sent',
+			});
+
+			useChatStore.getState().mergeLoadedMessages('s1', [
+				{ id: 2, localId: 'history-y', role: 'user', content: 'my question', timestamp: 1 },
+				{ id: 3, localId: 'history-z', role: 'assistant', content: 'answer', timestamp: 2 },
+			]);
+
+			const messages = useChatStore.getState().messages;
+			expect(messages).toHaveLength(2);
+			expect(messages[0]).toMatchObject({ id: 2, localId: 'optimistic-b', status: 'sent' });
+			expect(messages[1]).toMatchObject({ id: 3, localId: 'history-z', content: 'answer' });
+		});
+
+		it('is ignored when localSessionId does not match the active session', () => {
+			useChatStore.getState().setIrisState(makeIrisState({ activeSessionId: 's1' }));
+			useChatStore.getState().addMessage({
+				id: 2, localId: 'optimistic-b', role: 'user', content: 'my question', timestamp: 1, status: 'sent',
+			});
+
+			useChatStore.getState().mergeLoadedMessages('s-other', [
+				{ id: 2, localId: 'history-y', role: 'user', content: 'my question', timestamp: 1 },
+				{ id: 3, localId: 'history-z', role: 'assistant', content: 'answer', timestamp: 2 },
+			]);
+
+			const messages = useChatStore.getState().messages;
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toMatchObject({ id: 2, localId: 'optimistic-b' });
+		});
+	});
+
+	describe('confirmSentMessage', () => {
+		it('stamps the matching optimistic user bubble with the server id and status sent', () => {
+			useChatStore.getState().addMessage({ localId: 'pending-c', role: 'user', content: 'pending question', timestamp: 1, status: 'sending' });
+
+			useChatStore.getState().confirmSentMessage('pending-c', 42);
+
+			const message = useChatStore.getState().messages.find((m) => m.localId === 'pending-c');
+			expect(message?.id).toBe(42);
+			expect(message?.status).toBe('sent');
+		});
+
+		it('is a no-op when no bubble matches the given localId', () => {
+			useChatStore.getState().addMessage({ localId: 'pending-d', role: 'user', content: 'pending question', timestamp: 1, status: 'sending' });
+
+			useChatStore.getState().confirmSentMessage('does-not-exist', 42);
+
+			const message = useChatStore.getState().messages.find((m) => m.localId === 'pending-d');
+			expect(message?.id).toBeUndefined();
+			expect(message?.status).toBe('sending');
+		});
+
+		it('is a no-op when the matching localId belongs to a non-user message', () => {
+			useChatStore.getState().addMessage({ localId: 'asst-x', role: 'assistant', content: 'assistant reply', timestamp: 1 });
+
+			useChatStore.getState().confirmSentMessage('asst-x', 42);
+
+			const message = useChatStore.getState().messages.find((m) => m.localId === 'asst-x');
+			expect(message?.id).toBeUndefined();
+		});
+	});
 });

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -868,6 +868,114 @@ describe('IrisChatView', () => {
 		});
 	});
 
+	describe('MergeSessionMessages / ConfirmSentMessage (reconnect reconciliation)', () => {
+		const seedActiveSession = (localSessionId: string, artemisSessionId?: number) => {
+			useChatStore.setState({
+				context: {
+					type: 'exercise',
+					id: 1,
+					title: 'Test Exercise',
+					shortName: 'TE',
+					courseId: 10,
+					locked: false,
+					source: 'user-selected',
+				},
+				activeSessionId: localSessionId,
+				sessions: [
+					{
+						id: localSessionId,
+						artemisSessionId: artemisSessionId ?? undefined,
+						preview: '',
+						title: '',
+						messageCount: 0,
+						createdAt: 0,
+						lastActivity: 0,
+					},
+				],
+				messageLoad: { localSessionId, status: 'success' },
+			});
+		};
+
+		it('merges MergeSessionMessages into the active session without wiping a live draft', async () => {
+			seedActiveSession('local-A', 42);
+			useChatStore.setState({ liveDraft: { runId: 'run-1', text: 'draft in progress' } });
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'mergeSessionMessages',
+				localSessionId: 'local-A',
+				artemisSessionId: 42,
+				messages: [
+					{ id: 1, role: 'assistant', content: 'merged answer', timestamp: 0, helpful: null },
+				],
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText('merged answer')).toBeInTheDocument();
+			});
+			// The whole point of a merge (vs. LoadMessages) is that it does not
+			// call resetTransientChatUi, so a live draft must survive it.
+			expect(useChatStore.getState().liveDraft).toEqual({ runId: 'run-1', text: 'draft in progress' });
+		});
+
+		it('ignores MergeSessionMessages for a local session that is not active', () => {
+			seedActiveSession('local-current', 99);
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({
+				type: 'mergeSessionMessages',
+				localSessionId: 'local-other',
+				artemisSessionId: 1,
+				messages: [
+					{ id: 5, role: 'assistant', content: 'should not appear', timestamp: 0, helpful: null },
+				],
+			});
+
+			expect(screen.queryByText('should not appear')).not.toBeInTheDocument();
+			expect(useChatStore.getState().messages).toEqual([]);
+		});
+
+		it('stamps the optimistic user bubble with its server id on ConfirmSentMessage', async () => {
+			seedActiveSession('local-A', 42);
+			const localId = 'optimistic-1';
+			useChatStore.setState({
+				messages: [
+					{ localId, role: 'user', content: 'hello', timestamp: 0, status: 'sending' },
+				],
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({ type: 'confirmSentMessage', localSessionId: 'local-A', localId, id: 7 });
+
+			await waitFor(() => {
+				const stamped = useChatStore.getState().messages.find((m) => m.localId === localId);
+				expect(stamped?.id).toBe(7);
+				expect(stamped?.status).toBe('sent');
+			});
+		});
+
+		it('ignores ConfirmSentMessage for a local session that is not active', () => {
+			seedActiveSession('local-current', 99);
+			const localId = 'optimistic-1';
+			useChatStore.setState({
+				messages: [
+					{ localId, role: 'user', content: 'hello', timestamp: 0, status: 'sending' },
+				],
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			dispatchExtensionMessage({ type: 'confirmSentMessage', localSessionId: 'local-other', localId, id: 7 });
+
+			const untouched = useChatStore.getState().messages.find((m) => m.localId === localId);
+			expect(untouched?.id).toBeUndefined();
+			expect(untouched?.status).toBe('sending');
+		});
+	});
+
 	it('does not show banner during initial connect or reconnect attempts', () => {
 		useChatStore.setState({ webSocketStatus: 'connecting' });
 		const mockApi = createMockVsCodeApi();

--- a/extension/test/unit/provider/chatWebviewProviderReconnect.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderReconnect.test.ts
@@ -1,0 +1,393 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ArtemisApiService } from '@extension/api';
+import { ChatWebviewProvider } from '@extension/provider/chatWebviewProvider';
+import { IrisChatSessionService } from '@extension/services/iris/chat/chatSessionService';
+import { IrisWebSocketMessageHandler } from '@extension/services/iris/chat/irisWebSocketMessageHandler';
+import { ContextStore } from '@extension/services/iris/context/contextStore';
+import { IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+import { IrisWebSocketSessionClient } from '@extension/services/iris/transport/irisWebSocketSessionClient';
+import { ActiveContext } from '@extension/types';
+import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
+
+/**
+ * Task 8: generation-scoped reconnect reconciliation wired into the provider.
+ *
+ * These tests exercise `_reconcileOnResubscribe` and the marker-open branch of
+ * `_handleChatMessage` directly against the real `IrisRunStateMachine`,
+ * `ContextStore` and `IrisWebSocketMessageHandler` the provider constructs.
+ * The websocket service is left undefined (matching the sibling provider test
+ * harnesses), so `onDidResubscribe` is not subscribed through the constructor;
+ * we drive the private reconcile entrypoint that the subscription would call.
+ */
+
+interface Harness {
+    provider: ChatWebviewProvider;
+    contextStore: ContextStore;
+    api: sinon.SinonStubbedInstance<ArtemisApiService>;
+    sessionClient: sinon.SinonStubbedInstance<IrisWebSocketSessionClient>;
+    postSpy: sinon.SinonSpy;
+    fetchStub: sinon.SinonStub;
+    publishSpy: sinon.SinonSpy;
+    sandbox: sinon.SinonSandbox;
+    setCurrentSessionId: (id: number | undefined) => void;
+}
+
+// Private surface we reach into. Casting once here keeps the tests readable
+// without sprinkling `as any` everywhere.
+interface ProviderInternals {
+    _runs: IrisRunStateMachine;
+    _reconcileMarker: unknown;
+    _reconcileOnResubscribe: (sessionId: number) => Promise<void>;
+    _handleChatMessage: (m: { text?: string; localId?: string; localSessionId?: string }) => Promise<void>;
+    _chatSessionService: IrisChatSessionService;
+    _chatMessageService: { sendMessage: (input: unknown) => Promise<unknown> };
+    _websocketMessageHandler: IrisWebSocketMessageHandler;
+}
+
+function internals(provider: ChatWebviewProvider): ProviderInternals {
+    return provider as unknown as ProviderInternals;
+}
+
+function buildHarness(): Harness {
+    const sandbox = sinon.createSandbox();
+    // A preceding unit-test suite in the aggregate run sometimes crashes before
+    // restoring its sandbox, leaving registerCommand wrapped. Restore a leaked
+    // wrapper first so our own stub can attach and be cleaned up in teardown.
+    const leaked = vscode.commands.registerCommand as unknown as { restore?: () => void; isSinonProxy?: boolean };
+    if (leaked.isSinonProxy && typeof leaked.restore === 'function') {
+        leaked.restore();
+    }
+    sandbox.stub(vscode.commands, 'registerCommand').returns({ dispose: () => undefined });
+    sandbox.stub(vscode.window, 'showErrorMessage');
+    sandbox.stub(vscode.window, 'showWarningMessage');
+
+    const mockContext = new MockExtensionContext();
+    const contextStore = new ContextStore(mockContext);
+    const api = sinon.createStubInstance(ArtemisApiService);
+
+    const noAi = {
+        isNoAiEnabled: false,
+        onNoAiStatusChanged: new vscode.EventEmitter<boolean>().event,
+    };
+    const registry = { getAllExercises: () => [] };
+    const courseDataCache = {
+        onCoursesLoaded: new vscode.EventEmitter<unknown>().event,
+        fetch: async () => undefined,
+    };
+
+    // ws service undefined => the constructor does not build/subscribe a live
+    // IrisWebSocketSessionClient; we inject a stubbed one below.
+    const provider = new ChatWebviewProvider(
+        vscode.Uri.file('/tmp'),
+        mockContext as unknown as vscode.ExtensionContext,
+        api as unknown as ArtemisApiService,
+        undefined,
+        noAi as never,
+        registry as never,
+        courseDataCache as never,
+        undefined,
+        contextStore,
+    );
+
+    const sessionClient = sinon.createStubInstance(IrisWebSocketSessionClient);
+    let currentSessionId: number | undefined;
+    Object.defineProperty(sessionClient, 'currentSessionId', {
+        get: () => currentSessionId,
+        configurable: true,
+    });
+    (provider as unknown as { _irisSessionManager: unknown })._irisSessionManager = sessionClient;
+
+    const postSpy = sandbox.spy(provider as unknown as { _postMessageSafe: (m: unknown) => void }, '_postMessageSafe');
+    const fetchStub = sandbox.stub(internals(provider)._chatSessionService, 'fetchActiveSessionHistory');
+    const publishSpy = sandbox.spy(internals(provider)._websocketMessageHandler, 'publishCurrentRunUi');
+
+    return {
+        provider,
+        contextStore,
+        api,
+        sessionClient,
+        postSpy,
+        fetchStub,
+        publishSpy,
+        sandbox,
+        setCurrentSessionId: (id) => { currentSessionId = id; },
+    };
+}
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 5));
+
+function context(id: number): ActiveContext {
+    return {
+        type: 'course', id, title: `Course ${id}`, courseId: id,
+        source: 'user-selected', locked: false, selectedAt: Date.now(),
+    };
+}
+
+/**
+ * Establish an active session with the given artemis id and return its local
+ * session id (`activeSession.id`). Uses the idempotent overview upsert so the
+ * session survives the cleanup pass inside switchSession.
+ */
+function activateSession(contextStore: ContextStore, courseId: number, artemisSessionId: number): string {
+    contextStore.setActiveContext(context(courseId));
+    const localId = contextStore.upsertSessionFromOverview({
+        contextKey: `course:${courseId}`,
+        artemisSessionId,
+        lastActivity: Date.now(),
+    });
+    contextStore.switchSession(localId);
+    return localId;
+}
+
+/** Open a generation and bind it to `runId`. Leaves the machine waiting with
+ *  pendingGeneration=false (a frame arrived). Returns the generation id. */
+function beginBoundRun(runs: IrisRunStateMachine, runId: string): number {
+    const generation = runs.beginGeneration();
+    runs.admit({ runId } as never);
+    return generation;
+}
+
+function assistant(id: number, over: Partial<{ final: boolean }> = {}) {
+    return { id, role: 'assistant' as const, content: 'a', timestamp: Date.now(), final: true, ...over };
+}
+
+const mergeCalls = (postSpy: sinon.SinonSpy) =>
+    postSpy.getCalls().filter(c => (c.args[0] as { type?: string })?.type === 'mergeSessionMessages');
+const confirmCalls = (postSpy: sinon.SinonSpy) =>
+    postSpy.getCalls().filter(c => (c.args[0] as { type?: string })?.type === 'confirmSentMessage');
+
+suite('ChatWebviewProvider reconnect reconciliation', () => {
+    let h: Harness;
+
+    setup(() => {
+        h = buildHarness();
+    });
+
+    teardown(() => {
+        h.provider.dispose();
+        h.sandbox.restore();
+    });
+
+    test('initial subscribe with no marker => no fetch', async () => {
+        activateSession(h.contextStore, 5, 42);
+        beginBoundRun(internals(h.provider)._runs, 'run-A');
+        // No marker was ever opened.
+        assert.strictEqual(internals(h.provider)._reconcileMarker, undefined);
+
+        await internals(h.provider)._reconcileOnResubscribe(42);
+
+        assert.strictEqual(h.fetchStub.callCount, 0, 'a resubscribe without a marker must not fetch');
+    });
+
+    test('run A marker (gen G) cannot reconcile once B started (gen G+1), gate fails', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const genA = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: genA, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+        // B starts and binds its own run: generation advances to G+1, pending
+        // is false again so only the generation-mismatch guard can catch this.
+        beginBoundRun(runs, 'run-B');
+        assert.strictEqual(runs.pendingGeneration, false);
+        assert.strictEqual(runs.generation, genA + 1);
+
+        await internals(h.provider)._reconcileOnResubscribe(42);
+
+        assert.strictEqual(h.fetchStub.callCount, 0, 'stale-generation marker must not fetch');
+    });
+
+    test('reconciliation for A completing after B starts cannot resolve or merge (post-await re-check)', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const genA = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: genA, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+
+        let resolveFetch: (v: unknown) => void = () => { /* noop */ };
+        h.fetchStub.onFirstCall().returns(new Promise(res => { resolveFetch = res; }) as never);
+
+        // Passes the pre-fetch gate, then parks on the await.
+        const p = internals(h.provider)._reconcileOnResubscribe(42);
+        await tick();
+        assert.strictEqual(h.fetchStub.callCount, 1, 'fetch must have started');
+
+        // While the fetch is in flight, B starts and binds, generation advances.
+        beginBoundRun(runs, 'run-B');
+
+        // The fetch now returns conclusive history for A. The post-await
+        // re-validation must still abort: neither merge nor resolve.
+        resolveFetch([assistant(99)]);
+        await p;
+        await tick();
+
+        assert.strictEqual(mergeCalls(h.postSpy).length, 0, 'stale fetch must not merge into the webview');
+        assert.strictEqual(runs.waiting, true, 'B is still waiting; A must not resolve it');
+        assert.ok(internals(h.provider)._reconcileMarker, 'marker must not be cleared by the aborted reconcile');
+    });
+
+    test('gen 2 POST resolves before gen 1: gen 1 late completion does not replace/clear gen 2 marker (but still confirms its bubble)', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        h.setCurrentSessionId(42);
+        // Drive the machine to generation 2, waiting.
+        beginBoundRun(runs, 'run-1');
+        beginBoundRun(runs, 'run-2');
+        assert.strictEqual(runs.generation, 2);
+
+        const sendStub = h.sandbox.stub(internals(h.provider)._chatMessageService, 'sendMessage');
+        sendStub.onFirstCall().resolves({ sent: true, sentMessageId: 100, generation: 2 });
+        sendStub.onSecondCall().resolves({ sent: true, sentMessageId: 50, generation: 1 });
+
+        // gen 2's POST returns first and opens the marker.
+        await internals(h.provider)._handleChatMessage({ text: 'b', localId: 'l2', localSessionId: 'session-42' });
+        const markerAfterGen2 = internals(h.provider)._reconcileMarker as { generation: number; baselineMessageId: number };
+        assert.strictEqual(markerAfterGen2.generation, 2);
+        assert.strictEqual(markerAfterGen2.baselineMessageId, 100);
+
+        // gen 1's POST returns late. It must NOT overwrite the newer marker...
+        await internals(h.provider)._handleChatMessage({ text: 'a', localId: 'l1', localSessionId: 'session-42' });
+        const markerAfterGen1 = internals(h.provider)._reconcileMarker as { generation: number; baselineMessageId: number };
+        assert.strictEqual(markerAfterGen1.generation, 2, 'gen 1 must not replace the gen 2 marker');
+        assert.strictEqual(markerAfterGen1.baselineMessageId, 100, 'gen 2 baseline must survive');
+
+        // ...but its optimistic bubble is still confirmed, independent of the marker.
+        const confirms = confirmCalls(h.postSpy);
+        assert.ok(confirms.some(c => (c.args[0] as { id?: number }).id === 100), 'gen 2 bubble confirmed');
+        assert.ok(confirms.some(c => (c.args[0] as { id?: number }).id === 50), 'gen 1 bubble still confirmed');
+    });
+
+    test('same-generation run rebind (A -> C) during fetch aborts resolution (currentRunId re-check)', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const genA = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: genA, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+
+        let resolveFetch: (v: unknown) => void = () => { /* noop */ };
+        h.fetchStub.onFirstCall().returns(new Promise(res => { resolveFetch = res; }) as never);
+
+        const p = internals(h.provider)._reconcileOnResubscribe(42);
+        await tick();
+
+        // A late unknown frame rebinds currentRunId within the SAME generation.
+        runs.admit({ runId: 'run-C' } as never);
+        assert.strictEqual(runs.currentRunId, 'run-C');
+        assert.strictEqual(runs.generation, genA, 'generation must be unchanged by the rebind');
+
+        // Conclusive history for A returns, but the run it proves finished is no
+        // longer the bound run, so nothing may resolve or merge.
+        resolveFetch([assistant(99)]);
+        await p;
+        await tick();
+
+        assert.strictEqual(mergeCalls(h.postSpy).length, 0, 'rebind must abort the merge');
+        assert.strictEqual(runs.waiting, true, 'C must not be resolved by A history');
+        assert.ok(internals(h.provider)._reconcileMarker, 'marker must not be cleared');
+    });
+
+    test('a real context change resets _runs and clears the marker', async () => {
+        const runs = internals(h.provider)._runs;
+        // Establish a first context (this itself resets, so set up state AFTER).
+        h.contextStore.setActiveContext(context(5));
+        beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: runs.generation, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+        assert.strictEqual(runs.waiting, true);
+
+        // Change to a genuinely different context.
+        h.contextStore.setActiveContext(context(6));
+
+        assert.strictEqual(internals(h.provider)._reconcileMarker, undefined, 'context change must clear the marker');
+        assert.strictEqual(runs.waiting, false, 'context change must reset the run machine');
+    });
+
+    test('pendingGeneration true (first frame never arrived) => no out-of-band resolution', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        // beginGeneration WITHOUT an admitted frame: pendingGeneration stays true.
+        const gen = runs.beginGeneration();
+        assert.strictEqual(runs.pendingGeneration, true);
+        internals(h.provider)._reconcileMarker = {
+            generation: gen, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+
+        await internals(h.provider)._reconcileOnResubscribe(42);
+
+        assert.strictEqual(h.fetchStub.callCount, 0, 'pendingGeneration must block the fetch');
+    });
+
+    test('a second resubscribe during an in-flight fetch is coalesced (re-runs once)', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const gen = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: gen, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+
+        let resolveFetch: (v: unknown) => void = () => { /* noop */ };
+        h.fetchStub.onFirstCall().returns(new Promise(res => { resolveFetch = res; }) as never);
+        // Inconclusive history keeps the marker + waiting alive so the coalesced
+        // re-run passes the gate again.
+        h.fetchStub.resolves([] as never);
+
+        const p = internals(h.provider)._reconcileOnResubscribe(42);
+        await tick();
+        assert.strictEqual(h.fetchStub.callCount, 1);
+
+        // Second resubscribe while the first fetch is in flight: must be coalesced.
+        void internals(h.provider)._reconcileOnResubscribe(42);
+        assert.strictEqual(h.fetchStub.callCount, 1, 'the second trigger must not start a parallel fetch');
+
+        resolveFetch([]);
+        await p;
+        await tick();
+
+        assert.strictEqual(h.fetchStub.callCount, 2, 'the coalesced trigger must re-run the fetch exactly once');
+    });
+
+    test('conclusive history resolves the run and publishes run UI', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const gen = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: gen, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+        h.fetchStub.resolves([assistant(99)] as never);
+        h.publishSpy.resetHistory();
+
+        await internals(h.provider)._reconcileOnResubscribe(42);
+        await tick();
+
+        assert.strictEqual(mergeCalls(h.postSpy).length, 1, 'history must be merged');
+        assert.strictEqual(runs.waiting, false, 'conclusive history must resolve the run');
+        assert.ok(h.publishSpy.called, 'run UI must be republished after resolution');
+        assert.strictEqual(internals(h.provider)._reconcileMarker, undefined, 'the resolved marker must be cleared');
+    });
+
+    test('inconclusive history merges but leaves waiting true', async () => {
+        const runs = internals(h.provider)._runs;
+        activateSession(h.contextStore, 5, 42);
+        const gen = beginBoundRun(runs, 'run-A');
+        internals(h.provider)._reconcileMarker = {
+            generation: gen, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
+        };
+        // Assistant message at/under the baseline does not prove the in-flight run ended.
+        h.fetchStub.resolves([assistant(10)] as never);
+        h.publishSpy.resetHistory();
+
+        await internals(h.provider)._reconcileOnResubscribe(42);
+        await tick();
+
+        assert.strictEqual(mergeCalls(h.postSpy).length, 1, 'history must still be merged');
+        assert.strictEqual(runs.waiting, true, 'inconclusive history must leave the run waiting');
+        assert.ok(internals(h.provider)._reconcileMarker, 'the marker must survive an inconclusive reconcile');
+        assert.ok(!h.publishSpy.called, 'no resolution => no run-UI republish');
+    });
+});

--- a/extension/test/unit/provider/chatWebviewProviderReconnect.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderReconnect.test.ts
@@ -158,6 +158,8 @@ const mergeCalls = (postSpy: sinon.SinonSpy) =>
     postSpy.getCalls().filter(c => (c.args[0] as { type?: string })?.type === 'mergeSessionMessages');
 const confirmCalls = (postSpy: sinon.SinonSpy) =>
     postSpy.getCalls().filter(c => (c.args[0] as { type?: string })?.type === 'confirmSentMessage');
+const runUiCalls = (postSpy: sinon.SinonSpy) =>
+    postSpy.getCalls().filter(c => (c.args[0] as { type?: string })?.type === 'updateIrisRunUi');
 
 suite('ChatWebviewProvider reconnect reconciliation', () => {
     let h: Harness;
@@ -359,8 +361,19 @@ suite('ChatWebviewProvider reconnect reconciliation', () => {
         internals(h.provider)._reconcileMarker = {
             generation: gen, localSessionId: 'session-42', artemisSessionId: 42, baselineMessageId: 10,
         };
+
+        // Seed a stale handler-side draft, mirroring the real scenario: earlier
+        // PARTIAL frames landed before the WS dropped mid-answer, and a pure
+        // disconnect never clears the handler's own projection (only the
+        // webview store is reset). The resolution publish below must clear it,
+        // not resurrect it as a phantom duplicate bubble.
+        internals(h.provider)._websocketMessageHandler.handleIrisWebSocketMessage({
+            type: 'PARTIAL', runId: 'run-A', partialResult: 'stale partial answer', partialSeq: 1,
+        });
+
         h.fetchStub.resolves([assistant(99)] as never);
         h.publishSpy.resetHistory();
+        h.postSpy.resetHistory();
 
         await internals(h.provider)._reconcileOnResubscribe(42);
         await tick();
@@ -369,6 +382,12 @@ suite('ChatWebviewProvider reconnect reconciliation', () => {
         assert.strictEqual(runs.waiting, false, 'conclusive history must resolve the run');
         assert.ok(h.publishSpy.called, 'run UI must be republished after resolution');
         assert.strictEqual(internals(h.provider)._reconcileMarker, undefined, 'the resolved marker must be cleared');
+
+        const runUiUpdates = runUiCalls(h.postSpy);
+        assert.strictEqual(runUiUpdates.length, 1, 'exactly one run UI projection must be published on resolution');
+        const projection = runUiUpdates[0].args[0] as { projection: { draft: unknown; waiting: boolean } };
+        assert.strictEqual(projection.projection.draft, null, 'the stale partial draft must be cleared, not resurrected');
+        assert.strictEqual(projection.projection.waiting, false, 'the republished projection must reflect the resolved run');
     });
 
     test('inconclusive history merges but leaves waiting true', async () => {

--- a/extension/test/unit/services/chatMessageService.test.ts
+++ b/extension/test/unit/services/chatMessageService.test.ts
@@ -7,6 +7,7 @@ import { ChatMessageService } from '@extension/services/iris/chat/chatMessageSer
 import { IrisChatSessionService } from '@extension/services/iris/chat/chatSessionService';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
 import type { RunLifecycle } from '@extension/services/iris/irisRunStateMachine';
+import { LogCategory, logger } from '@extension/services/loggingService';
 import * as workspaceFileChecker from '@extension/services/workspace/workspaceFileChecker';
 import type { ActiveContext } from '@extension/types';
 import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
@@ -172,10 +173,55 @@ suite('ChatMessageService', () => {
         });
 
         test('should return sent:true on success', async () => {
+            mockApiService.sendChatMessage.resolves({ id: 42 } as any);
             createService();
             const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
-            assert.deepStrictEqual(result, { sent: true });
+            assert.deepStrictEqual(result, { sent: true, sentMessageId: 42, generation: 1 });
             assert.ok(mockApiService.sendChatMessage.calledOnce);
+        });
+    });
+
+    suite('Persisted message id', () => {
+        test('returns the persisted user-message id and the send\'s generation', async () => {
+            mockApiService.sendChatMessage.resolves({ id: 99 } as any);
+            const lifecycle = { beginGeneration: sandbox.stub().returns(7), abortGeneration: sandbox.stub() };
+            createService(mockApiService as unknown as ArtemisApiService, { lifecycle });
+
+            const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
+
+            assert.deepStrictEqual(result, { sent: true, sentMessageId: 99, generation: 7 });
+        });
+
+        test('leaves sentMessageId undefined and warns when the API returns no numeric id', async () => {
+            mockApiService.sendChatMessage.resolves({} as any);
+            const warnStub = sandbox.stub(logger, 'warn');
+            const lifecycle = { beginGeneration: sandbox.stub().returns(7), abortGeneration: sandbox.stub() };
+            createService(mockApiService as unknown as ArtemisApiService, { lifecycle });
+
+            const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
+
+            assert.deepStrictEqual(result, { sent: true, sentMessageId: undefined, generation: 7 });
+            assert.ok(
+                warnStub.calledWith(
+                    'Send persisted without a numeric id; reconnect reconciliation unavailable for this send',
+                    LogCategory.IRIS_CHAT,
+                ),
+                'must warn that reconnect reconciliation is unavailable for this send',
+            );
+        });
+
+        test('leaves sentMessageId undefined when the API returns a non-numeric id', async () => {
+            // The parser only validates object-shape, so a stringified or null
+            // id is possible at runtime even though the type says number.
+            mockApiService.sendChatMessage.resolves({ id: '42' } as any);
+            createService();
+
+            const result = await service.sendMessage({ text: 'Hello', isNoAiEnabled: false });
+
+            assert.ok(result.sent);
+            if (result.sent) {
+                assert.strictEqual(result.sentMessageId, undefined);
+            }
         });
     });
 

--- a/extension/test/unit/services/chatSessionService.test.ts
+++ b/extension/test/unit/services/chatSessionService.test.ts
@@ -1534,6 +1534,55 @@ suite('IrisChatSessionService Test Suite', () => {
         });
     });
 
+    suite('fetchActiveSessionHistory', () => {
+        test('returns the formatted messages from getChatMessages', async () => {
+            mockApiService.getChatMessages.withArgs(5).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hello' }], sentAt: '2024-01-01T10:00:00Z' } as never,
+                { id: 200, sender: 'LLM', content: [{ textContent: 'Hi there' }], final: true } as never,
+            ]);
+
+            const result = await chatSessionService.fetchActiveSessionHistory(5);
+
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0].id, 100);
+            assert.strictEqual(result[0].role, 'user');
+            assert.strictEqual(result[0].content, 'Hello');
+            assert.strictEqual(result[1].id, 200);
+            assert.strictEqual(result[1].role, 'assistant');
+            assert.strictEqual(result[1].final, true);
+        });
+
+        test('posts nothing and does not clear sessions for the context', async () => {
+            const clearSpy = sinon.spy(contextStore, 'clearSessionsForContext');
+            mockApiService.getChatMessages.withArgs(5).resolves([
+                { id: 100, sender: 'USER', content: [{ textContent: 'Hello' }] },
+            ]);
+
+            await chatSessionService.fetchActiveSessionHistory(5);
+
+            assert.ok(postMessageSpy.notCalled, 'fetchActiveSessionHistory must not post any webview message');
+            assert.ok(clearSpy.notCalled, 'fetchActiveSessionHistory must not clear sessions for the context');
+        });
+
+        test('returns [] when artemisApiService is undefined', async () => {
+            const serviceWithoutApi = new IrisChatSessionService(
+                {
+                    contextStore,
+                    artemisApiService: undefined,
+                    postMessage: postMessageSpy,
+                    postSnapshot: onPostSnapshotSpy,
+                },
+                () => mockIrisWebSocketSessionClient as any,
+                { resetRuns: resetRunsSpy },
+            );
+
+            const result = await serviceWithoutApi.fetchActiveSessionHistory(5);
+
+            assert.deepStrictEqual(result, []);
+            assert.ok(postMessageSpy.notCalled, 'must not post anything when the API service is missing');
+        });
+    });
+
     suite('resetRuns on conversation-reset paths', () => {
         // Each reset path clears the WS session and messages, so each must also
         // drop host run state or the old run's projection survives into the new


### PR DESCRIPTION
Closes #355 (Core scope).

When the WebSocket drops mid-answer and the terminal frame is missed, the completed Iris answer was only recoverable by a manual reload, and the reconnect auto-reload only fired when availability was `unavailable`, not on a normal mid-answer drop. This recovers the answer non-destructively after a genuine resubscribe and frees the stuck composer, without corrupting the message list.

## What changed

- **Non-destructive merge (A):** a new `mergeSessionMessages` path merges persisted history by id instead of the destructive whole-array replace (`applyLoadedMessages` stays only on init/switch/manual reload). The optimistic user bubble is stamped with its persisted id from the send POST response (`confirmSentMessage`), so the merge matches it by id and it leaves its `sending` state.
- **Genuine-resubscribe trigger (B):** a new `onDidResubscribe` transport event fires only after a subscription is actually re-established, not on the premature connection-state signal (which precedes resubscribe and also resolves on rate-limit / not-connected / caught failure).
- **Conclusive resolution (C):** a generation-scoped marker `{ generation, localSessionId, artemisSessionId, baselineMessageId }`. After a resubscribe, if a run was dispatched and we are still waiting, the active session history is fetched non-destructively and the run is resolved only on conclusive proof (a non-intermediate assistant message newer than the send baseline), never on mere fetch success. Persisted history cannot prove a run ended (a missed `FAILED` produces no message), so the never-bound and died-with-no-message cases fall back to the existing manual reload.

The reconcile path re-validates generation, bound run id, session, and marker identity both before and after the fetch, uses a coalescing single-flight, and resets run state plus the marker together on every real context change and session navigation.

## Deliberately out of scope (follow-up issues)

- A 90s escape hatch with run tombstoning for the narrow died-with-no-message case (today: manual reload).
- A ready-time resync against the 200-message pending-queue cap (a different, webview-not-ready failure mode).

## Also fixed here

The 3s resubscribe rate-limit could permanently suppress the resubscribe (and therefore reconciliation) on a rapid reconnect, since every reconnect is a fresh STOMP session but the throttle blocked the mandatory resubscribe with no retry. Connection-triggered resubscriptions now bypass the rate-limit read; the throttle still guards the non-connection-triggered callers against loops.

## Testing

- vitest: pure `historyResolvesRun` and `mergeHistory` helpers, the `resolveCurrentRun` state-machine invariant, the `onDidResubscribe` fire conditions (incl. the forced-past-throttle path), and the store actions.
- mocha: `fetchActiveSessionHistory` (fetch-only, posts nothing), the send-path id/generation return, and 10 provider tests covering the reconcile race cases (stale marker, older reconciliation vs newer run, out-of-order POST completion, same-generation run rebind, context-change reset, coalesced resubscribe, conclusive vs inconclusive history).
- Full build, the Open VSX clean variant, and the clean-bundle verifier all pass.

Not yet done: a live end-to-end check (kill the WebSocket mid-answer against a running Artemis + Pyris stack and confirm the answer recovers with no duplicate or dropped bubbles). Worth running before merge.
