### PR TITLE
Harden the release: retry the Marketplace publish, document the two traps 0.4.9 hit

### DIFF
--- a/.github/workflows/release-openvsx.yml
+++ b/.github/workflows/release-openvsx.yml
@@ -179,6 +179,13 @@ jobs:
           name=$(echo "$run_json" | jq -r '.name // ""')
           head_sha=$(echo "$run_json" | jq -r '.head_sha // ""')
           app_id=$(echo "$run_json" | jq -r '.app.id // 0')
+          # Distinguish "no check run at all" from "wrong shape". They produced the
+          # same cryptic empty-field error before, which reads like a broken
+          # workflow when the real answer is usually "you dispatched too early".
+          if [[ -z "$name" && -z "$head_sha" ]]; then
+            echo "::error::No 'CI gate' check run exists on $SHA yet, so CI has not started or is still running on this commit. Wait for it to finish, then dispatch again. This is the usual cause right after pushing to main."
+            exit 1
+          fi
           if [[ "$name" != "CI gate" || "$head_sha" != "$SHA" || "$app_id" != "15368" ]]; then
             echo "::error::CI gate response shape unexpected. name='$name' head_sha='$head_sha' app_id='$app_id' (expected CI gate / $SHA / 15368)."
             exit 1
@@ -362,7 +369,10 @@ jobs:
     needs: [prepare, build]
     if: ${{ !inputs.dry_run && inputs.publish_marketplace }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10: a failing attempt can burn the gallery's own 180s timeout, and
+    # three of those plus the backoff between them is ~10.5 minutes. At 10 the
+    # retry loop would be killed mid-recovery, which is worse than not retrying.
+    timeout-minutes: 20
     environment: production  # same env as openvsx -> approval typically resolves both with one click
     permissions:
       actions: read
@@ -397,7 +407,33 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          vsce publish --skip-duplicate --no-dependencies --packagePath "$VSIX_FILE" 2>&1 | tee /tmp/vsce_out.txt
+          # Three attempts. The gallery endpoint fails at the transport layer
+          # often enough to stall a whole release: 0.4.9 died twice, once on
+          # 'Request timeout: /_apis/gallery' after 180s and once on
+          # 'read ECONNRESET' after 72s, then succeeded on an unchanged third
+          # try. Each failure cost a manual re-run and an environment approval,
+          # and blocked the tag, the GitHub release and the EduIDE bump behind it.
+          #
+          # Retrying is safe by construction rather than by luck: --skip-duplicate
+          # means an upload that landed but timed out while waiting for the
+          # response comes back as a duplicate on the next attempt, which the
+          # check below already reads as success. A package the gallery genuinely
+          # rejects fails all three attempts and still fails the job.
+          attempt=1
+          max_attempts=3
+          while true; do
+            if vsce publish --skip-duplicate --no-dependencies --packagePath "$VSIX_FILE" 2>&1 | tee /tmp/vsce_out.txt; then
+              break
+            fi
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "::error::vsce publish failed $max_attempts times. The underlying error is in the log above."
+              exit 1
+            fi
+            delay=$(( attempt * 30 ))
+            echo "::warning::vsce publish attempt $attempt of $max_attempts failed. Retrying in ${delay}s."
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
           if grep -qiE 'already (exists|published)|skipping' /tmp/vsce_out.txt; then
             echo "::warning::Marketplace already had $INPUT_VERSION; --skip-duplicate skipped the upload (treated as a retry)."
           fi

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -138,10 +138,12 @@ Releasing is driven by `.github/workflows/release-openvsx.yml` (manual `workflow
 ### Cutting a release
 
 1. Bump the `version` in `extension/package.json` and add the matching `## [x.y.z]` section to `CHANGELOG.md`; merge to `dev` (or `main`).
-2. Go to **Actions → "Release to Open VSX and VS Marketplace" → Run workflow**.
-3. Pick the branch (`main` for a normal release, `dev` for an ad-hoc / hotfix release of pre-merge work), enter the exact `version` (must match `package.json`), and leave both publish toggles on - or tick **Dry run** to build and validate only.
-4. Approve the `production` environment gate when prompted.
-5. On success the workflow tags the commit, creates the GitHub release with the changelog notes, and (after the Open VSX publish) dispatches the EduIDE bundled-extension bump PR.
+2. For a normal release, sync `dev` into `main` **with a real merge commit, never a squash**. A squash carries no parent link, so `main` never gets `dev` as an ancestor and the next sync computes its merge base from the release before it. The 0.4.7 and 0.4.8 syncs were squashed, and by 0.4.9 that produced conflicts in eight files that had nothing to do with the release. If the sync PR conflicts for this reason, the resolution is "main becomes dev": the tree should end up identical to `dev`, with `dev` recorded as the second parent.
+3. Wait for CI to finish on the commit you are about to release. The workflow requires a green `CI gate` check run on that exact SHA and fails immediately if none exists yet, which is easy to trip by dispatching straight after a push.
+4. Go to **Actions → "Release to Open VSX and VS Marketplace" → Run workflow**.
+5. Pick the branch (`main` for a normal release, `dev` for an ad-hoc / hotfix release of pre-merge work), enter the exact `version` (must match `package.json`), and leave both publish toggles on - or tick **Dry run** to build and validate only.
+6. Approve the `production` environment gate when prompted.
+7. On success the workflow tags the commit, creates the GitHub release with the changelog notes, and (after the Open VSX publish) dispatches the EduIDE bundled-extension bump PR.
 
 ### Marketplace docs are generated
 


### PR DESCRIPTION
Three changes, all from things that actually went wrong while releasing 0.4.9.

## Retry the Marketplace publish

The gallery endpoint fails at the transport layer often enough to stall a whole release. 0.4.9 failed twice:

| Attempt | Error | Time to failure |
|---|---|---|
| 1 | `Request timeout: /_apis/gallery` | 180s |
| 2 | `read ECONNRESET` | 72s |
| 3 | succeeded, unchanged | |

Nothing changed between the second and third attempt. Same VSIX, same PAT, same runner, same artifact, because the recovery used "Re-run failed jobs" on the original run as the workflow itself advises. The only variable was time. Neither error came from the gallery looking at the package and rejecting it; the same VSIX went to Open VSX first try.

Each failure cost a manual re-run and an environment approval, and held back the tag, the GitHub release and the EduIDE bump, all of which depend on this job.

**Retrying is safe by construction, not by luck.** `--skip-duplicate` was already there and the step already treats "already published" as success, so an upload that landed but timed out while waiting for the response comes back as a duplicate on the next attempt. A package the gallery genuinely rejects still fails all three attempts and still fails the job.

The job timeout moves from 10 to 20 minutes: three failed attempts plus backoff is about 10.5, and a retry loop killed halfway through recovery is worse than not retrying at all.

Left `ovsx publish` alone. The same argument would apply, but it has never flaked, and its checksum guard makes the failure mode there different enough to deserve its own thought.

## A CI gate error that says what happened

Dispatching the release a few seconds after pushing to `main` failed with:

```
CI gate response shape unexpected. name='' head_sha='' app_id='0'
```

That reads like a broken workflow. The real cause was that CI had not started yet on that commit. "No check run exists" and "the response has the wrong shape" are now separate messages, and the first one says to wait and dispatch again.

## The missing step in the release runbook

`DEVELOPER.md` said "merge to `dev` (or `main`)" and then jumped to running the workflow. How `dev` reaches `main` was not written down anywhere, and that gap is what produced the eight-file conflict during this release: the 0.4.7 and 0.4.8 syncs were squashed, so `main` never had `dev` as an ancestor and git fell back to the 0.4.6 release as the merge base. The runbook now says to sync with a real merge commit, why, and how to resolve it if it conflicts anyway. Waiting for CI before dispatching is written down too.

## Verification

The workflow parses (`js-yaml`) and the retry block passes `bash -n`. The behaviour itself cannot be exercised without a real release: the next one will be the test, and its failure mode is the current one, a job that fails and is re-run by hand.