### PR TITLE
chore(release): prepare 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-08-08
+
 ### Changed
 
 - **Iris streaming:** Iris answers now stream in as they are generated instead of appearing all at once, and the chat shows which tools Iris used during a run, replacing the progress display that stopped working with Artemis 9.6.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.9-dev",
+  "version": "0.4.9",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Version bump and changelog cut for 0.4.9.

- `extension/package.json`: `0.4.9-dev` -> `0.4.9`
- `CHANGELOG.md`: the accumulated `## [Unreleased]` content becomes `## [0.4.9] - 2026-08-08`, and `## [Unreleased]` stays as the empty header for the next cycle.

Same shape as `chore(release): prepare 0.4.8` (#321).

The release workflow's two gates were checked locally against this branch: `extension/package.json` reads `0.4.9`, and `CHANGELOG.md` has exactly one `## [0.4.9]` header with a non-empty body (3979 bytes extracted by the workflow's own awk).

Next step after this merges is the `sync dev -> main` PR, then the release workflow from `main`, dry run first.