### PR TITLE
fix(iris-chat): stop timeline hover chrome moving the list, and a failed offer covering its error (#368)

### DIFF
--- a/extension/src/webview/views/IrisChat/components/EpisodeTimeline.module.css
+++ b/extension/src/webview/views/IrisChat/components/EpisodeTimeline.module.css
@@ -64,8 +64,13 @@
 
 .nodeHint { background: var(--vscode-charts-blue); }
 
+/* This spacer is what the hover foot of a non-last row occupies (see .foot): reserving it here once
+   is why revealing that foot costs no height. It must match the foot's pinned 16px line box exactly
+   — at 14px the 11px timestamp overflowed it by 1.4px (the inherited line-height is 1.4) and grew
+   upward over the row's own text. Positioned so the foot can anchor to it. */
 .body {
-    padding-bottom: 14px;
+    position: relative;
+    padding-bottom: 16px;
     border-radius: 6px;
 }
 
@@ -74,26 +79,52 @@
     padding-bottom: 0;
 }
 
-/* Hover/focus chrome: collapsed at rest, expands the row open with a short animation. The transition
-   DELAY lives on the resting state so collapse LINGERS ~0.4s (a grace window to reach Dismiss); the
-   hover/focus rule zeroes it so opening is immediate. `:focus-within` keeps it keyboard-reachable. */
+/* Hover/focus chrome. It is taken OUT OF FLOW into the spacer .body already reserves, so revealing
+   it changes nothing about the row's height and cannot push the following rows or the rest of the
+   message list around (#368). Only opacity animates. The transition DELAY lives on the resting
+   state so the fade-out LINGERS ~0.4s (a grace window to reach Dismiss); the hover/focus rule
+   zeroes it so opening is immediate. `:focus-within` keeps it keyboard-reachable.
+
+   Out of flow, this branch only ever carries the timestamp: every foot that holds a button belongs
+   to the latest row, which is .rowLast and therefore static (below). Its line box is pinned to the
+   spacer's 16px so it can never exceed it and grow upward into the row's own text. */
 .foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    max-height: 0;
+    line-height: 16px;
     opacity: 0;
-    overflow: hidden;
-    margin-top: 0;
-    transition: max-height .16s ease .4s, opacity .16s ease .4s, margin-top .16s ease .4s;
+    transition: opacity .16s ease .4s;
 }
 
 .row:hover .foot,
 .row:focus-within .foot {
-    max-height: 28px;
+    opacity: 1;
+    transition: opacity .16s ease 0s;
+}
+
+/* The last row has no spacer to borrow, so its foot stays in flow. To keep the row's height stable
+   it is simply always present, receding by colour like every other footer in the chat rather than
+   collapsing. `.footPersistent` below already did exactly this whenever the row carries buttons. */
+.rowLast .foot {
+    position: static;
     opacity: 1;
     margin-top: 6px;
-    transition: max-height .16s ease 0s, opacity .16s ease 0s, margin-top .16s ease 0s;
+    color: var(--vscode-descriptionForeground);
+    transition: color 120ms ease;
+}
+
+.rowLast:hover .foot,
+.rowLast:focus-within .foot {
+    color: var(--vscode-foreground);
+}
+
+.rowLast .foot .time {
+    color: inherit;
 }
 
 .row:hover .body,
@@ -101,9 +132,12 @@
     background: color-mix(in srgb, var(--vscode-foreground) 5%, transparent);
 }
 
+/* Must not wrap: out of flow it has no height budget beyond the one reserved line, so a second line
+   would grow upward over the row's text instead of pushing anything down. */
 .time {
     color: var(--vscode-descriptionForeground);
     font-size: 11px;
+    white-space: nowrap;
 }
 
 /* Condensed line an answered offer collapses to, in place of the (now-gone) answer buttons. */
@@ -135,11 +169,14 @@
 }
 
 /* An offer (or a Dismiss row) keeps its actions visible at rest — an offer you must hover to find
-   is no offer. The persistent variant pins the foot open regardless of hover/focus. */
+   is no offer. The persistent variant pins the foot open regardless of hover/focus. Buttons are
+   targets, so this variant always stays in flow: it must never float over the row above it, even
+   if a future change lets a non-last row carry actions. */
 .foot.footPersistent {
-    max-height: 28px;
+    position: static;
     opacity: 1;
     margin-top: 6px;
+    color: var(--vscode-foreground);
     transition: none;
 }
 

--- a/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
+++ b/extension/src/webview/views/IrisChat/components/MessageBubble.tsx
@@ -93,8 +93,10 @@ function MessageBubbleComponent({
     // A consented offer bubble (Moment-1 "stuck" / Moment-3 "abandon") renders its own accept/decline
     // buttons until answered. Same ownership split as Dismiss: a grouped (timeline) row never renders
     // its own buttons (the EpisodeTimeline footer owns the grouped case).
+    // `!isFailed` mirrors showDismiss above: a send that never reached the server has no offer to
+    // answer, and its floating bar would otherwise cover the error footer below the bubble (#368).
     const offer = message.offer;
-    const showOfferButtons = isProactive && !grouped && !!offer && !offer.answered && !!onOfferAnswer;
+    const showOfferButtons = isProactive && !grouped && !!offer && !offer.answered && !!onOfferAnswer && !isFailed;
 
     return (
         <div

--- a/extension/test/react/views/IrisChat/components/MessageBubble.test.tsx
+++ b/extension/test/react/views/IrisChat/components/MessageBubble.test.tsx
@@ -231,6 +231,28 @@ describe('MessageBubble', () => {
 			fireEvent.click(screen.getByRole('button', { name: 'Show me' }));
 			expect(onOfferAnswer).toHaveBeenCalledWith('off-1', 'ep-1', 'stuck', 'accept');
 		});
+
+		// The bar is absolutely positioned and overhangs the bubble, so on a failed send it would
+		// cover the error footer. There is also nothing to answer: the offer never reached the
+		// server. Mirrors the same guard on Dismiss (#368).
+		it('renders no offer buttons on a failed send, so they cannot cover the error footer', () => {
+			render(
+				<MessageBubble
+					message={{
+						localId: 'l1', role: 'assistant', content: 'hint', timestamp: 0,
+						status: 'error', errorMessage: 'Failed to send message',
+						origin: 'proactive', proactiveEpisodeId: 'ep-1',
+						offer: { offerId: 'off-1', moment: 'stuck' },
+					}}
+					onFeedback={vi.fn()}
+					onOfferAnswer={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByRole('button', { name: 'Show me' })).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Not now' })).not.toBeInTheDocument();
+			// The error footer it was covering must still be there.
+			expect(screen.getByRole('alert')).toHaveTextContent('Failed to send message');
+		});
 	});
 
 	it('keeps the timestamp in the DOM for assistant messages (not hover-gated mount)', () => {


### PR DESCRIPTION
Closes #368. Replaces #369, which could not be reopened after its base branch was deleted by the #367 merge. Same commit, rebased onto `feat/struggle-v3-integration` so it no longer carries #367's changes a second time.

Both items are the same class of problem #367 fixed for the message bubble: hover chrome that occupies layout space, or overhangs it, instead of being reserved once.

## 1. The episode timeline moved the whole list on hover

`.foot` animated `max-height` from `0` to `28px` plus a `margin-top`. That is real flow, so hovering any row grew it and pushed every following row and every following message down, measured at roughly 34px per hovered row.

It now sits **out of flow, inside the spacer `.body` already reserves**, so revealing it costs no height and only opacity animates. The grace window is unchanged in intent: the transition delay still lives on the resting state, so the fade-out lingers about 0.4s and the pointer can still travel to Dismiss.

Two details that fell out of the implementation:

- **The last row has no spacer to borrow** (`.rowLast .body` has no bottom padding), so an out-of-flow foot would have covered its own text. It stays in flow and is instead always present, receding by colour like every other footer in the chat after #367. So: out of flow for every row that has the space, always-on for the one that does not.
- **`.footPersistent` is pinned to `position: static`** defensively. Today every actionable foot belongs to the latest row, but a bar carrying real buttons must never float over the row above it if that ever changes.

**The spacer is now 16px, not 14px**, and the foot pins the same 16px line box. At 14px the 11px timestamp overflowed it by 1.4px, because the inherited `--theme-line-height` is `1.4`, and grew *upward* into the row's own text. `.time` also stops wrapping, since out of flow it has no height budget beyond that one line.

## 2. A failed proactive offer covered its own error row

`showOfferButtons` did not exclude `isFailed`, unlike `showDismiss` one line above it. A send that never reached the server still rendered its floating action bar (`bottom: -14px`) over an error footer that starts only 4px below the bubble. Invisible at rest, since the bar sits at `opacity: 0`; on hover it covered the error text.

Gating on `!isFailed` is the root fix rather than a layout workaround: there is nothing to answer in that state, because the offer never reached the server.

## Verification

- `tsc --noEmit`, `eslint src/webview test/react`, full vitest React suite: **78 files, 1077 tests** pass.
- New regression test: a failed proactive offer renders neither offer button, and its error footer stays readable. It caught a real mistake while being written (the status value is `error`, not `failed`).
- Geometry compared side by side against the previous behaviour in a static harness linking the real stylesheets, measuring the shift of the message below the card.

## Reviewed and deliberately not changed

`EpisodeTimeline`'s own offer gate also does not exclude an error status, but a failed *grouped* offer is unreachable: `postOfferBubble` creates offers without a status, the `addMessage` contract does not accept one, loaded messages cannot carry ephemeral offers, and `markMessageFailed` only touches sending user messages. Widening that gate would be speculative.

## Open

Not yet checked in a running Extension Development Host. Draft until that happens.
