### PR TITLE
Iris chat: wait for workspace detection instead of racing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
+- **Opening an exercise for the first time:** The chat now waits for the workspace to be recognised instead of racing it, so an exercise you have never chatted about before opens its conversation instead of leaving you on the course list. A course or topic you pick yourself is no longer overridden a moment later, and a chat that cannot reach the server says so and offers a retry rather than pretending the folder has no exercise.
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
 - **Brief connection problems:** A short outage no longer hides the conversation you were reading or empties your conversation history, and a message that could not be sent keeps its text behind a single Retry that reconnects and then sends it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ### Fixed
 
-- **Opening an exercise for the first time:** The chat now waits for the workspace to be recognised instead of racing it, so an exercise you have never chatted about before opens its conversation instead of leaving you on the course list. A course or topic you pick yourself is no longer overridden a moment later, and a chat that cannot reach the server says so and offers a retry rather than pretending the folder has no exercise.
+- **Opening an exercise for the first time:** The chat now waits for the workspace to be recognised instead of racing it, so an exercise you have never chatted about before opens its conversation instead of leaving you on the course list. A course or topic you pick yourself is no longer overridden a moment later, and a chat that cannot reach the server says so and offers a retry rather than pretending the folder has no exercise. A course whose instructor has switched Iris off now says that too, instead of offering a retry that could never work.
 - **Exercise description header:** Tightened the spacing under the "Exercise Description" heading and added a divider line, so the description starts directly below the title instead of after a large gap.
 - **Stale credentials at startup:** Credentials that are no longer valid on the configured Artemis server are now reliably detected during startup validation and cleared, instead of lingering until a later request fails.
 - **Brief connection problems:** A short outage no longer hides the conversation you were reading or empties your conversation history, and a message that could not be sent keeps its text behind a single Retry that reconnects and then sends it.

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -152,12 +152,14 @@ export async function activate(context: vscode.ExtensionContext) {
 	providerRegistry.setChatWebviewProvider(chatWebviewProvider);
 	providerRegistry.setArtemisWebviewProvider(artemisWebviewProvider);
 
-	context.subscriptions.push(wireWorkspaceDetection({
+	const workspaceDetection = wireWorkspaceDetection({
 		api: artemisApiService,
 		registry: exerciseRegistry,
 		courseDataCache,
 		sink: buildChatProviderSink(chatWebviewProvider),
-	}));
+	});
+	context.subscriptions.push(workspaceDetection);
+	chatWebviewProvider.attachStartupDetection(workspaceDetection);
 
 	context.subscriptions.push(telemetryManager);
 	context.subscriptions.push(artemisWebsocketService);

--- a/extension/src/extension/controller/commands/irisCommands.ts
+++ b/extension/src/extension/controller/commands/irisCommands.ts
@@ -75,9 +75,6 @@ export class IrisCommandModule {
                 return;
             }
 
-            logger.info('Focusing Iris chat view...', LogCategory.IRIS_CHAT);
-            await vscode.commands.executeCommand('iris.chatView.focus');
-
             const chatProvider = this.context.providerRegistry.getChatWebviewProvider();
             const title = exerciseTitle || `Exercise ${exerciseId}`;
 
@@ -88,6 +85,15 @@ export class IrisCommandModule {
                 logger.warn('WARNING: Chat provider is unavailable or does not support topic selection', LogCategory.IRIS_CHAT);
                 return;
             }
+            // Before the focus, not after: focusing resolves the webview, and a
+            // resolved view is what lets the startup coordinator acquire the
+            // workspace conversation. Announcing our destination afterwards
+            // would be too late.
+            chatProvider.admitExplicitIntent('askIrisAbout');
+
+            logger.info('Focusing Iris chat view...', LogCategory.IRIS_CHAT);
+            await vscode.commands.executeCommand('iris.chatView.focus');
+
             // The payload's courseId travels WITH the target: on a fresh window
             // no conversation is open, so the service has no course of its own
             // and would answer `no-course` if this were dropped here.
@@ -114,13 +120,19 @@ export class IrisCommandModule {
                 return;
             }
 
-            await vscode.commands.executeCommand('iris.chatView.focus');
-
             const chatProvider = this.context.providerRegistry.getChatWebviewProvider();
             if (!chatProvider || typeof chatProvider.askIrisAbout !== 'function') {
                 logger.warn('Iris chat provider is unavailable or does not support topic selection.', LogCategory.IRIS_CHAT);
                 return;
             }
+            // Before the focus, not after: focusing resolves the webview, and a
+            // resolved view is what lets the startup coordinator acquire the
+            // workspace conversation. Announcing our destination afterwards
+            // would be too late.
+            chatProvider.admitExplicitIntent('askIrisAbout');
+
+            await vscode.commands.executeCommand('iris.chatView.focus');
+
             const title = courseTitle || `Course ${courseId}`;
             // A course chat IS the course, so the hint is the entity itself.
             const outcome = await chatProvider.askIrisAbout(

--- a/extension/src/extension/provider/chatViewStatePresenter.ts
+++ b/extension/src/extension/provider/chatViewStatePresenter.ts
@@ -6,6 +6,7 @@ import type { ServerContext } from '@shared/types/serverContext';
 
 import type { ContextStore } from '@extension/services/iris/context/contextStore';
 import type { IrisConversationService } from '@extension/services/iris/conversation/conversationService';
+import type { DetectionUiState } from '@extension/services/iris/startup/chatStartupCoordinator';
 
 type IrisViewState = ExtMsg<'updateIrisState'>['state'];
 type ConversationSnapshot = ReturnType<IrisConversationService['state']['snapshot']>;
@@ -23,7 +24,7 @@ const NO_CONVERSATION = {
     sendInFlight: false,
     navigationInFlight: false,
     conversations: [],
-} as const satisfies Omit<IrisViewState, 'exercises' | 'courses' | 'workspaceExerciseId'>;
+} as const satisfies Omit<IrisViewState, 'exercises' | 'courses' | 'workspaceExerciseId' | 'detectionState'>;
 
 export class ChatViewStatePresenter {
     constructor(
@@ -38,6 +39,13 @@ export class ChatViewStatePresenter {
          * getter in `chatWebviewProvider.ts`.
          */
         private readonly _getConversation: () => IrisConversationService | undefined,
+        /**
+         * The startup coordinator's latest published detection state. A
+         * getter, not a value, for the same reason `_getConversation` is: the
+         * coordinator is constructed after the presenter, so a plain value
+         * here would capture whatever it was at construction time forever.
+         */
+        private readonly _getDetectionState: () => DetectionUiState,
     ) {}
 
     public postSnapshot(): void {
@@ -53,6 +61,7 @@ export class ChatViewStatePresenter {
                 exercises: snapshot.exercises,
                 courses: snapshot.courses,
                 workspaceExerciseId: this._contextStore.getWorkspaceExerciseId(),
+                detectionState: this._getDetectionState(),
                 ...this._serializeConversation(),
             },
             showDiagnostics,
@@ -131,7 +140,7 @@ export class ChatViewStatePresenter {
      * carries `courseId`), so it is resolved against the tracked-course
      * repository, which is where a display name for a course lives.
      */
-    private _serializeConversation(): Omit<IrisViewState, 'exercises' | 'courses' | 'workspaceExerciseId'> {
+    private _serializeConversation(): Omit<IrisViewState, 'exercises' | 'courses' | 'workspaceExerciseId' | 'detectionState'> {
         const conversation = this._getConversation();
         if (!conversation) { return NO_CONVERSATION; }
         const snapshot = conversation.state.snapshot();

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -26,6 +26,8 @@ import { IrisConversationService } from '@extension/services/iris/conversation/c
 import { toWireMessages } from '@extension/services/iris/conversation/messageFormatting';
 import { SEND_REJECTION_MESSAGES, SendCoordinator } from '@extension/services/iris/conversation/sendCoordinator';
 import { createRunLifecycle, IrisRunStateMachine } from '@extension/services/iris/irisRunStateMachine';
+import type { DetectionUiState } from '@extension/services/iris/startup/chatStartupCoordinator';
+import { ChatStartupCoordinator } from '@extension/services/iris/startup/chatStartupCoordinator';
 import { LogCategory, logger } from '@extension/services/loggingService';
 import type { ITelemetryManager, StruggleContext } from '@extension/services/telemetry';
 import { getReactWebviewHtml } from '@extension/services/ui';
@@ -91,6 +93,24 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     private _conversation: IrisConversationService | undefined;
     /** The send path. Built next to `_conversation`. */
     private _sendCoordinator: SendCoordinator | undefined;
+    /**
+     * The single owner of the automatic cold start. Built in the constructor
+     * with a shim `start` that just calls `_startConversation()`, so
+     * constructing it here changes nothing observable; `resolveWebviewView`
+     * still starts the conversation itself until Task 7 cuts it over.
+     */
+    private readonly _startupCoordinator: ChatStartupCoordinator;
+    /**
+     * The coordinator's latest published detection state. Nothing reads or
+     * writes it yet: Task 7 starts calling `onViewResolved`/`onDetectionSettled`,
+     * and Task 8 puts it on the wire.
+     */
+    private _detectionState: DetectionUiState = 'unsettled';
+    /**
+     * The workspace-detection handle (from `wireWorkspaceDetection`), wired by
+     * Task 8. Until then there is nothing for the startup Retry to re-run.
+     */
+    private _detectionHandle: { retry(): void } | undefined;
     /** Generation opened by the most recent send, for the reconnect marker. */
     private _lastSendGeneration: number | undefined;
     /** Last conversation announced to the webview, so a navigation can be told
@@ -269,6 +289,23 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                 }),
             );
         }
+
+        // Constructed unconditionally (not gated on `_conversation` existing)
+        // so the field stays non-optional: `_conversationForNavigation` never
+        // reaches `admitExplicitIntent` when `_conversation` is undefined, and
+        // the shim `start` below already no-ops in that case too.
+        this._startupCoordinator = new ChatStartupCoordinator({
+            // Shim only. `_acquireConversation` does not exist until Task 7,
+            // which is also what starts calling `onViewResolved` and
+            // `onDetectionSettled`; until then this just runs today's start,
+            // unchanged.
+            start: () => this._startConversation(),
+            publishDetectionState: (state) => {
+                this._detectionState = state;
+                this._viewStatePresenter.postSnapshot();
+            },
+            retryDetection: () => this._detectionHandle?.retry(),
+        });
 
         this._disposables.push(
             this._fileMonitorService.onDidUpdateFiles(update => {
@@ -616,6 +653,16 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     }
 
     /**
+     * The coordinator's latest published detection state. Nothing calls
+     * `publishDetectionState` yet (Task 7 starts that), so this reads
+     * `'unsettled'` until then. Task 8 puts the value on the wire; this
+     * getter is what it will read from.
+     */
+    public get detectionState(): DetectionUiState {
+        return this._detectionState;
+    }
+
+    /**
      * Access the WebSocket message handler for wiring up received-message events.
      */
     public get websocketMessageHandler(): IrisWebSocketMessageHandler {
@@ -678,6 +725,11 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     public clearWorkspaceExercise(): void {
         this._contextStore.clearWorkspaceFlag();
         this._viewStatePresenter.postSnapshot();
+    }
+
+    /** See `StartupLatch`. Called before anything that can resolve the view. */
+    public admitExplicitIntent(reason: string): void {
+        this._startupCoordinator.admitExplicitIntent(reason);
     }
 
     // ── Conversation-first entry points for the commands ───────────────
@@ -1138,6 +1190,11 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             this._answerFailedNavigation(command, 'Wait for Iris to finish answering before switching.');
             return undefined;
         }
+        // Admitted: the student named a destination. Whether the navigation then
+        // succeeds is irrelevant to the cold start, which must not overrule them.
+        // Placed after the refusals on purpose: a command that never reached the
+        // conversation named nothing.
+        this._startupCoordinator.admitExplicitIntent(command);
         return conversation;
     }
 

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -38,6 +38,7 @@ import {
     NoAiDetectionService,
     toExerciseSource,
 } from '@extension/services/workspace';
+import type { DetectionOutcome } from '@extension/services/workspace/detectionOutcome';
 import type { IChatWebviewProvider } from '@extension/types/IChatWebviewProvider';
 
 import { BaseWebviewProvider } from './baseWebviewProvider';
@@ -94,21 +95,21 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     /** The send path. Built next to `_conversation`. */
     private _sendCoordinator: SendCoordinator | undefined;
     /**
-     * The single owner of the automatic cold start. Built in the constructor
-     * with a shim `start` that just calls `_startConversation()`, so
-     * constructing it here changes nothing observable; `resolveWebviewView`
-     * still starts the conversation itself until Task 7 cuts it over.
+     * The single owner of the automatic cold start. `resolveWebviewView` only
+     * reports that the view exists (`onViewResolved`); `attachStartupDetection`
+     * feeds it workspace-detection outcomes. The coordinator itself decides
+     * when both have arrived and calls `_acquireConversation` exactly once.
      */
     private readonly _startupCoordinator: ChatStartupCoordinator;
     /**
-     * The coordinator's latest published detection state. Nothing reads or
-     * writes it yet: Task 7 starts calling `onViewResolved`/`onDetectionSettled`,
-     * and Task 8 puts it on the wire.
+     * The coordinator's latest published detection state. Task 8 puts the
+     * value on the wire; this field is what that getter will read from.
      */
     private _detectionState: DetectionUiState = 'unsettled';
     /**
      * The workspace-detection handle (from `wireWorkspaceDetection`), wired by
-     * Task 8. Until then there is nothing for the startup Retry to re-run.
+     * `attachStartupDetection` at activation. Until then there is nothing for
+     * the startup Retry to re-run.
      */
     private _detectionHandle: { retry(): void } | undefined;
     /** Generation opened by the most recent send, for the reconnect marker. */
@@ -293,13 +294,9 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         // Constructed unconditionally (not gated on `_conversation` existing)
         // so the field stays non-optional: `_conversationForNavigation` never
         // reaches `admitExplicitIntent` when `_conversation` is undefined, and
-        // the shim `start` below already no-ops in that case too.
+        // `_acquireConversation` below already no-ops in that case too.
         this._startupCoordinator = new ChatStartupCoordinator({
-            // Shim only. `_acquireConversation` does not exist until Task 7,
-            // which is also what starts calling `onViewResolved` and
-            // `onDetectionSettled`; until then this just runs today's start,
-            // unchanged.
-            start: () => this._startConversation(),
+            start: (workspace) => this._acquireConversation(workspace),
             publishDetectionState: (state) => {
                 this._detectionState = state;
                 this._viewStatePresenter.postSnapshot();
@@ -537,28 +534,34 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         });
         this._viewDisposables.push(configListener);
 
-        void this._startConversation().catch((error: unknown) => {
-            logger.error('Iris conversation start failed', LogCategory.IRIS_CHAT, error);
-        });
+        // The coordinator owns the one-shot cold start now: it fires
+        // `_acquireConversation` only once the view AND workspace detection
+        // have both settled, in whichever order they arrive.
+        this._startupCoordinator.onViewResolved();
+        // Independent of the one-shot acquisition: a recreated webview needs
+        // the disabled banner re-evaluated even when the conversation is
+        // unchanged and the startup latch has long been consumed.
+        void this._refreshAvailability();
 
         // Init data is sent when the webview signals ready (see _handleMessage / _sendInitData)
     }
 
     /**
      * The conversation-first acquisition. One call gives the id, the topic, the
-     * title and the transcript; without a detected workspace exercise it makes
-     * no request at all and the webview shows the cold-start course chooser.
+     * title and the transcript. Called exactly once, by the startup
+     * coordinator, once the view has resolved and workspace detection has
+     * matched an exercise.
      *
      * The availability check afterwards is not a duplicate of the one
      * `_onConversationChanged` runs: re-opening the view re-installs the SAME
      * conversation, so that hook's id guard early-returns and nothing would
      * ever ask whether Iris is enabled here.
      */
-    private async _startConversation(): Promise<void> {
+    private async _acquireConversation(workspace: { exerciseId: number; courseId: number }): Promise<void> {
         const conversation = this._conversation;
         if (!conversation) { return; }
         try {
-            await conversation.start(this._workspaceForStart());
+            await conversation.start(workspace);
         } catch (error: unknown) {
             // A failed acquisition leaves no session and therefore no
             // transcript, so the loader would spin forever. The banner's Retry
@@ -595,14 +598,6 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         void this._refreshAvailability().catch((error: unknown) => {
             logger.error('Iris availability re-check failed', LogCategory.IRIS_CHAT, error);
         });
-    }
-
-    /** The detected workspace exercise, in the shape `start` expects. */
-    private _workspaceForStart(): { exerciseId: number; courseId: number } | undefined {
-        const exercise = this._contextStore.getWorkspaceExercise();
-        return exercise?.courseId === undefined
-            ? undefined
-            : { exerciseId: exercise.id, courseId: exercise.courseId };
     }
 
     // ── Rendering ──────────────────────────────────────────────────────
@@ -730,6 +725,21 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     /** See `StartupLatch`. Called before anything that can resolve the view. */
     public admitExplicitIntent(reason: string): void {
         this._startupCoordinator.admitExplicitIntent(reason);
+    }
+
+    /**
+     * Feeds the coordinator workspace-detection outcomes, and gives it the
+     * Retry the startup-unavailable banner offers. Called once, at
+     * activation, with the handle `wireWorkspaceDetection` returns.
+     */
+    public attachStartupDetection(handle: {
+        onDetectionSettled: vscode.Event<DetectionOutcome>;
+        retry(): void;
+    }): void {
+        this._detectionHandle = handle;
+        this._disposables.push(handle.onDetectionSettled(
+            outcome => this._startupCoordinator.onDetectionSettled(outcome),
+        ));
     }
 
     // ── Conversation-first entry points for the commands ───────────────

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -21,7 +21,7 @@ import { historyResolvesRun } from '@extension/services/iris/chat/historyResolut
 import type { AvailabilityContext } from '@extension/services/iris/chat/irisAvailabilityService';
 import { resolveCourseIdForExercise } from '@extension/services/iris/context/courseIdResolver';
 import { collectUncommittedFiles } from '@extension/services/iris/conversation/collectUncommittedFiles';
-import type { CourseSwitchOutcome, TopicChangeOutcome } from '@extension/services/iris/conversation/conversationService';
+import type { CourseSwitchOutcome, StartOutcome, TopicChangeOutcome } from '@extension/services/iris/conversation/conversationService';
 import { IrisConversationService } from '@extension/services/iris/conversation/conversationService';
 import { toWireMessages } from '@extension/services/iris/conversation/messageFormatting';
 import { SEND_REJECTION_MESSAGES, SendCoordinator } from '@extension/services/iris/conversation/sendCoordinator';
@@ -568,8 +568,9 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     private async _acquireConversation(workspace: { exerciseId: number; courseId: number }): Promise<void> {
         const conversation = this._conversation;
         if (!conversation) { return; }
+        let outcome: StartOutcome;
         try {
-            await conversation.start(workspace);
+            outcome = await conversation.start(workspace);
         } catch (error: unknown) {
             // A failed acquisition leaves no session and therefore no
             // transcript, so the loader would spin forever. The banner's Retry
@@ -585,6 +586,16 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                 message: 'Iris could not be reached. Retry to reload the conversation.',
             });
             throw error;
+        }
+        // A course whose instructor switched Iris off is a destination, not a
+        // failure (see `IrisConversationService.start`): NOT re-thrown, or the
+        // coordinator would re-arm its latch for an answer that will never
+        // change, and Retry would repeat the same 403 forever. Same banner
+        // `_handleSwitchCourse` shows for the identical case reached by a
+        // course switch instead of a cold start.
+        if (outcome.kind === 'disabled') {
+            this._announceCourseDisabled(workspace.courseId);
+            return;
         }
         await this._refreshAvailability();
     }

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -102,8 +102,9 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
      */
     private readonly _startupCoordinator: ChatStartupCoordinator;
     /**
-     * The coordinator's latest published detection state. Task 8 puts the
-     * value on the wire; this field is what that getter will read from.
+     * The coordinator's latest published detection state, read by the
+     * presenter's `_getDetectionState` getter and put on the wire in every
+     * `updateIrisState` snapshot.
      */
     private _detectionState: DetectionUiState = 'unsettled';
     /**
@@ -221,6 +222,12 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
             // capturing it by value here would capture `undefined` forever.
             // Same reasoning as the `_websocketMessageHandler` getter below.
             () => this._conversation,
+            // A getter, not a value: `_detectionState` is mutated in place by
+            // `publishDetectionState` below (`ChatStartupCoordinator`'s only
+            // way to report progress), so capturing it by value here would
+            // freeze the snapshot at whatever it was when the presenter was
+            // constructed (always `'unsettled'`).
+            () => this._detectionState,
         );
         this._fileMonitorService = new FileMonitorService();
         this._disposables.push(this._fileMonitorService);
@@ -654,10 +661,8 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
     }
 
     /**
-     * The coordinator's latest published detection state. Nothing calls
-     * `publishDetectionState` yet (Task 7 starts that), so this reads
-     * `'unsettled'` until then. Task 8 puts the value on the wire; this
-     * getter is what it will read from.
+     * The coordinator's latest published detection state, also what the
+     * presenter puts on the wire in every `updateIrisState` snapshot.
      */
     public get detectionState(): DetectionUiState {
         return this._detectionState;
@@ -976,6 +981,14 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
                     void this.reloadIrisChat().catch((err: unknown) => {
                         logger.error('Retry reload failed', LogCategory.IRIS_CHAT, err);
                     });
+                    break;
+                case WebviewCmd.RetryStartupDetection:
+                    // The startup-unavailable banner's Retry. Routes to the
+                    // coordinator's own `retry()`, which re-runs DETECTION,
+                    // NOT `reloadIrisChat()`: on this path there may be no
+                    // workspace exercise at all yet, so a conversation reload
+                    // would start whatever happens to be left over, or nothing.
+                    this._startupCoordinator.retry();
                     break;
                 case WebviewCmd.MessageFeedback: {
                     const { sessionId, messageId, feedback } = getPayload<WebCmd<'messageFeedback'>>(message);

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -548,9 +548,10 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
 
     /**
      * The conversation-first acquisition. One call gives the id, the topic, the
-     * title and the transcript. Called exactly once, by the startup
-     * coordinator, once the view has resolved and workspace detection has
-     * matched an exercise.
+     * title and the transcript. Called by the startup coordinator, once the
+     * view has resolved and workspace detection has matched an exercise; a
+     * rejection re-arms the coordinator's latch (see `ChatStartupDeps.start`),
+     * so this can run again after a transient failure.
      *
      * The availability check afterwards is not a duplicate of the one
      * `_onConversationChanged` runs: re-opening the view re-installs the SAME
@@ -565,13 +566,18 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
         } catch (error: unknown) {
             // A failed acquisition leaves no session and therefore no
             // transcript, so the loader would spin forever. The banner's Retry
-            // routes back through reloadIrisChat.
+            // routes back through reloadIrisChat. Re-thrown (rather than
+            // swallowed) so the coordinator learns the attempt failed and can
+            // re-arm its latch: without that, a single transient 500 leaves
+            // the student stuck on the cold-start chooser forever, since the
+            // latch was already consumed before this call and nothing else
+            // ever gets another shot at it.
             logger.error('Iris conversation start failed', LogCategory.IRIS_CHAT, error);
             this._postMessageSafe({
                 type: ExtensionMsg.ShowUnavailableState,
                 message: 'Iris could not be reached. Retry to reload the conversation.',
             });
-            return;
+            throw error;
         }
         await this._refreshAvailability();
     }

--- a/extension/src/extension/provider/chatWebviewProvider.ts
+++ b/extension/src/extension/provider/chatWebviewProvider.ts
@@ -626,6 +626,20 @@ export class ChatWebviewProvider extends BaseWebviewProvider implements vscode.W
 
     private async _sendInitData(): Promise<void> {
         this._viewStatePresenter.postSnapshot();
+        // A conversation already installed (the webview was disposed and
+        // recreated while one was open — no `retainContextWhenHidden`, so
+        // collapsing and reopening the sidebar does exactly this) gets no
+        // other chance at its transcript: `_acquireConversation` is one-shot
+        // behind the startup latch, and the install that originally called
+        // `_deliverTranscript` addressed a webview instance that is gone.
+        // Kept immediately after the snapshot above, with no `await` between
+        // them: the webview's own guard keys an incoming transcript on the
+        // session the snapshot just named, so it has to follow it, never
+        // overtake it. `'load'` (not `'merge'`) on purpose — it is also the
+        // only mode that sets `loadedSessionId`, which is what clears the
+        // loader in the first place; `'merge'` never touches it.
+        const detail = this._conversation?.state.snapshot().detail;
+        if (detail) { this._deliverTranscript(detail, 'load'); }
         await this._populateAvailableContexts();
         void this._fileMonitorService.triggerUpdate();
         this._postNoAiStatus(this._noAiDetectionService.isNoAiEnabled);

--- a/extension/src/extension/services/iris/conversation/conversationService.ts
+++ b/extension/src/extension/services/iris/conversation/conversationService.ts
@@ -94,6 +94,18 @@ export type CourseSwitchOutcome =
     | { kind: 'stale' }
     | { kind: 'rejected'; reason: 'send-in-flight' | 'failed' };
 
+/**
+ * What the cold start did. `disabled` still landed us in the course, same as
+ * `CourseSwitchOutcome`'s kind above; it is a definitive answer, not a
+ * failure, so `start` reports it instead of throwing. Every OTHER problem
+ * (network, 5xx, ...) still throws: those are transient and the caller's
+ * retry has to keep working.
+ */
+export type StartOutcome =
+    | { kind: 'ok' }
+    | { kind: 'disabled' }
+    | { kind: 'stale' };
+
 type ProbeResult =
     | { kind: 'ok'; detail: SessionDetail; guard: GuardTuple }
     /** 400/404: the row is wrong and has been forgotten. */
@@ -229,13 +241,29 @@ export class IrisConversationService {
      * request; the webview shows the cold-start course chooser (spec 5.7). The
      * dashboard course-list request is a different request and is unaffected.
      */
-    public async start(workspace: { exerciseId: number; courseId: number } | undefined): Promise<void> {
-        if (!workspace) { return; }
+    public async start(workspace: { exerciseId: number; courseId: number } | undefined): Promise<StartOutcome> {
+        if (!workspace) { return { kind: 'ok' }; }
         const target: ServerContext = { mode: 'PROGRAMMING_EXERCISE_CHAT', entityId: workspace.exerciseId };
-        await this._navigate(async (isCurrent) => {
+        return await this._navigate(async (isCurrent) => {
             const captured = this.state.beginLoad();
-            const detail = await this._api.getCurrentChat('PROGRAMMING_EXERCISE_CHAT', workspace.exerciseId, workspace.courseId);
-            if (!this._install(detail, captured, isCurrent)) { return; }
+            let detail: SessionDetail;
+            try {
+                detail = await this._api.getCurrentChat('PROGRAMMING_EXERCISE_CHAT', workspace.exerciseId, workspace.courseId);
+            } catch (error) {
+                // A cold start into a course whose Iris is off is the same
+                // destination as a switch into one (see `switchCourse`): land
+                // there, so the banner has a course to label and the caller
+                // does not treat a definitive refusal as a reachability
+                // problem worth retrying forever.
+                if (isIrisCourseDisabled(error)) {
+                    logger.info(`Iris is switched off in course ${workspace.courseId}; entering it anyway`, LogCategory.IRIS_CHAT);
+                    return this._enterCourseWithoutConversation(workspace.courseId, isCurrent)
+                        ? { kind: 'disabled' } as const
+                        : { kind: 'stale' } as const;
+                }
+                throw error;
+            }
+            if (!this._install(detail, captured, isCurrent)) { return { kind: 'ok' } as const; }
             // A course session came back: it is empty by construction
             // (findOrCreateEmptyCourseSession). The `empty` check still guards
             // it, because this staging is automatic rather than asked for, and
@@ -246,6 +274,7 @@ export class IrisConversationService {
             }
             void this.refreshOverview();
             this._emit();
+            return { kind: 'ok' } as const;
         });
     }
 

--- a/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
+++ b/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
@@ -43,6 +43,15 @@ export class ChatStartupCoordinator {
     }
 
     public admitExplicitIntent(reason: string): void {
+        // `wasEligible` still means exactly what it always did, even though
+        // `cancel()` now also acts on a `consumed` latch (an attempt in
+        // flight): `_uiStateFor` only ever publishes `unavailable` to the UI
+        // while the latch IS eligible (an `unavailable` outcome never
+        // consumes it — see `_maybeStart`'s early return below), so a
+        // `consumed` latch can never be carrying a live `unavailable` banner
+        // to clear here. Reading `wasEligible` before `cancel()` therefore
+        // still answers the only question that matters: was a dead-Retry
+        // banner actually on screen for this outcome.
         const wasEligible = this._latch.state === 'eligible';
         this._latch.cancel(reason);
         // The student is on their way somewhere. A startup-unavailable banner

--- a/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
+++ b/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
@@ -5,6 +5,12 @@ import { StartupLatch } from './startupLatch';
 export type DetectionUiState = 'unsettled' | 'settled' | 'unavailable';
 
 export interface ChatStartupDeps {
+    /**
+     * Acquire the conversation for `workspace`. Resolves on success. Rejects
+     * on failure, AFTER having already shown whatever banner the failure
+     * needs — the coordinator's only reaction to a rejection is re-arming its
+     * latch, never a banner of its own.
+     */
     start(workspace: { exerciseId: number; courseId: number }): Promise<void>;
     publishDetectionState(state: DetectionUiState): void;
     retryDetection(): void;
@@ -82,6 +88,16 @@ export class ChatStartupCoordinator {
         void this._deps.start({
             exerciseId: this._outcome.exerciseId,
             courseId: this._outcome.courseId,
+        }).catch(() => {
+            // The attempt itself failed (a transient network error, not a
+            // decision) — `start` has already shown whatever banner that
+            // needs. Re-arm rather than leave the latch spent: without this,
+            // a single failed acquisition strands the student on the
+            // cold-start chooser for good, since nothing else ever gets
+            // another shot at the latch. This does NOT resurrect a latch an
+            // explicit student intent already cancelled; `reArmAfterFailedStart`
+            // only moves `consumed` -> `eligible`.
+            this._latch.reArmAfterFailedStart();
         });
     }
 }

--- a/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
+++ b/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
@@ -1,0 +1,87 @@
+import type { DetectionOutcome } from '@extension/services/workspace/detectionOutcome';
+
+import { StartupLatch } from './startupLatch';
+
+export type DetectionUiState = 'unsettled' | 'settled' | 'unavailable';
+
+export interface ChatStartupDeps {
+    start(workspace: { exerciseId: number; courseId: number }): Promise<void>;
+    publishDetectionState(state: DetectionUiState): void;
+    retryDetection(): void;
+}
+
+/**
+ * The single owner of the chat's automatic cold start.
+ *
+ * Two things have to be true before the chat may acquire a conversation by
+ * itself: the webview exists, and workspace detection has settled. They arrive
+ * in either order and used to race, which is why a first-ever exercise folder
+ * could land on the course chooser and stay there forever.
+ */
+export class ChatStartupCoordinator {
+    private readonly _latch = new StartupLatch();
+    private _viewResolved = false;
+    private _outcome: DetectionOutcome | undefined;
+
+    constructor(private readonly _deps: ChatStartupDeps) {}
+
+    public onViewResolved(): void {
+        this._viewResolved = true;
+        this._maybeStart();
+    }
+
+    public onDetectionSettled(outcome: DetectionOutcome): void {
+        this._outcome = outcome;
+        this._deps.publishDetectionState(this._uiStateFor(outcome));
+        this._maybeStart();
+    }
+
+    public admitExplicitIntent(reason: string): void {
+        const wasEligible = this._latch.state === 'eligible';
+        this._latch.cancel(reason);
+        // The student is on their way somewhere. A startup-unavailable banner
+        // left on screen would now offer a Retry that can no longer do
+        // anything, because `retry()` requires an eligible latch.
+        if (wasEligible && this._outcome?.kind === 'unavailable') {
+            this._deps.publishDetectionState('settled');
+        }
+    }
+
+    /**
+     * `unavailable` is only worth showing while the Retry it offers can still
+     * act. Once the latch is consumed or cancelled, `retry()` is a no-op, so
+     * publishing `unavailable` would put a dead button in front of the student.
+     * Two real orders reach that state: a `no-match` consumes the latch and a
+     * later folder change settles `unavailable`, or an explicit navigation
+     * cancels it and detection then fails.
+     */
+    private _uiStateFor(outcome: DetectionOutcome): DetectionUiState {
+        if (outcome.kind !== 'unavailable') { return 'settled'; }
+        return this._latch.state === 'eligible' ? 'unavailable' : 'settled';
+    }
+
+    /**
+     * The startup Retry. It re-runs DETECTION rather than reloading the
+     * conversation: on this path there may be no workspace exercise at all, so
+     * a reload would start whatever happens to be left over, or nothing.
+     */
+    public retry(): void {
+        if (this._latch.state !== 'eligible') { return; }
+        this._outcome = undefined;
+        this._deps.publishDetectionState('unsettled');
+        this._deps.retryDetection();
+    }
+
+    private _maybeStart(): void {
+        if (!this._viewResolved || this._outcome === undefined) { return; }
+        // An unreachable server is not an answer. Keep the latch so the Retry
+        // can still reach the conversation the student actually has.
+        if (this._outcome.kind === 'unavailable') { return; }
+        if (!this._latch.consume()) { return; }
+        if (this._outcome.kind === 'no-match') { return; }
+        void this._deps.start({
+            exerciseId: this._outcome.exerciseId,
+            courseId: this._outcome.courseId,
+        });
+    }
+}

--- a/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
+++ b/extension/src/extension/services/iris/startup/chatStartupCoordinator.ts
@@ -4,7 +4,7 @@ import { StartupLatch } from './startupLatch';
 
 export type DetectionUiState = 'unsettled' | 'settled' | 'unavailable';
 
-export interface ChatStartupDeps {
+interface ChatStartupDeps {
     /**
      * Acquire the conversation for `workspace`. Resolves on success. Rejects
      * on failure, AFTER having already shown whatever banner the failure

--- a/extension/src/extension/services/iris/startup/startupLatch.ts
+++ b/extension/src/extension/services/iris/startup/startupLatch.ts
@@ -9,14 +9,28 @@ export type LatchState = 'eligible' | 'consumed' | 'cancelled';
  * success: a navigation that was accepted and then answered `no-course` still
  * means the student said where they wanted to go, and a background detection
  * must not overrule it afterwards.
+ *
+ * `consumed` is no longer a terminal state (`reArmAfterFailedStart` can leave
+ * it), so `cancel()` has to be able to record an intent that arrives WHILE an
+ * automatic attempt is still in flight, not only while the latch is still
+ * `eligible`. That in-flight attempt cannot itself be aborted, but recording
+ * the cancellation here is what stops it being revived if that attempt goes
+ * on to fail: without this, a start still pending when the student explicitly
+ * navigates away silently drops that intent, and a later `reArmAfterFailedStart`
+ * hands the automatic path a second chance the student had already refused.
  */
 export class StartupLatch {
     private _state: LatchState = 'eligible';
 
     public get state(): LatchState { return this._state; }
 
+    /**
+     * Acts from `eligible` (nothing has started yet) OR `consumed` (an
+     * automatic attempt is in flight, or already finished) — anything but
+     * `cancelled` itself, which is left alone rather than re-logged.
+     */
     public cancel(reason: string): void {
-        if (this._state !== 'eligible') { return; }
+        if (this._state === 'cancelled') { return; }
         this._state = 'cancelled';
         logger.info(`Automatic chat startup cancelled by ${reason}`, LogCategory.IRIS_CHAT);
     }
@@ -32,9 +46,10 @@ export class StartupLatch {
      * Undoes a single `consume()`, but ONLY from `consumed`. Exists for one
      * caller: the automatic start attempt itself failed (a transient network
      * error, not a decision), so the permission it spent is given back
-     * rather than burned for good. A `cancelled` latch never moves: an
-     * explicit student intent still wins permanently, even when the
-     * automatic attempt that raced it goes on to fail.
+     * rather than burned for good. A `cancelled` latch never moves — INCLUDING
+     * one `cancel()` moved there FROM `consumed`, while that very attempt was
+     * still in flight: an explicit student intent still wins permanently,
+     * even when the automatic attempt that raced it goes on to fail.
      */
     public reArmAfterFailedStart(): void {
         if (this._state !== 'consumed') { return; }

--- a/extension/src/extension/services/iris/startup/startupLatch.ts
+++ b/extension/src/extension/services/iris/startup/startupLatch.ts
@@ -1,6 +1,6 @@
 import { LogCategory, logger } from '@extension/services/loggingService';
 
-export type LatchState = 'eligible' | 'consumed' | 'cancelled';
+type LatchState = 'eligible' | 'consumed' | 'cancelled';
 
 /**
  * Permission for the chat to acquire a conversation on its own, exactly once.

--- a/extension/src/extension/services/iris/startup/startupLatch.ts
+++ b/extension/src/extension/services/iris/startup/startupLatch.ts
@@ -27,4 +27,18 @@ export class StartupLatch {
         this._state = 'consumed';
         return true;
     }
+
+    /**
+     * Undoes a single `consume()`, but ONLY from `consumed`. Exists for one
+     * caller: the automatic start attempt itself failed (a transient network
+     * error, not a decision), so the permission it spent is given back
+     * rather than burned for good. A `cancelled` latch never moves: an
+     * explicit student intent still wins permanently, even when the
+     * automatic attempt that raced it goes on to fail.
+     */
+    public reArmAfterFailedStart(): void {
+        if (this._state !== 'consumed') { return; }
+        this._state = 'eligible';
+        logger.info('Automatic chat startup re-armed after a failed attempt', LogCategory.IRIS_CHAT);
+    }
 }

--- a/extension/src/extension/services/iris/startup/startupLatch.ts
+++ b/extension/src/extension/services/iris/startup/startupLatch.ts
@@ -1,0 +1,30 @@
+import { LogCategory, logger } from '@extension/services/loggingService';
+
+export type LatchState = 'eligible' | 'consumed' | 'cancelled';
+
+/**
+ * Permission for the chat to acquire a conversation on its own, exactly once.
+ *
+ * Cancelled by the first explicit student intent, at ADMISSION rather than at
+ * success: a navigation that was accepted and then answered `no-course` still
+ * means the student said where they wanted to go, and a background detection
+ * must not overrule it afterwards.
+ */
+export class StartupLatch {
+    private _state: LatchState = 'eligible';
+
+    public get state(): LatchState { return this._state; }
+
+    public cancel(reason: string): void {
+        if (this._state !== 'eligible') { return; }
+        this._state = 'cancelled';
+        logger.info(`Automatic chat startup cancelled by ${reason}`, LogCategory.IRIS_CHAT);
+    }
+
+    /** True only on the single transition out of `eligible`. */
+    public consume(): boolean {
+        if (this._state !== 'eligible') { return false; }
+        this._state = 'consumed';
+        return true;
+    }
+}

--- a/extension/src/extension/services/workspace/detectionOutcome.ts
+++ b/extension/src/extension/services/workspace/detectionOutcome.ts
@@ -1,0 +1,15 @@
+/**
+ * What a workspace-detection run concluded.
+ *
+ * `unavailable` exists so a server we could not reach is never rendered as
+ * "this folder is not an exercise". The two look identical to the student and
+ * only one of them is worth a Retry.
+ *
+ * `courseId` is required on `matched`: the chat's acquisition needs it, and a
+ * match without one would consume the startup latch, suppress the cold-start
+ * chooser and leave nothing on screen to act on.
+ */
+export type DetectionOutcome =
+    | { kind: 'matched'; exerciseId: number; courseId: number }
+    | { kind: 'no-match' }
+    | { kind: 'unavailable' };

--- a/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
+++ b/extension/src/extension/services/workspace/wireWorkspaceDetection.ts
@@ -4,6 +4,7 @@ import type { ArtemisApiService } from '@extension/api';
 import type { CourseDataCache } from '@extension/services/courseDataCache';
 import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
 
+import type { DetectionOutcome } from './detectionOutcome';
 import { detectAndRegisterWorkspaceExercise } from './workspaceDetectionService';
 
 export interface WorkspaceRegisterInput {
@@ -28,9 +29,12 @@ interface WorkspaceDetectionDeps {
     sink: WorkspaceDetectionSink;
 }
 
-export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Disposable {
+export function wireWorkspaceDetection(
+    deps: WorkspaceDetectionDeps,
+): vscode.Disposable & { onDetectionSettled: vscode.Event<DetectionOutcome>; retry(): void } {
     let generation = 0;
     let disposed = false;
+    const settled = new vscode.EventEmitter<DetectionOutcome>();
 
     const runDetection = async (): Promise<void> => {
         const token = ++generation;
@@ -48,9 +52,13 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
                 deps.sink.clearWorkspaceExercise();
             },
         };
-        await detectAndRegisterWorkspaceExercise(
+        const outcome = await detectAndRegisterWorkspaceExercise(
             deps.api, callbacks, deps.registry, deps.courseDataCache,
         );
+        if (disposed || token !== generation) {
+            return;
+        }
+        settled.fire(outcome);
     };
 
     void runDetection();
@@ -58,10 +66,13 @@ export function wireWorkspaceDetection(deps: WorkspaceDetectionDeps): vscode.Dis
     const coursesSub = deps.courseDataCache.onCoursesLoaded(() => void runDetection());
 
     return {
+        onDetectionSettled: settled.event,
+        retry: () => void runDetection(),
         dispose: () => {
             disposed = true;
             folderSub.dispose();
             coursesSub.dispose();
+            settled.dispose();
         },
     };
 }

--- a/extension/src/extension/services/workspace/workspaceDetectionService.ts
+++ b/extension/src/extension/services/workspace/workspaceDetectionService.ts
@@ -6,8 +6,9 @@ import type { ArtemisApiService } from '@extension/api';
 import type { CourseDataCache } from '@extension/services/courseDataCache';
 import { ExerciseRegistry, type ExerciseRegistryEntry } from '@extension/services/exerciseRegistry';
 import { logger } from '@extension/services/loggingService';
-import type { CourseDashboardEntry, ExerciseDetail } from '@extension/types';
+import type { CourseDashboardCourse, CourseDashboardEntry, ExerciseDetail } from '@extension/types';
 
+import type { DetectionOutcome } from './detectionOutcome';
 import { checkWorkspaceFiles } from './workspaceFileChecker';
 
 const execFileAsync = promisify(execFile);
@@ -331,8 +332,55 @@ export async function detectWorkspaceForRepoUris(
 }
 
 /**
- * Searches archived courses for one whose exercises match the current workspace git remote.
+ * Result of searching the archived courses for a repository match.
+ *
+ * `reachable` is false when any per-course detail request threw, which means
+ * an absent `entry` is not proof of "no match" - the course that would have
+ * matched may be the one that could not be read.
+ */
+export interface ArchiveSearchResult {
+    entry?: CourseDashboardEntry;
+    reachable: boolean;
+}
+
+/**
+ * Searches the given archived courses for one whose exercises match `repositoryUrl`.
  * Fetches archived course details one at a time (sequential) to avoid loading all at once.
+ * A per-course failure does not abort the search - the remaining courses are still tried -
+ * but it does mark the result unreachable, since the failed course could have been the match.
+ */
+export async function searchArchivedCoursesForRepository(
+    artemisApi: ArtemisApiService,
+    repositoryUrl: string,
+    archivedCourses: CourseDashboardCourse[]
+): Promise<ArchiveSearchResult> {
+    let reachable = true;
+
+    for (const course of archivedCourses) {
+        if (course.id === undefined) {
+            continue;
+        }
+        try {
+            const entry = await artemisApi.getCourseForDashboard(course.id);
+            const exercises: ExerciseSource[] = getEntryExercises(entry)
+                .map(ex => toExerciseSource(ex, entry.course?.id))
+                .filter((s): s is ExerciseSource => s !== null);
+
+            if (findExerciseByRepositoryUrl(repositoryUrl, exercises)) {
+                logger.irisChat(`Found workspace match in archived course: ${entry.course?.title}`);
+                return { entry, reachable };
+            }
+        } catch (error) {
+            reachable = false;
+            logger.irisChatWarn(`Failed to load archived course ${course.id}`, error);
+        }
+    }
+
+    return { reachable };
+}
+
+/**
+ * Searches archived courses for one whose exercises match the current workspace git remote.
  * @returns The matching CourseDashboardEntry, or null if not found / already in active courses.
  */
 export async function findWorkspaceCourseInArchive(
@@ -355,30 +403,10 @@ export async function findWorkspaceCourseInArchive(
         return null; // Already matched in active courses
     }
 
-    // Fetch lightweight archived course list
-    const archivedCourses = await artemisApi.getArchivedCourses();
-
-    // Check each archived course sequentially until we find a match
-    for (const course of archivedCourses) {
-        if (course.id === undefined) {
-            continue;
-        }
-        try {
-            const entry = await artemisApi.getCourseForDashboard(course.id);
-            const exercises: ExerciseSource[] = getEntryExercises(entry)
-                .map(ex => toExerciseSource(ex, entry.course?.id))
-                .filter((s): s is ExerciseSource => s !== null);
-
-            if (findExerciseByRepositoryUrl(repositoryUrl, exercises)) {
-                logger.irisChat(`Found workspace match in archived course: ${entry.course?.title}`);
-                return entry;
-            }
-        } catch {
-            // Skip courses that fail to load
-        }
-    }
-
-    return null;
+    const result = await searchArchivedCoursesForRepository(
+        artemisApi, repositoryUrl, await artemisApi.getArchivedCourses(),
+    );
+    return result.entry ?? null;
 }
 
 /**
@@ -398,78 +426,135 @@ interface WorkspaceRegistrationCallbacks {
     clearStaleWorkspaceContext: () => void;
 }
 
+/**
+ * Detects and registers the workspace exercise for a known repository URL.
+ * The URL is a parameter (not re-read from git) so every branch below is
+ * reachable from a test without a real repository on disk.
+ */
+export async function detectWorkspaceExerciseForRepository(
+    repositoryUrl: string,
+    artemisApiService: ArtemisApiService | undefined,
+    callbacks: WorkspaceRegistrationCallbacks,
+    registry: ExerciseRegistry,
+    courseDataCache?: CourseDataCache,
+): Promise<DetectionOutcome> {
+    let exercises = registry.getAllExercises();
+    let reachable = true;
+
+    // If registry is empty, populate it from the shared course cache (or API as fallback).
+    // The cache deduplicates concurrent fetches so this is cheap if data is already loaded.
+    if (exercises.length === 0) {
+        logger.irisChat('Registry empty, fetching courses to populate exercises...');
+        try {
+            const dashboardData = await courseDataCache?.fetch();
+            if (!dashboardData) {
+                // _doFetch swallows its error and returns undefined, so this
+                // is the only signal the cache gives us. An empty `courses`
+                // array is a truthy response and stays reachable.
+                reachable = false;
+            } else {
+                for (const courseData of dashboardData.courses ?? []) {
+                    registry.registerFromCourseData(courseData);
+                }
+            }
+            exercises = registry.getAllExercises();
+            logger.irisChat(`Registry populated with ${exercises.length} exercises`);
+        } catch (error) {
+            reachable = false;
+            logger.irisChatWarn('Failed to fetch courses for registry population', error);
+        }
+    }
+
+    // findExerciseByRepositoryUrl, not detectWorkspaceExercise: the latter
+    // re-reads the git remote and would undo the whole point of the split.
+    let detected = findExerciseByRepositoryUrl(repositoryUrl, exercises);
+
+    // Fallback: search archived courses if no match in active courses
+    if (!detected && artemisApiService) {
+        logger.irisChat('No match in active courses, checking archived courses...');
+        let archivedCourses: CourseDashboardCourse[] = [];
+        try {
+            archivedCourses = await artemisApiService.getArchivedCourses();
+        } catch (error) {
+            reachable = false;
+            logger.irisChatWarn('Failed to list archived courses', error);
+        }
+        const archive = await searchArchivedCoursesForRepository(
+            artemisApiService, repositoryUrl, archivedCourses,
+        );
+        if (!archive.reachable) {
+            reachable = false;
+        }
+        if (archive.entry) {
+            registry.registerFromCourseData(archive.entry);
+            detected = findExerciseByRepositoryUrl(repositoryUrl, registry.getAllExercises());
+        }
+    }
+
+    if (!detected) {
+        if (!reachable) {
+            logger.irisChat('Workspace detection could not reach the server');
+            return { kind: 'unavailable' };
+        }
+        logger.irisChat('No exercise matches the workspace remote');
+        callbacks.clearStaleWorkspaceContext();
+        return { kind: 'no-match' };
+    }
+
+    if (detected.courseId === undefined) {
+        // Not registered at all. Flagging it as the workspace exercise would
+        // set `workspaceExerciseId`, and `isColdStart` requires that to be
+        // null: the student would get the ordinary chat shell with an empty
+        // "Choose a course" header instead of the cold-start chooser, for an
+        // exercise that can never be opened anyway.
+        logger.irisChat(`Workspace exercise ${detected.id} has no course; not usable`);
+        callbacks.clearStaleWorkspaceContext();
+        return { kind: 'no-match' };
+    }
+
+    logger.irisChat(`Detected workspace exercise: ${detected.title} (ID: ${detected.id})`);
+
+    const baseTitle = detected.title.replace(/ \(Workspace\)$/i, '');
+    callbacks.registerExercise({
+        id: detected.id,
+        title: `${baseTitle} (Workspace)`,
+        shortName: detected.shortName,
+        courseId: detected.courseId,
+        repositoryUri: detected.repositoryUri,
+        source: 'workspace-detected',
+        isWorkspace: true,
+    });
+    return { kind: 'matched', exerciseId: detected.id, courseId: detected.courseId };
+}
+
 export async function detectAndRegisterWorkspaceExercise(
     artemisApiService: ArtemisApiService | undefined,
     callbacks: WorkspaceRegistrationCallbacks,
     exerciseRegistry: ExerciseRegistry,
     courseDataCache?: CourseDataCache,
-): Promise<void> {
-
+    // Injected so the no-remote branch is testable. `getWorkspaceRepositoryUrl`
+    // is called module-locally, so sinon cannot intercept it through the module
+    // object; a default parameter is the smallest honest seam.
+    resolveRepositoryUrl: () => Promise<string | null> = getWorkspaceRepositoryUrl,
+): Promise<DetectionOutcome> {
     try {
-        const registry = exerciseRegistry;
-        let exercises = registry.getAllExercises();
-
-        // If registry is empty, populate it from the shared course cache (or API as fallback).
-        // The cache deduplicates concurrent fetches so this is cheap if data is already loaded.
-        if (exercises.length === 0) {
-            logger.irisChat('Registry empty, fetching courses to populate exercises...');
-            try {
-                const dashboardData = await courseDataCache?.fetch();
-                const courses = dashboardData?.courses;
-
-                if (courses && Array.isArray(courses) && courses.length > 0) {
-                    for (const courseData of courses) {
-                        registry.registerFromCourseData(courseData);
-                    }
-                }
-                exercises = registry.getAllExercises();
-                logger.irisChat(`Registry populated with ${exercises.length} exercises`);
-            } catch (error) {
-                logger.irisChatWarn('Failed to fetch courses for registry population', error);
-            }
-        }
-
-        let detected = await detectWorkspaceExercise(exercises);
-
-        // Fallback: search archived courses if no match in active courses
-        if (!detected && artemisApiService) {
-            logger.irisChat('No match in active courses, checking archived courses...');
-            try {
-                const archivedEntry = await findWorkspaceCourseInArchive(artemisApiService, []);
-                if (archivedEntry) {
-                    registry.registerFromCourseData(archivedEntry);
-                    exercises = registry.getAllExercises();
-                    detected = await detectWorkspaceExercise(exercises);
-                }
-            } catch (error) {
-                logger.irisChatWarn('Failed to fetch archived courses for workspace detection', error);
-            }
-        }
-
-        if (detected) {
-            logger.irisChat(`Detected workspace exercise: ${detected.title} (ID: ${detected.id})`);
-        } else {
-            logger.irisChat('No workspace exercise detected matching current git remote');
-        }
-
-        if (!detected) {
+        const repositoryUrl = await resolveRepositoryUrl();
+        if (!repositoryUrl) {
+            // Conclusive and server-independent: this folder is not an Artemis
+            // exercise checkout. It must stay `no-match` even when the dashboard
+            // is also unreachable, or every non-exercise window would offer a
+            // Retry for a server that has nothing to do with the answer.
+            logger.irisChat('No git remote in the workspace; not an exercise folder');
             callbacks.clearStaleWorkspaceContext();
-            return;
+            return { kind: 'no-match' };
         }
-
-        const baseTitle = detected.title.replace(/ \(Workspace\)$/i, '');
-        const displayTitle = `${baseTitle} (Workspace)`;
-
-        callbacks.registerExercise({
-            id: detected.id,
-            title: displayTitle,
-            shortName: detected.shortName,
-            courseId: detected.courseId,
-            repositoryUri: detected.repositoryUri,
-            source: 'workspace-detected',
-            isWorkspace: true,
-        });
-    } catch {
-        // Not a git repository or command failed - ignore silently
+        return await detectWorkspaceExerciseForRepository(
+            repositoryUrl, artemisApiService, callbacks, exerciseRegistry, courseDataCache,
+        );
+    } catch (error) {
+        // `noImplicitReturns` makes this mandatory, and the conservative answer
+        // is the right one: an unexpected failure is not evidence of absence.
+        logger.irisChatWarn('Workspace detection failed unexpectedly', error);
+        return { kind: 'unavailable' };
     }
 }

--- a/extension/src/extension/types/IChatWebviewProvider.ts
+++ b/extension/src/extension/types/IChatWebviewProvider.ts
@@ -21,4 +21,10 @@ export interface IChatWebviewProvider {
      * course of its own; see `ChatWebviewProvider.askIrisAbout`.
      */
     askIrisAbout(target: ServerContext, courseHint?: number): Promise<TopicChangeOutcome>;
+    /**
+     * Cancels the automatic cold start: the student has explicitly navigated
+     * somewhere, so a late background detection must not pull them back out.
+     * See `ChatStartupCoordinator.admitExplicitIntent`.
+     */
+    admitExplicitIntent(reason: string): void;
 }

--- a/extension/src/shared/messageContracts/extensionMessages.ts
+++ b/extension/src/shared/messageContracts/extensionMessages.ts
@@ -230,6 +230,17 @@ interface ExtensionMsgPayloads {
             /** The detected workspace exercise, when any. Comes from
              *  workspace detection, not from `IrisConversationService`. */
             workspaceExerciseId: number | undefined;
+            /**
+             * Workspace detection's own progress, independent of whether it
+             * found anything. `'unsettled'` means detection has not answered
+             * yet: the webview must not treat "nothing open" as "no exercise
+             * here" while that is still true, or a student is told to pick a
+             * course while the extension is still working it out.
+             * `'unavailable'` means detection could not reach the server at
+             * all, which is not an answer either. Sourced from
+             * `ChatStartupCoordinator`'s `DetectionUiState`.
+             */
+            detectionState: 'unsettled' | 'settled' | 'unavailable';
         };
         showDiagnostics?: boolean;
     };

--- a/extension/src/shared/messageContracts/webviewCommands.ts
+++ b/extension/src/shared/messageContracts/webviewCommands.ts
@@ -97,6 +97,15 @@ export const WebviewCmd = {
     OpenFile: 'openFile',
     OpenDiagnostics: 'openDiagnostics',
     OpenHelpPopup: 'openHelpPopup',
+    /**
+     * The startup-unavailable banner's Retry: re-runs workspace DETECTION,
+     * not a conversation reload. `ReloadChatSession` (above) is the
+     * unavailable-conversation banner's Retry and reads the OPEN
+     * conversation; on this path there may be no workspace exercise at all
+     * yet, so a reload would start whatever happens to be left over, or
+     * nothing.
+     */
+    RetryStartupDetection: 'retryStartupDetection',
 
     // Dev tools
     FreshSsrPreview: 'freshSsrPreview',
@@ -208,6 +217,7 @@ interface WebviewCmdPayloads {
     openFile: { filePath: string };
     openDiagnostics: undefined;
     openHelpPopup: undefined;
+    retryStartupDetection: undefined;
 
     // Dev tools
     freshSsrPreview: { darkMode: boolean };

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -29,6 +29,7 @@ type WireIrisState = ExtMsg<'updateIrisState'>['state'];
 type ConversationTopic = NonNullable<WireIrisState['committedContext']>;
 type ContentState = NonNullable<WireIrisState['contentState']>;
 type ConversationSummary = NonNullable<WireIrisState['conversations']>[number];
+type DetectionUiState = WireIrisState['detectionState'];
 
 interface ChatState {
     /**
@@ -37,6 +38,16 @@ interface ChatState {
      * frame stays on the loader instead of flashing the welcome state.
      */
     hasReceivedInitialIrisState: boolean;
+    /**
+     * Workspace detection's own progress, mirrored from the wire. Lets the
+     * cold-start view tell "detection has not answered yet" and "detection
+     * could not reach the server" apart from "there is genuinely nothing
+     * open" (`courseId`/`currentSessionId`/`workspaceExerciseId` all null).
+     * Defaults to `'settled'`: a test double that never sends the field
+     * (every fixture predating this one) must keep behaving like a snapshot
+     * that has already resolved, not like a permanently-pending detection.
+     */
+    detectionState: DetectionUiState;
     exercises: ContextItem[];
     courses: ContextItem[];
 
@@ -232,6 +243,7 @@ export const useChatStore = create<ChatState>()(
         (set) => ({
             // Initial state
             hasReceivedInitialIrisState: false,
+            detectionState: 'settled',
             exercises: [],
             courses: [],
             courseId: null,
@@ -271,6 +283,12 @@ export const useChatStore = create<ChatState>()(
                     exercises: state.exercises,
                     courses: state.courses,
                     hasReceivedInitialIrisState: true,
+                    // The wire type marks this required (the presenter always
+                    // fills it), but a fixture/test double predating this
+                    // field omits it, and the fallback keeps those behaving
+                    // like an already-settled snapshot rather than a
+                    // permanently-pending detection.
+                    detectionState: state.detectionState ?? 'settled',
                     courseId: state.courseId ?? null,
                     courseTitle: state.courseTitle ?? null,
                     currentSessionId: state.currentSessionId ?? null,

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -631,15 +631,14 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
      * which can fail identically forever (e.g. an archived-courses lookup
      * that keeps throwing on every attempt), so it cannot be the only way
      * off that screen when the student's courses are already sitting in the
-     * store from an earlier dashboard fetch. Reuses the exact mechanism the
-     * ordinary cold start already uses to reach the picker: the same
-     * `requestCoursesIfEmpty` fetch-if-needed call and the same inline
-     * `CoursePicker` render, gated by `showCourseChooser` above, rather than
-     * a second picker or a second fetch path.
+     * store from an earlier dashboard fetch. Only flips the flag:
+     * `showCourseChooser` becoming true is what the `coldStartFetched` effect
+     * above already watches, so THAT is the one fetch-if-needed call, the
+     * same one the ordinary cold start reaches it through. Calling
+     * `requestCoursesIfEmpty` here too would fire it twice for one click.
      */
     const handleChooseCourseFromOutage = () => {
         setOutageChooserRequested(true);
-        requestCoursesIfEmpty();
     };
 
     const selectTopic = (mode: string, entityId: number, name?: string) => {

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -42,6 +42,18 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     const [pickerOpen, setPickerOpen] = useState(false);
     const [historyOpen, setHistoryOpen] = useState(false);
     const [coursePickerOpen, setCoursePickerOpen] = useState(false);
+    /**
+     * The student asked to see the course list anyway, from the startup-
+     * outage screen. Detection may never come back (it can fail identically
+     * on every retry, e.g. an archived-courses lookup that keeps throwing),
+     * so Retry cannot be the ONLY way off that screen: without this, a
+     * student whose courses are already sitting in the store from an earlier
+     * dashboard fetch would be stuck behind an outage banner forever. Reset
+     * is not needed: once a course is picked, `courseId` stops being null and
+     * `detectionUnavailable` (which this flag only matters under) goes false
+     * on its own.
+     */
+    const [outageChooserRequested, setOutageChooserRequested] = useState(false);
     // True while the host is reading the dashboard course list. A fresh
     // installation tracks nothing, so an empty list is only meaningful once
     // that fetch has finished; without this the picker says "No courses
@@ -585,22 +597,49 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // The header, the topic row and the composer's own "choose a course"
     // wording all assume the ordinary "nothing open" shell. Both the waiting
     // and the outage states get their own message-area branch instead.
+    // `outageChooserRequested` deliberately does NOT enter this: the header
+    // stays suppressed even once the student has bypassed the outage screen,
+    // for the same reason it is suppressed on the ordinary cold start (there
+    // is no course to put in it yet).
     const suppressOrdinaryShell = startupPending || detectionUnavailable;
+
+    // The cold-start chooser itself, and the ONE other path allowed to reach
+    // it: a student who bypassed a startup outage that will not clear on its
+    // own. Both render the identical inline picker below; this is not a
+    // second chooser, it is the same one reached from a second precondition.
+    const showCourseChooser = isColdStart || (detectionUnavailable && outageChooserRequested);
 
     // The cold start renders the course list as the whole screen, so it must
     // fetch on its own: there is no picker for the student to open first.
     const coldStartFetched = useRef(false);
     useEffect(() => {
-        if (!isColdStart || coldStartFetched.current) { return; }
+        if (!showCourseChooser || coldStartFetched.current) { return; }
         coldStartFetched.current = true;
         requestCoursesIfEmpty();
-        // Only the cold start can trigger it, and the ref makes it once-only.
-        // `requestCoursesIfEmpty` is deliberately absent from the deps: it is a
-        // new function on every render and reads the store, not the closure.
-    }, [isColdStart]);
+        // Reached from either precondition can trigger it, and the ref makes
+        // it once-only. `requestCoursesIfEmpty` is deliberately absent from
+        // the deps: it is a new function on every render and reads the
+        // store, not the closure.
+    }, [showCourseChooser]);
 
     const handleRetryStartupDetection = () => {
         postCommand(vscodeApi, 'retryStartupDetection');
+    };
+
+    /**
+     * The startup-outage screen's second action. Retry re-runs detection,
+     * which can fail identically forever (e.g. an archived-courses lookup
+     * that keeps throwing on every attempt), so it cannot be the only way
+     * off that screen when the student's courses are already sitting in the
+     * store from an earlier dashboard fetch. Reuses the exact mechanism the
+     * ordinary cold start already uses to reach the picker: the same
+     * `requestCoursesIfEmpty` fetch-if-needed call and the same inline
+     * `CoursePicker` render, gated by `showCourseChooser` above, rather than
+     * a second picker or a second fetch path.
+     */
+    const handleChooseCourseFromOutage = () => {
+        setOutageChooserRequested(true);
+        requestCoursesIfEmpty();
     };
 
     const selectTopic = (mode: string, entityId: number, name?: string) => {
@@ -642,6 +681,12 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // "Choose a course" would send the student back to the picker they just
         // used, past a banner that already gives the real reason.
         disabledPlaceholder = 'Iris chat is not available here';
+    } else if (showCourseChooser) {
+        // Ahead of `detectionUnavailable` on purpose: once the student has
+        // bypassed the outage screen (`outageChooserRequested`), the message
+        // area is showing the course picker, not the outage explanation, and
+        // the composer must agree with what is actually on screen.
+        disabledPlaceholder = 'Choose a course to start chatting';
     } else if (startupPending) {
         // Not "Choose a course": detection has not answered yet, so there may
         // be nothing to choose from at all.
@@ -869,7 +914,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                 counting them. Only a course with Iris switched off genuinely
                 has no conversation behind the banner. */}
             <div className={styles.messagesSection}>
-                {isColdStart ? (
+                {showCourseChooser ? (
                     <div className={styles.coldStart}>
                         <p className={styles.coldStartText}>
                             No Artemis workspace detected. Choose a course to get started.
@@ -904,9 +949,16 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     </div>
                 ) : detectionUnavailable ? (
                     // Detection could not reach the server. Reuses the cold
-                    // start's layout (a short explanation plus one action),
-                    // but the action re-runs detection rather than opening
-                    // the course chooser: there may be no course to choose.
+                    // start's layout (a short explanation plus an action),
+                    // but the primary action re-runs detection rather than
+                    // opening the course chooser directly: there may be no
+                    // course to choose. A SECOND action escapes this screen
+                    // even when detection cannot: the same failure (e.g. an
+                    // archived-courses lookup that keeps throwing) can repeat
+                    // on every retry, and the student's courses may already
+                    // be sitting in the store from an earlier dashboard
+                    // fetch. Without it, Retry would be the only way out and
+                    // this screen would be a dead end.
                     <div className={styles.coldStart}>
                         <p className={styles.coldStartText}>
                             Could not reach the Artemis server to detect your workspace.
@@ -916,6 +968,12 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                             onClick={handleRetryStartupDetection}
                         >
                             Retry
+                        </button>
+                        <button
+                            className={styles.disclaimerLink}
+                            onClick={handleChooseCourseFromOutage}
+                        >
+                            Choose a course instead
                         </button>
                     </div>
                 ) : store.disabledMessage ? null

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -546,10 +546,46 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // `messagesHydrated` is: before it, "nothing is open" and "we have not
     // been told yet" are indistinguishable, and guessing the former flashes
     // the course chooser at every student who does have a conversation.
+    //
+    // `detectionState === 'settled'` is load-bearing, not defensive: workspace
+    // detection is asynchronous, and the very first snapshot can say "nothing
+    // is open" while detection is still running. Offering the course chooser
+    // at that moment tells the student to pick one by hand while the
+    // extension is still working out which exercise their folder is.
     const isColdStart = store.hasReceivedInitialIrisState
+        && store.detectionState === 'settled'
         && store.courseId === null
         && store.currentSessionId === null
         && store.workspaceExerciseId === null;
+
+    // Detection could not reach the server. That is not "no exercise here",
+    // and the student must not be asked to pick a course as if it were.
+    //
+    // `courseId === null` is load-bearing, not defensive: entering a course
+    // whose Iris is disabled deliberately sets `courseId` and leaves
+    // `currentSessionId` null (#375). Without this clause, a failed
+    // background detection would cover that course's own banner with a
+    // startup-outage screen.
+    const detectionUnavailable = store.hasReceivedInitialIrisState
+        && store.detectionState === 'unavailable'
+        && store.courseId === null
+        && store.currentSessionId === null;
+
+    // Nothing open and no answer yet. Distinct from both of the above, and it
+    // has to suppress the ordinary shell: the header falls back to "Choose a
+    // course" (`ChatHeader`) and the composer to "Choose a course to start
+    // chatting" (below), so merely dropping a spinner into the message area
+    // would still tell the student to pick a course while detection is
+    // mid-flight.
+    const startupPending = store.hasReceivedInitialIrisState
+        && store.detectionState === 'unsettled'
+        && store.courseId === null
+        && store.currentSessionId === null;
+
+    // The header, the topic row and the composer's own "choose a course"
+    // wording all assume the ordinary "nothing open" shell. Both the waiting
+    // and the outage states get their own message-area branch instead.
+    const suppressOrdinaryShell = startupPending || detectionUnavailable;
 
     // The cold start renders the course list as the whole screen, so it must
     // fetch on its own: there is no picker for the student to open first.
@@ -562,6 +598,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // `requestCoursesIfEmpty` is deliberately absent from the deps: it is a
         // new function on every render and reads the store, not the closure.
     }, [isColdStart]);
+
+    const handleRetryStartupDetection = () => {
+        postCommand(vscodeApi, 'retryStartupDetection');
+    };
 
     const selectTopic = (mode: string, entityId: number, name?: string) => {
         postCommand(vscodeApi, 'selectTopic', { mode, entityId, name });
@@ -602,6 +642,12 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // "Choose a course" would send the student back to the picker they just
         // used, past a banner that already gives the real reason.
         disabledPlaceholder = 'Iris chat is not available here';
+    } else if (startupPending) {
+        // Not "Choose a course": detection has not answered yet, so there may
+        // be nothing to choose from at all.
+        disabledPlaceholder = 'Looking for your Artemis exercise…';
+    } else if (detectionUnavailable) {
+        disabledPlaceholder = 'Could not reach the Artemis server. Retry above.';
     } else if (!hasConversation) {
         disabledPlaceholder = 'Choose a course to start chatting';
     } else if (store.isNoAiDetected) {
@@ -692,8 +738,11 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
             {/* Header: course line + conversation line. The popovers are
                 anchored to this section (position: relative) so they render
-                directly beneath the header. */}
-            {!isColdStart && (
+                directly beneath the header. Suppressed on the cold start (no
+                course to name) AND while detection is pending/unavailable
+                (the header falls back to "Choose a course", which is not
+                true yet, or not true at all, in either of those states). */}
+            {!isColdStart && !suppressOrdinaryShell && (
             <div className={styles.contextSection}>
                 <ChatHeader
                     courseTitle={store.courseTitle}
@@ -835,9 +884,43 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                             onClose={closePopovers}
                         />
                     </div>
+                ) : startupPending ? (
+                    // Nothing open, and detection has not answered yet.
+                    // Reuses the hydration loader's shape (below), with its
+                    // own copy: "Loading conversation…" would claim one is
+                    // open, and there may turn out to be none at all.
+                    <div className={styles.loadingState} role="status" aria-busy="true" aria-live="polite">
+                        {irisLogoUri && (
+                            <img
+                                src={irisLogoUri}
+                                alt=""
+                                width="48"
+                                height="48"
+                                className={styles.loadingLogo}
+                            />
+                        )}
+                        <span>Looking for your Artemis exercise…</span>
+                        <span className={styles.loadingSpinner} aria-hidden="true" />
+                    </div>
+                ) : detectionUnavailable ? (
+                    // Detection could not reach the server. Reuses the cold
+                    // start's layout (a short explanation plus one action),
+                    // but the action re-runs detection rather than opening
+                    // the course chooser: there may be no course to choose.
+                    <div className={styles.coldStart}>
+                        <p className={styles.coldStartText}>
+                            Could not reach the Artemis server to detect your workspace.
+                        </p>
+                        <button
+                            className={styles.retryButton}
+                            onClick={handleRetryStartupDetection}
+                        >
+                            Retry
+                        </button>
+                    </div>
                 ) : store.disabledMessage ? null
                 : messagesLoading ? (
-                    <div className={styles.loadingState} aria-busy="true" aria-live="polite">
+                    <div className={styles.loadingState} role="status" aria-busy="true" aria-live="polite">
                         {irisLogoUri && (
                             <img
                                 src={irisLogoUri}
@@ -885,8 +968,11 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
 
                 {/* The topic lives here, on the composer, not in the header:
                     it is what the next message is about, so it belongs beside
-                    the thing that writes that message. */}
-                {!isColdStart && (
+                    the thing that writes that message. Suppressed for the same
+                    reason the header is: with no course open yet (or not
+                    genuinely, in the pending/unavailable states) there is
+                    nothing for it to name. */}
+                {!isColdStart && !suppressOrdinaryShell && (
                     <div className={styles.topicRow}>
                         <button
                             className={styles.topicButton}

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1148,6 +1148,13 @@ describe('IrisChatView waits for workspace detection before offering the course 
         // words "choose a course", so a text-based query is not precise
         // enough here.
         expect(screen.queryByRole('dialog', { name: 'Select course' })).toBeNull();
+        // The ordinary header must stay suppressed too: it falls back to a
+        // "Choose a course" button whenever no course is open, which is not
+        // true yet while detection is still unavailable. Exact string, not a
+        // pattern: "Choose a course instead" (the outage screen's own escape
+        // hatch) must NOT satisfy this query, so a text-based match would
+        // hide a regression here behind that other button's presence.
+        expect(screen.queryByRole('button', { name: 'Choose a course' })).toBeNull();
         // Same composer surface, same trap: without its own branch, the
         // `!hasConversation` fallback would say "Choose a course to start
         // chatting" here too, which is simply false while the server cannot

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1085,6 +1085,100 @@ describe('IrisChatView cold start', () => {
     });
 });
 
+/**
+ * Task 8: `isColdStart` used to fire the instant a snapshot said "nothing is
+ * open", which is exactly when workspace detection is still running. These
+ * pin the two states that keep the chooser from appearing prematurely (or at
+ * all, when the server cannot be reached), plus the guard that stops a failed
+ * background detection from covering an unrelated course's own banner.
+ */
+describe('IrisChatView waits for workspace detection before offering the course list', () => {
+    const nothingOpen = {
+        exercises: [],
+        courses: [],
+        contentState: 'unknown' as const,
+        courseId: undefined,
+        currentSessionId: undefined,
+        workspaceExerciseId: undefined,
+    };
+
+    it('the course chooser waits for detection to settle', async () => {
+        render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
+        dispatchExtensionMessage({
+            type: 'updateIrisState',
+            state: { ...nothingOpen, detectionState: 'unsettled' },
+        });
+
+        // Awaited, not a synchronous query: `dispatchExtensionMessage` fires a
+        // DOM event outside of React's own event handling, so the state
+        // update is not guaranteed to have flushed by the next line. The
+        // waiting copy is this state's own signature, and finding it also
+        // proves the assertion below is not just reading the pre-dispatch
+        // frame.
+        expect(await screen.findByText(/looking for your artemis exercise/i)).toBeInTheDocument();
+        expect(screen.queryByText(/choose a course/i)).toBeNull();
+
+        dispatchExtensionMessage({
+            type: 'updateIrisState',
+            state: { ...nothingOpen, detectionState: 'settled' },
+        });
+
+        expect(await screen.findByText(/choose a course/i)).toBeInTheDocument();
+    });
+
+    it('an unreachable server offers a retry instead of the chooser', async () => {
+        const api = createMockVsCodeApi();
+        render(<IrisChatView vscodeApi={api} />);
+        dispatchExtensionMessage({
+            type: 'updateIrisState',
+            state: { ...nothingOpen, detectionState: 'unavailable' },
+        });
+
+        const retryButton = await screen.findByRole('button', { name: /retry/i });
+        expect(screen.queryByText(/choose a course/i)).toBeNull();
+        await userEvent.click(retryButton);
+
+        expect(
+            getPostMessageCalls(api).some(([m]) => (m as { command?: string }).command === 'retryStartupDetection'),
+        ).toBe(true);
+    });
+
+    it('a disabled course keeps its banner when detection fails behind it', async () => {
+        // The banner comes from `showDisabledState`, not from the view-state
+        // snapshot: a snapshot with a course and no session sets no
+        // `disabledMessage` at all, so establishing it first is what makes
+        // this test about the interaction rather than about an empty screen.
+        render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
+        dispatchExtensionMessage({
+            type: 'showDisabledState',
+            message: 'Iris chat is not enabled for this course.',
+        });
+        // courseId set, no session: exactly what entering an Iris-disabled
+        // course produces (#375). `unavailable` then arrives from a
+        // background detection that has nothing to do with that course.
+        dispatchExtensionMessage({
+            type: 'updateIrisState',
+            state: {
+                exercises: [],
+                courses: [{ id: 42, title: 'Iris Disabled Course' }],
+                courseId: 42,
+                courseTitle: 'Iris Disabled Course',
+                currentSessionId: undefined,
+                contentState: 'unknown' as const,
+                detectionState: 'unavailable',
+            },
+        });
+
+        // Awaited first, so the second snapshot's re-render has genuinely
+        // flushed before the retry-button check below: `dispatchExtensionMessage`
+        // fires a DOM event outside of React's own event handling, and a
+        // synchronous query here would otherwise risk reading the frame from
+        // before that snapshot landed, passing regardless of what it rendered.
+        expect(await screen.findByText(/not enabled for this course/)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+    });
+});
+
 describe('IrisChatView course refresh', () => {
     const coldStartState = {
         exercises: [],

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1117,6 +1117,13 @@ describe('IrisChatView waits for workspace detection before offering the course 
         // frame.
         expect(await screen.findByText(/looking for your artemis exercise/i)).toBeInTheDocument();
         expect(screen.queryByText(/choose a course/i)).toBeNull();
+        // The composer is a second surface with its own "choose a course"
+        // fallback (IrisChatView.tsx, the `!hasConversation` placeholder
+        // branch): a spinner in the message area is not enough if the input
+        // right below it still tells the student to pick a course.
+        const input = screen.getByRole('textbox', { name: 'Chat input' }) as HTMLTextAreaElement;
+        expect(input.placeholder).toMatch(/looking for your artemis exercise/i);
+        expect(input.placeholder).not.toMatch(/choose a course/i);
 
         dispatchExtensionMessage({
             type: 'updateIrisState',
@@ -1134,13 +1141,46 @@ describe('IrisChatView waits for workspace detection before offering the course 
             state: { ...nothingOpen, detectionState: 'unavailable' },
         });
 
-        const retryButton = await screen.findByRole('button', { name: /retry/i });
-        expect(screen.queryByText(/choose a course/i)).toBeNull();
+        const retryButton = await screen.findByRole('button', { name: /^retry$/i });
+        // The chooser ITSELF (the picker dialog) must not be showing — the
+        // outage screen also carries a "Choose a course instead" escape
+        // hatch (see the dedicated test below), whose own label contains the
+        // words "choose a course", so a text-based query is not precise
+        // enough here.
+        expect(screen.queryByRole('dialog', { name: 'Select course' })).toBeNull();
+        // Same composer surface, same trap: without its own branch, the
+        // `!hasConversation` fallback would say "Choose a course to start
+        // chatting" here too, which is simply false while the server cannot
+        // even be reached.
+        const input = screen.getByRole('textbox', { name: 'Chat input' }) as HTMLTextAreaElement;
+        expect(input.placeholder).toMatch(/could not reach the artemis server/i);
+        expect(input.placeholder).not.toMatch(/choose a course/i);
         await userEvent.click(retryButton);
 
         expect(
             getPostMessageCalls(api).some(([m]) => (m as { command?: string }).command === 'retryStartupDetection'),
         ).toBe(true);
+    });
+
+    it('the outage screen offers a second way to the course chooser, so Retry is not the only way out', async () => {
+        // Detection can fail identically on every retry (e.g. an
+        // archived-courses lookup that keeps throwing), which would strand a
+        // student behind the outage screen forever even though their courses
+        // are already sitting in the store from an earlier dashboard fetch.
+        render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
+        dispatchExtensionMessage({
+            type: 'updateIrisState',
+            state: { ...nothingOpen, detectionState: 'unavailable' },
+        });
+
+        const chooseInstead = await screen.findByRole('button', { name: /choose a course instead/i });
+        // Retry is still there, unchanged: this is a second way out, not a
+        // replacement for it.
+        expect(screen.getByRole('button', { name: /^retry$/i })).toBeInTheDocument();
+
+        await userEvent.click(chooseInstead);
+
+        expect(await screen.findByText(/choose a course/i)).toBeInTheDocument();
     });
 
     it('a disabled course keeps its banner when detection fails behind it', async () => {

--- a/extension/test/react/fixtures/irisInitPayload.ts
+++ b/extension/test/react/fixtures/irisInitPayload.ts
@@ -24,6 +24,10 @@ export function createIrisInitPayload(
             navigationInFlight: false,
             conversations: [],
             workspaceExerciseId: undefined,
+            // This fixture's default shape already has a course and an open
+            // session, i.e. not a cold start: 'settled' is simply the value
+            // that state would carry once detection has long since resolved.
+            detectionState: 'settled',
             ...overrides,
         },
     };

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -66,6 +66,9 @@ describe('Iris Chat Flow', () => {
 			currentSessionId: null,
 			conversationTitle: null,
 			workspaceExerciseId: null,
+			// 'settled': these flows are about the ordinary steady state, not
+			// about workspace detection's own progress.
+			detectionState: 'settled',
 			exercises: [],
 			courses: [],
 			messages: [],

--- a/extension/test/react/flows/messageContracts.test.ts
+++ b/extension/test/react/flows/messageContracts.test.ts
@@ -217,6 +217,7 @@ describe('Message contracts: ExtensionToWebviewMessage types', () => {
                     { sessionId: 42, courseId: 5, mode: 'PROGRAMMING_EXERCISE_CHAT', entityId: 12, entityName: 'Sorting', title: 'Recursion help', lastActivity: 1_700_000_000_000 },
                 ],
                 workspaceExerciseId: 12,
+                detectionState: 'settled',
             },
         } satisfies ExtMsg<'updateIrisState'>;
 

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -30,6 +30,11 @@ const makeIrisState = (overrides: Partial<ExtMsg<'updateIrisState'>['state']> = 
 	navigationInFlight: false,
 	conversations: [],
 	workspaceExerciseId: undefined,
+	// This suite pins the store's OWN mirroring behaviour, not the
+	// derived cold-start gating IrisChatView computes from it, so no test
+	// here cares which value this carries: 'settled' keeps it out of the
+	// way.
+	detectionState: 'settled',
 	...overrides,
 });
 
@@ -788,6 +793,19 @@ describe('useChatStore', () => {
 
 				useChatStore.getState().setIrisState(makeIrisState());
 				expect(useChatStore.getState().workspaceExerciseId).toBeNull();
+			});
+
+			it('setIrisState mirrors detectionState, defaulting to settled when the wire omits it', () => {
+				// Unlike the fields above, 'settled' is not the wire's own
+				// absent value (the real presenter always sends a real one):
+				// it is what keeps a test double that predates this field
+				// behaving like an already-resolved snapshot, not a
+				// permanently pending detection.
+				useChatStore.getState().setIrisState(makeIrisState({ detectionState: 'unavailable' }));
+				expect(useChatStore.getState().detectionState).toBe('unavailable');
+
+				useChatStore.getState().setIrisState({ ...makeIrisState(), detectionState: undefined as never });
+				expect(useChatStore.getState().detectionState).toBe('settled');
 			});
 		});
 

--- a/extension/test/react/views/IrisChat/IrisChatView.test.tsx
+++ b/extension/test/react/views/IrisChat/IrisChatView.test.tsx
@@ -52,6 +52,12 @@ describe('IrisChatView', () => {
 			currentSessionId: null,
 			conversationTitle: null,
 			workspaceExerciseId: null,
+			// 'settled': most of this suite's tests are about the ordinary
+			// steady state (open conversation, or the legitimate "nothing to
+			// do" cold start), not about workspace detection's own progress.
+			// Tests that DO care about the pending/unavailable states set
+			// this explicitly.
+			detectionState: 'settled',
 			exercises: [],
 			courses: [],
 			messages: [],

--- a/extension/test/unit/controller/irisCommands.test.ts
+++ b/extension/test/unit/controller/irisCommands.test.ts
@@ -14,11 +14,16 @@ interface Harness {
     asked: Array<{ target: ServerContext; courseHint?: number }>;
     info: sinon.SinonStub;
     sandbox: sinon.SinonSandbox;
+    executeCommandStub: sinon.SinonStub;
+    chatProvider: {
+        askIrisAbout: (target: ServerContext, courseHint?: number) => Promise<TopicChangeOutcome>;
+        admitExplicitIntent: (reason: string) => void;
+    };
 }
 
 function buildHarness(outcome: TopicChangeOutcome): Harness {
     const sandbox = sinon.createSandbox();
-    sandbox.stub(vscode.commands, 'executeCommand').resolves();
+    const executeCommandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
     sandbox.stub(vscode.window, 'showWarningMessage');
     sandbox.stub(vscode.window, 'showErrorMessage');
     const info = sandbox.stub(vscode.window, 'showInformationMessage');
@@ -29,12 +34,13 @@ function buildHarness(outcome: TopicChangeOutcome): Harness {
             asked.push({ target, courseHint });
             return outcome;
         },
+        admitExplicitIntent: sandbox.stub(),
     };
     const context = {
         providerRegistry: { getChatWebviewProvider: () => chatProvider },
     } as unknown as CommandContext;
 
-    return { module: new IrisCommandModule(context), asked, info, sandbox };
+    return { module: new IrisCommandModule(context), asked, info, sandbox, executeCommandStub, chatProvider };
 }
 
 suite('askIrisOutcomeMessage', () => {
@@ -128,4 +134,48 @@ suite('Ask Iris commands', () => {
             courseHint: 42,
         }]);
     });
+
+    const ORDERING_VARIANTS: Array<{ name: string; invoke: (harness: Harness) => Promise<void> }> = [
+        {
+            name: 'exercise',
+            invoke: (harness) => harness.module.getHandlers()[WebviewCmd.AskIrisAboutExercise]({
+                type: 'command',
+                command: WebviewCmd.AskIrisAboutExercise,
+                payload: { exerciseId: 5, exerciseTitle: 'BFS', courseId: 9 },
+            }),
+        },
+        {
+            name: 'course',
+            invoke: (harness) => harness.module.getHandlers()[WebviewCmd.AskIrisAboutCourse]({
+                type: 'command',
+                command: WebviewCmd.AskIrisAboutCourse,
+                payload: { courseId: 9, courseTitle: 'Algorithms' },
+            }),
+        },
+    ];
+
+    for (const variant of ORDERING_VARIANTS) {
+        test(`Ask Iris about a ${variant.name} admits before the chat view is focused`, async () => {
+            h = buildHarness({ kind: 'staged' });
+
+            const order: string[] = [];
+            // Extend the executeCommand stub this harness already installs
+            // rather than adding a second one on the same method.
+            h.executeCommandStub.callsFake(async (id: string) => {
+                if (id === 'iris.chatView.focus') { order.push('focus'); }
+                return undefined;
+            });
+            h.chatProvider.admitExplicitIntent = () => order.push('admit');
+            const originalAskIrisAbout = h.chatProvider.askIrisAbout;
+            h.chatProvider.askIrisAbout = async (target: ServerContext, courseHint?: number) => {
+                order.push('ask');
+                return originalAskIrisAbout(target, courseHint);
+            };
+
+            await variant.invoke(h);
+
+            assert.deepStrictEqual(order, ['admit', 'focus', 'ask'],
+                'focusing resolves the view, so the latch must already be cancelled');
+        });
+    }
 });

--- a/extension/test/unit/provider/chatViewStatePresenter.test.ts
+++ b/extension/test/unit/provider/chatViewStatePresenter.test.ts
@@ -320,10 +320,22 @@ suite('ChatViewStatePresenter: conversation-first fields (Task 10)', () => {
     // entirely, so only a host-side test can catch a presenter that hard-codes
     // the value instead of reading it from the getter.
     test('the snapshot carries the current detection state', () => {
-        const presenter = h.build(() => undefined, () => 'unavailable');
+        // A single snapshot cannot tell "reads the getter every call" apart
+        // from "reads it once and caches it": both answer the same value on
+        // the first post. The getter's return value changes between the two
+        // `postSnapshot()` calls below specifically to rule out caching — a
+        // presenter that memoized the first read (e.g. `this._cached ??=
+        // this._getDetectionState()`) would still pass a single-snapshot
+        // version of this test but would freeze the wire at `'unavailable'`
+        // forever in production, and the course chooser would never appear.
+        let detectionState: 'unsettled' | 'settled' | 'unavailable' = 'unavailable';
+        const presenter = h.build(() => undefined, () => detectionState);
 
         presenter.postSnapshot();
-
         assert.strictEqual(h.latestState().detectionState, 'unavailable');
+
+        detectionState = 'settled';
+        presenter.postSnapshot();
+        assert.strictEqual(h.latestState().detectionState, 'settled');
     });
 });

--- a/extension/test/unit/provider/chatViewStatePresenter.test.ts
+++ b/extension/test/unit/provider/chatViewStatePresenter.test.ts
@@ -56,11 +56,22 @@ function fakeConversation(over: {
     } as unknown as IrisConversationService;
 }
 
+type DetectionUiState = ExtMsg<'updateIrisState'>['state']['detectionState'];
+
 interface Harness {
     contextStore: ContextStore;
     postSpy: sinon.SinonSpy;
     sandbox: sinon.SinonSandbox;
-    build: (getConversation: () => IrisConversationService | undefined) => ChatViewStatePresenter;
+    /**
+     * `getDetectionState` defaults to `'settled'`: none of the pre-existing
+     * tests in this file care about it, and `'settled'` is the value that
+     * keeps their conversation-shaped assertions unaffected by an unrelated
+     * field.
+     */
+    build: (
+        getConversation: () => IrisConversationService | undefined,
+        getDetectionState?: () => DetectionUiState,
+    ) => ChatViewStatePresenter;
     latestState: () => ExtMsg<'updateIrisState'>['state'];
 }
 
@@ -74,7 +85,8 @@ function buildHarness(): Harness {
         contextStore,
         postSpy,
         sandbox,
-        build: (getConversation) => new ChatViewStatePresenter(contextStore, postSpy as never, getConversation),
+        build: (getConversation, getDetectionState = () => 'settled') =>
+            new ChatViewStatePresenter(contextStore, postSpy as never, getConversation, getDetectionState),
         latestState: () => posted[posted.length - 1].state,
     };
 }
@@ -301,5 +313,17 @@ suite('ChatViewStatePresenter: conversation-first fields (Task 10)', () => {
         const state = h.latestState();
 
         assert.strictEqual(state.workspaceExerciseId, 12);
+    });
+
+    // Task 8: the coordinator's live detection state has to reach the wire.
+    // The React tests inject snapshots directly and bypass this bridge
+    // entirely, so only a host-side test can catch a presenter that hard-codes
+    // the value instead of reading it from the getter.
+    test('the snapshot carries the current detection state', () => {
+        const presenter = h.build(() => undefined, () => 'unavailable');
+
+        presenter.postSnapshot();
+
+        assert.strictEqual(h.latestState().detectionState, 'unavailable');
     });
 });

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -549,6 +549,40 @@ suite('ChatWebviewProvider: reload Iris chat', () => {
 });
 
 /**
+ * Task 8: the startup-unavailable banner's own Retry. It must re-run
+ * workspace DETECTION through the coordinator, never the conversation reload
+ * (`reloadIrisChat`) that `ReloadChatSession` uses: on this path there may be
+ * no workspace exercise at all, so a reload would start whatever happens to
+ * be left over, or nothing.
+ */
+suite('ChatWebviewProvider: retryStartupDetection', () => {
+    let h: Harness;
+
+    setup(() => { h = buildHarness(); });
+    teardown(() => { h.provider.dispose(); h.sandbox.restore(); });
+
+    test('retryStartupDetection re-runs detection and does not reload the conversation', async () => {
+        const retry = sinon.spy();
+        h.provider.attachStartupDetection({
+            onDetectionSettled: new vscode.EventEmitter<DetectionOutcome>().event,
+            retry,
+        });
+        // Assert on the reload ENTRY POINT, not on an API call it would make:
+        // with no open session `reloadIrisChat()` returns early and touches
+        // no stub, so a wrongly routed command would slip past an
+        // API-level assertion.
+        const reload = h.sandbox.spy(h.provider, 'reloadIrisChat');
+
+        dispatch(h.provider, 'retryStartupDetection');
+        await settle();
+
+        assert.strictEqual(retry.calledOnce, true);
+        assert.strictEqual(reload.called, false,
+            'startup retry must not take the conversation-reload path');
+    });
+});
+
+/**
  * The dispatcher cut-over. A recording double stands in for the conversation
  * service so each test can assert WHICH navigation the host performed, and so
  * the host's own gating can be told apart from the service's internal one

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -9,6 +9,7 @@ import { ApiError } from '@extension/domain/errors';
 import { ChatWebviewProvider } from '@extension/provider/chatWebviewProvider';
 import { ContextStore } from '@extension/services/iris/context/contextStore';
 import type { TopicChangeOutcome } from '@extension/services/iris/conversation/conversationService';
+import type { DetectionOutcome } from '@extension/services/workspace/detectionOutcome';
 import { MockExtensionContext } from '@test/unit/mocks/vscodeMocks';
 
 interface Harness {
@@ -65,6 +66,36 @@ function buildHarness(): Harness {
     provider.onDidChangeExerciseContext(({ exerciseId }) => exerciseEvents.push(exerciseId));
 
     return { provider, contextStore, api, exerciseEvents, sandbox };
+}
+
+/** A minimal `vscode.WebviewView` double, just enough for `resolveWebviewView`
+ *  to run without touching a real webview. */
+function makeWebviewStub(): vscode.WebviewView {
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        html: '',
+        onDidReceiveMessage: () => ({ dispose: () => undefined }),
+        asWebviewUri: (u: vscode.Uri) => u,
+        cspSource: 'https://example',
+    } as unknown as vscode.Webview;
+    return {
+        webview,
+        onDidDispose: () => ({ dispose: () => undefined }),
+        onDidChangeVisibility: () => ({ dispose: () => undefined }),
+        visible: false,
+        show: () => undefined,
+        title: '',
+        description: '',
+        badge: undefined,
+        viewType: 'irisChat',
+    } as unknown as vscode.WebviewView;
+}
+
+/** Resolves the webview view, the trigger that reports `onViewResolved` to
+ *  the startup coordinator and re-runs the availability check. */
+async function resolveView(h: Harness): Promise<void> {
+    h.provider.resolveWebviewView(makeWebviewStub(), {} as never, {} as never);
+    await Promise.resolve();
 }
 
 /** Spies on the coordinator's admission entry point, white-box: nothing on the
@@ -301,8 +332,6 @@ suite('ChatWebviewProvider: availability is checked without a send', () => {
     });
     teardown(() => { h.provider.dispose(); h.sandbox.restore(); });
 
-    const startConversation = () => (h.provider as unknown as { _startConversation: () => Promise<void> })._startConversation();
-
     test('a conversation landing in a course with Iris disabled posts the banner before any send', async () => {
         h.api.getCurrentChat.resolves(detail({
             sessionId: 1, courseId: 42, context: { mode: 'COURSE_CHAT', entityId: 42 },
@@ -318,19 +347,29 @@ suite('ChatWebviewProvider: availability is checked without a send', () => {
 
     test('re-opening the view re-asks even though the conversation did not change', async () => {
         // `_onConversationChanged` guards on the session id, so a re-install of
-        // the SAME conversation posts no banner through that path at all.
-        h.provider.registerWorkspaceExercise({
-            id: 5, title: 'BFS', courseId: 42, source: 'workspace-detected', isWorkspace: true,
-        });
+        // the SAME conversation posts no banner through that path at all: the
+        // re-check now comes from `resolveWebviewView` itself
+        // (`_refreshAvailability`, unconditional), independent of the
+        // coordinator's one-shot `_acquireConversation`. Rewritten for the
+        // Task 7 cutover: acquisition no longer happens directly off a
+        // registered workspace exercise, so this drives it through a
+        // detection outcome instead, the way the real activation path does.
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
         h.api.getCurrentChat.resolves(detail({ sessionId: 1, courseId: 42 }));
-        await startConversation();
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 5, courseId: 42 });
+        await settle();
 
         postSpy.resetHistory();
         check.resetHistory();
-        await startConversation();
+        await resolveView(h);
+        await settle();
 
         assert.strictEqual(check.callCount, 1);
         assert.strictEqual(posted(postSpy, 'showDisabledState').length, 1);
+        detection.dispose();
     });
 
     test('an answer that outlived its conversation is not published', async () => {
@@ -356,6 +395,75 @@ suite('ChatWebviewProvider: availability is checked without a send', () => {
         await settle();
 
         assert.strictEqual(posted(postSpy, 'showDisabledState').length, 0);
+    });
+});
+
+/**
+ * Task 7: the cutover. `resolveWebviewView` no longer acquires a conversation
+ * by itself; the coordinator does it once both the view and workspace
+ * detection have settled, in either order.
+ */
+suite('ChatWebviewProvider: the startup coordinator owns the cold start', () => {
+    let h: Harness;
+
+    setup(() => { h = buildHarness(); });
+    teardown(() => { h.provider.dispose(); h.sandbox.restore(); });
+
+    test('resolving the view does not acquire a conversation on its own', async () => {
+        // Both lines are load-bearing. Without a registered workspace exercise
+        // `_workspaceForStart()` (the old code path) answers undefined and
+        // `start(undefined)` deliberately issues no request, so the assertion
+        // would hold BEFORE the cutover too and prove nothing.
+        h.provider.registerWorkspaceExercise({
+            id: 5, title: 'BFS', courseId: 42, source: 'workspace-detected', isWorkspace: true,
+        });
+        h.api.getCurrentChat.resolves(detail({ sessionId: 1, courseId: 42 }));
+
+        await resolveView(h);
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.called, false,
+            'the coordinator owns the cold start now, not resolveWebviewView');
+    });
+
+    test('an exercise detected after the view resolved acquires the conversation', async () => {
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.resolves(detail({ sessionId: 1, courseId: 9 }));
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.strictEqual(h.api.getCurrentChat.calledOnce, true);
+        detection.dispose();
+    });
+
+    test('a rejecting start still surfaces the unreachable banner, so the workspace-known Retry works', async () => {
+        // Carried over from Task 4's review: the coordinator consumes the
+        // startup latch BEFORE calling `start()`, and calls it as `void` with
+        // no rejection handling of its own. That is only safe because
+        // `_acquireConversation` catches the failure itself and shows the
+        // "Iris could not be reached" banner, whose Retry reloads the
+        // now-known conversation. Without this test that recovery path is
+        // unverified: a broken `_acquireConversation` catch would silently
+        // drop both the detected workspace exercise AND any banner.
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.rejects(new Error('network down'));
+        const postSpy = h.sandbox.spy(h.provider as unknown as { _postMessageSafe: (m: unknown) => void }, '_postMessageSafe');
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        const unavailable = postSpy.getCalls()
+            .map(c => c.args[0] as { type?: string; message?: string })
+            .find(m => m?.type === 'showUnavailableState');
+        assert.ok(unavailable, 'a rejecting start must still show the unavailable banner');
+        assert.match(String(unavailable?.message), /retry/i);
+        detection.dispose();
     });
 });
 

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -510,6 +510,104 @@ suite('ChatWebviewProvider: the startup coordinator owns the cold start', () => 
         detection.dispose();
     });
 
+    /**
+     * A course whose instructor switched Iris off answers the cold-start
+     * acquisition with the same 403 `iris.course_disabled` that `switchCourse`
+     * already handles. Before this fix `start` let it propagate and
+     * `_acquireConversation` treated it like any other failure: the student
+     * got the "could not be reached" banner and a Retry that could only ever
+     * repeat the identical 403.
+     */
+    test('a disabled course at cold start shows the disabled banner, not the unreachable one', async () => {
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.rejects(new ApiError('Request failed', 403, 'error.iris.course_disabled', 'iris.course_disabled'));
+        const postSpy = h.sandbox.spy(h.provider as unknown as { _postMessageSafe: (m: unknown) => void }, '_postMessageSafe');
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        const posted = postSpy.getCalls().map(c => c.args[0] as { type?: string });
+        assert.ok(posted.some(m => m?.type === 'showDisabledState'),
+            'a switched-off course must show the disabled banner');
+        assert.ok(!posted.some(m => m?.type === 'showUnavailableState'),
+            'a definitive answer is not a reachability problem, and must not offer a Retry that can never succeed');
+        detection.dispose();
+    });
+
+    test('a disabled course at cold start still enters the course, so the header names it', async () => {
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.rejects(new ApiError('Request failed', 403, 'error.iris.course_disabled', 'iris.course_disabled'));
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        const conversation = (h.provider as unknown as {
+            _conversation: { state: { snapshot(): { courseId?: number; currentSessionId?: number } } };
+        })._conversation;
+        const snapshot = conversation.state.snapshot();
+        assert.strictEqual(snapshot.courseId, 9, 'the header must name the course, not fall back to "Choose a course"');
+        assert.strictEqual(snapshot.currentSessionId, undefined, 'entered with no conversation, since Iris is off there');
+        detection.dispose();
+    });
+
+    test('a disabled course at cold start does not re-arm the startup latch', async () => {
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.rejects(new ApiError('Request failed', 403, 'error.iris.course_disabled', 'iris.course_disabled'));
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1, 'the disabled answer was received once');
+
+        // A later settled `matched` outcome (a fresh detection cycle, exactly
+        // what re-arming exists to serve for a TRANSIENT failure) must not
+        // trigger a second acquisition attempt: the disabled answer is
+        // definitive, and retrying it would only repeat the same 403 forever.
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1,
+            'a disabled course must not re-arm the startup latch');
+        detection.dispose();
+    });
+
+    test('a different cold-start failure (500) still shows the unreachable banner and still re-arms', async () => {
+        // The regression guard for the fix above: only the exact 403
+        // `iris.course_disabled` answer may skip the unreachable banner and
+        // the re-arm. Everything else keeps today's behaviour.
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.onFirstCall().rejects(new ApiError('Request failed', 500, 'Internal Server Error'));
+        h.api.getCurrentChat.onSecondCall().resolves(detail({ sessionId: 1, courseId: 9 }));
+        const postSpy = h.sandbox.spy(h.provider as unknown as { _postMessageSafe: (m: unknown) => void }, '_postMessageSafe');
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        const posted = postSpy.getCalls().map(c => c.args[0] as { type?: string });
+        assert.ok(posted.some(m => m?.type === 'showUnavailableState'),
+            'a transient failure must still show the unavailable banner');
+        assert.ok(!posted.some(m => m?.type === 'showDisabledState'),
+            'a 500 is not a settings refusal and must not be reported as one');
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1, 'the first, failing attempt was made');
+
+        // Re-resolving the view (the same recovery the panel-collapse test
+        // above exercises) must get another shot, proving the latch re-armed.
+        await resolveView(h);
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 2,
+            'a non-disabled failure must still re-arm the latch');
+        detection.dispose();
+    });
+
     test('re-resolving the view with an installed conversation republishes its transcript once ready', async () => {
         // FINDING 1: `_acquireConversation` is a ONE-SHOT behind the startup
         // latch (see `after a failed acquisition...` above for the failed-

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -75,6 +75,9 @@ function makeWebviewStub(): vscode.WebviewView {
         options: {} as vscode.WebviewOptions,
         html: '',
         onDidReceiveMessage: () => ({ dispose: () => undefined }),
+        // Needed once anything reaches the `ready` handshake: `_markReady`
+        // flushes the pending queue straight through `webview.postMessage`.
+        postMessage: () => Promise.resolve(true),
         asWebviewUri: (u: vscode.Uri) => u,
         cspSource: 'https://example',
     } as unknown as vscode.Webview;
@@ -98,9 +101,20 @@ async function resolveView(h: Harness): Promise<void> {
     await Promise.resolve();
 }
 
+/** Simulates the webview's own `ready` handshake message, white-box: the test
+ *  webview stub never wires a real `onDidReceiveMessage` listener, so nothing
+ *  drives `_onReady` (and therefore `_sendInitData`) on its own. This is the
+ *  one signal that flushes the queued messages and runs init data — the path
+ *  a rehydrated transcript actually travels on a re-resolve. */
+function sendReady(provider: ChatWebviewProvider): void {
+    (provider as unknown as { _handleMessage: (m: unknown) => void })._handleMessage({ type: 'ready' });
+}
+
 /** Spies on the coordinator's admission entry point, white-box: nothing on the
- *  public surface observes admission directly, since Task 5 does not cut the
- *  cold start over yet. */
+ *  public surface observes admission directly. `admitExplicitIntent` only
+ *  cancels the startup latch (and clears a dead-Retry banner when one was
+ *  showing), so a navigation that never reaches an unavailable outage screen
+ *  leaves no externally visible trace of having admitted at all. */
 function spyOnAdmission(h: Harness): sinon.SinonSpy {
     const coordinator = (h.provider as unknown as {
         _startupCoordinator: { admitExplicitIntent: (r: string) => void };
@@ -493,6 +507,84 @@ suite('ChatWebviewProvider: the startup coordinator owns the cold start', () => 
 
         assert.strictEqual(h.api.getCurrentChat.callCount, 2,
             'a re-resolved view must get another shot at the exercise it already knows about');
+        detection.dispose();
+    });
+
+    test('re-resolving the view with an installed conversation republishes its transcript once ready', async () => {
+        // FINDING 1: `_acquireConversation` is a ONE-SHOT behind the startup
+        // latch (see `after a failed acquisition...` above for the failed-
+        // attempt half of that). `_deliverTranscript` is the ONLY producer of
+        // `loadMessages` (chatWebviewProvider.ts, its own doc comment), and
+        // the only place that currently calls it is `IrisConversationService`'s
+        // own `_install`/`onSubscriptionActive`, both reached only through an
+        // ACQUISITION or a reconnect. A re-resolve of an already-installed
+        // conversation triggers neither, so nothing on THAT path re-delivers
+        // the transcript. `_refreshAvailability` (unconditional on every
+        // resolve, see the sibling suite above) is not a substitute: it only
+        // ever posts a banner, never `loadMessages`.
+        //
+        // The republish lives in `_sendInitData`, reached only through the
+        // webview's own `ready` handshake (`_onReady`), never from
+        // `resolveWebviewView` directly: `_postMessageSafe` queues everything
+        // until `ready` arrives and flushes the WHOLE queue before
+        // `_onReady` runs, so anything posted synchronously inside
+        // `resolveWebviewView` would reach the real webview BEFORE the
+        // `updateIrisState` that names the session, and the webview's own
+        // guard (keyed on the session `updateIrisState` sets) would silently
+        // drop it. Hence `sendReady` below, not a second `resolveView` alone.
+        //
+        // Concretely: the student is in an exercise workspace, the chat
+        // auto-acquires a conversation, they switch the sidebar to Explorer
+        // and back. VS Code disposes and re-resolves the view (no
+        // `retainContextWhenHidden`, extension.ts), the fresh webview boots
+        // and signals `ready`. Without the republish it gets
+        // `currentSessionId` in its `updateIrisState` but no `loadMessages`
+        // ever, so its `loadedSessionId` never matches and the loading
+        // spinner never clears.
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.resolves(detail({
+            sessionId: 1,
+            courseId: 9,
+            messages: [{ id: 100, role: 'user', content: 'hi', sentAt: '2026-01-01T00:00:00Z' }] as never,
+        }));
+        // The acquisition fires an unawaited `refreshOverview()` of its own
+        // (conversationService.ts); without this the stub's default answer
+        // (undefined) reaches `setOverview` and `postSnapshot` throws on the
+        // republish, unrelated to what this test is actually pinning down.
+        h.api.listChatSessionsForCourse.resolves([]);
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1, 'the conversation is installed once');
+        const postSpy = h.sandbox.spy(h.provider as unknown as { _postMessageSafe: (m: unknown) => void }, '_postMessageSafe');
+
+        // The panel is collapsed and reopened: a fresh `WebviewView`, a fresh
+        // resolve, and the fresh webview's own `ready` signal. No new
+        // detection event and no new acquisition attempt (the latch is
+        // already consumed) — this is the "already installed" case, distinct
+        // from the failed-acquisition test above.
+        await resolveView(h);
+        sendReady(h.provider);
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1,
+            'the one-shot latch must stay one-shot: this is a REPUBLISH, not a second acquisition');
+        const posted = postSpy.getCalls().map(c => c.args[0] as { type?: string; sessionId?: number });
+        const loads = posted.filter(m => m?.type === 'loadMessages');
+        assert.strictEqual(loads.length, 1,
+            'a re-resolved view with an already-installed conversation must get its transcript republished, or the fresh webview spins forever');
+        assert.strictEqual(loads[0]?.sessionId, 1);
+        // The ordering invariant `_install` itself relies on (see its own
+        // "AFTER the emit, never before it" comment): the snapshot that names
+        // the session must reach the webview before the transcript for it, or
+        // the webview's session guard drops the transcript on the floor.
+        const snapshotIndex = posted.findIndex(m => m?.type === 'updateIrisState');
+        const loadIndex = posted.findIndex(m => m?.type === 'loadMessages');
+        assert.ok(snapshotIndex >= 0 && snapshotIndex < loadIndex,
+            'updateIrisState must be posted before loadMessages, or the webview\'s session guard drops the republish');
         detection.dispose();
     });
 });
@@ -1212,12 +1304,12 @@ suite('ChatWebviewProvider: the conversation owns the transcript', () => {
 });
 
 /**
- * Task 5: admission. The coordinator is constructed and wired into the
- * synchronous navigation gate, but `resolveWebviewView` still starts the
- * conversation the old way (see the shim in the constructor), so none of
- * this is observable yet. What these tests pin down is WHEN admission
- * happens relative to a navigation: at the gate, not on success, and never
- * for a command the gate refused outright.
+ * Admission. The startup coordinator sits behind the synchronous navigation
+ * gate: every explicit navigation admits its intent (cancelling the startup
+ * latch) before it does anything else, so an automatic cold start can never
+ * fire underneath a student who has already moved. What these tests pin down
+ * is WHEN admission happens relative to a navigation: at the gate, not on
+ * success, and never for a command the gate refused outright.
  */
 suite('ChatWebviewProvider: startup admission', () => {
     let h: Harness;

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -67,6 +67,16 @@ function buildHarness(): Harness {
     return { provider, contextStore, api, exerciseEvents, sandbox };
 }
 
+/** Spies on the coordinator's admission entry point, white-box: nothing on the
+ *  public surface observes admission directly, since Task 5 does not cut the
+ *  cold start over yet. */
+function spyOnAdmission(h: Harness): sinon.SinonSpy {
+    const coordinator = (h.provider as unknown as {
+        _startupCoordinator: { admitExplicitIntent: (r: string) => void };
+    })._startupCoordinator;
+    return sinon.spy(coordinator, 'admitExplicitIntent');
+}
+
 function detail(over: Partial<SessionDetail> = {}): SessionDetail {
     return {
         sessionId: 1,
@@ -1026,5 +1036,91 @@ suite('ChatWebviewProvider: the conversation owns the transcript', () => {
         // acquisition then turned into a real server session while the webview
         // was telling the student there was nothing to talk about.
         assert.strictEqual(h.api.getCurrentChat.callCount, 0);
+    });
+});
+
+/**
+ * Task 5: admission. The coordinator is constructed and wired into the
+ * synchronous navigation gate, but `resolveWebviewView` still starts the
+ * conversation the old way (see the shim in the constructor), so none of
+ * this is observable yet. What these tests pin down is WHEN admission
+ * happens relative to a navigation: at the gate, not on success, and never
+ * for a command the gate refused outright.
+ */
+suite('ChatWebviewProvider: startup admission', () => {
+    let h: Harness;
+
+    // A `teardown` hook, not a call at the end of each test body: mocha runs
+    // it even when the test's own assertions throw, so a sandbox stub (e.g.
+    // on `vscode.commands.registerCommand`) never leaks into the next test.
+    setup(() => { h = buildHarness(); });
+    teardown(() => { h.provider.dispose(); h.sandbox.restore(); });
+
+    const NAVIGATIONS: Array<{ reason: string; run: (p: ChatWebviewProvider) => Promise<void> }> = [
+        {
+            reason: 'selectTopic',
+            run: p => (p as never as { _handleSelectTopic: (t: unknown) => Promise<void> })
+                ._handleSelectTopic({ mode: 'PROGRAMMING_EXERCISE_CHAT', entityId: 5 }),
+        },
+        {
+            reason: 'openConversation',
+            run: p => (p as never as {
+                _handleOpenConversation: (params: { courseId: number; sessionId: number }) => Promise<void>;
+            })._handleOpenConversation({ courseId: 42, sessionId: 7 }),
+        },
+        {
+            reason: 'switchCourse',
+            run: p => (p as never as { _handleSwitchCourse: (id: number) => Promise<void> })
+                ._handleSwitchCourse(42),
+        },
+        {
+            reason: 'newConversation',
+            run: p => (p as never as { _handleNewConversation: () => Promise<void> })
+                ._handleNewConversation(),
+        },
+    ];
+
+    for (const nav of NAVIGATIONS) {
+        test(`${nav.reason} admits its intent even when the navigation then fails`, async () => {
+            // Every one of the four either ends in an API call or refuses for a
+            // reason internal to the service (e.g. no course yet on a cold
+            // start): failing the calls that DO happen, on every handler,
+            // proves admission happened at admission and not on success.
+            h.api.getCurrentChat.rejects(new ApiError('nope', 500));
+            h.api.getChatSessionById.rejects(new ApiError('nope', 500));
+            h.api.createCourseSession.rejects(new ApiError('nope', 500));
+            const admit = spyOnAdmission(h);
+
+            await nav.run(h.provider);
+
+            assert.strictEqual(admit.calledOnce, true, `${nav.reason} did not admit`);
+            assert.strictEqual(admit.firstCall.args[0], nav.reason);
+        });
+    }
+
+    const NON_NAVIGATIONS = ['refreshCourses', 'reconnectWebSocket'] as const;
+
+    for (const command of NON_NAVIGATIONS) {
+        test(`${command} does NOT admit an intent`, async () => {
+            const admit = spyOnAdmission(h);
+
+            dispatch(h.provider, command);
+            await settle();
+
+            assert.strictEqual(admit.called, false,
+                'it names no destination, so it is not a navigation the cold start must yield to');
+        });
+    }
+
+    test('a navigation refused because a send is in flight does NOT admit', async () => {
+        const fake = injectFakeConversation(h.provider);
+        fake.sendInFlight = true;
+        const admit = spyOnAdmission(h);
+
+        await (h.provider as never as { _handleSwitchCourse: (id: number) => Promise<void> })
+            ._handleSwitchCourse(42);
+
+        assert.strictEqual(admit.called, false,
+            'a refused command never reached the conversation, so it named no destination');
     });
 });

--- a/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
+++ b/extension/test/unit/provider/chatWebviewProviderConversationFirst.test.ts
@@ -465,6 +465,36 @@ suite('ChatWebviewProvider: the startup coordinator owns the cold start', () => 
         assert.match(String(unavailable?.message), /retry/i);
         detection.dispose();
     });
+
+    test('after a failed acquisition, re-resolving the view acquires again', async () => {
+        // The regression this fix round exists for: `resolveWebviewView` runs
+        // again whenever VS Code disposes and recreates the webview (the
+        // panel has no `retainContextWhenHidden`), which happens simply from
+        // collapsing and reopening the sidebar view. Without the latch coming
+        // back after a failed attempt, the student who hit one transient
+        // error is stuck on the cold-start chooser for good, with no banner
+        // and no automatic retry — only `artemis.resetIrisChat` recovers.
+        const detection = new vscode.EventEmitter<DetectionOutcome>();
+        h.provider.attachStartupDetection({ onDetectionSettled: detection.event, retry: () => undefined });
+        h.api.getCurrentChat.onFirstCall().rejects(new Error('network down'));
+        h.api.getCurrentChat.onSecondCall().resolves(detail({ sessionId: 1, courseId: 9 }));
+
+        await resolveView(h);
+        detection.fire({ kind: 'matched', exerciseId: 3, courseId: 9 });
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 1, 'the first, failing attempt was made');
+
+        // The panel is collapsed and reopened: a fresh `WebviewView`, a fresh
+        // resolve, no new detection event (the workspace exercise did not
+        // change).
+        await resolveView(h);
+        await settle();
+
+        assert.strictEqual(h.api.getCurrentChat.callCount, 2,
+            'a re-resolved view must get another shot at the exercise it already knows about');
+        detection.dispose();
+    });
 });
 
 suite('ChatWebviewProvider: reload Iris chat', () => {

--- a/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
+++ b/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
@@ -123,13 +123,10 @@ suite('ChatStartupCoordinator', () => {
     });
 
     test('a rejecting start does not resurrect a latch an explicit intent later cancelled', async () => {
-        // `cancel()` only ever acts on an `eligible` latch (by design: an
-        // intent arriving while the automatic attempt is still in flight is
-        // moot, since that attempt already has permission). So the
-        // cancellation that matters here can only land AFTER the re-arm has
-        // already put the latch back into play — which is exactly the window
-        // this fix opens up, and exactly where "the explicit intent still
-        // wins, permanently" has to keep holding.
+        // A DIFFERENT window than the interleaving test below: here the
+        // intent arrives AFTER the re-arm has already put the latch back
+        // into play (not while the first attempt is still in flight), and
+        // it still has to win permanently.
         const start = sinon.stub();
         start.onFirstCall().rejects(new Error('network down'));
         const publishDetectionState = sinon.spy();
@@ -153,6 +150,45 @@ suite('ChatStartupCoordinator', () => {
 
         assert.strictEqual(start.callCount, 1,
             'a cancelled latch must never restart, no matter how it got there');
+    });
+
+    test('an explicit intent admitted WHILE the attempt is still pending is not resurrected by a later re-arm', async () => {
+        // The real interleaving: `start()` is a genuine HTTP round trip, so
+        // it stays pending for hundreds of milliseconds — plenty of time for
+        // the student to click "Ask Iris about" or switch a topic. Before
+        // `cancel()` could record an intent on a `consumed` latch, this
+        // window silently dropped it: `cancel()` no-opped (state was
+        // `consumed`, not `eligible`), the attempt then failed and re-armed
+        // the latch as if nothing had happened, and a later settle started
+        // automatically anyway — exactly the automatic cold start the
+        // student's own navigation was supposed to rule out for good.
+        let rejectStart: (error: unknown) => void = () => undefined;
+        const start = sinon.stub().returns(new Promise((_resolve, reject) => { rejectStart = reject; }));
+        const publishDetectionState = sinon.spy();
+        const retryDetection = sinon.spy();
+        const coordinator = new ChatStartupCoordinator({ start, publishDetectionState, retryDetection });
+
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.callCount, 1, 'the automatic attempt began, and its promise is still pending');
+
+        // The student explicitly navigates away WHILE the attempt is
+        // in flight — no response has arrived yet.
+        coordinator.admitExplicitIntent('askIrisAbout');
+
+        // The in-flight attempt now fails: the same transient error this
+        // whole fix targets.
+        rejectStart(new Error('network down'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // A later trigger (a folder change, or the view re-resolving after
+        // VS Code disposed and recreated the webview) must not restart:
+        // the intent from mid-flight still has to win, permanently.
+        coordinator.onDetectionSettled(MATCH);
+
+        assert.strictEqual(start.callCount, 1,
+            'an intent admitted mid-flight must survive the in-flight attempt failing');
     });
 
     test('an admitted intent clears a startup-unavailable banner', () => {

--- a/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
+++ b/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
@@ -93,6 +93,68 @@ suite('ChatStartupCoordinator', () => {
             'retry() is a no-op once the latch is spent, so the button must not appear');
     });
 
+    test('a rejecting start leaves the latch eligible, and a later settled match starts again', async () => {
+        // Regression guard: a transient failure (e.g. a 500 from the acquire
+        // call) must not permanently strand the student on the cold-start
+        // chooser. The latch was consumed before the attempt was even made,
+        // which is what stops a double start; on failure that permission has
+        // to come back.
+        const start = sinon.stub();
+        start.onFirstCall().rejects(new Error('network down'));
+        start.onSecondCall().resolves();
+        const publishDetectionState = sinon.spy();
+        const retryDetection = sinon.spy();
+        const coordinator = new ChatStartupCoordinator({ start, publishDetectionState, retryDetection });
+
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled(MATCH);
+        // Let the rejected promise's `.catch` run.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.strictEqual(start.callCount, 1, 'the first, failing attempt was made');
+
+        // A fresh detection settle (e.g. a folder change, or the view
+        // resolving again after VS Code disposed and recreated it) is the
+        // next trigger; with the latch re-armed it must start again.
+        coordinator.onDetectionSettled(MATCH);
+
+        assert.strictEqual(start.callCount, 2, 'a later settle must get another shot at the latch');
+    });
+
+    test('a rejecting start does not resurrect a latch an explicit intent later cancelled', async () => {
+        // `cancel()` only ever acts on an `eligible` latch (by design: an
+        // intent arriving while the automatic attempt is still in flight is
+        // moot, since that attempt already has permission). So the
+        // cancellation that matters here can only land AFTER the re-arm has
+        // already put the latch back into play — which is exactly the window
+        // this fix opens up, and exactly where "the explicit intent still
+        // wins, permanently" has to keep holding.
+        const start = sinon.stub();
+        start.onFirstCall().rejects(new Error('network down'));
+        const publishDetectionState = sinon.spy();
+        const retryDetection = sinon.spy();
+        const coordinator = new ChatStartupCoordinator({ start, publishDetectionState, retryDetection });
+
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled(MATCH);
+        await Promise.resolve();
+        await Promise.resolve();
+        assert.strictEqual(start.callCount, 1, 'the first, failing attempt was made, and the latch is eligible again');
+
+        // The student explicitly navigates away now that the latch is
+        // eligible again.
+        coordinator.admitExplicitIntent('switchCourse');
+
+        // A later detection settle (e.g. a folder change) must not restart:
+        // the explicit navigation wins, permanently, even though a prior
+        // failed automatic attempt had reopened the latch.
+        coordinator.onDetectionSettled(MATCH);
+
+        assert.strictEqual(start.callCount, 1,
+            'a cancelled latch must never restart, no matter how it got there');
+    });
+
     test('an admitted intent clears a startup-unavailable banner', () => {
         const { coordinator, publishDetectionState } = makeCoordinator();
         coordinator.onViewResolved();

--- a/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
+++ b/extension/test/unit/services/iris/startup/chatStartupCoordinator.test.ts
@@ -1,0 +1,106 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import { ChatStartupCoordinator } from '@extension/services/iris/startup/chatStartupCoordinator';
+
+function makeCoordinator() {
+    const start = sinon.stub().resolves();
+    const publishDetectionState = sinon.spy();
+    const retryDetection = sinon.spy();
+    const coordinator = new ChatStartupCoordinator({ start, publishDetectionState, retryDetection });
+    return { coordinator, start, publishDetectionState, retryDetection };
+}
+
+const MATCH = { kind: 'matched', exerciseId: 3, courseId: 9 } as const;
+
+suite('ChatStartupCoordinator', () => {
+    test('starts once when the view resolves first', () => {
+        const { coordinator, start } = makeCoordinator();
+        coordinator.onViewResolved();
+        assert.strictEqual(start.called, false, 'nothing may start before detection settles');
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.callCount, 1);
+        assert.deepStrictEqual(start.firstCall.args[0], { exerciseId: 3, courseId: 9 });
+    });
+
+    test('starts once when detection settles first', () => {
+        const { coordinator, start } = makeCoordinator();
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.called, false, 'nothing may start before there is a view');
+        coordinator.onViewResolved();
+        assert.strictEqual(start.callCount, 1);
+    });
+
+    test('a view resolved twice does not start twice', () => {
+        const { coordinator, start } = makeCoordinator();
+        coordinator.onDetectionSettled(MATCH);
+        coordinator.onViewResolved();
+        coordinator.onViewResolved();
+        assert.strictEqual(start.callCount, 1);
+    });
+
+    test('an admitted intent cancels the automatic start for good', () => {
+        const { coordinator, start } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.admitExplicitIntent('switchCourse');
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.called, false,
+            'a late detection must not pull the student out of the course they chose');
+    });
+
+    test('no-match consumes the latch, so a later match cannot start', () => {
+        const { coordinator, start, publishDetectionState } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled({ kind: 'no-match' });
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'settled');
+
+        // A folder change re-runs detection. The student has been looking at the
+        // chooser since the first answer; the chat must not acquire under them.
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.called, false, 'no-match must really consume, not merely decline');
+    });
+
+    test('unavailable keeps eligibility and a retry can still start', () => {
+        const { coordinator, start, publishDetectionState, retryDetection } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled({ kind: 'unavailable' });
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'unavailable');
+        assert.strictEqual(start.called, false);
+
+        coordinator.retry();
+        assert.strictEqual(retryDetection.calledOnce, true);
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'unsettled');
+
+        coordinator.onDetectionSettled(MATCH);
+        assert.strictEqual(start.callCount, 1, 'unavailable must not have burned the latch');
+    });
+
+    test('retry after the latch is gone does nothing', () => {
+        const { coordinator, retryDetection } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled(MATCH);
+        coordinator.retry();
+        assert.strictEqual(retryDetection.called, false);
+    });
+
+    test('an outage after the latch was consumed does not offer a dead retry', () => {
+        const { coordinator, publishDetectionState } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled({ kind: 'no-match' });
+        // A folder change re-runs detection, and this time the server is down.
+        coordinator.onDetectionSettled({ kind: 'unavailable' });
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'settled',
+            'retry() is a no-op once the latch is spent, so the button must not appear');
+    });
+
+    test('an admitted intent clears a startup-unavailable banner', () => {
+        const { coordinator, publishDetectionState } = makeCoordinator();
+        coordinator.onViewResolved();
+        coordinator.onDetectionSettled({ kind: 'unavailable' });
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'unavailable');
+
+        coordinator.admitExplicitIntent('switchCourse');
+        assert.strictEqual(publishDetectionState.lastCall.args[0], 'settled',
+            'the student navigated away; the dead Retry must not stay behind it');
+    });
+});

--- a/extension/test/unit/services/iris/startup/startupLatch.test.ts
+++ b/extension/test/unit/services/iris/startup/startupLatch.test.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+
+import { StartupLatch } from '@extension/services/iris/startup/startupLatch';
+
+suite('StartupLatch', () => {
+    test('consumes exactly once', () => {
+        const latch = new StartupLatch();
+        assert.strictEqual(latch.consume(), true);
+        assert.strictEqual(latch.consume(), false, 'a second automatic start must never happen');
+        assert.strictEqual(latch.state, 'consumed');
+    });
+
+    test('a cancelled latch can never be consumed', () => {
+        const latch = new StartupLatch();
+        latch.cancel('switchCourse');
+        assert.strictEqual(latch.consume(), false);
+        assert.strictEqual(latch.state, 'cancelled');
+    });
+
+    test('cancelling after consumption does not resurrect anything', () => {
+        const latch = new StartupLatch();
+        latch.consume();
+        latch.cancel('selectTopic');
+        assert.strictEqual(latch.state, 'consumed');
+        assert.strictEqual(latch.consume(), false);
+    });
+});

--- a/extension/test/unit/services/iris/startup/startupLatch.test.ts
+++ b/extension/test/unit/services/iris/startup/startupLatch.test.ts
@@ -17,11 +17,23 @@ suite('StartupLatch', () => {
         assert.strictEqual(latch.state, 'cancelled');
     });
 
-    test('cancelling after consumption does not resurrect anything', () => {
+    test('cancelling after consumption records the intent, and a later re-arm cannot undo it', () => {
+        // The old behaviour here was `cancel()` no-opping on a `consumed`
+        // latch, on the premise that `consumed` was terminal. It stopped
+        // being terminal the moment `reArmAfterFailedStart` existed: an
+        // intent arriving while the automatic attempt is still in flight
+        // (a real HTTP round trip, easily pending for hundreds of
+        // milliseconds) must still be recorded, or a later failure of that
+        // very attempt hands the automatic path a second chance the student
+        // had already refused.
         const latch = new StartupLatch();
         latch.consume();
+
         latch.cancel('selectTopic');
-        assert.strictEqual(latch.state, 'consumed');
+        assert.strictEqual(latch.state, 'cancelled', 'an intent arriving mid-flight must still be recorded');
+
+        latch.reArmAfterFailedStart();
+        assert.strictEqual(latch.state, 'cancelled', 'a later re-arm must not revive it');
         assert.strictEqual(latch.consume(), false);
     });
 

--- a/extension/test/unit/services/iris/startup/startupLatch.test.ts
+++ b/extension/test/unit/services/iris/startup/startupLatch.test.ts
@@ -24,4 +24,33 @@ suite('StartupLatch', () => {
         assert.strictEqual(latch.state, 'consumed');
         assert.strictEqual(latch.consume(), false);
     });
+
+    test('reArmAfterFailedStart returns a consumed latch to eligible', () => {
+        const latch = new StartupLatch();
+        latch.consume();
+
+        latch.reArmAfterFailedStart();
+
+        assert.strictEqual(latch.state, 'eligible');
+        assert.strictEqual(latch.consume(), true, 'a re-armed latch can be consumed again');
+    });
+
+    test('reArmAfterFailedStart never resurrects a cancelled latch', () => {
+        const latch = new StartupLatch();
+        latch.cancel('switchCourse');
+
+        latch.reArmAfterFailedStart();
+
+        assert.strictEqual(latch.state, 'cancelled',
+            'an explicit student intent must win permanently, even over a failed automatic attempt');
+        assert.strictEqual(latch.consume(), false);
+    });
+
+    test('reArmAfterFailedStart on a still-eligible latch is a no-op', () => {
+        const latch = new StartupLatch();
+
+        latch.reArmAfterFailedStart();
+
+        assert.strictEqual(latch.state, 'eligible');
+    });
 });

--- a/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
+++ b/extension/test/unit/services/workspace/wireWorkspaceDetection.test.ts
@@ -192,6 +192,52 @@ suite('wireWorkspaceDetection', () => {
         assert.strictEqual(sink._register.callCount, 0);
         disposable.dispose();
     });
+
+    test('publishes every settled outcome, including the one from activation', async () => {
+        detectStub.resolves({ kind: 'matched', exerciseId: 42, courseId: 9 });
+        const seen: unknown[] = [];
+
+        const handle = wireWorkspaceDetection({
+            api: undefined, registry, courseDataCache, sink: makeSinkSpy(),
+        });
+        handle.onDetectionSettled(outcome => seen.push(outcome));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        detectStub.resolves({ kind: 'no-match' });
+        handle.retry();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.deepStrictEqual(seen, [
+            { kind: 'matched', exerciseId: 42, courseId: 9 },
+            { kind: 'no-match' },
+        ]);
+        handle.dispose();
+    });
+
+    test('a superseded run cannot emit its late result', async () => {
+        let resolveFirst: (o: unknown) => void = () => undefined;
+        detectStub.onFirstCall().returns(new Promise(res => { resolveFirst = res; }));
+        detectStub.onSecondCall().resolves({ kind: 'no-match' });
+
+        const handle = wireWorkspaceDetection({
+            api: undefined, registry, courseDataCache, sink: makeSinkSpy(),
+        });
+        const seen: unknown[] = [];
+        handle.onDetectionSettled(outcome => seen.push(outcome));
+
+        handle.retry();
+        await Promise.resolve();
+        await Promise.resolve();
+        resolveFirst({ kind: 'matched', exerciseId: 1, courseId: 2 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.deepStrictEqual(seen, [{ kind: 'no-match' }],
+            'the superseded activation run must not emit after a newer one settled');
+        handle.dispose();
+    });
 });
 
 suite('buildChatProviderSink', () => {

--- a/extension/test/unit/services/workspace/workspaceDetectionOutcome.test.ts
+++ b/extension/test/unit/services/workspace/workspaceDetectionOutcome.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import type { CourseDataCache } from '@extension/services/courseDataCache';
+import type { ExerciseRegistry } from '@extension/services/exerciseRegistry';
+import {
+    detectAndRegisterWorkspaceExercise,
+    detectWorkspaceExerciseForRepository,
+    searchArchivedCoursesForRepository,
+} from '@extension/services/workspace/workspaceDetectionService';
+
+const REPO_URL = 'https://artemis.example/git/AB/ab-student.git';
+
+function emptyRegistry(): ExerciseRegistry {
+    return { getAllExercises: () => [], registerFromCourseData: () => undefined } as unknown as ExerciseRegistry;
+}
+
+suite('detectAndRegisterWorkspaceExercise outcome', () => {
+    let sandbox: sinon.SinonSandbox;
+    setup(() => { sandbox = sinon.createSandbox(); });
+    teardown(() => { sandbox.restore(); });
+
+    // Both of these MUST inject the resolver. The unit runner launches with no
+    // workspace folder (`.vscode-test.mjs:20` passes only `--user-data-dir`),
+    // so the real `getWorkspaceRepositoryUrl()` answers null and the wrapper
+    // would short-circuit to no-match without ever reaching the branch under
+    // test.
+
+    test('an unreachable dashboard reports unavailable and does not clear the workspace', async () => {
+        const clearStaleWorkspaceContext = sinon.spy();
+        const fetch = sinon.stub().resolves(undefined);
+        const cache = { fetch } as unknown as CourseDataCache;
+
+        const outcome = await detectAndRegisterWorkspaceExercise(
+            undefined,
+            { registerExercise: () => undefined, clearStaleWorkspaceContext },
+            emptyRegistry(),
+            cache,
+            async () => REPO_URL,
+        );
+
+        assert.strictEqual(fetch.calledOnce, true, 'the dashboard branch was never reached');
+        assert.strictEqual(outcome.kind, 'unavailable');
+        assert.strictEqual(clearStaleWorkspaceContext.called, false,
+            'an unreachable server must not be reported as "no exercise here"');
+    });
+
+    test('a student with zero courses is a no-match, not an outage', async () => {
+        const clearStaleWorkspaceContext = sinon.spy();
+        const fetch = sinon.stub().resolves({ courses: [] });
+        const cache = { fetch } as unknown as CourseDataCache;
+
+        const outcome = await detectAndRegisterWorkspaceExercise(
+            undefined,
+            { registerExercise: () => undefined, clearStaleWorkspaceContext },
+            emptyRegistry(),
+            cache,
+            async () => REPO_URL,
+        );
+
+        assert.strictEqual(fetch.calledOnce, true, 'the dashboard branch was never reached');
+        assert.strictEqual(outcome.kind, 'no-match');
+        assert.strictEqual(clearStaleWorkspaceContext.calledOnce, true);
+    });
+
+    test('an archived course whose detail cannot be read reports unreachable', async () => {
+        const getCourseForDashboard = sinon.stub().rejects(new Error('offline'));
+        const api = { getCourseForDashboard } as never;
+
+        const result = await searchArchivedCoursesForRepository(
+            api, 'https://artemis.example/git/AB/ab-student.git', [{ id: 1 } as never],
+        );
+
+        assert.strictEqual(getCourseForDashboard.calledOnce, true,
+            'the probe must actually have been attempted');
+        assert.strictEqual(result.entry, undefined);
+        assert.strictEqual(result.reachable, false,
+            'the archive is where the match would have been; failing to read it is not proof of absence');
+    });
+
+    test('an archive searched successfully with no hit is reachable', async () => {
+        const api = { getCourseForDashboard: async () => ({ course: { id: 1 }, exercises: [] }) } as never;
+
+        const result = await searchArchivedCoursesForRepository(
+            api, 'https://artemis.example/git/AB/ab-student.git', [{ id: 1 } as never],
+        );
+
+        assert.strictEqual(result.entry, undefined);
+        assert.strictEqual(result.reachable, true);
+    });
+
+    test('an exercise with no course is not made the workspace exercise', async () => {
+        const registerExercise = sinon.spy();
+        const clearStaleWorkspaceContext = sinon.spy();
+        const cache = { fetch: async () => ({ courses: [] }) } as unknown as CourseDataCache;
+        // The orphan is already in the registry and matches REPO_URL, so the
+        // core reaches the courseId branch deterministically.
+        const registry = {
+            getAllExercises: () => [{ id: 4, title: 'Orphan', repositoryUri: REPO_URL, courseId: undefined }],
+            registerFromCourseData: () => undefined,
+        } as unknown as ExerciseRegistry;
+
+        const outcome = await detectWorkspaceExerciseForRepository(
+            REPO_URL,
+            undefined,
+            { registerExercise, clearStaleWorkspaceContext },
+            registry,
+            cache,
+        );
+
+        assert.strictEqual(outcome.kind, 'no-match');
+        assert.strictEqual(registerExercise.called, false,
+            'a non-null workspaceExerciseId would suppress the cold-start chooser the student needs');
+        assert.strictEqual(clearStaleWorkspaceContext.calledOnce, true);
+    });
+
+    test('a folder with no git remote is a no-match even when the server is down', async () => {
+        const clearStaleWorkspaceContext = sinon.spy();
+        const cache = { fetch: async () => undefined } as unknown as CourseDataCache;
+
+        const outcome = await detectAndRegisterWorkspaceExercise(
+            undefined,
+            { registerExercise: () => undefined, clearStaleWorkspaceContext },
+            emptyRegistry(),
+            cache,
+            async () => null,               // the injected resolver, see Step 5
+        );
+
+        assert.strictEqual(outcome.kind, 'no-match',
+            'whether this folder is an exercise checkout does not depend on the server');
+        assert.strictEqual(clearStaleWorkspaceContext.calledOnce, true);
+    });
+
+    test('an unexpected throw is unavailable, never a silent no-match', async () => {
+        const clearStaleWorkspaceContext = sinon.spy();
+        const registry = { getAllExercises: () => { throw new Error('boom'); } } as unknown as ExerciseRegistry;
+
+        const outcome = await detectAndRegisterWorkspaceExercise(
+            undefined,
+            { registerExercise: () => undefined, clearStaleWorkspaceContext },
+            registry,
+            undefined,
+            async () => REPO_URL,
+        );
+
+        assert.strictEqual(outcome.kind, 'unavailable');
+        assert.strictEqual(clearStaleWorkspaceContext.called, false);
+    });
+});


### PR DESCRIPTION
Part 1 of three for #376. The issue stays open.

Opening a folder for an exercise you have never chatted about lands you on the course list, and nothing ever takes you off it. The chat asks "which exercise is this folder?" exactly once, in `resolveWebviewView`, and workspace detection needs a login plus a dashboard round trip to answer. On a fresh window it has not answered yet.

Nothing retries. The single subscriber of `onDidChangeWorkspaceExercise` only fires a telemetry event, and `render()` reaches `_sendInitData` through the new webview's ready message but never `resolveWebviewView`.

**This predates the persistence work in #376.** The tracked-item store hides it for exercises you have opened before, which is why it reads as a first-visit problem rather than a race.

## What changes

**Detection answers with a reason.** `matched | no-match | unavailable` instead of `void`. A folder with no git remote is a conclusive `no-match` before any request goes out, so a non-Artemis window never offers a Retry for a server that has nothing to do with the answer. An unreachable dashboard, or an archive probe that throws, is `unavailable` and does not clear a previously matched exercise. Previously both collapsed into "no exercise here".

**One owner decides whether the chat starts by itself.** `ChatStartupCoordinator` holds a one-shot latch. The view resolving and the detection settling arrive in either order and rendezvous there; exactly one acquisition happens. `resolveWebviewView` no longer starts anything.

**An explicit navigation wins, permanently.** The latch is cancelled at admission, not at success: a request that was accepted and then answered `no-course` still means you said where you wanted to go. Admission sits in `_conversationForNavigation`, after the two refusals and before the return, so a command refused because a send is in flight named no destination and does not cancel.

The counterexample that forced this: entering a course whose Iris is disabled deliberately sets `courseId` and leaves `currentSessionId` undefined. A guard of "no conversation open and no navigation in flight" would be true there, and a late detection would pull you out of a course you had just chosen.

Ask-Iris admits before it focuses the chat, because focusing resolves the webview, which is the signal that wakes the coordinator.

**The UI waits instead of guessing.** `detectionState` travels on the wire. While detection is unsettled the ordinary shell is suppressed — the header and the composer placeholder both fall back to "Choose a course", so hiding only the message list would still tell you to pick one. An unreachable server says so and offers a Retry that re-runs detection, plus a second way into the course chooser so the screen is never a trap.

## Task ordering

Admission lands before the cutover, deliberately. Reversed, the coordinator's deferred start becomes the *newest* navigation and beats a request you already made — worse than today.

## Review found three regressions this branch introduced. All fixed here.

1. **A failed acquisition was unrecoverable.** The latch is consumed before the attempt, so a transient failure burned the permission. Now a rejected start re-arms it.
2. **The re-arm then broke the cancel.** `consumed` had been terminal, so `cancel()` ignoring it was harmless. Once a re-arm existed, an intent admitted while the attempt was in flight was silently dropped and the later rejection revived the latch. `cancel()` now records the intent from `consumed`, and the re-arm refuses to act from `cancelled`.
3. **A recreated webview never got its transcript back.** `_startConversation` used to deliver it on every resolve; the split preserved the availability recheck but not the transcript. Republished from `_sendInitData`, immediately after the snapshot that names the session — the ordering was verified at the real `postMessage` boundary, because posting it from `resolveWebviewView` arrives ahead of `updateIrisState` and gets dropped by the session guard.

## Verification

Every test was verified by mutation: the defect it claims to catch was introduced, the test confirmed red, the change reverted. That found two tests of mine that passed before the code existed, and one that asserted before React had rendered.

`npm run compile` clean, 1433 unit tests, 1238 webview tests.

Not in this PR: the tracked-item store itself, session identity, and the honest wording for an entry the server reports gone.
