### PR TITLE
chore: open 0.4.11-dev, and record how the release sync actually works

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -139,6 +139,20 @@ Releasing is driven by `.github/workflows/release-openvsx.yml` (manual `workflow
 
 1. Bump the `version` in `extension/package.json` and add the matching `## [x.y.z]` section to `CHANGELOG.md`; merge to `dev` (or `main`).
 2. For a normal release, sync `dev` into `main` **with a real merge commit, never a squash**. A squash carries no parent link, so `main` never gets `dev` as an ancestor and the next sync computes its merge base from the release before it. The 0.4.7 and 0.4.8 syncs were squashed, and by 0.4.9 that produced conflicts in eight files that had nothing to do with the release. If the sync PR conflicts for this reason, the resolution is "main becomes dev": the tree should end up identical to `dev`, with `dev` recorded as the second parent.
+
+   **The GitHub UI cannot do this.** The repository allows squash merges only (`allow_merge_commit` is off), so the merge button on the sync PR would undo the point of the step and the API rejects `--merge` outright. Do it locally and push, which also lets you verify the result before it reaches `main`:
+
+   ```bash
+   git fetch origin
+   git checkout -B sync-main origin/main
+   git merge --no-ff origin/dev -m "chore(release): sync dev → main for X.Y.Z (#PR)"
+   # verify before pushing: the tree must equal dev's, and dev must be a parent
+   [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse origin/dev^{tree})" ] && echo "tree ok"
+   git log -1 --format='%P'   # two parents: main, then dev
+   git push origin HEAD:main
+   ```
+
+   The push goes straight at a protected branch and needs admin rights. Open the sync PR anyway (`--base main --head dev`): it carries the release notes and CI runs on it, and GitHub closes it as merged once the push lands. Do **not** delete the branch afterwards, since the head branch is `dev` itself.
 3. Wait for CI to finish on the commit you are about to release. The workflow requires a green `CI gate` check run on that exact SHA and fails immediately if none exists yet, which is easy to trip by dispatching straight after a push.
 4. Go to **Actions → "Release to Open VSX and VS Marketplace" → Run workflow**.
 5. Pick the branch (`main` for a normal release, `dev` for an ad-hoc / hotfix release of pre-merge work), enter the exact `version` (must match `package.json`), and leave both publish toggles on - or tick **Dry run** to build and validate only.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-thaumantias",
-  "version": "0.4.10",
+  "version": "0.4.11-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-thaumantias",
-      "version": "0.4.10",
+      "version": "0.4.11-dev",
       "license": "MIT",
       "dependencies": {
         "@stomp/stompjs": "7.3.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "iris-thaumantias",
   "displayName": "Artemis - TUM",
   "description": "Artemis brings interactive learning to life with instant, individual feedback on programming exercises, quizzes, modeling tasks, and more. This VS Code extension integrates Iris, an LLM-based virtual assistant that supports students with instant answers about exercises, lectures, and learning performance. Iris provides context-aware, personalized assistance for programming exercises, encouraging independent problem-solving through subtle hints and guiding questions instead of giving full solutions.",
-  "version": "0.4.10",
+  "version": "0.4.11-dev",
   "publisher": "aet-tum",
   "license": "MIT",
   "icon": "media/artemis-blue.png",


### PR DESCRIPTION
Post-release housekeeping for 0.4.10.

## Opens 0.4.11-dev

`extension/package.json` and both version fields in the lockfile.

## Fixes a real gap in the release runbook

`DEVELOPER.md` said to sync `dev` into `main` **with a real merge commit, never a squash**, and explained why at length, but not *how*. The obvious route does not exist:

```
allow_merge_commit: false
allow_rebase_merge: false
allow_squash_merge: true
```

The merge button on the sync PR would produce exactly the squash the step forbids, and the API rejects `--merge` with `Merge commits are not allowed on this repository`. Both the 0.4.9 and 0.4.10 syncs were therefore done locally and pushed straight at `main` — visible in `f0dbd8f8` and `d614d341`, which carry a local author rather than the GitHub merge bot. That is worth writing down instead of rediscovering it under release pressure.

The added steps carry the commands, the two checks worth running before the push (tree equality with `dev`, and two parents in the right order), the note that the push needs admin rights against a protected branch, and the warning not to delete the head branch, which on that PR is `dev` itself.

## 0.4.10 shipped clean

Both registries published on the first attempt. The retry added in #391 was in place and did not need to fire, unlike 0.4.9 which took two manual re-runs. Tag `0.4.10` on `d614d341`, GitHub release published, EduIDE bump PR opened automatically.