### PR TITLE
chore(release): prepare 0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to the Artemis VS Code extension will be documented in this 
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-08-09
+
 ### Changed
 
 - **VS Code Compatibility**: Lowered the minimum required VS Code version from 1.97.0 to 1.93.0 (August 2024), so four more releases of VS Code can install the extension. 1.93 is the genuine floor: it is the release that finalised the Terminal Shell Integration API the struggle detection depends on.
 
+### Security
+
+- **WebSocket client**: Updated `ws` to 8.21.0. It ships inside the extension and carries the live connection to Artemis, so the fix only reaches you with this release. Addresses [CVE-2026-45736](https://nvd.nist.gov/vuln/detail/CVE-2026-45736), where closing a connection could disclose uninitialised memory.
+
 ### Internal
 
 - **Release pipeline:** The Marketplace publish now retries transient network failures instead of stalling the whole release, and the release runbook documents the dev-to-main sync and the CI gate timing.
+- **Dependencies:** Brought the build and test toolchain up to date (esbuild, vite, vitest, eslint, and the React and testing libraries). Every type package in `extension/package.json` is now pinned to an exact version, with `engines.vscode` the only range, so the compiler can no longer accept a VS Code API that the declared minimum version does not have.
 
 ## [0.4.9] - 2026-08-08
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-thaumantias",
-  "version": "0.4.10-dev",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-thaumantias",
-      "version": "0.4.10-dev",
+      "version": "0.4.10",
       "license": "MIT",
       "dependencies": {
         "@stomp/stompjs": "7.3.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.10-dev",
+  "version": "0.4.10",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Version bump and changelog for 0.4.10.

Two things in this release actually reach users, which is why it is worth cutting rather than waiting:

**`ws` 8.21.0** is a runtime dependency bundled into the extension and carries the live connection to Artemis. [CVE-2026-45736](https://nvd.nist.gov/vuln/detail/CVE-2026-45736) lets `websocket.close()` disclose uninitialised memory when a `TypedArray` is passed as the reason. It was merged in #307 nine commits ago, but a dependency fix in `dev` protects nobody until it ships.

**The minimum VS Code version drops to 1.93** (#400), so four more releases of VS Code can install the extension.

Everything else in the twelve commits since 0.4.9 is toolchain: five dependency batches, the vitest peer repair, and the type-package pinning. Summarised in one Internal line rather than enumerated, since none of it changes what the extension does.

## A new section type

The changelog gains a `### Security` heading, the first in this file. `Fixed` would understate a CVE and `Internal` would hide it from exactly the people it concerns. It follows the Keep a Changelog vocabulary the rest of the file already uses.

## Checks

The release workflow validates the changelog section it is about to publish, so that validation was run locally against this file first:

```
header_count: 1
non-blank lines in section: 7
```

`extension/package-lock.json` carries the version in two places; both moved.

## After this merges

Per the runbook in `DEVELOPER.md`, in order: sync `dev` into `main` with a **real merge commit, never a squash** (the 0.4.7 and 0.4.8 squashes are what produced the eight-file conflict at 0.4.9), wait for CI to finish on the release commit before dispatching, then run the release workflow from `main`.

This is also the first release to carry the publish retry from #391, which should absorb the transient Marketplace timeouts that needed two manual re-runs at 0.4.9.