### PR TITLE
fix(iris-chat): stop a stale selection from pinning the chat context forever (#371)

### DIFF
--- a/extension/src/extension/services/iris/chat/chatContextManager.ts
+++ b/extension/src/extension/services/iris/chat/chatContextManager.ts
@@ -43,20 +43,34 @@ export function pickBestContextFromSnapshot(snapshot: ContextSnapshot): ActiveCo
     return null;
 }
 
-function shouldOverrideWithWorkspace(
+/**
+ * Pure policy: may workspace detection take over the active context?
+ *
+ * @param userChoseThisSession whether the student made an explicit selection in THIS window, as
+ *   opposed to one restored from persistence. The active context is stored together with its
+ *   `source`, so treating `user-selected` alone as a veto let a single choice pin every future
+ *   window forever, whatever the student actually had open (#371). Deliberately not a timestamp
+ *   comparison: `selectedAt` is wall-clock, so a backward clock step could void a selection the
+ *   student had just made — a worse failure than the one being fixed.
+ */
+export function shouldOverrideWithWorkspace(
     active: ActiveContext | null,
     detected: TrackedExercise,
+    userChoseThisSession: boolean,
 ): boolean {
     if (!active) {
         return true;
     }
-    // An explicit user choice (e.g. "Ask Iris about this exercise") must never
-    // be silently overwritten by background workspace re-detection — that
-    // produces the "I clicked B but the chat shows A" bug.
-    if (active.source === 'user-selected') {
+    // An explicit user choice (e.g. "Ask Iris about this exercise") must never be silently
+    // overwritten by background workspace re-detection — that produces the "I clicked B but the
+    // chat shows A" bug. A choice restored from a previous window is not that: it says nothing
+    // about the exercise now open.
+    if (active.source === 'user-selected' && userChoseThisSession) {
         return false;
     }
-    return active.id !== detected.id;
+    // Compare the entity, not just the number: a COURSE with id 3 is not exercise 3, and must not
+    // suppress the override just because the ids collide.
+    return active.type !== 'exercise' || active.id !== detected.id;
 }
 
 export type ChatContextReason =
@@ -88,6 +102,13 @@ interface SwitchContextParams {
 }
 
 export class ChatContextManager {
+    /**
+     * Set once the student picks a context in this window. Distinguishes a live choice from one
+     * restored out of persistence, which carries the same `user-selected` source but says nothing
+     * about what is open now. Read by {@link shouldOverrideWithWorkspace}; see #371.
+     */
+    private _userChoseThisSession = false;
+
     constructor(
         private readonly deps: IrisServiceDeps,
         private readonly _chatSessionService: IrisChatSessionService,
@@ -102,6 +123,12 @@ export class ChatContextManager {
         const reason = params.reason ?? 'user-selected';
         const source = this._mapReasonToSource(reason);
         const isWorkspaceRelated = reason === 'workspace-detected' || reason === 'auto-workspace';
+
+        // Every explicit selection funnels through here, so this is the one place that has to
+        // record it. From now on background detection leaves the context alone (#371).
+        if (source === 'user-selected') {
+            this._userChoseThisSession = true;
+        }
 
         // Step 1: Register in context store
         if (params.type === 'exercise') {
@@ -161,6 +188,12 @@ export class ChatContextManager {
         itemName: string,
         itemShortName?: string
     ): void {
+        // Recorded before the no-op below, because the student picking the row that is ALREADY
+        // active is still a choice: it is how you confirm a context restored from a previous
+        // window, and it must arm the veto even though nothing else has to happen (#371).
+        // This path is only ever reached from the webview's selection message.
+        this._userChoseThisSession = true;
+
         const active = this.deps.contextStore.getActiveContext();
         if (active?.type === contextType && active.id === itemId) {
             // Re-selecting the already-active context is a no-op: no register,
@@ -222,7 +255,7 @@ export class ChatContextManager {
         if (input.source === 'workspace-detected') {
             const active = this.deps.contextStore.getActiveContext();
             const exercise = this.deps.contextStore.getExerciseById(input.id);
-            if (exercise && shouldOverrideWithWorkspace(active, exercise)) {
+            if (exercise && shouldOverrideWithWorkspace(active, exercise, this._userChoseThisSession)) {
                 logger.context('Source is workspace-detected, setting active context to workspace exercise');
                 this.deps.contextStore.setActiveContext({
                     type: 'exercise',
@@ -262,6 +295,9 @@ export class ChatContextManager {
         const snapshot = this.deps.contextStore.snapshot();
         const best = pickBestContextFromSnapshot(snapshot);
         if (best) {
+            // Logged because this is the only path that picks a context without any explicit signal:
+            // silent, it is indistinguishable in the log from "no context was chosen at all".
+            logger.context(`Auto-selected ${best.type} ${best.id} (${best.title}) from snapshot`);
             this.deps.contextStore.setActiveContext(best);
             this.deps.contextStore.switchToFirstSession();
         }

--- a/extension/src/extension/services/iris/chat/chatContextManager.ts
+++ b/extension/src/extension/services/iris/chat/chatContextManager.ts
@@ -53,7 +53,7 @@ export function pickBestContextFromSnapshot(snapshot: ContextSnapshot): ActiveCo
  *   comparison: `selectedAt` is wall-clock, so a backward clock step could void a selection the
  *   student had just made — a worse failure than the one being fixed.
  */
-export function shouldOverrideWithWorkspace(
+function shouldOverrideWithWorkspace(
     active: ActiveContext | null,
     detected: TrackedExercise,
     userChoseThisSession: boolean,

--- a/extension/test/unit/services/chatContextManager.test.ts
+++ b/extension/test/unit/services/chatContextManager.test.ts
@@ -411,14 +411,10 @@ suite('ChatContextManager Test Suite', () => {
             // Reproduces the bug where clicking "Ask Iris about exercise B"
             // was silently overwritten by background workspace re-detection of
             // exercise A on the next chat-view-visible event.
-            contextStore.setActiveContext({
-                type: 'exercise',
-                id: 999,
-                title: 'User-Picked Exercise',
-                source: 'user-selected',
-                locked: false,
-                selectedAt: Date.now(),
-            });
+            // Goes through the real selection path on purpose: what protects the context is that the
+            // student chose it in THIS session, which only the manager can know. Writing the store
+            // directly would model a context restored from a previous window instead (#371).
+            chatContextManager.handleContextSelection('exercise', 999, 'User-Picked Exercise');
 
             chatContextManager.registerExerciseAndAutoSelect({
                 id: 123,
@@ -466,6 +462,109 @@ suite('ChatContextManager Test Suite', () => {
 
             const snapshot = contextStore.snapshot();
             assert.strictEqual(snapshot.activeContext?.id, 123);
+            assert.strictEqual(snapshot.activeContext?.source, 'workspace-detected');
+        });
+
+        test('SHOULD override a user-selected context restored from an earlier session (#371)', () => {
+            // The active context is persisted together with its `source`, so a choice made days ago
+            // came back as `user-selected` and vetoed detection in every later window: the chat
+            // opened on "Struggle Test Course" while the workspace held Graph Traversal.
+            // Writing the store directly is exactly what restoration looks like to the manager —
+            // an active context carrying `user-selected` that it never handed out itself.
+            contextStore.setActiveContext({
+                type: 'course',
+                id: 1,
+                title: 'Struggle Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now(),
+            });
+
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 3,
+                title: 'Graph Traversal (Workspace)',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.id, 3, 'a stale selection must not veto workspace detection');
+            assert.strictEqual(snapshot.activeContext?.type, 'exercise');
+            assert.strictEqual(snapshot.activeContext?.source, 'workspace-detected');
+        });
+
+        test('should override a course context whose id collides with the detected exercise id (#371)', () => {
+            // The override guard used to compare ids alone, so course 3 read as "already exercise 3".
+            contextStore.setActiveContext({
+                type: 'course',
+                id: 3,
+                title: 'Course Three',
+                source: 'system-default',
+                locked: false,
+                selectedAt: Date.now(),
+            });
+
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 3,
+                title: 'Exercise Three (Workspace)',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.type, 'exercise', 'a course must not suppress an exercise override');
+            assert.strictEqual(snapshot.activeContext?.source, 'workspace-detected');
+        });
+
+        test('should NOT override a restored context the student re-selected in this session (#371)', () => {
+            // Confirming a restored context by clicking its already-active row in the picker is a
+            // real choice, even though it is a no-op for everything else. If the marker were only
+            // armed inside switchContext, the same-context early return would skip it and the next
+            // detection would yank the context away.
+            contextStore.setActiveContext({
+                type: 'course',
+                id: 1,
+                title: 'Struggle Test Course',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now(),
+            });
+
+            chatContextManager.handleContextSelection('course', 1, 'Struggle Test Course');
+
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 3,
+                title: 'Graph Traversal (Workspace)',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.type, 'course', 're-selection must count as a choice');
+            assert.strictEqual(snapshot.activeContext?.id, 1);
+        });
+
+        test('should override a restored user-selected course that also collides on id (#371)', () => {
+            // Both guards would have blocked this one: the stale `user-selected` source and the
+            // id-only comparison. Neither may survive on its own.
+            contextStore.setActiveContext({
+                type: 'course',
+                id: 3,
+                title: 'Course Three',
+                source: 'user-selected',
+                locked: false,
+                selectedAt: Date.now(),
+            });
+
+            chatContextManager.registerExerciseAndAutoSelect({
+                id: 3,
+                title: 'Exercise Three (Workspace)',
+                source: 'workspace-detected',
+                isWorkspace: true,
+            });
+
+            const snapshot = contextStore.snapshot();
+            assert.strictEqual(snapshot.activeContext?.type, 'exercise');
             assert.strictEqual(snapshot.activeContext?.source, 'workspace-detected');
         });
 


### PR DESCRIPTION
Closes #371.

Opening a workspace for exercise *Graph Traversal* (id 3) showed the chat bound to **"Struggle Test Course"**. Detection had run and succeeded; the override was simply refused.

## Cause

The active context is persisted **together with its `source`**, and `source === 'user-selected'` was an absolute veto over workspace detection:

```ts
if (active.source === 'user-selected') { return false; }
```

The restored context was `{ type: 'course', id: 1, source: 'user-selected', selectedAt: <2026-07-24> }` — a choice made three days and several windows earlier. It came back looking like a live user decision on every start and pinned the chat regardless of what was open.

The evidence trail from the Output channel, which is what identified this over the two candidates we had been guessing at:

- `Detected workspace exercise: Graph Traversal (ID: 3)` — detection works, registry already populated, so not a timing problem.
- `Source is workspace-detected, setting active context…` — never logged, so the override branch was skipped.
- `New active context set to:` — never logged at startup, proving the context came from persistence rather than from any code path in that session.

## Fix

The veto is right *within* a session (background re-detection must not yank the chat away mid-work) and wrong *across* one. It is now scoped by an in-memory marker on the manager, armed whenever a selection is made through the picker. A restored context carries `user-selected` but no marker, so detection may take it over once, at startup.

Two deliberate details:

- **Not a `selectedAt` comparison against activation time.** That was the first implementation, and it is wrong: both values are wall-clock, so a backward clock step could void a selection the student had *just* made — a worse failure than the bug being fixed. It also could not be tested honestly, because `setActiveContext` unconditionally re-stamps `selectedAt`.
- **Armed at the top of `handleContextSelection`, before the same-context early return.** Clicking the already-active row in the picker is how you confirm a restored context; it must count as a choice even though nothing else happens. Every existing no-op guarantee there is untouched. That method has exactly one caller, the webview selection message, so background code cannot arm it.

Also fixes a latent defect in the same guard: it compared ids without comparing `type`, so an active **course** with id N suppressed the override of **exercise** N.

`_autoSelectFromSnapshot` now logs its pick. It was the only path that chooses a context with no explicit signal, and its silence is what made the first diagnosis round inconclusive.

## Tests

Four cases in `chatContextManager.test.ts`, all through the manager rather than hand-built state:

| Case | Expected |
| --- | --- |
| restored `user-selected` course, workspace detects a different exercise | override |
| selection made in this session, detection runs for another id | preserved |
| restored context re-selected via the picker, then detection | preserved |
| course id N vs detected exercise id N | override |

The pre-existing veto test had to change: it wrote the store directly, which under the new semantics *is* a restored context. It now goes through `handleContextSelection`, testing the guard through the public API.

## Verification

`tsc --noEmit`, `eslint src/extension test/unit` and the vitest React suite (78 files, 1077 tests) pass.

**The mocha unit suite could not be run locally** — VS Code's test runner aborts before any test with `IPC handle … is longer than 103 chars`, because this checkout sits at a deep path and macOS caps unix socket paths at 104 bytes. It is environmental and pre-existing, `--user-data-dir` is not honoured by the test CLI, and CI runs the suite. The changed tests are therefore verified by the **Unit tests** job on this PR, not locally.

## Open

Not yet re-checked in a running Extension Development Host. Draft until the original repro (open the Graph Traversal workspace, chat must bind to it) is confirmed fixed.