### PR TITLE
fix(iris-chat): stop hover chrome reserving dead space in the message list (#366)

### DIFF
--- a/extension/src/webview/styles/richContent.module.css
+++ b/extension/src/webview/styles/richContent.module.css
@@ -1,10 +1,10 @@
 .richContent {
     color: inherit;
-    line-height: 1.6;
+    line-height: 1.5;
 }
 
 .richContent p {
-    margin: 0 0 12px 0;
+    margin: 0 0 10px 0;
 }
 
 .richContent p:last-child {
@@ -13,7 +13,7 @@
 
 .richContent ul,
 .richContent ol {
-    margin: 8px 0;
+    margin: 6px 0;
     padding-left: 24px;
 }
 

--- a/extension/src/webview/views/IrisChat/components/ChatMessageList.module.css
+++ b/extension/src/webview/views/IrisChat/components/ChatMessageList.module.css
@@ -5,17 +5,23 @@
     background: var(--theme-background);
 }
 
+/* The single source of vertical rhythm for the list. It can be this tight because no child
+   reserves dead space for hover chrome any more: each message carries its buttons and timestamp
+   in one always-mounted footer row instead of an absolutely positioned time below the bubble. */
 .content {
     min-height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 8px;
 }
 
-/* Folded episode container (C7). Wraps the fold-line toggle and any expanded timeline beneath it. */
+/* Folded episode container (C7). Wraps the fold-line toggle and any expanded timeline beneath it.
+   Owns the spacing between the two: the children carry no vertical margin of their own, so that
+   nothing stacks on top of the list container's own gap (#366). */
 .episodeFold {
     display: flex;
     flex-direction: column;
+    gap: 8px;
 }
 
 /* Borderless summary line for a CLOSED episode: chevron + outcome + topic. No box (closed sessions
@@ -25,7 +31,9 @@
     align-items: center;
     gap: 4px;
     align-self: flex-start;
-    margin: 8px 16px;
+    /* Horizontal inset only: it aligns the row with .messageWrapper's 16px padding. A vertical
+       margin would stack on the parent's gap and push this ~12px row far off the conversation. */
+    margin: 0 16px;
     padding: 2px 0;
     font-size: 12px;
     color: var(--vscode-descriptionForeground);

--- a/extension/src/webview/views/IrisChat/components/EarlierHintsGroup.module.css
+++ b/extension/src/webview/views/IrisChat/components/EarlierHintsGroup.module.css
@@ -1,6 +1,9 @@
+/* Owns the spacing to the expanded children, so the summary row itself needs no vertical margin
+   that would stack on the list container's gap (#366). */
 .group {
     display: flex;
     flex-direction: column;
+    gap: 8px;
 }
 
 /* Quiet summary line for a run of closed episodes: chevron + "N earlier hints". Same muted, borderless
@@ -10,7 +13,8 @@
     align-items: center;
     gap: 4px;
     align-self: flex-start;
-    margin: 8px 16px;
+    /* Horizontal inset only, matching .episodeFoldLine — the parents own the vertical rhythm. */
+    margin: 0 16px;
     padding: 2px 0;
     font-size: 12px;
     color: var(--vscode-descriptionForeground);
@@ -28,6 +32,7 @@
 .children {
     display: flex;
     flex-direction: column;
+    gap: 8px;
     margin-left: 22px;
     border-left: 1px solid color-mix(in srgb, var(--vscode-foreground) 12%, transparent);
 }

--- a/extension/src/webview/views/IrisChat/components/EpisodeTimeline.module.css
+++ b/extension/src/webview/views/IrisChat/components/EpisodeTimeline.module.css
@@ -3,7 +3,9 @@
 .timeline {
     display: flex;
     flex-direction: column;
-    margin: 8px 16px;
+    /* Horizontal inset only; the flex parent (.content or .episodeFold) owns the vertical gap, so
+       nothing stacks on top of it (#366). */
+    margin: 0 16px;
     padding: 12px 14px;
     background: color-mix(in srgb, var(--vscode-charts-blue) 7%, transparent);
     border-radius: 8px;

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.module.css
@@ -2,9 +2,13 @@
     display: flex;
     align-items: flex-start;
     gap: 8px;
-    padding: 8px 16px;
+    padding: 4px 16px;
     position: relative;
 }
+
+/* Marks a card whose action bar overhangs its bubble. The clearance itself is reserved between
+   the bubble and the footer row below it (see .messageWrapper.proactiveWrapper .footRow), not at
+   the bottom of the wrapper, because the bar overlaps that row and not the next message. */
 
 .messageWrapper.user {
     flex-direction: row-reverse;
@@ -192,64 +196,85 @@
     justify-content: space-between;
 }
 
+/* One footer row per message carrying BOTH hover surfaces: feedback buttons on the left, the
+   timestamp on the right. Always mounted and always occupying its space, so hover only changes
+   colour and the list can never reflow under the cursor. Because the space is reserved exactly
+   once (rather than once for the buttons and again as dead space under the bubble for an
+   absolutely positioned timestamp), the list rhythm can be tight. At rest it recedes rather than
+   disappearing, mirroring the Artemis web client, which keeps its rate buttons permanently visible.
+
+   Sits in .bubbleColumn under the bubble, not inside it (see the note in MessageBubble.tsx).
+   The 16px inset lines the buttons up with the bubble's own text, which the bubble achieves
+   through its padding. */
+.footRow {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-left: 16px;
+    color: var(--vscode-descriptionForeground);
+    transition: color 120ms ease;
+}
+
+/* The assistant column is laid out flex-start, so the row would shrink-wrap and the timestamp's
+   `margin-left: auto` would have no free space to push into. Stretching it to the column width is
+   what puts the time at the trailing edge, opposite the buttons. */
+.messageWrapper.assistant .footRow {
+    align-self: stretch;
+}
+
+/* On a card with an action bar the bar hangs 14px below the bubble (see .actionRow), which is
+   exactly the band this row would otherwise occupy. Push the row clear of it. */
+.messageWrapper.proactiveWrapper .footRow {
+    margin-top: 14px;
+}
+
+/* Recede via COLOUR, never via container opacity: opacity composites the text into whatever is
+   behind it, so it cannot guarantee a contrast ratio. A user message also has no focusable child,
+   so an opacity-based rest state would never lift for keyboard users. */
+.messageWrapper:hover .footRow,
+.messageWrapper:focus-within .footRow,
+.footRow.visible {
+    color: var(--vscode-foreground);
+}
+
+/* A user row carries only the timestamp, which belongs at the trailing edge under its bubble. */
+.messageWrapper.user .footRow {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 .feedbackContainer {
     display: flex;
     gap: 4px;
-    margin-top: 8px;
-    opacity: 0;
-    transition: opacity 150ms ease;
-}
-
-.messageWrapper:hover .feedbackContainer,
-.messageWrapper:focus-within .feedbackContainer,
-.feedbackContainer.visible {
-    opacity: 1;
 }
 
 .feedbackButton {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    height: 28px;
+    padding: 4px 6px;
     background: transparent;
-    border: 1px solid var(--vscode-panel-border);
+    border: none;
     border-radius: 4px;
-    color: var(--vscode-foreground);
+    color: inherit;
     cursor: pointer;
-    transition: all 150ms ease;
+    transition: background 150ms ease;
 }
 
 .feedbackButton:hover {
-    background: var(--vscode-list-hoverBackground);
+    background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
 }
 
 .feedbackButton.selected {
-    background: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    border-color: var(--vscode-button-background);
+    color: var(--vscode-charts-blue);
 }
 
+/* Pushed to the trailing edge, so it reads right-aligned next to the buttons and stays
+   right-aligned on a user message, which has no buttons at all. */
 .timestamp {
-    position: absolute;
-    bottom: -18px;
+    margin-left: auto;
     font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    opacity: 0;
-    transition: opacity 120ms ease;
-}
-
-.messageWrapper:hover .timestamp,
-.messageWrapper:focus-within .timestamp {
-    opacity: 0.7;
-}
-
-.messageWrapper.user .timestamp {
-    right: 16px;
-}
-
-.messageWrapper.assistant .timestamp {
-    left: 16px;
+    color: inherit;
 }
 
 /* A dismissed proactive card stays visible but recedes (spec §6.3: collapse, never delete). */

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
@@ -102,6 +102,9 @@ function MessageBubbleComponent({
                 [styles.user]: isUser,
                 [styles.assistant]: isAssistant,
                 [styles.groupedWrapper]: isProactive && grouped,
+                // Reserves room for the action bar that overhangs this card's bottom edge. Gated on
+                // the same condition as the bar itself, so a card without one keeps the tight rhythm.
+                [styles.proactiveWrapper]: showDismiss || showOfferButtons,
             })}
         >
             <div className={styles.bubbleColumn}>
@@ -167,39 +170,6 @@ function MessageBubbleComponent({
                         </>
                     )}
 
-                    {showFeedback && (
-                        <div
-                            className={clsx(styles.feedbackContainer, {
-                                [styles.visible]: hasFeedback,
-                            })}
-                        >
-                            <button
-                                className={clsx(styles.feedbackButton, {
-                                    [styles.selected]: message.helpful === true,
-                                })}
-                                onClick={() => handleFeedback('positive')}
-                                aria-label="Helpful"
-                            >
-                                <ThumbsUp
-                                    size={16}
-                                    fill={message.helpful === true ? 'currentColor' : 'none'}
-                                />
-                            </button>
-                            <button
-                                className={clsx(styles.feedbackButton, {
-                                    [styles.selected]: message.helpful === false,
-                                })}
-                                onClick={() => handleFeedback('negative')}
-                                aria-label="Not helpful"
-                            >
-                                <ThumbsDown
-                                    size={16}
-                                    fill={message.helpful === false ? 'currentColor' : 'none'}
-                                />
-                            </button>
-                        </div>
-                    )}
-
                     {(showDismiss || showOfferButtons) && (
                         <div className={clsx(styles.actionRow, { [styles.actionRowCard]: isProactive })}>
                             {/* Consented offer buttons on a non-grouped proactive bubble (a grouped/timeline row's
@@ -263,17 +233,50 @@ function MessageBubbleComponent({
                         )}
                     </div>
                 )}
+
+                {/* One footer row carries the feedback buttons and the timestamp, so the space for
+                    both is reserved exactly once and hover only changes their colour, never the
+                    layout. It sits OUTSIDE the bubble on purpose: .proactiveDismissed dims the
+                    bubble with opacity, which would composite this row too and put the 11px
+                    timestamp below any usable contrast. Suppressed inside an episode block, where
+                    the timeline owns the per-row chrome. */}
+                {!grouped && (
+                    <div className={clsx(styles.footRow, { [styles.visible]: hasFeedback })}>
+                        {showFeedback && (
+                            <div className={styles.feedbackContainer}>
+                                <button
+                                    className={clsx(styles.feedbackButton, {
+                                        [styles.selected]: message.helpful === true,
+                                    })}
+                                    onClick={() => handleFeedback('positive')}
+                                    aria-label="Helpful"
+                                >
+                                    <ThumbsUp
+                                        size={16}
+                                        fill={message.helpful === true ? 'currentColor' : 'none'}
+                                    />
+                                </button>
+                                <button
+                                    className={clsx(styles.feedbackButton, {
+                                        [styles.selected]: message.helpful === false,
+                                    })}
+                                    onClick={() => handleFeedback('negative')}
+                                    aria-label="Not helpful"
+                                >
+                                    <ThumbsDown
+                                        size={16}
+                                        fill={message.helpful === false ? 'currentColor' : 'none'}
+                                    />
+                                </button>
+                            </div>
+                        )}
+                        <span className={styles.timestamp} data-testid="message-timestamp">
+                            {relativeTime}
+                        </span>
+                    </div>
+                )}
             </div>
 
-            {/* Per-message timestamps are suppressed inside an episode block: the bubbles are tight, so an
-                absolute-positioned time would overlap the neighbouring row. The block reads as one session.
-                Outside a block the timestamp is always mounted (revealed on hover/focus via CSS) so assistive
-                tech can reach it and the reveal needs no JS hover state. */}
-            {!grouped && (
-                <span className={styles.timestamp} data-testid="message-timestamp">
-                    {relativeTime}
-                </span>
-            )}
         </div>
     );
 }


### PR DESCRIPTION
Closes #366.

The collapsed proactive-episode row sat far below the conversation it belonged to, and the message list read airy throughout. Both had the same root cause: vertical space was reserved by the children rather than owned by their container, and much of it existed only to host chrome that is invisible at rest.

## What changed

**Containers own the vertical rhythm.** The fold line, the "N earlier hints" summary and the timeline card each carried `margin: 8px 16px`. Margins do not collapse inside a flex container, so that stacked on the list's own `gap` and on the preceding item's padding: roughly 34px above a 12px-tall row, roughly 46px after an open episode card. They now keep only the horizontal 16px inset, which is load-bearing (it aligns them with the bubble text), and the parents space them with `gap`.

**One footer row per message instead of two reservations.** Each message reserved space twice for chrome the student cannot see at rest: a feedback row inside the bubble (`opacity: 0`, but permanently in flow) and a timestamp positioned absolutely at `bottom: -18px`, which is why the list gap had to be 18px in the first place. Both now live in a single always-mounted footer row, so the space is reserved once and the list gap drops to 8px.

Two deliberate details there:

- It recedes via `--vscode-descriptionForeground`, not via container `opacity`. Opacity composites the text into whatever is behind it, so it cannot guarantee a contrast ratio, and it would multiply with `.proactiveDismissed`'s own `0.6`. A user row also has no focusable child, so an opacity-based rest state would never lift for keyboard users.
- It sits outside the bubble for the same reason: the bubble is what `.proactiveDismissed` and the failed state dim.

**Feedback buttons follow the Artemis web client**, whose rate buttons are permanently visible: borderless, `padding: 4px 6px`, selection carried by colour plus the filled icon rather than a border.

**Action-bar clearance moved to where the collision is.** A proactive card floats its action bar 14px below its own bottom edge. The tighter rhythm no longer leaves room for that by accident, so only cards that actually render a bar reserve the clearance, between the bubble and the footer row.

**Body text** drops to `line-height: 1.5` with 10px paragraphs, also matching the client. `richContent` is used only by `MessageBubble`, so this touches nothing outside the chat.

## Effect

| Above the collapsed episode row | before | after |
| --- | --- | --- |
| after a message bubble | ~34px | 12px |
| after an open episode card | ~46px | 20px |

Hover changes colour only. The list never reflows under the cursor.

## Verification

- `tsc --noEmit`, `eslint src/webview`, and the full vitest React suite (78 files, 1076 tests) pass.
- Variants were compared side by side in a static harness that links the real stylesheets, including a rebuild of the Artemis web client's spacing for reference.
- Reviewed against the tighter rhythm for collisions with every absolutely positioned element in these files.

## Deliberately out of scope

- `EpisodeTimeline`'s `.foot` still animates `max-height` on hover, which does reflow the timeline card. That behaviour is pre-existing, untouched here, and deliberate: the transition delay is documented as a grace window so the pointer can reach Dismiss.
- A failed proactive offer can overlap its error footer. Pre-existing and unchanged by this diff; worth its own issue.

## Open

Not yet checked in a running Extension Development Host. Draft until that happens.