### PR TITLE
Iris logo: elevation on light themes, and stop squashing the mascot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
 - **Brief connection problems:** A short outage no longer hides the conversation you were reading or empties your conversation history, and a message that could not be sent keeps its text behind a single Retry that reconnects and then sends it.
+- **Iris logo:** The mascot now has a subtle shadow, so on light themes it no longer sits on the surface as a flat block, and it keeps its proportions instead of being squashed into a square.
 
 ### Internal
 

--- a/extension/src/webview/components/AskIris/AskIris.module.css
+++ b/extension/src/webview/components/AskIris/AskIris.module.css
@@ -30,6 +30,7 @@
   height: 40px;
   flex-shrink: 0;
   object-fit: contain;
+  filter: var(--theme-iris-logo-shadow);
 }
 
 .title {

--- a/extension/src/webview/styles/base.css
+++ b/extension/src/webview/styles/base.css
@@ -62,6 +62,14 @@
   --theme-backdrop: none;
   --theme-transition: none;
 
+  /*
+   * Elevation for the Iris mascot. drop-shadow, not box-shadow: the asset has
+   * transparent corners, so a box shadow would trace the element box instead of
+   * the artwork. Barely visible on dark themes, which is why there is no
+   * per-theme value; override here if one is ever wanted.
+   */
+  --theme-iris-logo-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 22%));
+
   /* Typography */
   --theme-font-family: var(--vscode-font-family);
   --theme-font-size: var(--vscode-font-size);

--- a/extension/src/webview/views/IrisChat/IrisChatView.module.css
+++ b/extension/src/webview/views/IrisChat/IrisChatView.module.css
@@ -25,6 +25,8 @@
 
 .irisIcon {
     flex-shrink: 0;
+    object-fit: contain;
+    filter: var(--theme-iris-logo-shadow);
 }
 
 .title {
@@ -264,6 +266,8 @@
 
 .loadingLogo {
     opacity: 0.8;
+    object-fit: contain;
+    filter: var(--theme-iris-logo-shadow);
 }
 
 .loadingSpinner {

--- a/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
+++ b/extension/src/webview/views/IrisChat/components/ThinkingIndicator.module.css
@@ -12,6 +12,8 @@
     width: 20px;
     height: 20px;
     flex-shrink: 0;
+    object-fit: contain;
+    filter: var(--theme-iris-logo-shadow);
     animation: pulse 2s ease-in-out infinite;
 }
 

--- a/extension/src/webview/views/IrisChat/components/WelcomeState.module.css
+++ b/extension/src/webview/views/IrisChat/components/WelcomeState.module.css
@@ -25,6 +25,8 @@
     color: var(--vscode-foreground);
     opacity: 0.8;
     margin-bottom: 8px;
+    object-fit: contain;
+    filter: var(--theme-iris-logo-shadow);
 }
 
 .title {


### PR DESCRIPTION
Closes #374.

The Iris mascot is a blue tile with rounded corners and transparent margins. On a light theme the card behind it is white, so the two met with nothing between them and the logo read as a block dropped onto the surface.

## The shadow

`base.css` gains one token next to the other `--theme-*` effects:

```css
--theme-iris-logo-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 22%));
```

`drop-shadow` rather than `box-shadow`, because the asset's corners are fully transparent: a box shadow follows the element box and would float a rectangle around the artwork instead of sitting under it. `drop-shadow` follows the alpha channel. The same treatment already exists for the Artemis logo in `DashboardView.module.css`.

All five render sites read the token, so a sixth one gets the treatment for free:

| File | Class | Rendered at |
|---|---|---|
| `AskIris.module.css` | `.logo` | 40px |
| `WelcomeState.module.css` | `.avatar` | 64px |
| `IrisChatView.module.css` | `.irisIcon` | 24px, header |
| `IrisChatView.module.css` | `.loadingLogo` | 48px |
| `ThinkingIndicator.module.css` | `.logo` | 20px |

There is no per-theme value. A 22% black shadow is imperceptible on a dark background, so branching on `body.vscode-dark` would mean also getting both high-contrast variants right for an effect nobody can see. The token is the place to add one if that ever changes.

None of the five rules had a `filter` before, so nothing is overwritten. The `ThinkingIndicator` pulse animates `transform`, not `filter`, so the two do not collide.

## The aspect ratio

The issue lists this as a side note. It is included here because it is the same one-line edit in the same rules and it makes the logo look at least as unfinished as the missing shadow.

The asset is 557x512, and four of the five sites drew it into a square box, stretching it vertically by about 8%. Only `AskIris` set `object-fit: contain`. The other four now do too.

## Where the issue was out of date

Written before the chat rework landed, so three of its notes no longer apply:

- `NudgeBanner` is listed as a render site. That component no longer exists.
- It warns that `.mainMuted .logo` sets `filter: grayscale(0.6)` and would silently drop the shadow, since `filter` is not additive. That rule is gone.
- It puts the `AskIris` logo at 48x48. It is 40x40.

## Verification

`tsc --noEmit`, `eslint src test`, the esbuild bundle and 1233 vitest tests are green. `--theme-iris-logo-shadow` appears six times in the built `webview-react.css`: the definition plus all five uses.

No automated test. A CSS custom property with no observable behaviour in jsdom can only be asserted by restating the stylesheet, which would pin the implementation and catch nothing. Checked visually instead, at every size, on light and dark surfaces.
