### PR TITLE
feat: lower the minimum VS Code version from 1.97 to 1.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+### Changed
+
+- **VS Code Compatibility**: Lowered the minimum required VS Code version from 1.97.0 to 1.93.0 (August 2024), so four more releases of VS Code can install the extension. 1.93 is the genuine floor: it is the release that finalised the Terminal Shell Integration API the struggle detection depends on.
+
 ### Internal
 
 - **Release pipeline:** The Marketplace publish now retries transient network failures instead of stalling the whole release, and the release runbook documents the dev-to-main sync and the CI gate timing.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ This guide covers building, running, and shipping the extension. The codebase is
 
 - **Node.js** v22.x or higher
 - **npm**
-- **VS Code** version 1.97.0 or higher
+- **VS Code** version 1.93.0 or higher
 - *(Optional, for packaging)* `vsce`: `npm install -g @vscode/vsce`
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Choose your preferred visual style:
 
 ### Requirements
 
-- **VS Code** version 1.97.0 or higher
+- **VS Code** version 1.93.0 or higher
 - Access to an **Artemis** server (e.g., `artemis.tum.de`)
 - A valid Artemis account (student or instructor)
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react": "18.3.31",
         "@types/react-dom": "18.3.7",
         "@types/sinon": "21.0.0",
-        "@types/vscode": "1.97.0",
+        "@types/vscode": "1.93.0",
         "@types/ws": "8.18.1",
         "@typescript-eslint/eslint-plugin": "8.58.0",
         "@typescript-eslint/parser": "8.58.0",
@@ -62,7 +62,7 @@
         "vscode-extension-tester": "8.22.0"
       },
       "engines": {
-        "vscode": "^1.97.0"
+        "vscode": "^1.93.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3600,9 +3600,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.97.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.97.0.tgz",
-      "integrity": "sha512-ueE73loeOTe7olaVyqP9mrRI54kVPJifUPjblZo9fYcv1CuVLPOEKEkqW0GkqPC454+nCEoigLWnC2Pp7prZ9w==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
+      "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ls1intum/artemis-extension"
   },
   "engines": {
-    "vscode": "^1.97.0"
+    "vscode": "^1.93.0"
   },
   "categories": [
     "Education",
@@ -316,7 +316,7 @@
     "@types/react": "18.3.31",
     "@types/react-dom": "18.3.7",
     "@types/sinon": "21.0.0",
-    "@types/vscode": "1.97.0",
+    "@types/vscode": "1.93.0",
     "@types/ws": "8.18.1",
     "@typescript-eslint/eslint-plugin": "8.58.0",
     "@typescript-eslint/parser": "8.58.0",


### PR DESCRIPTION
Follow-up to #397, which pinned `@types/vscode` and in doing so made the real floor measurable.

The declared minimum was set higher than anything in the codebase required. Four releases of VS Code were locked out for nothing.

## The floor is 1.93, measured

Sweeping `@types/vscode` downwards against `tsc --noEmit`:

| version | type errors |
|---|---|
| 1.90, 1.91, 1.92 | 19 |
| **1.93** – 1.96 | **0** |
| 1.97 (previous floor) | 0 |

Every one of the 19 comes from a single API family:

```
Namespace 'vscode' has no exported member 'TerminalShellExecution'.        (10x)
Property 'onDidStartTerminalShellExecution' does not exist on 'window'.     (3x)
Property 'onDidEndTerminalShellExecution' does not exist on 'window'.       (2x)
Property 'shellIntegration' does not exist on type 'Terminal'.
Namespace 'vscode' has no exported member 'TerminalShellIntegration'.
```

Terminal Shell Integration was finalised in 1.93, and the struggle detection's E4 boundary trigger listens on it. So 1.93 is not a round number picked for comfort. It is the last version the extension can actually run on without dropping that trigger.

## The floor stays honest on its own

`@types/vscode` moves to 1.93.0 in the same commit and is now equal to the floor by construction, not by coincidence. The compiler refuses any API a user on the minimum version would not have. Same guarantee #397 established, at the new level, and the reason this change does not need a CI version matrix to stay true.

## Verification

Not only against the types. On a **real VS Code 1.93.0**, downloaded and launched via `vscode-test --code-version 1.93.0`:

- **1506** host unit tests pass, 0 failures
- **135** struggle-detection tests pass, the suite covering the very API at the boundary

On the toolchain: `check-types`, `lint`, `knip` clean, 1297 webview tests pass.

Both packagers build, and the floor survives manifest generation, which was worth confirming rather than assuming since the clean variant rewrites the manifest:

```
iris-thaumantias-0.4.10-dev.vsix          engines.vscode: ^1.93.0
iris-thaumantias-0.4.10-dev-openvsx.vsix  engines.vscode: ^1.93.0
```

## Contribution points

`tsc` covers the TypeScript API exhaustively but says nothing about `contributes`, where a point introduced after 1.93 would silently do nothing rather than fail. Checked by hand: `commands`, `configuration`, `menus.commandPalette`, `views`, `viewsContainers.activitybar`, plus the `browser` and `extensionKind` manifest fields. The newest of them is `browser` (1.53) and webview-type views (1.50). Nothing comes close to 1.93.

Docs and changelog follow: `README.md` and `DEVELOPER.md` both stated 1.97.0.