### PR TITLE
Iris chat: hold the server echo until the POST names the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Brief connection problems:** A short outage no longer hides the conversation you were reading or empties your conversation history, and a message that could not be sent keeps its text behind a single Retry that reconnects and then sends it.
 - **Iris logo:** The mascot now has a subtle shadow, so on light themes it no longer sits on the surface as a flat block, and it keeps its proportions instead of being squashed into a square.
 - **Course and exercise lists:** The chat kept a list of its own that only ever grew, so a deleted course, or one you were removed from, stayed on offer and then failed when you picked it. The lists come from the server now, and nothing from a previous account or Artemis server is left behind when you switch. When the server cannot be reached, the course list says so and offers a retry instead of reporting that you have no courses.
+- **Sending a message:** Your own message no longer appears twice for a moment before collapsing into one.
 
 ### Internal
 

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -275,6 +275,22 @@ function ownsPendingEcho(state: ChatState, localId: string): boolean {
     return state.pendingEcho?.localId === localId;
 }
 
+/**
+ * The bubble `message` should be held against instead of being upserted
+ * straight away, if any: a user message that already carries a server id,
+ * while exactly one optimistic bubble is still waiting for one and nothing
+ * is held yet. Shared by both entry points our own echo can arrive through:
+ * the store's `addMessage` (called directly by tests, and for the
+ * optimistic bubble itself) and `applyCommit` (the real path a wire
+ * `addMessage` frame is routed through, IrisChatView.tsx:140-160).
+ */
+function echoOwner(state: ChatState, message: ChatMessage): ChatMessage | undefined {
+    if (message.role !== 'user' || message.id === undefined || state.pendingEcho !== null) {
+        return undefined;
+    }
+    return soleSendingBubble(state.messages);
+}
+
 export const useChatStore = create<ChatState>()(
     devtools(
         (set) => ({
@@ -367,9 +383,7 @@ export const useChatStore = create<ChatState>()(
             addMessage: (message, sessionId) => {
                 const state = useChatStore.getState();
                 if (sessionId !== undefined && sessionId !== state.currentSessionId) { return; }
-                const owner = message.role === 'user' && message.id !== undefined && state.pendingEcho === null
-                    ? soleSendingBubble(state.messages)
-                    : undefined;
+                const owner = echoOwner(state, message);
                 if (owner && state.currentSessionId !== null) {
                     set(
                         { pendingEcho: { message, sessionId: state.currentSessionId, localId: owner.localId } },
@@ -400,6 +414,28 @@ export const useChatStore = create<ChatState>()(
                 const currentSessionId = useChatStore.getState().currentSessionId;
                 if (messageSessionId !== currentSessionId) { return; }
 
+                // The real path our own echo arrives on: IrisChatView routes
+                // every addMessage wire frame through applyCommit, never
+                // through the store's addMessage. A user echo never carries a
+                // projection (irisWebSocketMessageHandler.ts's
+                // _renderForeignUserMessage sends none), and a commit that
+                // DOES carry one must keep applying it atomically, which is
+                // this action's entire purpose, so the hold is scoped to the
+                // projection-less case only. This capture is non-terminal: it
+                // only ever adds to the buffer, never releases it.
+                if (projection === undefined) {
+                    const state = useChatStore.getState();
+                    const owner = echoOwner(state, message);
+                    if (owner && state.currentSessionId !== null) {
+                        set(
+                            { pendingEcho: { message, sessionId: state.currentSessionId, localId: owner.localId } },
+                            false,
+                            'holdEcho',
+                        );
+                        return;
+                    }
+                }
+
                 // One set() so the message and its run state can never be
                 // observed apart, and the draft is never cleared first.
                 set((s) => {
@@ -421,17 +457,22 @@ export const useChatStore = create<ChatState>()(
             },
 
             markMessageFailed: (localId, errorMessage, errorReason) => {
-                // This send is over and will never name an id, so whatever it
-                // was holding belongs to somebody else and must be shown. Only
-                // for the owning bubble: a stale rejection for another send
-                // says nothing, exactly as the guard below already treats it.
-                if (ownsPendingEcho(useChatStore.getState(), localId)) {
-                    useChatStore.getState().flushPendingEcho();
-                }
                 const current = useChatStore.getState().messages;
                 const target = current.find((m) => m.localId === localId);
                 if (!target || target.role !== 'user' || target.status !== 'sending') {
                     return false;
+                }
+                // Only past this point does the send actually get marked
+                // failed. It is over and will never name an id, so if it was
+                // the bubble the held echo was waiting on, whatever the echo
+                // is belongs to somebody else and must be shown now. Placed
+                // AFTER the guard above rather than before it: a call that
+                // does not actually mark anything failed (the bubble already
+                // left some other way, or was never a pending user send) must
+                // not release the buffer either, the same staleness rule the
+                // guard just enforced for the mark-failed itself.
+                if (ownsPendingEcho(useChatStore.getState(), localId)) {
+                    useChatStore.getState().flushPendingEcho();
                 }
                 set((state) => ({
                     messages: state.messages.map((m) =>
@@ -476,7 +517,11 @@ export const useChatStore = create<ChatState>()(
                     // The id settles whose message it is. Equal means the
                     // bubble and the echo are one message and the echo is
                     // redundant; different means it was somebody else's and
-                    // has been waiting to be shown.
+                    // has been waiting to be shown. Discarding it here rather
+                    // than flushing it means the coalescing below keeps the
+                    // LOCAL row as the survivor, where the old echo-in-messages
+                    // coalescing (the branch just below, for the case the echo
+                    // beat this call without a hold) kept the SERVER row instead.
                     if (store.pendingEcho?.message.id === id) {
                         set({ pendingEcho: null }, false, 'discardEcho');
                     } else {

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -112,6 +112,18 @@ interface ChatState {
     // Messages
     messages: ChatMessage[];
     /**
+     * The server's echo of a prompt we drew optimistically, held back until
+     * the POST names an id and settles whose message it is. Matching on text
+     * instead would fold another client's identical message into our bubble
+     * and delete it, so identity has to come from the id, which only the POST
+     * response can supply.
+     *
+     * `localId` names the bubble this echo is waiting on. A signal about any
+     * other bubble (a stale rejection, a later send) says nothing about this
+     * echo and must leave it held.
+     */
+    pendingEcho: { message: ChatMessage; sessionId: number; localId: string } | null;
+    /**
      * The conversation whose transcript is currently in `messages`. `null`
      * until the first transcript arrives; the webview shows the loader until
      * this matches the open conversation.
@@ -198,6 +210,7 @@ interface ChatState {
     removeMessage: (localId: string) => void;
     /** Stamps a still-pending optimistic user bubble with its server id and `status: 'sent'`. No-op if no such bubble exists. */
     confirmSentMessage: (localId: string, id: number) => void;
+    flushPendingEcho: () => void;
     setOpenSessionError: (message: string | null) => void;
 
     // Streaming actions
@@ -246,6 +259,22 @@ function upsertMessage(messages: ChatMessage[], message: ChatMessage): ChatMessa
     return [...messages, message];
 }
 
+/**
+ * The one optimistic user bubble waiting for its id, if there is exactly one.
+ * An error bubble is not waiting for anything, so it does not count.
+ */
+function soleSendingBubble(messages: ChatMessage[]): ChatMessage | undefined {
+    const pending = messages.filter(
+        (m) => m.role === 'user' && m.id === undefined && m.status === 'sending',
+    );
+    return pending.length === 1 ? pending[0] : undefined;
+}
+
+/** The held echo is waiting on exactly this bubble. */
+function ownsPendingEcho(state: ChatState, localId: string): boolean {
+    return state.pendingEcho?.localId === localId;
+}
+
 export const useChatStore = create<ChatState>()(
     devtools(
         (set) => ({
@@ -271,6 +300,7 @@ export const useChatStore = create<ChatState>()(
             composerText: '',
             openSessionError: null,
             messages: [],
+            pendingEcho: null,
             loadedSessionId: null,
             streaming: IDLE_STREAMING,
             liveDraft: null,
@@ -335,8 +365,20 @@ export const useChatStore = create<ChatState>()(
             },
 
             addMessage: (message, sessionId) => {
-                if (sessionId !== undefined && sessionId !== useChatStore.getState().currentSessionId) { return; }
-                set((state) => ({ messages: upsertMessage(state.messages, message) }), false, 'addMessage');
+                const state = useChatStore.getState();
+                if (sessionId !== undefined && sessionId !== state.currentSessionId) { return; }
+                const owner = message.role === 'user' && message.id !== undefined && state.pendingEcho === null
+                    ? soleSendingBubble(state.messages)
+                    : undefined;
+                if (owner && state.currentSessionId !== null) {
+                    set(
+                        { pendingEcho: { message, sessionId: state.currentSessionId, localId: owner.localId } },
+                        false,
+                        'holdEcho',
+                    );
+                    return;
+                }
+                set((s) => ({ messages: upsertMessage(s.messages, message) }), false, 'addMessage');
             },
 
             applyRunUi: (projection) => {
@@ -379,6 +421,13 @@ export const useChatStore = create<ChatState>()(
             },
 
             markMessageFailed: (localId, errorMessage, errorReason) => {
+                // This send is over and will never name an id, so whatever it
+                // was holding belongs to somebody else and must be shown. Only
+                // for the owning bubble: a stale rejection for another send
+                // says nothing, exactly as the guard below already treats it.
+                if (ownsPendingEcho(useChatStore.getState(), localId)) {
+                    useChatStore.getState().flushPendingEcho();
+                }
                 const current = useChatStore.getState().messages;
                 const target = current.find((m) => m.localId === localId);
                 if (!target || target.role !== 'user' || target.status !== 'sending') {
@@ -395,12 +444,45 @@ export const useChatStore = create<ChatState>()(
             },
 
             removeMessage: (localId) => {
+                // Only when the bubble that was waiting is the one going away.
+                // A retry removes the PREVIOUS failed bubble first
+                // (IrisChatView.tsx:341), which must not release anything.
+                if (ownsPendingEcho(useChatStore.getState(), localId)) {
+                    useChatStore.getState().flushPendingEcho();
+                }
                 set((state) => ({
                     messages: state.messages.filter((m) => m.localId !== localId),
                 }), false, 'removeMessage');
             },
 
+            flushPendingEcho: () => {
+                const held = useChatStore.getState().pendingEcho;
+                if (!held) { return; }
+                set((s) => ({
+                    // Only into the conversation it was captured in. A held
+                    // echo whose conversation has been left is already part of
+                    // the transcript the server hands over on the way back, so
+                    // dropping it there loses nothing.
+                    messages: held.sessionId === s.currentSessionId
+                        ? upsertMessage(s.messages, held.message)
+                        : s.messages,
+                    pendingEcho: null,
+                }), false, 'flushPendingEcho');
+            },
+
             confirmSentMessage: (localId, id) => {
+                const store = useChatStore.getState();
+                if (ownsPendingEcho(store, localId)) {
+                    // The id settles whose message it is. Equal means the
+                    // bubble and the echo are one message and the echo is
+                    // redundant; different means it was somebody else's and
+                    // has been waiting to be shown.
+                    if (store.pendingEcho?.message.id === id) {
+                        set({ pendingEcho: null }, false, 'discardEcho');
+                    } else {
+                        store.flushPendingEcho();
+                    }
+                }
                 set((s) => {
                     // The echo may already be here (it can outrun the POST
                     // response). Then this bubble and that row are the SAME

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -365,6 +365,12 @@ export const useChatStore = create<ChatState>()(
                         && (state.courseId ?? null) === previous.courseId
                         ? previous.notice
                         : null,
+                    // A held echo belongs to the conversation it was captured
+                    // in. Carrying it across would show one conversation's
+                    // message in another.
+                    pendingEcho: previous.pendingEcho?.sessionId === (state.currentSessionId ?? null)
+                        ? previous.pendingEcho
+                        : null,
                 }), false, 'setIrisState');
             },
 
@@ -372,6 +378,9 @@ export const useChatStore = create<ChatState>()(
                 set({
                     messages,
                     loadedSessionId: sessionId,
+                    // The server's own transcript replaces everything we were
+                    // holding, and it already contains whatever the echo was.
+                    pendingEcho: null,
                 }, false, 'applyLoadedMessages');
             },
 

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -208,8 +208,19 @@ interface ChatState {
         errorReason: NonNullable<ChatMessage['errorReason']>,
     ) => boolean;
     removeMessage: (localId: string) => void;
-    /** Stamps a still-pending optimistic user bubble with its server id and `status: 'sent'`. No-op if no such bubble exists. */
+    /**
+     * Stamps a still-pending optimistic user bubble with its server id and
+     * `status: 'sent'`. Before that, discards or flushes `pendingEcho` if it
+     * is held for this `localId`, whether or not a matching bubble is still
+     * in `messages`: a call for a `localId` with no bubble is not a no-op
+     * when a held echo is still waiting on it.
+     */
     confirmSentMessage: (localId: string, id: number) => void;
+    /**
+     * Releases a held `pendingEcho` into `messages` (or drops it if its
+     * conversation has since been left), and clears the slot either way.
+     * A no-op when nothing is held.
+     */
     flushPendingEcho: () => void;
     setOpenSessionError: (message: string | null) => void;
 
@@ -255,7 +266,10 @@ function upsertMessage(messages: ChatMessage[], message: ChatMessage): ChatMessa
     // own POST response. It is appended, and `confirmSentMessage` resolves the
     // two into one once the response names the id. Matching on the TEXT instead
     // would fold another client's identical message into our bubble and delete
-    // it: identical text says nothing about identity.
+    // it: identical text says nothing about identity. In practice `applyCommit`
+    // holds that echo in `pendingEcho` before it ever reaches here (see
+    // `echoOwner`), so this append is the fallback for when no bubble is
+    // waiting to claim it, not the primary path.
     return [...messages, message];
 }
 
@@ -279,10 +293,11 @@ function ownsPendingEcho(state: ChatState, localId: string): boolean {
  * The bubble `message` should be held against instead of being upserted
  * straight away, if any: a user message that already carries a server id,
  * while exactly one optimistic bubble is still waiting for one and nothing
- * is held yet. Shared by both entry points our own echo can arrive through:
- * the store's `addMessage` (called directly by tests, and for the
- * optimistic bubble itself) and `applyCommit` (the real path a wire
- * `addMessage` frame is routed through, IrisChatView.tsx:140-160).
+ * is held yet. Used by `applyCommit`, the real path a wire `addMessage`
+ * frame is routed through (IrisChatView.tsx:140-160) and the only place our
+ * own echo can arrive on. The store's own `addMessage` never calls this: its
+ * only production caller draws the optimistic bubble itself, which never
+ * carries a server id.
  */
 function echoOwner(state: ChatState, message: ChatMessage): ChatMessage | undefined {
     if (message.role !== 'user' || message.id === undefined || state.pendingEcho !== null) {
@@ -392,15 +407,6 @@ export const useChatStore = create<ChatState>()(
             addMessage: (message, sessionId) => {
                 const state = useChatStore.getState();
                 if (sessionId !== undefined && sessionId !== state.currentSessionId) { return; }
-                const owner = echoOwner(state, message);
-                if (owner && state.currentSessionId !== null) {
-                    set(
-                        { pendingEcho: { message, sessionId: state.currentSessionId, localId: owner.localId } },
-                        false,
-                        'holdEcho',
-                    );
-                    return;
-                }
                 set((s) => ({ messages: upsertMessage(s.messages, message) }), false, 'addMessage');
             },
 
@@ -497,6 +503,17 @@ export const useChatStore = create<ChatState>()(
                 // Only when the bubble that was waiting is the one going away.
                 // A retry removes the PREVIOUS failed bubble first
                 // (IrisChatView.tsx:341), which must not release anything.
+                //
+                // Unlike `markMessageFailed`, this releases on `localId`
+                // ownership alone, without first checking the bubble is still
+                // in `messages`. That is safe rather than sloppy: a
+                // `pendingEcho` can only ever be armed for a bubble that WAS
+                // in `messages` at capture time (`echoOwner` reads it off
+                // `state.messages`), and every path that removes a bubble by
+                // some other means already clears `pendingEcho` itself
+                // (`applyLoadedMessages`), so there is no real route left by
+                // which `removeMessage` runs against a `localId` whose bubble
+                // is already gone while the echo is still held.
                 if (ownsPendingEcho(useChatStore.getState(), localId)) {
                     useChatStore.getState().flushPendingEcho();
                 }

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -111,6 +111,26 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         }
     }, [store.streaming.isStreaming]);
 
+    // Last resort. Deliberately above BOTH request timeouts that can run
+    // before a send settles: the POST (30s, CONFIG.API.REQUEST_TIMEOUT_MS)
+    // and, when that times out, the coordinator's reconciliation GET
+    // (sendCoordinator.ts:204), which has the same budget. A shorter deadline
+    // would race a send that is still legitimately being resolved and put
+    // back the very duplicate this removes.
+    useEffect(() => {
+        const held = store.pendingEcho;
+        if (!held) { return; }
+        const timer = setTimeout(() => {
+            // Only the hold this timer was armed for. A settled hold replaced
+            // by a newer one before React ran the cleanup would otherwise be
+            // flushed by the old timer.
+            if (useChatStore.getState().pendingEcho === held) {
+                useChatStore.getState().flushPendingEcho();
+            }
+        }, 65_000);
+        return () => clearTimeout(timer);
+    }, [store.pendingEcho]);
+
     // Message listener - handles messages from extension
     useExtensionMessage((msg) => {
         // Reads the store directly, not the render-time closure: messages

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1454,6 +1454,30 @@ describe('IrisChatView transcript keying', () => {
             .find(m => m.command === 'sendMessage');
         expect(send?.payload?.sessionId).toBe(900);
     });
+
+    it('holds the server echo of our own send instead of rendering it a second time (issue #380)', async () => {
+        // The real path: the server's echo of our own prompt arrives as an
+        // addMessage wire frame (irisWebSocketMessageHandler.ts's
+        // _renderForeignUserMessage), which IrisChatView routes through
+        // applyCommit, not through the store's addMessage.
+        const api = createMockVsCodeApi();
+        render(<IrisChatView vscodeApi={api} />);
+        dispatchExtensionMessage({ type: 'updateIrisState', state: activeState });
+        dispatchExtensionMessage(transcript(900, 'first'));
+        await screen.findByText('first');
+
+        await userEvent.type(screen.getByRole('textbox'), 'hello{Enter}');
+        await screen.findByText('hello');
+
+        dispatchExtensionMessage({
+            type: 'addMessage',
+            sessionId: 900,
+            message: { id: 91, role: 'user', content: 'hello', timestamp: 2 },
+        });
+
+        await waitFor(() => expect(useChatStore.getState().pendingEcho?.message.id).toBe(91));
+        expect(screen.getAllByText('hello')).toHaveLength(1);
+    });
 });
 
 describe('IrisChatView actions that used to read the old model', () => {

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1478,6 +1478,111 @@ describe('IrisChatView transcript keying', () => {
         await waitFor(() => expect(useChatStore.getState().pendingEcho?.message.id).toBe(91));
         expect(screen.getAllByText('hello')).toHaveLength(1);
     });
+
+    // @testing-library/react's asyncWrapper (used internally by waitFor,
+    // findBy* and every userEvent call) drains a microtask queue after each
+    // act()-wrapped operation via a Promise that only resolves through
+    // `jest.advanceTimersByTime(0)`, gated on a global `jest` object Vitest
+    // never defines (node_modules/@testing-library/react/dist/pure.js,
+    // jestFakeTimersAreEnabled). Under vi.useFakeTimers() that leaves the
+    // drain's own setTimeout unfired, so the call hangs forever regardless
+    // of the `advanceTimers` option passed to userEvent.setup. This stub is
+    // the documented workaround (vitest-dev/vitest#3184 comment by
+    // xsjcTony) for that cross-library gap; it is local to this test and
+    // restored in the finally block.
+    function installFakeTimersActShim(): () => void {
+        const previous = (globalThis as { jest?: unknown }).jest;
+        (globalThis as { jest?: unknown }).jest = {
+            ...(previous as object ?? {}),
+            advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
+        };
+        return () => {
+            (globalThis as { jest?: unknown }).jest = previous;
+        };
+    }
+
+    it('shows a held echo again if the send never settles', async () => {
+        vi.useFakeTimers();
+        const restoreJestShim = installFakeTimersActShim();
+        try {
+            const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+            const api = createMockVsCodeApi();
+            render(<IrisChatView vscodeApi={api} />);
+            dispatchExtensionMessage({ type: 'updateIrisState', state: { ...activeState } });
+            dispatchExtensionMessage({
+                type: 'loadMessages',
+                sessionId: activeState.currentSessionId,
+                messages: [],
+            });
+            // The dispatch above lands outside act() (it goes through the
+            // window message listener, not a userEvent/RTL helper), so the
+            // composer's disabled flag has not necessarily re-rendered into
+            // the DOM yet. Typing into it before it actually flips would
+            // silently no-op, which is indistinguishable from a hang once
+            // fake timers are active.
+            await waitFor(() => expect(screen.getByRole('textbox')).not.toBeDisabled());
+
+            await user.type(screen.getByRole('textbox'), 'hi{Enter}');
+            dispatchExtensionMessage({
+                type: 'addMessage',
+                sessionId: activeState.currentSessionId,
+                message: { id: 91, role: 'user', content: 'hi', timestamp: 2 },
+            });
+            expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+            // The dispatch above lands outside act() too, so the view's own
+            // last-resort effect (which reads `store.pendingEcho` from the
+            // component's render, not straight off the store) has not
+            // necessarily re-rendered and armed its timer for THIS hold yet.
+            // Flush that render before advancing the clock, or the timer
+            // that fires below may still be the old (unarmed) one.
+            await act(async () => {});
+
+            // Neither a confirmation nor a rejection ever arrives.
+            await act(async () => { vi.advanceTimersByTime(70_000); });
+
+            expect(useChatStore.getState().pendingEcho).toBeNull();
+            expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+        } finally {
+            restoreJestShim();
+            vi.useRealTimers();
+        }
+    });
+
+    it('an expired timer does not flush a newer hold', async () => {
+        vi.useFakeTimers();
+        const restoreJestShim = installFakeTimersActShim();
+        try {
+            render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
+            // `makeIrisState` lives in useChatStore.test.ts; this file drives
+            // the store through the wire message the view already handles.
+            dispatchExtensionMessage({ type: 'updateIrisState', state: { ...activeState } });
+            const session = activeState.currentSessionId as number;
+            const store = useChatStore.getState();
+
+            store.addMessage({ localId: 'local-1', role: 'user', content: 'a', timestamp: 1, status: 'sending' }, session);
+            store.addMessage({ id: 91, localId: 'echo-a', role: 'user', content: 'a', timestamp: 2 }, session);
+            // Flush so the component actually renders with this hold and
+            // arms ITS OWN timer for it, rather than skipping straight to
+            // whatever pendingEcho happens to be by the time React next
+            // renders (which the two mutations below would otherwise let it
+            // do, defeating the point of this test).
+            await act(async () => {});
+            await act(async () => { vi.advanceTimersByTime(64_000); });
+
+            // The first hold settles, a second one is taken, and the first timer
+            // is still a second away from firing.
+            useChatStore.getState().confirmSentMessage('local-1', 91);
+            store.addMessage({ localId: 'local-2', role: 'user', content: 'b', timestamp: 3, status: 'sending' }, session);
+            store.addMessage({ id: 92, localId: 'echo-b', role: 'user', content: 'b', timestamp: 4 }, session);
+            await act(async () => {});
+            await act(async () => { vi.advanceTimersByTime(2_000); });
+
+            expect(useChatStore.getState().pendingEcho?.message.id).toBe(92);
+        } finally {
+            restoreJestShim();
+            vi.useRealTimers();
+        }
+    });
 });
 
 describe('IrisChatView actions that used to read the old model', () => {

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1479,82 +1479,53 @@ describe('IrisChatView transcript keying', () => {
         expect(screen.getAllByText('hello')).toHaveLength(1);
     });
 
-    // @testing-library/react's asyncWrapper (used internally by waitFor,
-    // findBy* and every userEvent call) drains a microtask queue after each
-    // act()-wrapped operation via a Promise that only resolves through
-    // `jest.advanceTimersByTime(0)`, gated on a global `jest` object Vitest
-    // never defines (node_modules/@testing-library/react/dist/pure.js,
-    // jestFakeTimersAreEnabled). Under vi.useFakeTimers() that leaves the
-    // drain's own setTimeout unfired, so the call hangs forever regardless
-    // of the `advanceTimers` option passed to userEvent.setup. This stub is
-    // the documented workaround (vitest-dev/vitest#3184 comment by
-    // xsjcTony) for that cross-library gap; it is local to this test and
-    // restored in the finally block.
-    function installFakeTimersActShim(): () => void {
-        const previous = (globalThis as { jest?: unknown }).jest;
-        (globalThis as { jest?: unknown }).jest = {
-            ...(previous as object ?? {}),
-            advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
-        };
-        return () => {
-            (globalThis as { jest?: unknown }).jest = previous;
-        };
-    }
+    // Both tests below drive the store directly (like the rest of this
+    // describe block's neighbours in useChatStore.test.ts) rather than
+    // through the composer. Their subject is the last-resort TIMER, not the
+    // send path (Task 3 covers that end to end), and driving through
+    // userEvent would additionally require working around a real, documented
+    // incompatibility between @testing-library/react's async helpers and
+    // Vitest fake timers (vitest-dev/vitest#3184: `waitFor`/`findBy*`/every
+    // userEvent call hangs forever under vi.useFakeTimers(), because RTL's
+    // internal drain only advances a global `jest.advanceTimersByTime` that
+    // Vitest never defines). Driving the store directly sidesteps that
+    // entirely, since plain `act()` does not go through that code path.
 
     it('shows a held echo again if the send never settles', async () => {
         vi.useFakeTimers();
-        const restoreJestShim = installFakeTimersActShim();
         try {
-            const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-            const api = createMockVsCodeApi();
-            render(<IrisChatView vscodeApi={api} />);
+            render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
             dispatchExtensionMessage({ type: 'updateIrisState', state: { ...activeState } });
-            dispatchExtensionMessage({
-                type: 'loadMessages',
-                sessionId: activeState.currentSessionId,
-                messages: [],
-            });
-            // The dispatch above lands outside act() (it goes through the
-            // window message listener, not a userEvent/RTL helper), so the
-            // composer's disabled flag has not necessarily re-rendered into
-            // the DOM yet. Typing into it before it actually flips would
-            // silently no-op, which is indistinguishable from a hang once
-            // fake timers are active.
-            await waitFor(() => expect(screen.getByRole('textbox')).not.toBeDisabled());
+            const session = activeState.currentSessionId as number;
+            const store = useChatStore.getState();
 
-            await user.type(screen.getByRole('textbox'), 'hi{Enter}');
-            dispatchExtensionMessage({
-                type: 'addMessage',
-                sessionId: activeState.currentSessionId,
-                message: { id: 91, role: 'user', content: 'hi', timestamp: 2 },
-            });
+            store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, session);
+            store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, session);
             expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
-            // The dispatch above lands outside act() too, so the view's own
-            // last-resort effect (which reads `store.pendingEcho` from the
-            // component's render, not straight off the store) has not
-            // necessarily re-rendered and armed its timer for THIS hold yet.
-            // Flush that render before advancing the clock, or the timer
-            // that fires below may still be the old (unarmed) one.
+            // Flush so the component actually renders with this hold and
+            // arms its own timer for it, rather than the effect never having
+            // mounted at all by the time the clock below is advanced. A
+            // plain synchronous act(() => {}) does not reliably force this
+            // component's pending update through (its state changes arrive
+            // via a Zustand subscription, not a React-owned event, so React
+            // schedules the commit on its normal, non-blocking scheduler);
+            // awaiting an async act() does.
             await act(async () => {});
 
             // Neither a confirmation nor a rejection ever arrives.
-            await act(async () => { vi.advanceTimersByTime(70_000); });
+            act(() => { vi.advanceTimersByTime(70_000); });
 
             expect(useChatStore.getState().pendingEcho).toBeNull();
             expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
         } finally {
-            restoreJestShim();
             vi.useRealTimers();
         }
     });
 
     it('an expired timer does not flush a newer hold', async () => {
         vi.useFakeTimers();
-        const restoreJestShim = installFakeTimersActShim();
         try {
             render(<IrisChatView vscodeApi={createMockVsCodeApi()} />);
-            // `makeIrisState` lives in useChatStore.test.ts; this file drives
-            // the store through the wire message the view already handles.
             dispatchExtensionMessage({ type: 'updateIrisState', state: { ...activeState } });
             const session = activeState.currentSessionId as number;
             const store = useChatStore.getState();
@@ -1565,21 +1536,28 @@ describe('IrisChatView transcript keying', () => {
             // arms ITS OWN timer for it, rather than skipping straight to
             // whatever pendingEcho happens to be by the time React next
             // renders (which the two mutations below would otherwise let it
-            // do, defeating the point of this test).
+            // do, defeating the point of this test). A plain synchronous
+            // act(() => {}) does not reliably force this component's pending
+            // update through (its state changes arrive via a Zustand
+            // subscription, not a React-owned event, so React schedules the
+            // commit on its normal, non-blocking scheduler); awaiting an
+            // async act() does.
             await act(async () => {});
             await act(async () => { vi.advanceTimersByTime(64_000); });
 
-            // The first hold settles, a second one is taken, and the first timer
-            // is still a second away from firing.
+            // The first hold settles, a second one is taken, and the first
+            // timer is still a second away from firing. Deliberately no
+            // flush between these store mutations and the advance below:
+            // React's re-render (and the cleanup that would cancel timer A)
+            // is only SCHEDULED by these synchronous store calls, not run
+            // yet, so timer A is still live when the clock crosses t=65s.
             useChatStore.getState().confirmSentMessage('local-1', 91);
             store.addMessage({ localId: 'local-2', role: 'user', content: 'b', timestamp: 3, status: 'sending' }, session);
             store.addMessage({ id: 92, localId: 'echo-b', role: 'user', content: 'b', timestamp: 4 }, session);
-            await act(async () => {});
-            await act(async () => { vi.advanceTimersByTime(2_000); });
+            act(() => { vi.advanceTimersByTime(2_000); });
 
             expect(useChatStore.getState().pendingEcho?.message.id).toBe(92);
         } finally {
-            restoreJestShim();
             vi.useRealTimers();
         }
     });

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1520,7 +1520,7 @@ describe('IrisChatView transcript keying', () => {
             const store = useChatStore.getState();
 
             store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, session);
-            store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, session);
+            store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, session);
             expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
             // Flush so the component actually renders with this hold and
             // arms its own timer for it, rather than the effect never having
@@ -1551,7 +1551,7 @@ describe('IrisChatView transcript keying', () => {
             const store = useChatStore.getState();
 
             store.addMessage({ localId: 'local-1', role: 'user', content: 'a', timestamp: 1, status: 'sending' }, session);
-            store.addMessage({ id: 91, localId: 'echo-a', role: 'user', content: 'a', timestamp: 2 }, session);
+            store.applyCommit({ id: 91, localId: 'echo-a', role: 'user', content: 'a', timestamp: 2 }, undefined, session);
             // Flush so the component actually renders with this hold and
             // arms ITS OWN timer for it, rather than skipping straight to
             // whatever pendingEcho happens to be by the time React next
@@ -1573,7 +1573,7 @@ describe('IrisChatView transcript keying', () => {
             // yet, so timer A is still live when the clock crosses t=65s.
             useChatStore.getState().confirmSentMessage('local-1', 91);
             store.addMessage({ localId: 'local-2', role: 'user', content: 'b', timestamp: 3, status: 'sending' }, session);
-            store.addMessage({ id: 92, localId: 'echo-b', role: 'user', content: 'b', timestamp: 4 }, session);
+            store.applyCommit({ id: 92, localId: 'echo-b', role: 'user', content: 'b', timestamp: 4 }, undefined, session);
             act(() => { vi.advanceTimersByTime(2_000); });
 
             expect(useChatStore.getState().pendingEcho?.message.id).toBe(92);

--- a/extension/test/react/components/irisChatConversationFirst.test.tsx
+++ b/extension/test/react/components/irisChatConversationFirst.test.tsx
@@ -1455,11 +1455,12 @@ describe('IrisChatView transcript keying', () => {
         expect(send?.payload?.sessionId).toBe(900);
     });
 
-    it('holds the server echo of our own send instead of rendering it a second time (issue #380)', async () => {
+    it('never shows the student their own message twice, even when the echo beats the response (issue #380)', async () => {
         // The real path: the server's echo of our own prompt arrives as an
         // addMessage wire frame (irisWebSocketMessageHandler.ts's
         // _renderForeignUserMessage), which IrisChatView routes through
-        // applyCommit, not through the store's addMessage.
+        // applyCommit, not through the store's addMessage. The POST response
+        // that names the message follows later as confirmSentMessage.
         const api = createMockVsCodeApi();
         render(<IrisChatView vscodeApi={api} />);
         dispatchExtensionMessage({ type: 'updateIrisState', state: activeState });
@@ -1469,13 +1470,32 @@ describe('IrisChatView transcript keying', () => {
         await userEvent.type(screen.getByRole('textbox'), 'hello{Enter}');
         await screen.findByText('hello');
 
+        const localId = getPostMessageCalls(api)
+            .map(([m]) => m as { command?: string; payload?: { localId?: string } })
+            .find(m => m.command === 'sendMessage')?.payload?.localId as string;
+
+        // The websocket echo wins the race.
         dispatchExtensionMessage({
             type: 'addMessage',
             sessionId: 900,
             message: { id: 91, role: 'user', content: 'hello', timestamp: 2 },
         });
 
-        await waitFor(() => expect(useChatStore.getState().pendingEcho?.message.id).toBe(91));
+        // This is the window the student sees. It must not contain two.
+        // Waited, not asserted bare: the store update from the dispatched
+        // event above lands outside React's `act`, so an immediate query can
+        // observe the DOM before the echo has actually rendered, letting a
+        // real duplicate slip past an unwaited assertion.
+        await waitFor(() => expect(screen.getAllByText('hello')).toHaveLength(1));
+
+        // The POST response arrives after, naming the message.
+        dispatchExtensionMessage({
+            type: 'confirmSentMessage',
+            sessionId: 900,
+            localId,
+            id: 91,
+        });
+
         expect(screen.getAllByText('hello')).toHaveLength(1);
     });
 

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -758,8 +758,10 @@ describe('useChatStore', () => {
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
 
-			// The server pushes our own prompt to every client, including us.
-			store.addMessage({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			// The server pushes our own prompt to every client, including us,
+			// through applyCommit: the real path a wire addMessage frame is
+			// routed through (IrisChatView.tsx:140-160).
+			store.applyCommit({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
 			expect(users).toHaveLength(1);
@@ -793,7 +795,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			useChatStore.getState().confirmSentMessage('local-1', 55);
 
@@ -809,7 +811,7 @@ describe('useChatStore', () => {
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
 			// Same text, another client. Only the id can tell them apart.
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			useChatStore.getState().confirmSentMessage('local-1', 55);
 
@@ -822,7 +824,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			useChatStore.getState().markMessageFailed('local-1', 'nope', 'iris-unavailable');
 
@@ -834,7 +836,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			// A rejection for an older send that has long since left the screen, and a
 			// confirmation for one too. Neither says anything about local-1's echo.
@@ -850,7 +852,7 @@ describe('useChatStore', () => {
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'failed-earlier', role: 'user', content: 'old', timestamp: 0, status: 'error' }, 7);
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			// Retrying an older failed send removes its bubble first (IrisChatView.tsx:341).
 			useChatStore.getState().removeMessage('failed-earlier');
@@ -862,7 +864,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			useChatStore.getState().removeMessage('local-1');
 
@@ -874,8 +876,8 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo-a', role: 'user', content: 'hi', timestamp: 2 }, 7);
-			store.addMessage({ id: 92, localId: 'echo-b', role: 'user', content: 'also hi', timestamp: 3 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo-a', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
+			store.applyCommit({ id: 92, localId: 'echo-b', role: 'user', content: 'also hi', timestamp: 3 }, undefined, 7);
 
 			// One slot. The second echo cannot be the one we are waiting on as well,
 			// and confirmSentMessage folds it by id if it turns out to be ours.
@@ -944,7 +946,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
 
 			useChatStore.setState({ messages: [] });
@@ -959,7 +961,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			// A reload hands over the server's transcript, which already contains it:
 			// the host records every websocket message before rendering it
@@ -976,7 +978,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			store.setIrisState(makeIrisState({ currentSessionId: 8 }));
 
@@ -987,7 +989,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			// Snapshots arrive for many reasons while a send is in flight.
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
@@ -999,7 +1001,7 @@ describe('useChatStore', () => {
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
-			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.applyCommit({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, undefined, 7);
 
 			// Reconciliation, not proof that this POST settled.
 			useChatStore.getState().mergeLoadedMessages(7, [

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -752,6 +752,138 @@ describe('useChatStore', () => {
 		});
 	});
 
+	describe('pendingEcho', () => {
+		it('holds the server echo while the optimistic bubble is still waiting for its id', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+
+			// The server pushes our own prompt to every client, including us.
+			store.addMessage({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
+			expect(users).toHaveLength(1);
+			expect(users[0].localId).toBe('local-1');
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(55);
+			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
+		});
+
+		it('appends an echo when no send is in flight', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'from the web client', timestamp: 2 }, 7);
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('does not treat a failed bubble left on screen as a send in flight', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'error' }, 7);
+
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('discards the held echo when the POST names the same message', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			useChatStore.getState().confirmSentMessage('local-1', 55);
+
+			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
+			expect(users).toHaveLength(1);
+			expect(users[0].id).toBe(55);
+			expect(users[0].status).toBe('sent');
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('renders the held echo when the POST names a different message', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			// Same text, another client. Only the id can tell them apart.
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			useChatStore.getState().confirmSentMessage('local-1', 55);
+
+			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
+			expect(users.map((m) => m.id).sort()).toEqual([55, 91]);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('renders the held echo when the owning send fails', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			useChatStore.getState().markMessageFailed('local-1', 'nope', 'iris-unavailable');
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('keeps holding when a signal names a bubble that does not own the echo', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			// A rejection for an older send that has long since left the screen, and a
+			// confirmation for one too. Neither says anything about local-1's echo.
+			useChatStore.getState().markMessageFailed('local-0', 'stale', 'iris-unavailable');
+			useChatStore.getState().confirmSentMessage('local-0', 42);
+
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(false);
+		});
+
+		it('keeps holding when an unrelated error bubble is removed', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'failed-earlier', role: 'user', content: 'old', timestamp: 0, status: 'error' }, 7);
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			// Retrying an older failed send removes its bubble first (IrisChatView.tsx:341).
+			useChatStore.getState().removeMessage('failed-earlier');
+
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+		});
+
+		it('renders the held echo when the owning bubble itself is removed', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			useChatStore.getState().removeMessage('local-1');
+
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('appends a second echo instead of replacing the held one', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo-a', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			store.addMessage({ id: 92, localId: 'echo-b', role: 'user', content: 'also hi', timestamp: 3 }, 7);
+
+			// One slot. The second echo cannot be the one we are waiting on as well,
+			// and confirmSentMessage folds it by id if it turns out to be ours.
+			expect(useChatStore.getState().messages.some((m) => m.id === 92)).toBe(true);
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+		});
+	});
+
 	// The store mirrors ONE server conversation. These tests pin that surface
 	// in isolation, driven directly through setIrisState and the actions.
 	describe('conversation mirror', () => {

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -929,14 +929,12 @@ describe('useChatStore', () => {
 			expect(useChatStore.getState().lastRunUiRevision).toBe(1);
 		});
 
-		it('does not release the buffer when markMessageFailed does not actually mark a bubble failed', () => {
-			// The bubble the echo is waiting on can leave the list some other
-			// way (e.g. applyLoadedMessages replacing the transcript wholesale
-			// during reconnect reconciliation) without going through
-			// removeMessage's owner-bound release. A later, stale
-			// markMessageFailed for that localId must not release the buffer
-			// either: the buffer is supposed to honour the exact same
-			// staleness rule the function's own guard already enforces.
+		it('a stale markMessageFailed after applyLoadedMessages already cleared the buffer stays inert', () => {
+			// applyLoadedMessages now clears the buffer itself (see the
+			// "drops a held echo when the transcript is replaced" test), so
+			// by the time this stale markMessageFailed runs there is nothing
+			// left to release. It must still report no match and must not
+			// resurrect or otherwise touch a buffer that is already empty.
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
@@ -944,10 +942,65 @@ describe('useChatStore', () => {
 			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
 
 			store.applyLoadedMessages(7, []);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
 
 			const returnValue = useChatStore.getState().markMessageFailed('local-1', 'stale', 'iris-unavailable');
 
 			expect(returnValue).toBe(false);
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('drops a held echo when the transcript is replaced', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			// A reload hands over the server's transcript, which already contains it:
+			// the host records every websocket message before rendering it
+			// (irisWebSocketMessageHandler.ts:101).
+			useChatStore.getState().applyLoadedMessages(7, [
+				{ id: 91, localId: 'server', role: 'user', content: 'hi', timestamp: 2 },
+			]);
+
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+			expect(useChatStore.getState().messages.filter((m) => m.id === 91)).toHaveLength(1);
+		});
+
+		it('drops a held echo when the open conversation changes', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			store.setIrisState(makeIrisState({ currentSessionId: 8 }));
+
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+		});
+
+		it('keeps a held echo across a snapshot for the same conversation', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			// Snapshots arrive for many reasons while a send is in flight.
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+		});
+
+		it('does not release a held echo on a reconnect merge', () => {
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+
+			// Reconciliation, not proof that this POST settled.
+			useChatStore.getState().mergeLoadedMessages(7, [
+				{ id: 91, localId: 'server', role: 'user', content: 'hi', timestamp: 2 },
+			]);
+
 			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
 		});
 	});

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -814,7 +814,7 @@ describe('useChatStore', () => {
 			useChatStore.getState().confirmSentMessage('local-1', 55);
 
 			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
-			expect(users.map((m) => m.id).sort()).toEqual([55, 91]);
+			expect(users.map((m) => m.id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([55, 91]);
 			expect(useChatStore.getState().pendingEcho).toBeNull();
 		});
 
@@ -880,6 +880,74 @@ describe('useChatStore', () => {
 			// One slot. The second echo cannot be the one we are waiting on as well,
 			// and confirmSentMessage folds it by id if it turns out to be ours.
 			expect(useChatStore.getState().messages.some((m) => m.id === 92)).toBe(true);
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
+		});
+
+		it('holds the server echo when it arrives through applyCommit, the real production path', () => {
+			// IrisChatView routes every addMessage wire frame (including the
+			// server's echo of our own prompt) through applyCommit, never
+			// through the store's addMessage (IrisChatView.tsx:140-160). The
+			// store's own addMessage is only ever called for the optimistic
+			// bubble (IrisChatView.tsx:320), which never carries a server id,
+			// so a hold that lives only in addMessage can never fire in
+			// production. A user echo carries no run-UI projection
+			// (irisWebSocketMessageHandler.ts's _renderForeignUserMessage
+			// sends none), which is the shape asserted here.
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+
+			store.applyCommit(
+				{ id: 55, localId: 'echo', role: 'user', content: 'hi', timestamp: 2, status: 'sent' },
+				undefined,
+				7,
+			);
+
+			const users = useChatStore.getState().messages.filter((m) => m.role === 'user');
+			expect(users).toHaveLength(1);
+			expect(users[0].localId).toBe('local-1');
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(55);
+			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
+		});
+
+		it('does not hold a commit that carries a run-UI projection, even if it looks like an echo', () => {
+			// The hold is scoped to the projection-less case on purpose: a
+			// commit with a projection attached must keep applying it
+			// atomically, which is applyCommit's entire reason to exist.
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+
+			store.applyCommit(
+				{ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2, status: 'sent' },
+				{ sessionId: 7, revision: 1, draft: null, activities: [], waiting: false, runState: null },
+				7,
+			);
+
+			expect(useChatStore.getState().pendingEcho).toBeNull();
+			expect(useChatStore.getState().messages.some((m) => m.id === 91)).toBe(true);
+			expect(useChatStore.getState().lastRunUiRevision).toBe(1);
+		});
+
+		it('does not release the buffer when markMessageFailed does not actually mark a bubble failed', () => {
+			// The bubble the echo is waiting on can leave the list some other
+			// way (e.g. applyLoadedMessages replacing the transcript wholesale
+			// during reconnect reconciliation) without going through
+			// removeMessage's owner-bound release. A later, stale
+			// markMessageFailed for that localId must not release the buffer
+			// either: the buffer is supposed to honour the exact same
+			// staleness rule the function's own guard already enforces.
+			const store = useChatStore.getState();
+			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
+			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
+			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
+			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
+
+			store.applyLoadedMessages(7, []);
+
+			const returnValue = useChatStore.getState().markMessageFailed('local-1', 'stale', 'iris-unavailable');
+
+			expect(returnValue).toBe(false);
 			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
 		});
 	});

--- a/extension/test/react/stores/useChatStore.test.ts
+++ b/extension/test/react/stores/useChatStore.test.ts
@@ -929,25 +929,30 @@ describe('useChatStore', () => {
 			expect(useChatStore.getState().lastRunUiRevision).toBe(1);
 		});
 
-		it('a stale markMessageFailed after applyLoadedMessages already cleared the buffer stays inert', () => {
-			// applyLoadedMessages now clears the buffer itself (see the
-			// "drops a held echo when the transcript is replaced" test), so
-			// by the time this stale markMessageFailed runs there is nothing
-			// left to release. It must still report no match and must not
-			// resurrect or otherwise touch a buffer that is already empty.
+		it('does not release the buffer when markMessageFailed does not actually mark a bubble failed', () => {
+			// The bubble the echo is waiting on can leave the messages array
+			// some other way (e.g. a reconnect wholesale-replacing it)
+			// without going through removeMessage's owner-bound release AND
+			// without going through applyLoadedMessages (which now clears the
+			// buffer itself, see the "drops a held echo when the transcript
+			// is replaced" test, so it can no longer stand in for this
+			// scenario). Forced directly via setState to isolate exactly
+			// that: the bubble is gone, the buffer is untouched. A later,
+			// stale markMessageFailed for that localId must not release the
+			// buffer either: the buffer is supposed to honour the exact same
+			// staleness rule the function's own guard already enforces.
 			const store = useChatStore.getState();
 			store.setIrisState(makeIrisState({ currentSessionId: 7 }));
 			store.addMessage({ localId: 'local-1', role: 'user', content: 'hi', timestamp: 1, status: 'sending' }, 7);
 			store.addMessage({ id: 91, localId: 'echo', role: 'user', content: 'hi', timestamp: 2 }, 7);
 			expect(useChatStore.getState().pendingEcho?.localId).toBe('local-1');
 
-			store.applyLoadedMessages(7, []);
-			expect(useChatStore.getState().pendingEcho).toBeNull();
+			useChatStore.setState({ messages: [] });
 
 			const returnValue = useChatStore.getState().markMessageFailed('local-1', 'stale', 'iris-unavailable');
 
 			expect(returnValue).toBe(false);
-			expect(useChatStore.getState().pendingEcho).toBeNull();
+			expect(useChatStore.getState().pendingEcho?.message.id).toBe(91);
 		});
 
 		it('drops a held echo when the transcript is replaced', () => {


### PR DESCRIPTION
Closes #380.

Send a message and, for a moment, two copies of it are on screen. Three things race for the same message: the webview draws an optimistic bubble immediately, Artemis pushes the message over the websocket because other clients have to see it, and the POST response comes back and names the id. When the push wins, both are rendered until `confirmSentMessage` folds them. On a fast server it is a blink; on a slow one it is plainly visible.

## Why the two obvious fixes are wrong

**Suppress user frames while our own send is in flight.** `sendInFlight` is set before file collection and stays set through the POST and its reconciliation, and another client can write throughout. Nothing re-delivers the transcript when a send settles, so a suppressed foreign message is lost for good.

**Match the echo against the optimistic bubble by text.** Two clients can legitimately send the same string. Folding on text would delete somebody else's message.

## What this does instead

The echo is **held**, not dropped. While exactly one optimistic bubble is waiting for its id, an incoming user message with an id goes into a single-slot buffer instead of the transcript. The id then settles whose message it is:

- the POST names that id: the echo is redundant, discard it;
- the POST names a different id: it was somebody else, render it;
- the send fails, or the bubble goes away: render it.

Nothing is lost on any path, and identity never comes from the text. The buffer records the `localId` of the bubble it is waiting on, so a stale rejection or a confirmation for a different send cannot release it, which is the same rule `markMessageFailed` already applies to its own bubble.

It is cleared when the server's transcript replaces the list and when the conversation changes. A 65-second timer in the view is the last resort: it clears both the POST's 30-second timeout and the reconciliation GET that can follow it, so the send settling normally wins the race, and the timer only fires when the send never answers at all.

## Review

Three tasks, each with its own review, plus a whole-branch review. Four defects in the plan were found by executing it, and two of them are worth naming because a green suite hid them:

**The first implementation could not work.** The hold was placed in the store's `addMessage`, which the echo never reaches: the wire message arrives through `applyCommit`. All ten tests passed because they called the store action directly with a shape production never produces. The fix moved the capture to the real path and added a test that goes through the view.

**Two tests were green without testing their subject.** One asserted the same null twice, so no change to the code under test could fail it. The other had an `act()` flush between the store mutations and the clock advance, which let React cancel the stale timer before it could fire, so the test proved React's cleanup rather than the guard in its title. Both were re-pinned and mutation-verified.

The whole-branch review then found that the capture in `addMessage`, kept for symmetry, had made the suite blind: with the real capture disabled, exactly one store test failed. It is deleted, the tests are armed through `applyCommit`, and the same mutation now fails eight.

Every guarantee on this branch is mutation-verified.

## Verification

`npm run compile`, `npm run lint`, `npx knip` clean; 1268 webview tests and 1505 host tests, no failures.

## Not in scope

The provider's outer send catch reports an error without emitting a rejection, so an exceptional failure there leaves the optimistic bubble pending. That is pre-existing and strands the bubble, not just the buffer; the timer keeps the buffer from being held forever on that path. It belongs in its own issue.
