### PR TITLE
chore: bump dev to 0.4.10-dev, plus a changelog note for the pipeline hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Internal
+
+- **Release pipeline:** The Marketplace publish now retries transient network failures instead of stalling the whole release, and the release runbook documents the dev-to-main sync and the CI gate timing.
+
 ## [0.4.9] - 2026-08-08
 
 ### Changed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.9",
+  "version": "0.4.10-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Two things, both bookkeeping after the 0.4.9 release.

## Bump `dev` to `0.4.10-dev`

Opens the next dev cycle. Without it, every build from `dev` reports itself as the published version.

One line in `extension/package.json`, same shape as `chore: bump dev to 0.4.8-dev` (#315).

Following that precedent, `extension/package-lock.json` is deliberately not touched: #315 did not update it either, and neither did the release-prep commits. Worth knowing that the lock's own `version` field has drifted as a result, it currently reads `0.4.9-dev`. It has never broken `npm ci`, so this PR leaves it alone rather than quietly changing a convention while doing something else.

## Changelog note for #391

An `### Internal` entry under `## [Unreleased]` recording the release-pipeline hardening: the Marketplace publish retries transient network failures now, and the runbook documents the dev-to-main sync and the CI gate timing.

It ships with the next release rather than 0.4.9, which is already cut and published. The `## [0.4.9]` section is untouched.

Note that this file is also the marketplace listing, so the entry is deliberately one line and stays out of `Changed` and `Fixed`, where students look.