### PR TITLE
Iris chat: let students type while Iris is answering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 - **Iris chat follows Artemis' conversations:** One conversation at a time, exactly the one the server has. Changing the topic now stays in that conversation and is written into the transcript as a divider instead of opening a second one; the `+` in the header starts a fresh conversation. Messages you write in the Artemis web client show up here as they arrive, and a course whose instructor has switched Iris off can be opened and says so.
 - **WebSocket status bar:** Removed the `artemis.showWebSocketStatusBar` setting. The connection indicator now appears automatically only when there is a problem; enable `artemis.developerMode` to keep it always visible with full diagnostics on hover. When the connection drops, students now see a plain-language explanation (no "WS" jargon) instead of a technical label.
 - **Server URL change:** Removed the manual "Clear Credentials" prompts that appeared when the Artemis server URL changed. Changing the server while logged in now logs you out automatically and returns you to the login view (a session is not valid across servers); the logout command remains for clearing credentials on demand.
+- **While Iris is answering:** You can already type your next message. You send it yourself once the answer is there.
 
 ### Fixed
 

--- a/extension/src/extension/services/iris/conversation/sendCoordinator.ts
+++ b/extension/src/extension/services/iris/conversation/sendCoordinator.ts
@@ -111,6 +111,15 @@ export class SendCoordinator {
         let generation: number | undefined;
         let postStarted = false;
         try {
+            // The webview mirrors `sendInFlight` and gates its composer on it,
+            // but nothing published the ACQUISITION: the only other
+            // notifyChanged is in the finally below, so the flag could travel
+            // exclusively as `false`. Inside the try, after both mutations, for
+            // the same reason the try opens here: a listener that throws
+            // synchronously must not skip the finally and latch the lock
+            // forever. `beginGeneration` is run-lifecycle state and is not part
+            // of the snapshot, so publishing ahead of it is safe.
+            this._conversation.notifyChanged();
             generation = this._deps.runLifecycle.beginGeneration();
             this._deps.resetRunUiAndPublish();
             // Under staging the effective context can be an exercise the

--- a/extension/src/webview/stores/useChatStore.ts
+++ b/extension/src/webview/stores/useChatStore.ts
@@ -674,3 +674,25 @@ export function selectCanChangeTopic(
 ): boolean {
     return state.contentState !== 'unknown' && !state.sendInFlight && !state.navigationInFlight;
 }
+
+/**
+ * Why a send would be refused right now, or `undefined` when it would go
+ * through. Gate and label are ONE derivation so the greyed-out button and the
+ * sentence explaining it can never disagree.
+ *
+ * The order is the host's own rejection order (`sendCoordinator.ts:80-81`), so
+ * whenever the host would refuse, the student reads the cause the host would
+ * have named. Local `streaming` ranks LAST: it has no host counterpart and
+ * covers only the window between the webview posting the command and the host
+ * taking its lock. Ranking it higher would mislabel the combination
+ * `streaming` + `navigationInFlight`, which is reachable during snapshot
+ * races and which the host rejects for navigation.
+ */
+export function selectSendBlockedReason(
+    state: Pick<ChatState, 'sendInFlight' | 'navigationInFlight' | 'streaming'>,
+): string | undefined {
+    if (state.sendInFlight) { return 'Iris is still answering'; }
+    if (state.navigationInFlight) { return 'The conversation is still loading'; }
+    if (state.streaming.isStreaming) { return 'Iris is still answering'; }
+    return undefined;
+}

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -470,9 +470,18 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // The banner can clear while the host still holds its lock: the
         // provider's availability refresh runs ahead of the reload that was
         // deferred until the send settles. Keep the pending resend AND its
-        // bubble; `sendBlocked` is in the dependency list, so the release runs
-        // this again.
-        if (sendBlocked) { return; }
+        // bubble.
+        //
+        // Read LIVE rather than through the render-time closure `sendBlocked`,
+        // for the same reason `handleSendMessage` and `handleRetry` do: a host
+        // snapshot can land between this render committing and this effect's
+        // passive-effect callback running, and the closure would then still
+        // see the stale, unlocked value. Reading live here means `sendBlocked`
+        // is no longer what gates this effect body, so it looks unused below,
+        // but it is NOT dead: it stays in the dependency array purely as the
+        // trigger that re-runs this effect once the live gate releases. Do not
+        // remove it from the deps just because the body does not read it.
+        if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return; }
         resendWhenReachable.current = null;
         // The banner also clears on a NAVIGATION. Cancel when the move is
         // already visible here.

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -332,7 +332,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         }
     }, [setIrisState, setShowDiagnostics, addMessage, applyLoadedMessages, setReferencedFiles, setWebSocketStatus, setDisabledMessage, setUnavailableMessage, setNoAiDetected, resetTransientChatUi, applyRunUi, applyCommit, markMessageFailed, setOpenSessionError, mergeLoadedMessages, confirmSentMessage, showNotice]);
 
-    const handleSendMessage = (text: string) => {
+    /**
+     * The single send funnel. Returns whether the send was ACCEPTED, i.e.
+     * whether the command actually went to the host. Callers that own the
+     * student's text (the composer) must keep it on `false`; a refusal here
+     * produces no bubble, so nothing else would be holding it.
+     */
+    const handleSendMessage = (text: string): boolean => {
         const localId = crypto.randomUUID();
         // The conversation the bubble is drawn in travels WITH the send, so the
         // host can refuse it if a navigation completed in between rather than
@@ -342,7 +348,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             // Nothing to address a rejection to. The composer is already
             // disabled in this state, so this is a defensive guard against a
             // programmer error.
-            return;
+            return false;
         }
 
         // Read LIVE rather than through the render-time closure: this funnel is
@@ -350,7 +356,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // run a tick behind the render that produced them. Every caller is
         // covered here, so this is the guarantee; the disabled button and the
         // inert Retry are only affordances.
-        if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return; }
+        if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return false; }
 
         // Clear any stale streaming state from the previous request
         resetTransientChatUi();
@@ -375,6 +381,7 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // rejection so the webview can ignore stale responses after a
         // navigation.
         postCommand(vscodeApi, 'sendMessage', { text, localId, sessionId });
+        return true;
     };
 
     const handleRetry = (localId: string) => {

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -397,8 +397,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         }
         // BEFORE the removal, never after: the funnel would refuse the send and
         // the bubble would already be gone, taking the student's text with it.
-        // Unreachable through the UI once isRetryDisabled is true; kept as the
-        // structural guarantee for any future caller.
+        // `isRetryDisabled` does not make this unreachable, it only narrows the
+        // window: a click can still land between the host taking the lock and
+        // React committing the render that disables the button. This guard is
+        // what closes that window, and the flow tests cover it.
         if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return; }
         // Remove the failed entry first so handleSendMessage's optimistic
         // add doesn't briefly produce two copies. Zustand+React batch the

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -32,11 +32,12 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // the host take a send right now", and carries the sentence that explains
     // a no.
     //
-    // Declared HERE, not next to the other derivations further down: Task 4
-    // puts `sendBlocked` in the dependency array of the deferred-resend effect
-    // at :440, and a dependency array is evaluated during render. A `const`
-    // declared below that effect would be in its temporal dead zone and throw
-    // a ReferenceError on every render.
+    // Declared HERE, above every effect, not next to the other derivations
+    // further down: the deferred-resend effect lists `sendBlocked` in its
+    // dependency array, and a dependency array is evaluated during render. A
+    // `const` declared below that effect would be in its temporal dead zone
+    // and throw a ReferenceError on every render. Keep this declaration ahead
+    // of any effect that reads it.
     const sendBlockedReason = selectSendBlockedReason(store);
     const sendBlocked = sendBlockedReason !== undefined;
     const {
@@ -394,6 +395,11 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             handleRetryChatLoad();
             return;
         }
+        // BEFORE the removal, never after: the funnel would refuse the send and
+        // the bubble would already be gone, taking the student's text with it.
+        // Unreachable through the UI once isRetryDisabled is true; kept as the
+        // structural guarantee for any future caller.
+        if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return; }
         // Remove the failed entry first so handleSendMessage's optimistic
         // add doesn't briefly produce two copies. Zustand+React batch the
         // two state updates in the same event tick, so there is no visible
@@ -459,6 +465,12 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         if (store.unavailableMessage !== null) { return; }
         const pending = resendWhenReachable.current;
         if (pending === null) { return; }
+        // The banner can clear while the host still holds its lock: the
+        // provider's availability refresh runs ahead of the reload that was
+        // deferred until the send settles. Keep the pending resend AND its
+        // bubble; `sendBlocked` is in the dependency list, so the release runs
+        // this again.
+        if (sendBlocked) { return; }
         resendWhenReachable.current = null;
         // The banner also clears on a NAVIGATION. Cancel when the move is
         // already visible here.
@@ -475,10 +487,10 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
         // so the resend does not leave a duplicate behind.
         store.removeMessage(pending.localId);
         handleSendMessage(pending.text);
-        // Deliberately keyed on the banner alone. `handleSendMessage` is
+        // Keyed on the banner and the send gate. `handleSendMessage` is
         // recreated every render, so listing it would re-run this on every
-        // render instead of on the transition that matters.
-    }, [store.unavailableMessage]);
+        // render instead of on the transitions that matter.
+    }, [store.unavailableMessage, sendBlocked]);
 
     // Popover open/close helpers. The two popovers are mutually exclusive.
     // Opening one always closes the other. Closing restores focus to
@@ -568,14 +580,19 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     // render because the message list is short and `messages.map` already
     // walks it; rebuilding a Map would be wasted work.
     const isRetryDisabled = (msg: { errorReason?: ChatMessage['errorReason'] }) => {
+        // A retry IS a send. While the host would refuse one, this is an inert
+        // control rather than an affordance whose only outcome is a rejection
+        // that also wipes the running request's indicator.
+        if (sendBlocked) { return true; }
         switch (msg.errorReason) {
             case 'iris-disabled':
                 // Persistent until the user navigates away from the
                 // disabled exercise; the banner already states this.
                 return true;
             case 'iris-unavailable':
-                // Never disabled. This button IS the reload while the banner is
-                // up: it reloads first and sends afterwards (see `handleRetry`).
+                // Never disabled for its own reason (the gate above still
+                // applies). This button IS the reload while the banner is up:
+                // it reloads first and sends afterwards (see `handleRetry`).
                 // Two Retry buttons at once, one of them dead, is a puzzle
                 // rather than an affordance.
                 return false;

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -1108,6 +1108,8 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                         onSendPrompt={handleSendMessage}
                         hasContext={hasConversation}
                         isChatDisabled={isChatDisabled}
+                        sendDisabled={sendBlocked}
+                        sendDisabledLabel={sendBlockedReason}
                         onRetry={handleRetry}
                         isRetryDisabled={isRetryDisabled}
                     />

--- a/extension/src/webview/views/IrisChat/IrisChatView.tsx
+++ b/extension/src/webview/views/IrisChat/IrisChatView.tsx
@@ -8,7 +8,7 @@ import { ExtensionMsg, postCommand } from '@shared/messageContracts';
 
 import { useClickOutside } from '@webview/hooks/useClickOutside';
 import { useExtensionMessage } from '@webview/hooks/useExtensionMessage';
-import { selectCanChangeTopic, useChatStore } from '@webview/stores/useChatStore';
+import { selectCanChangeTopic, selectSendBlockedReason, useChatStore } from '@webview/stores/useChatStore';
 
 import { ChatHeader } from './components/ChatHeader';
 import { ChatInput } from './components/ChatInput';
@@ -28,6 +28,17 @@ interface IrisChatViewProps {
 
 export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
     const store = useChatStore();
+    // Sending and composing are different questions. This one answers "would
+    // the host take a send right now", and carries the sentence that explains
+    // a no.
+    //
+    // Declared HERE, not next to the other derivations further down: Task 4
+    // puts `sendBlocked` in the dependency array of the deferred-resend effect
+    // at :440, and a dependency array is evaluated during render. A `const`
+    // declared below that effect would be in its temporal dead zone and throw
+    // a ReferenceError on every render.
+    const sendBlockedReason = selectSendBlockedReason(store);
+    const sendBlocked = sendBlockedReason !== undefined;
     const {
         setIrisState, setShowDiagnostics, addMessage,
         applyLoadedMessages,
@@ -332,6 +343,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
             // programmer error.
             return;
         }
+
+        // Read LIVE rather than through the render-time closure: this funnel is
+        // reached from event handlers and from an effect, either of which can
+        // run a tick behind the render that produced them. Every caller is
+        // covered here, so this is the guarantee; the disabled button and the
+        // inert Retry are only affordances.
+        if (selectSendBlockedReason(useChatStore.getState()) !== undefined) { return; }
 
         // Clear any stale streaming state from the previous request
         resetTransientChatUi();
@@ -1124,10 +1142,11 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                     </div>
                 )}
 
-                {/* Chat input — disabled while we are still hydrating the
-                    message list so a fast user does not race the load and
-                    have their just-sent message swallowed when the server
-                    snapshot arrives. */}
+                {/* Composing and sending are gated separately. The textarea is
+                    disabled only while there is nothing to write into, e.g.
+                    while the transcript is still hydrating, so a fast user
+                    cannot race the load. Sending is refused separately while
+                    the host would reject it. */}
                 <ChatInput
                     onSend={handleSendMessage}
                     value={store.composerText}
@@ -1137,15 +1156,13 @@ export function IrisChatView({ vscodeApi }: IrisChatViewProps) {
                         || !hasConversation
                         || isChatUnavailable
                         || messagesLoading
-                        || store.streaming.isStreaming
                     }
+                    sendDisabled={sendBlocked}
+                    sendDisabledLabel={sendBlockedReason}
+                    placeholder={sendBlocked ? 'Type your next message…' : undefined}
                     disabledPlaceholder={
                         disabledPlaceholder
-                        ?? (messagesLoading
-                            ? 'Loading conversation…'
-                            : store.streaming.isStreaming
-                                ? 'Iris is responding…'
-                                : undefined)
+                        ?? (messagesLoading ? 'Loading conversation…' : undefined)
                     }
                 />
 

--- a/extension/src/webview/views/IrisChat/components/ChatInput.module.css
+++ b/extension/src/webview/views/IrisChat/components/ChatInput.module.css
@@ -66,3 +66,26 @@
 .sendButton:active:not(.sendButtonDisabled) {
     transform: scale(0.95);
 }
+
+/* The button itself is `disabled`, and Chromium does not fire pointer events
+   on disabled form controls, so a title on the button would never show. The
+   wrapper is the hover target instead. */
+.sendWrap {
+    display: flex;
+    flex-shrink: 0;
+}
+
+/* Present for assistive technology, invisible on screen. A disabled button is
+   skipped by tab navigation, so the reason has to hang off the textarea,
+   which IS focusable in exactly this state. */
+.srOnly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/extension/src/webview/views/IrisChat/components/ChatInput.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatInput.tsx
@@ -6,7 +6,15 @@ import TextareaAutosize from 'react-textarea-autosize';
 import styles from './ChatInput.module.css';
 
 interface ChatInputProps {
-    onSend: (text: string) => void;
+    /**
+     * Hands the draft to the send funnel. Returns whether the send was
+     * ACCEPTED: the funnel reads live host state, so it can still refuse a
+     * send that this component's last render believed was fine. Strictly
+     * boolean rather than "undefined means fine", because a caller that
+     * forgets to answer must not silently look like an acceptance and take
+     * the student's text with it.
+     */
+    onSend: (text: string) => boolean;
     /**
      * There is nothing to write into: no conversation, Iris switched off,
      * Iris unreachable, transcript not delivered yet. Disables the textarea,
@@ -80,8 +88,16 @@ export function ChatInput({
         // The guard sits AHEAD of the clear on purpose: a blocked Enter must
         // leave the draft exactly where the student left it.
         if (!canSend) { return; }
-        onSend(value.trim());
-        setValue(''); // Clear input immediately (optimistic)
+        // `canSend` is only as fresh as the last committed render. An Enter
+        // that lands in the window between the host taking the lock and React
+        // disabling the button reaches the funnel, which refuses it from live
+        // state. Clearing regardless would delete text that was never sent,
+        // and no bubble would carry it either. So: clear ONLY on acceptance.
+        // Restoring the draft from inside the funnel cannot work instead,
+        // because this line runs after `onSend` returns and would wipe it.
+        if (onSend(value.trim())) {
+            setValue(''); // Clear input immediately (optimistic)
+        }
     };
 
     return (

--- a/extension/src/webview/views/IrisChat/components/ChatInput.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatInput.tsx
@@ -1,13 +1,31 @@
 import clsx from 'clsx';
 import Send from 'lucide-react/dist/esm/icons/send';
-import { KeyboardEvent, useState } from 'react';
+import { KeyboardEvent, useId, useState } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import styles from './ChatInput.module.css';
 
 interface ChatInputProps {
     onSend: (text: string) => void;
+    /**
+     * There is nothing to write into: no conversation, Iris switched off,
+     * Iris unreachable, transcript not delivered yet. Disables the textarea,
+     * the send button and the submit guard.
+     */
     disabled: boolean;
+    /**
+     * Composing is fine, sending has to wait. Disables the send button and
+     * the submit guard only; the textarea stays editable and keeps its draft.
+     * Deliberately a second flag rather than a wider `disabled`: those are
+     * different facts and the student is allowed to act on one of them.
+     */
+    sendDisabled?: boolean;
+    /**
+     * Why sending is blocked. Surfaced twice, on the button for the mouse and
+     * on the textarea for assistive technology, and only while
+     * `sendDisabled && !disabled`.
+     */
+    sendDisabledLabel?: string;
     placeholder?: string;
     disabledPlaceholder?: string;
     /**
@@ -24,12 +42,15 @@ interface ChatInputProps {
 export function ChatInput({
     onSend,
     disabled,
+    sendDisabled = false,
+    sendDisabledLabel,
     placeholder = 'Ask Iris anything...',
     disabledPlaceholder = 'Select a course or exercise to start chatting',
     value: controlledValue,
     onValueChange,
 }: ChatInputProps) {
     const [localValue, setLocalValue] = useState('');
+    const sendBlockedId = useId();
     const value = controlledValue ?? localValue;
     const setValue = (text: string) => {
         if (controlledValue === undefined) {
@@ -38,6 +59,13 @@ export function ChatInput({
         }
         onValueChange?.(text);
     };
+
+    // Bound to "you may write but not send". While the composer is disabled
+    // outright, sending is blocked for one of four other reasons and this
+    // sentence would be a lie.
+    const reason = sendDisabled && !disabled ? sendDisabledLabel : undefined;
+
+    const canSend = value.trim().length > 0 && !disabled && !sendDisabled;
 
     const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
         // Enter without Shift sends message
@@ -49,14 +77,12 @@ export function ChatInput({
     };
 
     const handleSend = () => {
-        const trimmed = value.trim();
-        if (trimmed && !disabled) {
-            onSend(trimmed);
-            setValue(''); // Clear input immediately (optimistic)
-        }
+        // The guard sits AHEAD of the clear on purpose: a blocked Enter must
+        // leave the draft exactly where the student left it.
+        if (!canSend) { return; }
+        onSend(value.trim());
+        setValue(''); // Clear input immediately (optimistic)
     };
-
-    const canSend = value.trim().length > 0 && !disabled;
 
     return (
         <div className={styles.container}>
@@ -73,21 +99,27 @@ export function ChatInput({
                         : placeholder
                 }
                 disabled={disabled}
+                aria-describedby={reason ? sendBlockedId : undefined}
                 minRows={1}
                 maxRows={6}
                 aria-label="Chat input"
             />
-            <button
-                className={clsx(styles.sendButton, {
-                    [styles.sendButtonDisabled]: !canSend,
-                    [styles.sendButtonActive]: canSend,
-                })}
-                onClick={handleSend}
-                disabled={!canSend}
-                aria-label="Send message"
-            >
-                <Send size={20} />
-            </button>
+            {reason && (
+                <span id={sendBlockedId} className={styles.srOnly}>{reason}</span>
+            )}
+            <span className={styles.sendWrap} title={reason}>
+                <button
+                    className={clsx(styles.sendButton, {
+                        [styles.sendButtonDisabled]: !canSend,
+                        [styles.sendButtonActive]: canSend,
+                    })}
+                    onClick={handleSend}
+                    disabled={!canSend}
+                    aria-label="Send message"
+                >
+                    <Send size={20} />
+                </button>
+            </span>
         </div>
     );
 }

--- a/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
+++ b/extension/src/webview/views/IrisChat/components/ChatMessageList.tsx
@@ -27,6 +27,13 @@ interface ChatMessageListProps {
     onSendPrompt: (text: string) => void;
     hasContext: boolean;
     isChatDisabled?: boolean;
+    /**
+     * Sending is refused right now. Only reaches the welcome prompts, which
+     * are sends and go inert with the send button.
+     */
+    sendDisabled?: boolean;
+    /** Why sending is blocked, surfaced on the welcome prompts. */
+    sendDisabledLabel?: string;
     /** Invoked when a failed user message's Retry button is clicked. */
     onRetry?: (localId: string) => void;
     /**
@@ -49,6 +56,8 @@ export function ChatMessageList({
     onSendPrompt,
     hasContext,
     isChatDisabled,
+    sendDisabled,
+    sendDisabledLabel,
     onRetry,
     isRetryDisabled,
 }: ChatMessageListProps) {
@@ -73,7 +82,13 @@ export function ChatMessageList({
         <div ref={scrollRef} className={styles.scrollContainer}>
             <div ref={contentRef} className={styles.content}>
                 {showWelcome ? (
-                    <WelcomeState onSendPrompt={onSendPrompt} hasContext={hasContext} isChatDisabled={isChatDisabled} />
+                    <WelcomeState
+                        onSendPrompt={onSendPrompt}
+                        hasContext={hasContext}
+                        isChatDisabled={isChatDisabled}
+                        sendDisabled={sendDisabled}
+                        sendDisabledLabel={sendDisabledLabel}
+                    />
                 ) : (
                     <>
                         {/* Marker rows render in transcript order, so a stored

--- a/extension/src/webview/views/IrisChat/components/WelcomeState.module.css
+++ b/extension/src/webview/views/IrisChat/components/WelcomeState.module.css
@@ -68,12 +68,17 @@
     text-align: center;
 }
 
-.promptButton:hover {
+.promptButton:hover:not(:disabled) {
     background: var(--vscode-button-secondaryHoverBackground);
     transform: translateY(-2px);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
-.promptButton:active {
+.promptButton:active:not(:disabled) {
     transform: translateY(0);
+}
+
+.promptButton:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }

--- a/extension/src/webview/views/IrisChat/components/WelcomeState.tsx
+++ b/extension/src/webview/views/IrisChat/components/WelcomeState.tsx
@@ -4,6 +4,19 @@ interface WelcomeStateProps {
     onSendPrompt: (text: string) => void;
     hasContext: boolean;
     isChatDisabled?: boolean;
+    /**
+     * Sending is refused right now. These prompt buttons ARE sends, so they
+     * go inert alongside the send button: without this they are the one send
+     * affordance left that reaches the funnel, and the funnel refuses in
+     * silence, with no bubble and no notice to show for the click.
+     */
+    sendDisabled?: boolean;
+    /**
+     * Why sending is blocked. Hung on the container rather than the buttons
+     * because a disabled button swallows the hover that would show it, same
+     * as the send button's wrapper in ChatInput.
+     */
+    sendDisabledLabel?: string;
 }
 
 const SUGGESTED_PROMPTS = [
@@ -12,7 +25,13 @@ const SUGGESTED_PROMPTS = [
     'What are the test cases checking?',
 ];
 
-export function WelcomeState({ onSendPrompt, hasContext, isChatDisabled }: WelcomeStateProps) {
+export function WelcomeState({
+    onSendPrompt,
+    hasContext,
+    isChatDisabled,
+    sendDisabled = false,
+    sendDisabledLabel,
+}: WelcomeStateProps) {
     if (!hasContext) {
         return (
             <div className={styles.container}>
@@ -50,12 +69,16 @@ export function WelcomeState({ onSendPrompt, hasContext, isChatDisabled }: Welco
                 <p className={styles.subtitle}>How can I help you today?</p>
             </div>
 
-            <div className={styles.promptsContainer}>
+            <div
+                className={styles.promptsContainer}
+                title={sendDisabled ? sendDisabledLabel : undefined}
+            >
                 {SUGGESTED_PROMPTS.map((prompt, index) => (
                     <button
                         key={index}
                         className={styles.promptButton}
                         onClick={() => onSendPrompt(prompt)}
+                        disabled={sendDisabled}
                     >
                         {prompt}
                     </button>

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockVsCodeApi, dispatchExtensionMessage } from '@test/react/__helpers__/vscodeApi';
@@ -986,6 +987,94 @@ describe('Iris Chat Flow', () => {
 			// Blocked: nothing sent, and the bubble is still there to retry.
 			expect(sends()).toHaveLength(0);
 			expect(useChatStore.getState().messages).toHaveLength(1);
+
+			act(() => { useChatStore.setState({ sendInFlight: false }); });
+
+			await waitFor(() => { expect(sends()).toHaveLength(1); });
+			expect((sends()[0][0] as { payload: { text: string } }).payload.text).toBe('Retry me');
+		});
+
+		/**
+		 * A stand-in for "a host snapshot lands between this render
+		 * committing and its effect running". React flushes a commit's
+		 * passive effects in tree order, and a PRECEDING sibling's own
+		 * `useEffect` runs strictly before `IrisChatView`'s. Mounted before
+		 * `IrisChatView`, this fires exactly once (guarded by `armed`), right
+		 * when `unavailableMessage` turns null, and mutates the store
+		 * directly, before the resend effect's own body runs in the SAME
+		 * flush.
+		 *
+		 * That is the only way found, with the tools available here, to make
+		 * a render commit with `sendBlocked === false` in its closure while
+		 * `useChatStore.getState().sendInFlight` is already `true` by the
+		 * time the effect body reads it. Every attempt to produce the same
+		 * gap purely through test-level `act()`/`setState` sequencing (two
+		 * sequential `act()` calls, raw `setState` outside `act()`, awaiting
+		 * across micro- and macrotasks) either collapsed both changes into
+		 * one render that saw them together, or let the whole effect
+		 * including the resend run to completion before the second change
+		 * was even applied. A closure read would have passed either of those
+		 * cases too, so they would not have exercised the bug this guards
+		 * against.
+		 */
+		function RaceInjector({ armed }: { armed: { current: boolean } }) {
+			const unavailable = useChatStore((s) => s.unavailableMessage);
+			useEffect(() => {
+				if (armed.current && unavailable === null) {
+					armed.current = false;
+					useChatStore.setState({ sendInFlight: true });
+				}
+			});
+			return null;
+		}
+
+		it('keeps the deferred resend when the lock lands before the effect body runs, not just before its render', async () => {
+			const armed = { current: false };
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: false,
+				unavailableMessage: 'Iris is temporarily unavailable',
+				messages: [{
+					localId: 'failed-1',
+					role: 'user' as const,
+					content: 'Retry me',
+					timestamp: Date.now(),
+					status: 'error' as const,
+					errorReason: 'iris-unavailable' as const,
+					errorMessage: 'Iris is temporarily unavailable',
+				}],
+			});
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<><RaceInjector armed={armed} /><IrisChatView vscodeApi={mockApi} /></>);
+
+			// Arms resendWhenReachable and asks for a reload.
+			await user.click(screen.getByRole('button', { name: /retry/i }));
+
+			const sends = () => (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+
+			// The ONLY state change in this act(): unlike the test above,
+			// `sendInFlight` is untouched here. RaceInjector flips it to
+			// `true` from inside its own effect, part of the SAME
+			// passive-effect flush, strictly before the resend effect's body
+			// runs, so this render's closure captures `sendBlocked === false`
+			// even though the lock is already live by the time that closure
+			// is read.
+			armed.current = true;
+			act(() => {
+				useChatStore.setState({ unavailableMessage: null });
+			});
+
+			// Blocked: nothing sent, and the bubble is still there to retry.
+			// Before the fix this failed right here: the stale closure let
+			// the effect through, it removed the bubble, and the funnel's own
+			// (already-live) guard then refused the send, losing the text for
+			// good.
+			expect(sends()).toHaveLength(0);
+			expect(useChatStore.getState().messages).toHaveLength(1);
+			expect(useChatStore.getState().messages[0].content).toBe('Retry me');
 
 			act(() => { useChatStore.setState({ sendInFlight: false }); });
 

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -876,6 +876,40 @@ describe('Iris Chat Flow', () => {
 			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
 		});
 
+		it('keeps the draft when a send click beats the disabling render', () => {
+			// The composer's own guard is only as fresh as the last committed
+			// render. The host can take the lock in between, and the funnel
+			// then refuses from live state. The clear must follow the funnel's
+			// answer, not the click: a refusal produces no bubble, so the
+			// composer is the only thing left holding the student's text.
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: false,
+				navigationInFlight: false,
+				streaming: { isStreaming: false },
+				composerText: 'Draft',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const send = screen.getByRole('button', { name: 'Send message' });
+			expect(send).toBeEnabled();
+
+			// Deliberately unwrapped, see the Retry race test below.
+			useChatStore.setState({ navigationInFlight: true });
+			expect(send).toBeEnabled();
+
+			fireEvent.click(send);
+
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(0);
+			// Clearing regardless of the funnel's answer makes this ''.
+			expect(useChatStore.getState().composerText).toBe('Draft');
+			expect(screen.getByRole('textbox', { name: 'Chat input' })).toHaveValue('Draft');
+		});
+
 		it('makes Retry inert while a send is in flight', async () => {
 			useChatStore.setState({
 				...HYDRATED,

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -893,6 +893,57 @@ describe('Iris Chat Flow', () => {
 			render(<IrisChatView vscodeApi={mockApi} />);
 
 			expect(screen.getByRole('button', { name: /retry/i })).toBeDisabled();
+		});
+
+		it('keeps the failed bubble when a Retry click beats the disabling render', () => {
+			// Disabling the button narrows the window, it does not close it. The
+			// host can take the lock between the render that drew an enabled
+			// Retry and the click on it, and `handleRetry` would then remove the
+			// bubble and hand a blocked send to the funnel, which refuses it: the
+			// student's text is gone and nothing was sent. The guard placed above
+			// that removal is the only thing standing between this click and that
+			// outcome, so this test is its only coverage.
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: false,
+				streaming: { isStreaming: false },
+				messages: [{
+					localId: 'failed-1',
+					role: 'user' as const,
+					content: 'Retry me',
+					timestamp: Date.now(),
+					status: 'error' as const,
+					errorMessage: 'Something went wrong',
+				}],
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const retry = screen.getByRole('button', { name: /retry/i });
+			expect(retry).toBeEnabled();
+
+			// The host takes the lock. The missing act() is the POINT of this
+			// test, not an oversight: wrapping it would flush the re-render, the
+			// button would come back disabled, the click would do nothing and
+			// this test would silently stop covering anything. Left unwrapped,
+			// React has not committed the disabling render yet, so the button in
+			// the DOM is still the enabled one the student is looking at. That
+			// stale button is the only way to reach `handleRetry` while the gate
+			// is shut, which is why the act() warning this line prints is
+			// expected. Do not "fix" it.
+			useChatStore.setState({ sendInFlight: true });
+			expect(retry).toBeEnabled();
+
+			fireEvent.click(retry);
+
+			const sends = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sends).toHaveLength(0);
+			// The bubble survived, so the text is still retryable once the lock
+			// clears. Without the guard above the removal this is 0.
+			expect(useChatStore.getState().messages).toHaveLength(1);
+			expect(useChatStore.getState().messages[0].content).toBe('Retry me');
 		});
 
 		it('holds a deferred resend until the gate releases, then sends it once', async () => {

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -588,6 +588,9 @@ describe('Iris Chat Flow', () => {
 			await user.type(textarea, 'Follow-up');
 			expect(useChatStore.getState().composerText).toBe('Follow-up');
 			expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+			// The invitation to keep writing is the whole point of leaving the
+			// textarea enabled, so the wording is part of the contract.
+			expect(textarea).toHaveAttribute('placeholder', 'Type your next message…');
 		});
 
 		it('attempting a second send while one is in flight does not fire a second sendMessage', async () => {
@@ -760,7 +763,16 @@ describe('Iris Chat Flow', () => {
 		});
 
 		it('keeps sending blocked while the host still holds the lock', async () => {
-			useChatStore.setState({ ...HYDRATED, sendInFlight: true, composerText: 'Draft' });
+			// `streaming` starts ON so the FINISHED projection below genuinely
+			// turns the run off. Without it the projection would move the run
+			// from off to off and the assertion would prove nothing about the
+			// lock outliving the run.
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: true,
+				streaming: { isStreaming: true },
+				composerText: 'Draft',
+			});
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
@@ -778,6 +790,8 @@ describe('Iris Chat Flow', () => {
 					},
 				});
 			});
+			// ...the run really is off, so only the lock is left to block on...
+			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
 			// ...but the host has not released its lock yet.
 			expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
 
@@ -859,6 +873,73 @@ describe('Iris Chat Flow', () => {
 			// saw the command.
 			expect(useChatStore.getState().messages).toHaveLength(0);
 			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+		});
+
+		it('makes Retry inert while a send is in flight', async () => {
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: true,
+				streaming: { isStreaming: true },
+				messages: [{
+					localId: 'failed-1',
+					role: 'user' as const,
+					content: 'Retry me',
+					timestamp: Date.now(),
+					status: 'error' as const,
+					errorMessage: 'Something went wrong',
+				}],
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			expect(screen.getByRole('button', { name: /retry/i })).toBeDisabled();
+		});
+
+		it('holds a deferred resend until the gate releases, then sends it once', async () => {
+			// The lock must NOT be held yet: Retry is inert while it is, so a
+			// blocked click could never arm the deferred resend in the first
+			// place. The sequence under test is arm first, then get blocked.
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: false,
+				unavailableMessage: 'Iris is temporarily unavailable',
+				messages: [{
+					localId: 'failed-1',
+					role: 'user' as const,
+					content: 'Retry me',
+					timestamp: Date.now(),
+					status: 'error' as const,
+					errorReason: 'iris-unavailable' as const,
+					errorMessage: 'Iris is temporarily unavailable',
+				}],
+			});
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// Arms resendWhenReachable and asks for a reload.
+			await user.click(screen.getByRole('button', { name: /retry/i }));
+
+			// The banner clears while the host now holds its lock: the
+			// availability refresh runs ahead of the reload that was deferred
+			// until the send settles. Both in one update, because that is the
+			// render the effect has to survive.
+			act(() => {
+				useChatStore.setState({ unavailableMessage: null, sendInFlight: true });
+			});
+
+			const sends = () => (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+
+			// Blocked: nothing sent, and the bubble is still there to retry.
+			expect(sends()).toHaveLength(0);
+			expect(useChatStore.getState().messages).toHaveLength(1);
+
+			act(() => { useChatStore.setState({ sendInFlight: false }); });
+
+			await waitFor(() => { expect(sends()).toHaveLength(1); });
+			expect((sends()[0][0] as { payload: { text: string } }).payload.text).toBe('Retry me');
 		});
 	});
 

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -85,6 +85,10 @@ describe('Iris Chat Flow', () => {
 			isNoAiDetected: false,
 			referencedFiles: null,
 			showDiagnostics: false,
+			sendInFlight: false,
+			navigationInFlight: false,
+			composerText: '',
+			unavailableMessage: null,
 			// Default flows assume init has happened. The cold-mount flow
 			// test below explicitly opts out to exercise pre-init behavior.
 			hasReceivedInitialIrisState: true,
@@ -566,7 +570,7 @@ describe('Iris Chat Flow', () => {
 			expect(lastPayload.localId).toBe(fresh!.localId);
 		});
 
-		it('ChatInput is disabled while a send is in flight', async () => {
+		it('keeps the composer usable while a send is in flight', async () => {
 			useChatStore.setState({ ...HYDRATED });
 			const user = userEvent.setup();
 			const mockApi = createMockVsCodeApi();
@@ -579,7 +583,11 @@ describe('Iris Chat Flow', () => {
 			await waitFor(() => {
 				expect(useChatStore.getState().streaming.isStreaming).toBe(true);
 			});
-			expect(textarea).toBeDisabled();
+
+			expect(textarea).toBeEnabled();
+			await user.type(textarea, 'Follow-up');
+			expect(useChatStore.getState().composerText).toBe('Follow-up');
+			expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
 		});
 
 		it('attempting a second send while one is in flight does not fire a second sendMessage', async () => {
@@ -595,9 +603,9 @@ describe('Iris Chat Flow', () => {
 				expect(useChatStore.getState().streaming.isStreaming).toBe(true);
 			});
 
-			// Typing into the disabled textarea is a no-op; an Enter press
-			// while disabled cannot reach handleSendMessage either. Verify
-			// that the only sendMessage command posted is the first one.
+			// Typing is allowed during a run now, sending is not. The Enter
+			// guard in ChatInput plus the funnel guard in handleSendMessage
+			// are what keep this to one command.
 			await user.click(textarea);
 			await user.keyboard('Second{Enter}');
 
@@ -698,6 +706,159 @@ describe('Iris Chat Flow', () => {
 
 			const retry = screen.getByRole('button', { name: 'Retry sending this message' });
 			expect(retry).toBeDisabled();
+		});
+
+		it('keeps a draft written during the run once the run ends', async () => {
+			useChatStore.setState({ ...HYDRATED });
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+			await user.type(textarea, 'First send{Enter}');
+			await waitFor(() => {
+				expect(useChatStore.getState().streaming.isStreaming).toBe(true);
+			});
+
+			// Both transitions travel the real wire, so this exercises the
+			// view's own message path and not just the local startStreaming
+			// that handleSendMessage already did.
+			act(() => {
+				dispatchExtensionMessage({
+					type: 'updateIrisRunUi',
+					projection: {
+						sessionId: OPEN,
+						revision: 1,
+						draft: null,
+						activities: [],
+						waiting: true,
+						runState: 'RUNNING',
+					},
+				});
+			});
+
+			await user.type(textarea, 'Follow-up');
+
+			act(() => {
+				dispatchExtensionMessage({
+					type: 'updateIrisRunUi',
+					projection: {
+						sessionId: OPEN,
+						revision: 2,
+						draft: null,
+						activities: [],
+						waiting: false,
+						runState: 'FINISHED',
+					},
+				});
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
+			});
+			expect(textarea).toHaveValue('Follow-up');
+		});
+
+		it('keeps sending blocked while the host still holds the lock', async () => {
+			useChatStore.setState({ ...HYDRATED, sendInFlight: true, composerText: 'Draft' });
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// The run is over as far as the run UI is concerned...
+			act(() => {
+				dispatchExtensionMessage({
+					type: 'updateIrisRunUi',
+					projection: {
+						sessionId: OPEN,
+						revision: 2,
+						draft: null,
+						activities: [],
+						waiting: false,
+						runState: 'FINISHED',
+					},
+				});
+			});
+			// ...but the host has not released its lock yet.
+			expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+
+			act(() => { useChatStore.setState({ sendInFlight: false }); });
+			expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
+		});
+
+		it('keeps sending blocked when the socket drops mid-send', async () => {
+			useChatStore.setState({
+				...HYDRATED,
+				sendInFlight: true,
+				streaming: { isStreaming: true },
+				composerText: 'Draft',
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// A disconnect resets the run UI, so isStreaming alone would say
+			// "go ahead" while the host would still reject.
+			act(() => {
+				dispatchExtensionMessage({ type: 'updateWebSocketStatus', status: 'disconnected' });
+			});
+
+			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+			expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+
+			act(() => { useChatStore.setState({ sendInFlight: false }); });
+			expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
+		});
+
+		it('blocks sending during a conversation switch and says so', async () => {
+			// The combination the host rejects for NAVIGATION, not for the run.
+			useChatStore.setState({
+				...HYDRATED,
+				navigationInFlight: true,
+				sendInFlight: false,
+				streaming: { isStreaming: true },
+				composerText: 'Draft',
+			});
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			await user.type(screen.getByRole('textbox', { name: 'Chat input' }), '{Enter}');
+
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(0);
+			expect(useChatStore.getState().composerText).toBe('Draft');
+			expect(screen.getByTitle('The conversation is still loading')).toBeInTheDocument();
+		});
+
+		it('refuses a blocked send at the funnel without disturbing anything', async () => {
+			// Only the host lock is set, deliberately. `showWelcome` is
+			// `messages.length === 0 && !hasRunSurface` (ChatMessageList.tsx:65-66),
+			// so seeding `streaming` here would hide the very buttons this test
+			// clicks. The lock alone blocks the funnel and keeps them on screen.
+			useChatStore.setState({
+				...HYDRATED,
+				messages: [],
+				sendInFlight: true,
+			});
+			const user = userEvent.setup();
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			// The welcome prompts call handleSendMessage directly
+			// (WelcomeState.tsx:58, via onSendPrompt), bypassing the composer,
+			// so a click lands on the funnel guard and nothing else.
+			await user.click(screen.getByRole('button', { name: 'Help me debug my code' }));
+
+			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
+				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
+			);
+			expect(sendCalls).toHaveLength(0);
+			// Without the guard, handleSendMessage would have added an
+			// optimistic bubble and called startStreaming before the host ever
+			// saw the command.
+			expect(useChatStore.getState().messages).toHaveLength(0);
+			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
 		});
 	});
 

--- a/extension/test/react/flows/irisChat.flow.test.tsx
+++ b/extension/test/react/flows/irisChat.flow.test.tsx
@@ -846,24 +846,40 @@ describe('Iris Chat Flow', () => {
 			expect(screen.getByTitle('The conversation is still loading')).toBeInTheDocument();
 		});
 
-		it('refuses a blocked send at the funnel without disturbing anything', async () => {
+		it('refuses a blocked send at the funnel without disturbing anything', () => {
+			// The welcome prompts are the shortest path to the funnel: they
+			// call handleSendMessage directly (WelcomeState.tsx, via
+			// onSendPrompt), with no composer in between. They are now gated
+			// like Retry, so the lock has to be taken AFTER the render that
+			// drew them live, the same way the Retry race test below reaches
+			// its guard. That stale button is the only way into the funnel
+			// while the gate is shut, which makes this test the coverage of
+			// the funnel guard itself.
+			//
 			// Only the host lock is set, deliberately. `showWelcome` is
-			// `messages.length === 0 && !hasRunSurface` (ChatMessageList.tsx:65-66),
-			// so seeding `streaming` here would hide the very buttons this test
-			// clicks. The lock alone blocks the funnel and keeps them on screen.
+			// `messages.length === 0 && !hasRunSurface` (ChatMessageList.tsx),
+			// so seeding `streaming` here would hide the very buttons this
+			// test clicks. The lock alone blocks the funnel and keeps them on
+			// screen.
 			useChatStore.setState({
 				...HYDRATED,
 				messages: [],
-				sendInFlight: true,
+				sendInFlight: false,
 			});
-			const user = userEvent.setup();
 			const mockApi = createMockVsCodeApi();
 			render(<IrisChatView vscodeApi={mockApi} />);
 
-			// The welcome prompts call handleSendMessage directly
-			// (WelcomeState.tsx:58, via onSendPrompt), bypassing the composer,
-			// so a click lands on the funnel guard and nothing else.
-			await user.click(screen.getByRole('button', { name: 'Help me debug my code' }));
+			const prompt = screen.getByRole('button', { name: 'Help me debug my code' });
+			expect(prompt).toBeEnabled();
+
+			// The missing act() is the POINT, exactly as in the Retry race test
+			// below: wrapping it would flush the disabling render, the click
+			// would land on an inert button, and this test would keep passing
+			// while covering nothing at all. The act() warning is expected.
+			useChatStore.setState({ sendInFlight: true });
+			expect(prompt).toBeEnabled();
+
+			fireEvent.click(prompt);
 
 			const sendCalls = (mockApi.postMessage as ReturnType<typeof vi.fn>).mock.calls.filter(
 				(call) => (call[0] as Record<string, unknown>).command === 'sendMessage'
@@ -874,6 +890,22 @@ describe('Iris Chat Flow', () => {
 			// saw the command.
 			expect(useChatStore.getState().messages).toHaveLength(0);
 			expect(useChatStore.getState().streaming.isStreaming).toBe(false);
+		});
+
+		it('makes the welcome prompts inert while a send is in flight', () => {
+			useChatStore.setState({
+				...HYDRATED,
+				messages: [],
+				sendInFlight: true,
+			});
+			const mockApi = createMockVsCodeApi();
+			render(<IrisChatView vscodeApi={mockApi} />);
+
+			const prompt = screen.getByRole('button', { name: 'Help me debug my code' });
+			expect(prompt).toBeDisabled();
+			// The reason travels with the disabling, so a hover explains the
+			// dead control instead of leaving the student guessing.
+			expect(prompt.parentElement).toHaveAttribute('title', 'Iris is still answering');
 		});
 
 		it('keeps the draft when a send click beats the disabling render', () => {

--- a/extension/test/react/stores/selectSendBlockedReason.test.ts
+++ b/extension/test/react/stores/selectSendBlockedReason.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectSendBlockedReason } from '@webview/stores/useChatStore';
+
+const IDLE = {
+	sendInFlight: false,
+	navigationInFlight: false,
+	streaming: { isStreaming: false },
+};
+
+describe('selectSendBlockedReason', () => {
+	it('is undefined when nothing blocks a send', () => {
+		expect(selectSendBlockedReason(IDLE)).toBeUndefined();
+	});
+
+	it('names the host lock', () => {
+		expect(selectSendBlockedReason({ ...IDLE, sendInFlight: true }))
+			.toBe('Iris is still answering');
+	});
+
+	it('names navigation', () => {
+		expect(selectSendBlockedReason({ ...IDLE, navigationInFlight: true }))
+			.toBe('The conversation is still loading');
+	});
+
+	it('names the local run before the host has taken its lock', () => {
+		expect(selectSendBlockedReason({ ...IDLE, streaming: { isStreaming: true } }))
+			.toBe('Iris is still answering');
+	});
+
+	it('ranks navigation above the local run, as the host does', () => {
+		// Reachable during snapshot races. The host tests sendInFlight, then
+		// navigationInFlight, and rejects this one for navigation, so the
+		// student must read the navigation sentence.
+		expect(selectSendBlockedReason({
+			...IDLE,
+			navigationInFlight: true,
+			streaming: { isStreaming: true },
+		})).toBe('The conversation is still loading');
+	});
+
+	it('ranks the host lock above navigation, as the host does', () => {
+		expect(selectSendBlockedReason({
+			...IDLE,
+			sendInFlight: true,
+			navigationInFlight: true,
+		})).toBe('Iris is still answering');
+	});
+});

--- a/extension/test/react/views/IrisChat/components/ChatInput.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatInput.test.tsx
@@ -153,4 +153,85 @@ describe('ChatInput', () => {
 		const svg = sendButton.querySelector('svg');
 		expect(svg).toBeInTheDocument();
 	});
+
+	it('keeps the textarea editable while only sending is blocked', async () => {
+		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+
+		expect(textarea).toBeEnabled();
+		await userEvent.type(textarea, 'Draft');
+		expect(textarea).toHaveValue('Draft');
+	});
+
+	it('disables the send button while sending is blocked, even with text', async () => {
+		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		await userEvent.type(screen.getByRole('textbox', { name: 'Chat input' }), 'Draft');
+
+		expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+	});
+
+	it('does not send on Enter while sending is blocked', async () => {
+		const onSend = vi.fn();
+		render(<ChatInput onSend={onSend} disabled={false} sendDisabled={true} />);
+		await userEvent.type(screen.getByRole('textbox', { name: 'Chat input' }), 'Draft{Enter}');
+
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it('keeps the draft when Enter is pressed while sending is blocked', async () => {
+		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
+		await userEvent.type(textarea, 'Draft{Enter}');
+
+		expect(textarea).toHaveValue('Draft');
+	});
+
+	it('still disables the textarea when composing is disabled', () => {
+		render(<ChatInput onSend={vi.fn()} disabled={true} sendDisabled={false} />);
+
+		expect(screen.getByRole('textbox', { name: 'Chat input' })).toBeDisabled();
+	});
+
+	it('shows the reason on the send button while only sending is blocked', () => {
+		render(
+			<ChatInput
+				onSend={vi.fn()}
+				disabled={false}
+				sendDisabled={true}
+				sendDisabledLabel="Iris is still answering"
+			/>
+		);
+
+		expect(screen.getByTitle('Iris is still answering')).toBeInTheDocument();
+	});
+
+	it('shows no send reason when composing is disabled too', () => {
+		render(
+			<ChatInput
+				onSend={vi.fn()}
+				disabled={true}
+				sendDisabled={true}
+				sendDisabledLabel="Iris is still answering"
+			/>
+		);
+
+		expect(screen.queryByTitle('Iris is still answering')).not.toBeInTheDocument();
+	});
+
+	it('describes the textarea with the reason while only sending is blocked', () => {
+		const { rerender } = render(
+			<ChatInput
+				onSend={vi.fn()}
+				disabled={false}
+				sendDisabled={true}
+				sendDisabledLabel="Iris is still answering"
+			/>
+		);
+		expect(screen.getByRole('textbox', { name: 'Chat input' }))
+			.toHaveAccessibleDescription('Iris is still answering');
+
+		rerender(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={false} />);
+		expect(screen.getByRole('textbox', { name: 'Chat input' }))
+			.not.toHaveAccessibleDescription();
+	});
 });

--- a/extension/test/react/views/IrisChat/components/ChatInput.test.tsx
+++ b/extension/test/react/views/IrisChat/components/ChatInput.test.tsx
@@ -6,31 +6,31 @@ import { ChatInput } from '@webview/views/IrisChat/components/ChatInput';
 
 describe('ChatInput', () => {
 	it('renders a textarea element', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
 		expect(textarea).toBeInTheDocument();
 	});
 
 	it('renders with default placeholder when not disabled', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 		const textarea = screen.getByPlaceholderText('Ask Iris anything...');
 		expect(textarea).toBeInTheDocument();
 	});
 
 	it('renders with custom placeholder', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} placeholder="Type here..." />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} placeholder="Type here..." />);
 		expect(screen.getByPlaceholderText('Type here...')).toBeInTheDocument();
 	});
 
 	it('renders disabled placeholder when disabled', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={true} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={true} />);
 		expect(
 			screen.getByPlaceholderText('Select a course or exercise to start chatting')
 		).toBeInTheDocument();
 	});
 
 	it('calls onSend when Enter pressed with content', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -41,7 +41,7 @@ describe('ChatInput', () => {
 	});
 
 	it('does NOT call onSend on Shift+Enter (inserts newline instead)', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -51,7 +51,7 @@ describe('ChatInput', () => {
 	});
 
 	it('clears input after successful send via Enter', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' }) as HTMLTextAreaElement;
 		await userEvent.type(textarea, 'Hello{Enter}');
@@ -59,8 +59,23 @@ describe('ChatInput', () => {
 		expect(textarea.value).toBe('');
 	});
 
+	it('keeps the draft when the send is refused', async () => {
+		// `canSend` is only as fresh as the last committed render, so an Enter
+		// can still reach a funnel that refuses it from live state. Clearing on
+		// a refusal deletes text that was never sent and that no failed bubble
+		// is carrying either.
+		const onSend = vi.fn(() => false);
+		render(<ChatInput onSend={onSend} disabled={false} />);
+
+		const textarea = screen.getByRole('textbox', { name: 'Chat input' }) as HTMLTextAreaElement;
+		await userEvent.type(textarea, 'Hello{Enter}');
+
+		expect(onSend).toHaveBeenCalledWith('Hello');
+		expect(textarea.value).toBe('Hello');
+	});
+
 	it('does not send empty message on Enter', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -70,7 +85,7 @@ describe('ChatInput', () => {
 	});
 
 	it('does not send whitespace-only message', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -80,13 +95,13 @@ describe('ChatInput', () => {
 	});
 
 	it('send button is disabled when input is empty', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 		const sendButton = screen.getByRole('button', { name: 'Send message' });
 		expect(sendButton).toBeDisabled();
 	});
 
 	it('send button is enabled when input has content', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
 		await userEvent.type(textarea, 'Hello');
@@ -96,7 +111,7 @@ describe('ChatInput', () => {
 	});
 
 	it('calls onSend when send button is clicked', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -110,7 +125,7 @@ describe('ChatInput', () => {
 	});
 
 	it('clears input after send button click', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' }) as HTMLTextAreaElement;
 		await userEvent.type(textarea, 'Hello');
@@ -121,13 +136,13 @@ describe('ChatInput', () => {
 	});
 
 	it('disables textarea when disabled prop is true', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={true} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={true} />);
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
 		expect(textarea).toBeDisabled();
 	});
 
 	it('does not send when disabled, even with Enter', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={true} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -138,7 +153,7 @@ describe('ChatInput', () => {
 	});
 
 	it('trims whitespace before sending', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} />);
 
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
@@ -148,14 +163,14 @@ describe('ChatInput', () => {
 	});
 
 	it('renders send button with SVG icon', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} />);
 		const sendButton = screen.getByRole('button', { name: 'Send message' });
 		const svg = sendButton.querySelector('svg');
 		expect(svg).toBeInTheDocument();
 	});
 
 	it('keeps the textarea editable while only sending is blocked', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} sendDisabled={true} />);
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
 
 		expect(textarea).toBeEnabled();
@@ -164,14 +179,14 @@ describe('ChatInput', () => {
 	});
 
 	it('disables the send button while sending is blocked, even with text', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} sendDisabled={true} />);
 		await userEvent.type(screen.getByRole('textbox', { name: 'Chat input' }), 'Draft');
 
 		expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
 	});
 
 	it('does not send on Enter while sending is blocked', async () => {
-		const onSend = vi.fn();
+		const onSend = vi.fn(() => true);
 		render(<ChatInput onSend={onSend} disabled={false} sendDisabled={true} />);
 		await userEvent.type(screen.getByRole('textbox', { name: 'Chat input' }), 'Draft{Enter}');
 
@@ -179,7 +194,7 @@ describe('ChatInput', () => {
 	});
 
 	it('keeps the draft when Enter is pressed while sending is blocked', async () => {
-		render(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={true} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={false} sendDisabled={true} />);
 		const textarea = screen.getByRole('textbox', { name: 'Chat input' });
 		await userEvent.type(textarea, 'Draft{Enter}');
 
@@ -187,7 +202,7 @@ describe('ChatInput', () => {
 	});
 
 	it('still disables the textarea when composing is disabled', () => {
-		render(<ChatInput onSend={vi.fn()} disabled={true} sendDisabled={false} />);
+		render(<ChatInput onSend={vi.fn(() => true)} disabled={true} sendDisabled={false} />);
 
 		expect(screen.getByRole('textbox', { name: 'Chat input' })).toBeDisabled();
 	});
@@ -195,7 +210,7 @@ describe('ChatInput', () => {
 	it('shows the reason on the send button while only sending is blocked', () => {
 		render(
 			<ChatInput
-				onSend={vi.fn()}
+				onSend={vi.fn(() => true)}
 				disabled={false}
 				sendDisabled={true}
 				sendDisabledLabel="Iris is still answering"
@@ -208,7 +223,7 @@ describe('ChatInput', () => {
 	it('shows no send reason when composing is disabled too', () => {
 		render(
 			<ChatInput
-				onSend={vi.fn()}
+				onSend={vi.fn(() => true)}
 				disabled={true}
 				sendDisabled={true}
 				sendDisabledLabel="Iris is still answering"
@@ -221,7 +236,7 @@ describe('ChatInput', () => {
 	it('describes the textarea with the reason while only sending is blocked', () => {
 		const { rerender } = render(
 			<ChatInput
-				onSend={vi.fn()}
+				onSend={vi.fn(() => true)}
 				disabled={false}
 				sendDisabled={true}
 				sendDisabledLabel="Iris is still answering"
@@ -230,7 +245,7 @@ describe('ChatInput', () => {
 		expect(screen.getByRole('textbox', { name: 'Chat input' }))
 			.toHaveAccessibleDescription('Iris is still answering');
 
-		rerender(<ChatInput onSend={vi.fn()} disabled={false} sendDisabled={false} />);
+		rerender(<ChatInput onSend={vi.fn(() => true)} disabled={false} sendDisabled={false} />);
 		expect(screen.getByRole('textbox', { name: 'Chat input' }))
 			.not.toHaveAccessibleDescription();
 	});

--- a/extension/test/react/views/IrisChat/components/WelcomeState.test.tsx
+++ b/extension/test/react/views/IrisChat/components/WelcomeState.test.tsx
@@ -80,6 +80,53 @@ describe('WelcomeState', () => {
 		expect(onSendPrompt).toHaveBeenCalledWith('What are the test cases checking?');
 	});
 
+	it('disables the prompt buttons while sending is blocked', () => {
+		// The prompts ARE sends. Left live while the funnel refuses, a click
+		// produces nothing at all: no bubble, no notice, no message.
+		render(
+			<WelcomeState
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+				sendDisabled={true}
+				sendDisabledLabel="Iris is still answering"
+			/>
+		);
+
+		for (const prompt of [
+			'Explain the exercise requirements',
+			'Help me debug my code',
+			'What are the test cases checking?',
+		]) {
+			expect(screen.getByRole('button', { name: prompt })).toBeDisabled();
+		}
+	});
+
+	it('explains the dead prompt buttons on hover while sending is blocked', () => {
+		render(
+			<WelcomeState
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+				sendDisabled={true}
+				sendDisabledLabel="The conversation is still loading"
+			/>
+		);
+
+		expect(screen.getByTitle('The conversation is still loading')).toBeInTheDocument();
+	});
+
+	it('leaves the prompt buttons live when sending is not blocked', () => {
+		render(
+			<WelcomeState
+				onSendPrompt={vi.fn()}
+				hasContext={true}
+				sendDisabledLabel="Iris is still answering"
+			/>
+		);
+
+		expect(screen.getByRole('button', { name: 'Help me debug my code' })).toBeEnabled();
+		expect(screen.queryByTitle('Iris is still answering')).not.toBeInTheDocument();
+	});
+
 	it('does not render prompt buttons when hasContext is false', () => {
 		render(<WelcomeState onSendPrompt={vi.fn()} hasContext={false} />);
 		expect(screen.queryAllByRole('button')).toHaveLength(0);

--- a/extension/test/unit/services/iris/conversation/sendCoordinator.test.ts
+++ b/extension/test/unit/services/iris/conversation/sendCoordinator.test.ts
@@ -519,4 +519,25 @@ suite('SendCoordinator', () => {
         c.api.resolveSend({ id: 11 });
         await sent;
     });
+
+    test('publishes the lock when it is taken, not only when it is released', async () => {
+        const c = coordinatorWith({ committed: COURSE42 });
+        // Record the flag AS EACH EVENT FIRES. Reading the state afterwards
+        // would pass without the notification, because the old code already
+        // sets the field; only the emission is new.
+        const seen: boolean[] = [];
+        c.conversation.onDidChange(() => { seen.push(c.state.sendInFlight); });
+
+        const sent = c.send({ text: 'hallo', localId: 'l1', sessionId: 1 });
+        await tick();
+
+        assert.ok(
+            seen.includes(true),
+            `no change event carried sendInFlight === true; saw [${seen.join(', ')}]`,
+        );
+
+        c.api.resolveSend({ id: 11 });
+        await sent;
+        assert.strictEqual(c.state.sendInFlight, false, 'the lock must still be released');
+    });
 });


### PR DESCRIPTION
Closes #383.

While Iris is answering, the composer is dead: the placeholder greys out and the textarea refuses keystrokes. A student who already knows their follow-up has to wait for the answer to finish before they can even start writing it.

One `disabled` flag was standing for five unrelated situations. Four of them genuinely mean "there is nothing to write into": no conversation, Iris switched off, Iris unreachable, transcript not delivered yet. The fifth does not. During a run there is a conversation, it is reachable, and the student has something to say. Only the *sending* has to wait.

So the textarea stays editable and keeps its draft, the send button stays disabled and says why, and Enter does nothing rather than clearing what was typed. Nothing is ever sent automatically: the draft was written before the answer was visible, so the student decides whether it still applies.

## The gate is not "is Iris streaming"

The obvious condition, `streaming.isStreaming`, is not an authoritative answer to "may I send now", and building on it would have left the two holes it was meant to close.

The host owns the real answer, and it already publishes it. But **it never published the acquisition**. `beginSend()` is a bare assignment, and `SendCoordinator` called `notifyChanged()` in exactly one place, the `finally` after `endSend()`. The mirrored `sendInFlight` therefore only ever reported the *release*. `ContextPicker` has been consuming that flag and has been blind for the same reason.

Hence the one host change here: a notification when the lock is taken, as the first statement inside the existing `try`. Before the `try` would be unsafe, because a listener throwing synchronously would skip the `finally` that releases the lock and latch it forever.

The gate then mirrors the host's own rejection order, and carries its own sentence so the two can never disagree:

```ts
sendInFlight        -> 'Iris is still answering'
navigationInFlight  -> 'The conversation is still loading'
streaming           -> 'Iris is still answering'
```

Local `streaming` ranks last because it has no host counterpart and only covers the window before the lock is taken. Ranking it above navigation would mislabel a reachable state that the host rejects for navigation.

## Every send path, not just the composer

`handleSendMessage` is the funnel for all four callers, so the guard lives there and reads live store state rather than a render closure. The affordances follow: the send button, Retry, and the welcome prompts all go inert while blocked.

Retry mattered more than it looks. Clicking it during a run posted a second send, the host rejected it with `send-in-flight`, and the matching rejection called `resetTransientChatUi()`, wiping the *running* request's thinking indicator. Pre-existing, and the same defect class this issue names.

Both retry paths remove their bubble before sending, so every guard sits above the removal. A guard below it would delete the student's text and send nothing.

## Accessibility

Chromium does not fire pointer events on disabled controls, so the reason sits on a wrapper around the button rather than on the button itself. That only serves the mouse, so the textarea, which *is* focusable in exactly this state, also carries the reason via `aria-describedby` on a visually hidden span. Deliberately not an `aria-live` region: interrupting a student mid-sentence to announce a state they can infer from the answer streaming in is worse than the gap it closes. Verified by hand in a real webview with VoiceOver, since neither point is provable in jsdom.

## What the reviews caught

Worth recording, because three of these were invisible at the level they were introduced.

**The webview never saw the lock being taken.** The original design gated on the mirrored `sendInFlight` and would not have worked. Found by review, confirmed against the code, and the reason this PR touches the host at all.

**A test that passed with zero coverage.** Gating the welcome prompts disabled the exact button the funnel-guard test clicked. The suite stayed green at 1068 tests while covering nothing. The test now reaches the handler through the window before the disabling render commits.

**A guard reading a stale closure.** The deferred resend checked the render-time value while the funnel checked live state. When those disagree, the resend is consumed, the bubble removed, and the funnel then refuses: text destroyed with no error bubble, strictly worse than the rejection it replaced.

**Two contradicting tests.** `ChatInput is disabled while a send is in flight` asserted today's opposite behaviour and was rewritten; its neighbour kept every assertion and lost only a comment that had become false.

## Verification

`npm run compile`, `npm run lint`, `npx knip` clean. 1297 webview tests and 1503 host tests, no failures. Every guarantee is mutation-verified: revert the production change, watch the named test fail, restore.

Manual QA in a real VS Code window: tooltip on hover, typing with Enter inert during a run, draft still present when the answer lands, screen reader reading the reason on focus.

## Not in scope

`composerText` survives a conversation switch, and the draft is still cleared optimistically before the host confirms. Both pre-existing. The new gate removes the two rejections that clear was most likely to hit.
